### PR TITLE
mark public functions as unsafe

### DIFF
--- a/rust/template/api.rs
+++ b/rust/template/api.rs
@@ -574,7 +574,7 @@ unsafe fn record_profile(prog: &Arc<HDDlog>) {
 }
 
 #[no_mangle]
-pub extern "C" fn ddlog_string_free(s: *mut raw::c_char)
+pub unsafe extern "C" fn ddlog_string_free(s: *mut raw::c_char)
 {
     if s.is_null() {
         return;

--- a/rust/template/differential_datalog/int.rs
+++ b/rust/template/differential_datalog/int.rs
@@ -97,13 +97,13 @@ pub extern "C" fn int_from_u64(v: u64) -> *mut Int {
 }
 
 #[no_mangle]
-pub extern "C" fn int_from_str(s: *const c_char, radix: u32) -> *mut Int {
+pub unsafe extern "C" fn int_from_str(s: *const c_char, radix: u32) -> *mut Int {
     let c_str = unsafe { CStr::from_ptr(s) };
     Box::into_raw(Box::new(Int::parse_bytes(c_str.to_bytes(), radix)))
 }
 
 #[no_mangle]
-pub extern "C" fn int_free(x: *mut Int) {
+pub unsafe extern "C" fn int_free(x: *mut Int) {
     if x.is_null() {
         return;
     }

--- a/rust/template/differential_datalog/profile.rs
+++ b/rust/template/differential_datalog/profile.rs
@@ -79,7 +79,7 @@ impl Profile {
         size_vec.iter().map(|(operator, size)| {
             let name = self.names.get(operator).map(|s|s.as_ref()).unwrap_or("???");
             let msg = format!("{} {}", name, operator);
-            write!(f, "{}      {}\n", size, msg)
+            writeln!(f, "{}      {}", size, msg)
         }).collect()
     }
 
@@ -103,7 +103,7 @@ impl Profile {
             /* Print the duration of the child before calling the function recursively on it */
             match child.value() {
                 None => {
-                    write!(f, "Unknown operator\n")?;
+                    writeln!(f, "Unknown operator")?;
                 },
                 Some(opid) => {
                     let name = self.names.get(opid).map(|s|s.as_ref()).unwrap_or("???");

--- a/rust/template/differential_datalog/uint.rs
+++ b/rust/template/differential_datalog/uint.rs
@@ -79,13 +79,13 @@ pub extern "C" fn uint_from_u64(v: u64) -> *mut Uint {
 }
 
 #[no_mangle]
-pub extern "C" fn uint_from_str(s: *const c_char, radix: u32) -> *mut Uint {
+pub unsafe extern "C" fn uint_from_str(s: *const c_char, radix: u32) -> *mut Uint {
     let c_str = unsafe { CStr::from_ptr(s) };
     Box::into_raw(Box::new(Uint::parse_bytes(c_str.to_bytes(), radix)))
 }
 
 #[no_mangle]
-pub extern "C" fn uint_free(x: *mut Uint) {
+pub unsafe extern "C" fn uint_free(x: *mut Uint) {
     if x.is_null() {
         return;
     }

--- a/rust/template/ovsdb.rs
+++ b/rust/template/ovsdb.rs
@@ -77,7 +77,7 @@ fn record_updatecmds(prog: &sync::Arc<HDDlog>, upds: &Vec<UpdCmd>)
 ///
 /// On error, returns a negative number and writes error message to stderr.
 #[no_mangle]
-pub extern "C" fn ddlog_dump_ovsdb_delta(prog:   *const HDDlog,
+pub unsafe extern "C" fn ddlog_dump_ovsdb_delta(prog:   *const HDDlog,
                                          module: *const c_char,
                                          table:  *const c_char,
                                          json:   *mut *mut c_char) -> c_int
@@ -149,7 +149,7 @@ fn dump_delta(db: &mut valmap::ValMap, module: *const c_char, table: *const c_ch
 
 /// Deallocates strings returned by other functions in this API.
 #[no_mangle]
-pub extern "C" fn ddlog_free_json(str: *mut c_char) {
+pub unsafe extern "C" fn ddlog_free_json(str: *mut c_char) {
     if str.is_null() { return; }
     let _ = unsafe{CString::from_raw(str)};
 }


### PR DESCRIPTION
Public functions that dereference raw pointer arguments should be marked unsafe. See https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref