### PR TITLE
Installation instructions, using stack and IDE

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,49 @@
 # Differential Datalog
-An in-memory incremental Datalog engine based on Differential Dataflow
+
+An in-memory incremental Datalog engine based on Differential Dataflow.
+This is currently very early work-in-progress.
+
+# Requirements
+
+We have only tested our software on Ubuntu Linux.
+
+The compilers are written in Haskell.  One needs the Glasgow Haskell
+Compiler.  The Haskell compiler is managed by the
+[stack](https://github.com/commercialhaskell/stack) tool.
+
+To download stack (if you don't already have it) you can use:
+
+```
+wget -qO- https://get.haskellstack.org/ | sh
+```
+
+# Building
+
+The first time you compile you need to initialize the project:
+
+```
+stack init
+```
+
+To build the software execute:
+
+```
+stack build
+```
+
+To run the tests execute:
+
+```
+cabal test
+```
+
+# Using IntelliJ IDEA
+
+You can download and install the community edition of IntelliJ IDEA
+from https://www.jetbrains.com/idea/download.
+
+Start IntelliJ.
+
+Install the IntelliJ-Hakell plugin: (File/Settings/Plugins -- search).
+
+The first time: open the project: File/New/Project from existing sources.


### PR DESCRIPTION
I have actually managed to load the project in IntelliJ.
Using stack seems to be even simpler than using cabal directly, so I think this is a win.
The only problem is that stack also installed a copy of the compiler and all the libraries.