### PR TITLE
Java code generation with useful methods and classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ tags
 *.facts
 *.jar
 java/test/span_uuid.java.dump
+java/test*/*_ddlog
 *.pyc
 souffle-grammar.pgt
 # idea project files

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ script:
 #- DDLOG_TEST_PROGRESS=1 stack --no-terminal test --haddock --no-haddock-deps
 #- DDLOG_TEST_PROGRESS=1 stack --no-terminal test --ta "$TEST_SUITE"  --haddock --no-haddock-deps
 - if [ x${TOOL} = xstack ]; then DDLOG_TEST_PROGRESS=1 stack --no-terminal test --ta "$TEST_SUITE"; fi
-- if [ x${TOOL} = xrun_souffle_tests ]; then cd test && ./run-souffle-tests.py -s 0 -r 17; fi
+- if [ x${TOOL} = xrun_souffle_tests ]; then cd test && travis_wait 30 ./run-souffle-tests.py -s 0 -r 17; fi
 - if [ x${JAVA} = x1 ]; then stack install && cd java/test && ./run.sh; fi
 
 before_deploy:

--- a/java/test/SpanTest.java
+++ b/java/test/SpanTest.java
@@ -263,7 +263,7 @@ public class SpanTest {
 
         // Alternative implementation of createCommand which does not
         // use reflection and is more efficient.
-        private DDlogCommand createCommandDirect(String commang, String arguments) {
+        private DDlogCommand createCommandDirect(String command, String arguments) {
             Matcher m = argsPattern.matcher(arguments);
             if (!m.find())
                 throw new RuntimeException("Cannot parse arguments for " + command);

--- a/java/test/SpanTest.java
+++ b/java/test/SpanTest.java
@@ -275,13 +275,13 @@ public class SpanTest {
             if (relation.equals("Container") || relation.equals("FWRule")) {
                 checkSize(args, 1);
                 DDlogRecord s = new DDlogRecord(args[0]);
-                DDlogRecord sa[] = { s };
+                DDlogRecord[] sa = { s };
                 o = DDlogRecord.makeStruct(relation, sa);
             } else if (relation.equals("Dependency") || relation.equals("Source") || relation.equals("Binding")) {
                 checkSize(args, 2);
                 DDlogRecord s0 = new DDlogRecord(args[0]);
                 DDlogRecord s1 = new DDlogRecord(args[1]);
-                DDlogRecord sa[] = { s0, s1 };
+                DDlogRecord[] sa = { s0, s1 };
                 o = DDlogRecord.makeStruct(relation, sa);
             } else {
                 throw new RuntimeException("Unexpected class: " + relation);

--- a/java/test/run.sh
+++ b/java/test/run.sh
@@ -37,4 +37,4 @@ java -Djava.library.path=. -cp ../ddlogapi.jar:. SpanTest ../../test/datalog_tes
 diff -q span_uuid.java.dump ../../test/datalog_tests/span_uuid.dump.expected
 
 # Cleanup
-rm -rf META-INF *.class
+rm -rf *.class

--- a/java/test/run.sh
+++ b/java/test/run.sh
@@ -24,8 +24,6 @@ cargo build --release
 popd
 # Build the Java library with the DDlog API
 make -C ..
-# Force linking with the static library by deleting the dynamic library
-rm -f ../../test/datalog_tests/span_uuid_ddlog/target/release/libspan_uuid_ddlog.so
 # Compile SpanTest.java
 javac -cp .. SpanTest.java
 # Create a shared library containing all the native code: ddlogapi.c, libspan_uuid_ddlog.a

--- a/java/test/run.sh
+++ b/java/test/run.sh
@@ -18,7 +18,7 @@ esac
 
 # Compile the span_uuid.dl DDlog program
 ddlog -i ../../test/datalog_tests/span_uuid.dl -L../../lib
-# Compile the rust program; generates ../test/datalog_tests/span_ddlog/target/release/libspan_ddlog.a and .so
+# Compile the rust program; generates ../test/datalog_tests/span_ddlog/target/release/libspan_ddlog.a
 pushd ../../test/datalog_tests/span_uuid_ddlog
 cargo build --release
 popd

--- a/java/test1/run.sh
+++ b/java/test1/run.sh
@@ -20,7 +20,7 @@ esac
 
 # Compile the redist.dl DDlog program
 ddlog -i ../../test/datalog_tests/redist.dl -L../../lib
-# Compile the rust program; generates ../test/datalog_tests/redist_ddlog/target/release/redist_ddlog.a and .so
+# Compile the rust program; generates ../test/datalog_tests/redist_ddlog/target/release/redist_ddlog.a
 pushd ../../test/datalog_tests/redist_ddlog
 cargo build --release
 popd

--- a/java/test1/run.sh
+++ b/java/test1/run.sh
@@ -39,4 +39,4 @@ java -Djava.library.path=. -cp ./fastutil-8.2.2.jar:../ddlogapi.jar:. RedistTest
 diff -q redist.java.dump ../../test/datalog_tests/redist.dump
 
 # Cleanup
-rm -rf META-INF *.class # redist.java.dump
+rm -rf *.class # redist.java.dump

--- a/java/test1/run.sh
+++ b/java/test1/run.sh
@@ -26,8 +26,6 @@ cargo build --release
 popd
 # Build the JAR with the DDlog API
 make -C ..
-# Force linking with the static library by deleting the dynamic library
-rm -f ../../test/datalog_tests/redist_ddlog/target/release/libredist_ddlog.so
 # Compile RedistTest.java
 javac -cp ..:fastutil-8.2.2.jar RedistTest.java
 # Create a shared library containing all the native code: ddlogapi.c, libredist_ddlog.a

--- a/java/test2/run.sh
+++ b/java/test2/run.sh
@@ -24,8 +24,6 @@ cargo build
 popd
 # Build the Java library with the DDlog API
 make -C ..
-# Force linking with the static library by deleting the dynamic library
-rm -f two_ddlog/target/debug/libtwo_ddlog.so
 # Compile TwoTest.java
 javac -cp .. TwoTest.java
 # Create a shared library containing all the native code: ddlogapi.c, libtwo_ddlog.a

--- a/java/test2/run.sh
+++ b/java/test2/run.sh
@@ -18,7 +18,7 @@ esac
 
 # Compile the span_uuid.dl DDlog program
 ddlog -i ./two.dl -L../../lib
-# Compile the rust program; generates two_ddlog/target/debug/two_ddlog.a and .so
+# Compile the rust program; generates two_ddlog/target/debug/two_ddlog.a
 pushd two_ddlog
 cargo build
 popd

--- a/java/test2/run.sh
+++ b/java/test2/run.sh
@@ -34,4 +34,4 @@ ${CC} -shared -fPIC -I${JAVA_HOME}/include -I${JAVA_HOME}/include/${JDK_OS} -I..
 java -Djava.library.path=. -cp ../ddlogapi.jar:. TwoTest
 
 # Cleanup
-rm -rf META-INF *.class
+rm -rf *.class

--- a/java/test3/SpanTest.java
+++ b/java/test3/SpanTest.java
@@ -1,0 +1,36 @@
+import java.io.IOException;
+import java.util.*;
+import java.lang.RuntimeException;
+
+import ddlogapi.DDlogAPI;
+import ddlogapi.DDlogCommand;
+import ddlogapi.DDlogRecord;
+
+public class SpanTest {
+    private final DDlogAPI api;
+
+    SpanTest() {
+        this.api = new DDlogAPI(1, r -> this.onCommit(r), false);
+    }
+
+    void onCommit(DDlogCommand command) {
+        System.out.println(command.toString());
+    }
+
+    void run() {
+        Span_string.Binding binding = new Span_string.Binding("1", "2");
+        DDlogCommand command0 = binding.createCommand(true);
+        Span_string.FWRule rule = new Span_string.FWRule("1");
+        DDlogCommand command1 = rule.createCommand(true);
+        DDlogCommand[] commands = { command0, command1 };
+        this.api.start();
+        this.api.applyUpdates(commands);
+        this.api.commit();
+        this.api.stop();
+    }
+
+    public static void main(String[] args) throws IOException {
+        SpanTest test = new SpanTest();
+        test.run();
+    }
+}

--- a/java/test3/SpanTest.java
+++ b/java/test3/SpanTest.java
@@ -10,7 +10,7 @@ public class SpanTest {
     private final DDlogAPI api;
 
     SpanTest() {
-        this.api = new DDlogAPI(1, r -> this.onCommit(r), false);
+        this.api = new DDlogAPI(1, null, false);
     }
 
     void onCommit(DDlogCommand command) {
@@ -25,7 +25,7 @@ public class SpanTest {
         DDlogCommand[] commands = { command0, command1 };
         this.api.start();
         this.api.applyUpdates(commands);
-        this.api.commit();
+        this.api.commit_dump_changes(r -> this.onCommit(r));
         this.api.stop();
     }
 

--- a/java/test3/run.sh
+++ b/java/test3/run.sh
@@ -18,7 +18,7 @@ esac
 
 # Compile the span_uuid.dl DDlog program
 ddlog -i ../../test/datalog_tests/span_string.dl -j -L../../lib
-# Compile the rust program; generates ../test/datalog_tests/span_ddlog/target/release/libspan_ddlog.a and .so
+# Compile the rust program; generates ../test/datalog_tests/span_ddlog/target/release/libspan_ddlog.a
 pushd ../../test/datalog_tests/span_string_ddlog
 cargo build --release
 popd

--- a/java/test3/run.sh
+++ b/java/test3/run.sh
@@ -27,7 +27,7 @@ make -C ..
 # Compile SpanTest.java and the generated Java file
 javac -cp .. SpanTest.java Span_string.java
 # Create a shared library containing all the native code: ddlogapi.c, libspan_string_ddlog.a
-${CC} -shared -fPIC -I${JAVA_HOME}/include -I${JAVA_HOME}/include/${JDK_OS} -I../../rust/template ../ddlogapi.c -L../../test/datalog_tests/span_string_ddlog/target/release/ -lspan_string_ddlog -o libddlogapi.${SHLIBEXT}
+${CC} -shared -fPIC -I${JAVA_HOME}/include -I${JAVA_HOME}/include/${JDK_OS} -I../../rust/template -I../../lib ../ddlogapi.c -L../../test/datalog_tests/span_string_ddlog/target/release/ -lspan_string_ddlog -o libddlogapi.${SHLIBEXT}
 # Run the java program pointing to the created shared library
 java -Djava.library.path=. -cp ../ddlogapi.jar:. SpanTest > spantest.dump
 diff spantest.dump spantest.dump.expected

--- a/java/test3/run.sh
+++ b/java/test3/run.sh
@@ -24,8 +24,6 @@ cargo build --release
 popd
 # Build the Java library with the DDlog API
 make -C ..
-# Force linking with the static library by deleting the dynamic library
-rm -f ../../test/datalog_tests/span_string_ddlog/target/release/libspan_string_ddlog.so
 # Compile SpanTest.java and the generated Java file
 javac -cp .. SpanTest.java Span_string.java
 # Create a shared library containing all the native code: ddlogapi.c, libspan_string_ddlog.a

--- a/java/test3/run.sh
+++ b/java/test3/run.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Shell script to build and run a Java program
+# tied to test/datalog_tests/span_string.dl program
+
+set -ex
+
+if command clang -v 2>/dev/null; then
+    export CC=clang
+else
+    export CC=gcc
+fi
+
+case `uname -s` in
+    Darwin*)    SHLIBEXT=dylib; JDK_OS=darwin;;
+    Linux*)     SHLIBEXT=so; JDK_OS=linux;;
+    *)          echo "Unsupported OS"; exit -1
+esac
+
+# Compile the span_uuid.dl DDlog program
+ddlog -i ../../test/datalog_tests/span_string.dl -j -L../../lib
+# Compile the rust program; generates ../test/datalog_tests/span_ddlog/target/release/libspan_ddlog.a and .so
+pushd ../../test/datalog_tests/span_string_ddlog
+cargo build --release
+popd
+# Build the Java library with the DDlog API
+make -C ..
+# Force linking with the static library by deleting the dynamic library
+rm -f ../../test/datalog_tests/span_string_ddlog/target/release/libspan_string_ddlog.so
+# Compile SpanTest.java and the generated Java file
+javac -cp .. SpanTest.java Span_string.java
+# Create a shared library containing all the native code: ddlogapi.c, libspan_string_ddlog.a
+${CC} -shared -fPIC -I${JAVA_HOME}/include -I${JAVA_HOME}/include/${JDK_OS} -I../../rust/template ../ddlogapi.c -L../../test/datalog_tests/span_string_ddlog/target/release/ -lspan_string_ddlog -o libddlogapi.${SHLIBEXT}
+# Run the java program pointing to the created shared library
+java -Djava.library.path=. -cp ../ddlogapi.jar:. SpanTest > spantest.dump
+diff spantest.dump spantest.dump.expected
+# Cleanup generated files
+rm -rf *.class Span_string.java

--- a/java/test3/spantest.dump.expected
+++ b/java/test3/spantest.dump.expected
@@ -1,0 +1,1 @@
+From 5 Insert RuleSpan{"1","2"}

--- a/java/test4/XTest.java
+++ b/java/test4/XTest.java
@@ -1,0 +1,47 @@
+import java.util.*;
+import ddlogapi.DDlogAPI;
+import ddlogapi.DDlogCommand;
+import ddlogapi.DDlogRecord;  // only needed if not using the reflection-based APIs
+
+public class XTest {
+    private final DDlogAPI api;
+
+    XTest() {
+        this.api = new DDlogAPI(1, null, false);
+    }
+
+    void onCommit(DDlogCommand command) {
+        System.out.println(command.toString());
+    }
+
+    void run() {
+        X.R0 r0 = new X.R0(true);
+        DDlogCommand command0 = r0.createCommand(true);
+        List<Boolean> l = Arrays.asList(true, true, false);
+
+        X.R1 r1 = new X.R1(0, l);
+        DDlogCommand command1 = r1.createCommand(true);
+
+        X.UUID u0 = new X.UUID(0, 1);
+        X.UUID u1 = new X.UUID(1, 2);
+        X.R2 r2 = new X.R2(u0, u1);
+        DDlogCommand command2 = r2.createCommand(true);
+
+        X.N n0 = new X.N(true, true);
+        X.N n1 = new X.N(false, false);
+        X.M m = new X.M(n0, n1);
+        X.R3 r3 = new X.R3(m);
+        DDlogCommand command3 = r3.createCommand(true);
+
+        DDlogCommand[] commands = { command0, command1, command2, command3 };
+        this.api.start();
+        this.api.applyUpdates(commands);
+        this.api.commit_dump_changes(r -> this.onCommit(r));
+        this.api.stop();
+    }
+
+    public static void main(String[] args) {
+        XTest test = new XTest();
+        test.run();
+    }
+}

--- a/java/test4/run.sh
+++ b/java/test4/run.sh
@@ -26,7 +26,7 @@ make -C ..
 # Compile XTest.java and the generated Java file
 javac -cp .. XTest.java X.java
 # Create a shared library containing all the native code: ddlogapi.c, libspan_string_ddlog.a
-${CC} -shared -fPIC -I${JAVA_HOME}/include -I${JAVA_HOME}/include/${JDK_OS} -I../../rust/template ../ddlogapi.c -Lx_ddlog/target/debug/ -lx_ddlog -o libddlogapi.${SHLIBEXT}
+${CC} -shared -fPIC -I${JAVA_HOME}/include -I${JAVA_HOME}/include/${JDK_OS} -I../../rust/template -I../../lib ../ddlogapi.c -Lx_ddlog/target/debug/ -lx_ddlog -o libddlogapi.${SHLIBEXT}
 # Run the java program pointing to the created shared library
 java -Djava.library.path=. -cp ../ddlogapi.jar:. XTest > xtest.dump
 diff xtest.dump xtest.dump.expected

--- a/java/test4/run.sh
+++ b/java/test4/run.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Shell script to build and run a Java program tied to ./x.dl
+
+set -ex
+
+if command clang -v 2>/dev/null; then
+    export CC=clang
+else
+    export CC=gcc
+fi
+
+case `uname -s` in
+    Darwin*)    SHLIBEXT=dylib; JDK_OS=darwin;;
+    Linux*)     SHLIBEXT=so; JDK_OS=linux;;
+    *)          echo "Unsupported OS"; exit -1
+esac
+
+# Compile the span_uuid.dl DDlog program
+ddlog -i x.dl -j -L../../lib
+# Compile the rust program; generates x_ddlog/target/debug/libx_ddlog.a
+pushd x_ddlog
+cargo build
+popd
+# Build the Java library with the DDlog API
+make -C ..
+# Compile XTest.java and the generated Java file
+javac -cp .. XTest.java X.java
+# Create a shared library containing all the native code: ddlogapi.c, libspan_string_ddlog.a
+${CC} -shared -fPIC -I${JAVA_HOME}/include -I${JAVA_HOME}/include/${JDK_OS} -I../../rust/template ../ddlogapi.c -Lx_ddlog/target/debug/ -lx_ddlog -o libddlogapi.${SHLIBEXT}
+# Run the java program pointing to the created shared library
+java -Djava.library.path=. -cp ../ddlogapi.jar:. XTest > xtest.dump
+diff xtest.dump xtest.dump.expected
+# Cleanup generated files
+rm -rf *.class X.java

--- a/java/test4/x.dl
+++ b/java/test4/x.dl
@@ -1,0 +1,21 @@
+
+typedef t0 = bool
+input relation R0[t0]
+output relation O0[t0]
+O0[x] :- R0[x].
+
+typedef t1 = (signed<32>, Set<bool>)
+input relation R1[t1]
+output relation O1[t1]
+O1[x] :- R1[x].
+
+typedef UUID = UUID {left: bit<64>, right: bit<64>}
+input relation R2(parent: UUID, child: UUID)
+output relation O2(child: UUID, parent: UUID)
+O2(c, p) :- R2(p, c).
+
+typedef N = N { b1: bool, b2: bool }
+typedef M = M { n1 : N, n2: N }
+input relation R3(m: M)
+output relation O3(m: M)
+O3(x) :- R3(x).

--- a/java/test4/xtest.dump.expected
+++ b/java/test4/xtest.dump.expected
@@ -1,0 +1,4 @@
+From 0 Insert true
+From 1 Insert (0, [false, true])
+From 2 Insert O2{UUID{1,2},UUID{0,1}}
+From 3 Insert O3{M{N{true,true},N{false,false}}}

--- a/src/Language/DifferentialDatalog/CompileJava.hs
+++ b/src/Language/DifferentialDatalog/CompileJava.hs
@@ -1,0 +1,205 @@
+{-
+Copyright (c) 2019 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-}
+
+{-# LANGUAGE RecordWildCards, FlexibleContexts, LambdaCase, TupleSections, OverloadedStrings, TemplateHaskell, QuasiQuotes #-}
+
+{- |
+Module     : CompileJava
+Description: Compile 'DatalogProgram' to Java API.
+-}
+
+module Language.DifferentialDatalog.CompileJava (
+    compileJava,
+) where
+
+import Prelude hiding((<>))
+import Control.Monad.State
+import Text.PrettyPrint
+import Data.Tuple
+import Data.Tuple.Select
+import Data.Maybe
+import Data.List
+import Data.Int
+import Data.Word
+import Data.Bits hiding (isSigned)
+import Data.List.Split
+import Data.FileEmbed
+import Data.String.Utils
+import Data.Char
+import System.FilePath
+import System.Directory
+import qualified Data.ByteString.Char8 as BS
+import Numeric
+import qualified Data.Set as S
+import qualified Data.Map as M
+import qualified Data.Graph.Inductive as G
+import qualified Data.Graph.Inductive.Query.DFS as G
+import Debug.Trace
+import Text.RawString.QQ
+import Data.WideWord
+import Debug.Trace
+
+import Language.DifferentialDatalog.PP
+import Language.DifferentialDatalog.Name
+import Language.DifferentialDatalog.Pos
+import Language.DifferentialDatalog.Ops
+import Language.DifferentialDatalog.Util
+import Language.DifferentialDatalog.Syntax
+import Language.DifferentialDatalog.Parse
+import Language.DifferentialDatalog.NS
+import Language.DifferentialDatalog.Expr
+import Language.DifferentialDatalog.DatalogProgram
+import Language.DifferentialDatalog.Relation
+import Language.DifferentialDatalog.Optimize
+import Language.DifferentialDatalog.Module
+import Language.DifferentialDatalog.ECtx
+import Language.DifferentialDatalog.Type
+import Language.DifferentialDatalog.Rule
+
+-- generate a Java program from a DDlog program
+-- The Java program has some utility function to more easily create
+-- records for the DDlog relations.  Note that Java does not support
+-- all DDlog types
+compileJava :: DatalogProgram -> String -> FilePath -> IO ()
+compileJava d sourceName javaFile = do
+    let content = generateJava d sourceName in
+         writeFile javaFile (render content)
+
+-- Generate a Java document from a program given the source filename
+generateJava :: DatalogProgram -> String -> Doc
+generateJava d sourceName =
+    preamble sourceName $+$
+    (braces' $ body d)
+
+-- Generates the preamble of a Java file
+preamble :: String -> Doc
+preamble sourceName =
+    pp ("package " ++ sourceName) $+$
+    pp ("import java.util.*" :: String) $+$
+    pp ("import DDlogRecord\n" :: String) $+$
+    pp ("class " ++ capitalize sourceName)
+
+-- Generates the body of the Java class containing all utility methods
+body :: DatalogProgram -> Doc
+body d = nest' $ genEnum d $+$
+          (vcat $ punctuate "\n" $ map (genRecord d) (M.keys $ progRelations d))
+
+-- generates an enum mapping table names to table ids
+genEnum :: DatalogProgram -> Doc
+genEnum d =
+  let relNames = map fst (M.toList $ progRelations d)
+      addToIds r = pp $ "idToName.put(TableIds." ++ r ++ ", \"" ++ r ++ "\");"
+      addToNames r = pp $ "nameToId.put(\"" ++ r ++ "\", TableIds." ++ r ++ ");"
+  in
+  pp ("public static enum TableIds " :: String) $+$
+  (braces' $ commaSep $ map (pp . makeIdentifier) relNames) $+$
+  "public static HashMap<TableIds, String> idToName = new HashMap<TableIds, String>();" $+$
+  "public static HashMap<String, TableIds> nameToId = new HashMap<String, TableIds>();" $+$
+  "static" $+$ (braces' $ vcat $ (map addToIds relNames) ++ (map addToNames relNames))
+
+-- given a relation name this creates a function to construct a DDlogRecord that can be inserted or
+-- deleted in the relation
+genRecord :: DatalogProgram -> String -> Doc
+genRecord d relationName =
+    let relations = progRelations d
+        rel = fromJust $ M.lookup relationName relations
+        rtype = relType rel in
+      pp ("public static DDlogRecord create_" ++ makeIdentifier relationName) <>
+        (parens $ arguments d rtype) $+$
+        (braces' $ funcBody d rtype $+$ "return r;")
+
+-- convert a DDlog string into an identifier
+makeIdentifier :: String -> String
+makeIdentifier str = capitalize $ legalize str
+
+-- capitalize the first letter of a string
+capitalize :: String -> String
+capitalize str = (toUpper (head str) : tail str)
+
+-- convert a DDlog identifier (possibly including namespaces) into a Java identifier
+legalize :: String -> String
+legalize n = map legalizeChar n
+
+-- convert characters that are illegal in Java identifiers into underscores
+legalizeChar :: Char -> Char
+legalizeChar c = if isAlpha c then c else '_'
+
+-- generate arguments
+arguments :: DatalogProgram -> Type -> Doc
+arguments d t =
+    case t of
+        TBool{..}   -> simpleType t <+> "a0"
+        TInt{..}    -> simpleType t <+> "a0"
+        TString{..} -> simpleType t <+> "a0"
+        TSigned{..} -> simpleType t <+> "a0"
+        TUser{..}   -> arguments d (resolveType d t)
+        TTuple{..}  -> commaSep $ map (\(i,t) -> (simpleType $ resolveType d t) <+> pp ("a" ++ (show i))) (zip [0..] typeTupArgs)
+        TStruct{..} -> let c0:tail = typeCons in
+                       if tail == [] then
+                           let fieldArg f = (simpleType $ resolveType d $ fieldType f) <+> (pp $ fieldName f) in
+                               commaSep $ map fieldArg (consArgs c0)
+                       -- we do not support multiple constructors
+                       else errorWithoutStackTrace $ "Unsupported type " ++ show t
+        -- Java has no support for unsigned, so we don't accept TBit
+        _           -> errorWithoutStackTrace $ "Unsupported type " ++ show t
+
+-- convert a simple type to a Java type
+simpleType :: Type -> Doc
+simpleType TBool{..} = "boolean"
+simpleType TInt{..} = "BigInt"
+simpleType TString{..} = "String"
+simpleType TSigned{..} | typeWidth == 32 = "int"
+simpleType TSigned{..} | typeWidth == 64 = "long"
+simpleType t = errorWithoutStackTrace $ "Unsupported type " ++ show t
+
+-- resolves a TypeDef to its underlying type
+resolveType :: DatalogProgram -> Type -> Type
+resolveType d t =
+    -- trace (show t) $
+    case t of
+        TUser{..} -> resolveType d actual
+                     where typeDef = (getType d typeName)
+                           maybeActual = tdefType typeDef
+                           actual = case maybeActual of
+                                Nothing -> errorWithoutStackTrace $ "Extern type not supported: " ++ show t
+                                Just something -> something
+        _         -> t
+
+funcBody :: DatalogProgram -> Type -> Doc
+funcBody d t =
+    case t of
+        TBool{..}   -> "DDlogRecord r = new DDlogRecord(a0);"
+        TInt{..}    -> "DDlogRecord r = new DDlogRecord(a0);"
+        TString{..} -> "DDlogRecord r = new DDlogRecord(a0);"
+        TSigned{..} -> "DDlogRecord r = new DDlogRecord(a0);"
+        TUser{..}   -> funcBody d (resolveType d t)
+        TStruct{..} -> let c0:tail = typeCons in
+                       if tail == [] then
+                         let fieldRec f = "DDlogRecord r" <> (pp $ fieldName f) <+>
+                               "= new DDlogRecord" <> (parens $ pp $ fieldName f) <> semi in
+                           (vcat $ map fieldRec (consArgs c0)) $$
+                         "DDlogRecord[] a = " <> (braces $ commaSep $ map (pp . fieldName) (consArgs c0)) <> semi $$
+                         "DDlogRecord r = DDlogRecord.makeStruct" <> (parens $ commaSep [doubleQuotes $ pp $ consName c0, "a"]) <> semi
+                         -- we do not support multiple constructors
+                       else errorWithoutStackTrace $ "Unsupported type " ++ show t
+        _           -> errorWithoutStackTrace $ "Unsupported type " ++ show t

--- a/src/Language/DifferentialDatalog/CompileJava.hs
+++ b/src/Language/DifferentialDatalog/CompileJava.hs
@@ -79,11 +79,11 @@ import Language.DifferentialDatalog.Rule
 -- generate a Java program from a DDlog program
 -- The Java program has some utility function to more easily create
 -- records for the DDlog relations.  Note that Java does not support
--- all DDlog types
-compileJava :: DatalogProgram -> String -> FilePath -> IO ()
-compileJava d sourceName javaFile = do
+-- all DDlog constructs
+compileJava :: DatalogProgram -> String -> IO ()
+compileJava d sourceName = do
     let content = generateJava d sourceName in
-         writeFile javaFile (render content)
+         writeFile (capitalize sourceName ++ ".java") (render content)
 
 -- Generate a Java document from a program given the source filename
 generateJava :: DatalogProgram -> String -> Doc
@@ -94,28 +94,166 @@ generateJava d sourceName =
 -- Generates the preamble of a Java file
 preamble :: String -> Doc
 preamble sourceName =
-    pp ("package " ++ sourceName) $+$
-    pp ("import java.util.*" :: String) $+$
-    pp ("import DDlogRecord\n" :: String) $+$
+    pp ("import java.util.*;" :: String) $+$
+    pp ("import ddlogapi.DDlogRecord;\n" :: String) $+$
+    pp ("import ddlogapi.DDlogCommand;\n" :: String) $+$
     pp ("class " ++ capitalize sourceName)
 
 -- Generates the body of the Java class containing all utility methods
 body :: DatalogProgram -> Doc
-body d = nest' $ genEnum d $+$
-          (vcat $ punctuate "\n" $ map (genRecord d) (M.keys $ progRelations d))
+body d = genEnum d $+$
+          (vcat $ punctuate "\n" $ map (genRecord d) (M.keys $ progRelations d)) $+$
+          (vcat $ punctuate "\n" $ map (genClass d) (M.keys $ progRelations d))
+
+-- Generate a Java class for an element of a specific relation
+genClass :: DatalogProgram -> String -> Doc
+genClass d relationName =
+    let relations = progRelations d
+        rel = fromJust $ M.lookup relationName relations
+        rtype = relType rel in
+      pp ("public static class " ++ makeIdentifier relationName) $+$
+        (braces' $ classBody d relationName rtype)
+
+-- given a (relation) type generate the body of a Java class storing the columns of the relation
+classBody :: DatalogProgram -> String -> Type -> Doc
+classBody d className t =
+  -- class fields
+  (classFields d t) $+$
+  -- constructor from DDlogRecord
+  ("public" <+> (pp className) <> (parens "DDlogRecord r") $+$ (braces' $ constructorBody d t)) $+$
+  -- constructor from fields
+  ("public" <+> (pp className) <> (parens $ parameters d t) $+$ (braces' $ constructorFieldsBody d t)) $+$
+  -- conversion to DDlogRecord
+  "public DDlogRecord asRecord()" $+$
+  (braces' $ ((pp ("return create_" :: String)) <> (pp className) <> (parens $ arguments d t)) <> semi) $+$
+  -- toString method
+  "@Override public String toString()" $+$
+  (braces' $ "return" <+> (doubleQuotes $ pp className) <+> "+ \"{\" +" <+> (toStringBody d t) <+> "+ \"}\"" <> semi) $+$
+  -- command to insert
+  "public DDlogCommand createCommand(boolean insert)" $+$
+  (braces' $ ("return new DDlogCommand(insert ? DDlogCommand.Kind.Insert : DDlogCommand.Kind.DeleteVal," $+$
+              (pp $ "TableId_" ++ className ++ ",") $+$
+              "this.asRecord());"))
+
+-- generates the body of the constructor from values for all fields
+constructorFieldsBody :: DatalogProgram -> Type -> Doc
+constructorFieldsBody d t =
+    case t of
+        TBool{..}   -> "this.a0 = a0;"
+        TInt{..}    -> "this.a0 = a0;"
+        TString{..} -> "this.a0 = a0;"
+        TSigned{..} -> "this.a0 = a0;"
+        TBit{..}    -> "this.a0 = a0;"
+        TUser{..}   -> constructorFieldsBody d (resolveType d t)
+        TTuple{..}  -> vcat $ map (\(i,t) ->
+                                     pp ("this.a" ++ (show i) ++ " = a" ++ (show i) ++ "") <> semi) (zip [0..] typeTupArgs)
+        TStruct{..} -> let c0:tail = typeCons in
+                       if tail == [] then
+                           let assignField f =
+                                 ("this." <> (pp $ fieldName f)) <+> "=" <+> (pp $ fieldName f) <> semi
+                           in
+                               vcat $ map assignField $ consArgs c0
+                       else errorWithoutStackTrace $ "Unsupported type " ++ show t
+        _           -> errorWithoutStackTrace $ "Unsupported type " ++ show t
+
+-- given a relation type generate the body of the toString method
+toStringBody :: DatalogProgram -> Type -> Doc
+toStringBody d t =
+    case t of
+        TBool{..}   -> "this.a0"
+        TInt{..}    -> "this.a0"
+        TString{..} -> "this.a0"
+        TSigned{..} -> "this.a0"
+        TBit{..}     -> "this.a0"
+        TUser{..}   -> toStringBody d (resolveType d t)
+        TTuple{..}  -> (cat $ punctuate " + \",\" + " (map (\i -> pp ("this.a" ++ (show i))) [0.. (length typeTupArgs)]))
+        TStruct{..} -> let c0:tail = typeCons in
+                       if tail == [] then
+                           let toStringField f =
+                                 ("this." <> (pp $ fieldName f)) <> ".toString()"
+                           in
+                               (cat $ punctuate " + \",\" + " (map toStringField (consArgs c0)))
+                       else errorWithoutStackTrace $ "Unsupported type " ++ show t
+        _           -> errorWithoutStackTrace $ "Unsupported type " ++ show t
+
+-- given a relation type generate the body of the constructor that
+-- initializes the corresponding Java class fields
+constructorBody :: DatalogProgram -> Type -> Doc
+constructorBody d t =
+    case t of
+        TBool{..}   -> "this.a0 = r." <> getRecord t <> semi
+        TInt{..}    -> "this.a0 = r." <> getRecord t <> semi
+        TString{..} -> "this.a0 = r." <> getRecord t <> semi
+        TSigned{..} -> "this.a0 = r." <> getRecord t <> semi
+        TBit{..}    -> "this.a0 = r." <> getRecord t <> semi
+        TUser{..}   -> constructorBody d (resolveType d t)
+        TTuple{..}  -> vcat $ map (\(i,t) ->
+                                     pp ("this.a" ++ (show i) ++ " = r.getStructField(" ++ (show i) ++ ").") <+>
+                                     (getRecord $ resolveType d t) <> semi) (zip [0..] typeTupArgs)
+        TStruct{..} -> let c0:tail = typeCons in
+                       if tail == [] then
+                           let assignField (i,f) =
+                                 ("this." <> (pp $ fieldName f)) <+> "= r.getStructField" <> (parens $ pp (i::Int)) <> "." <>
+                                 (getRecord $ resolveType d $ fieldType f) <> semi
+                           in
+                               vcat $ map assignField (zip [0..] (consArgs c0))
+                       else errorWithoutStackTrace $ "Unsupported type " ++ show t
+        _           -> errorWithoutStackTrace $ "Unsupported type " ++ show t
+
+-- given a relation type generate arguments for the call to the create_CLASS method
+-- supplying fields as arguments
+arguments :: DatalogProgram -> Type -> Doc
+arguments d t =
+    case t of
+        TBool{..}   -> "this.a0"
+        TInt{..}    -> "this.a0"
+        TBit{..}    -> "this.a0"
+        TString{..} -> "this.a0"
+        TSigned{..} -> "this.a0"
+        TUser{..}   -> arguments d (resolveType d t)
+        TTuple{..}  -> commaSep $ map (\i -> pp ("this.a" ++ (show i))) [0 .. length typeTupArgs]
+        TStruct{..} -> let c0:tail = typeCons
+                           printField p = "this." <> (pp $ fieldName p)
+                       in
+                       if tail == [] then
+                           commaSep $ map printField (consArgs c0)
+                       else errorWithoutStackTrace $ "Unsupported type " ++ show t
+        _           -> errorWithoutStackTrace $ "Unsupported type " ++ show t
+
+
+-- given a (relation) type generate the fields of a clas storing the columns of the relation
+classFields :: DatalogProgram -> Type -> Doc
+classFields d t =
+    case t of
+        TBool{..}   -> "public" <+> simpleType t <+> "a0" <> semi
+        TInt{..}    -> "public" <+> simpleType t <+> "a0" <> semi
+        TBit{..}    -> "public" <+> simpleType t <+> "a0" <> semi
+        TString{..} -> "public" <+> simpleType t <+> "a0" <> semi
+        TSigned{..} -> "public" <+> simpleType t <+> "a0" <> semi
+        TUser{..}   -> classFields d (resolveType d t)
+        TTuple{..}  -> vcat $ map (\(i,t) -> ("public" <+> (simpleType $ resolveType d t)) <+>
+                                    pp ("a" ++ (show i) ++ ";")) (zip [0..] typeTupArgs)
+        TStruct{..} -> let c0:tail = typeCons in
+                       if tail == [] then
+                           let fieldField f = ("public" <+> (simpleType $ resolveType d $ fieldType f)) <+>
+                                 (pp $ fieldName f) <> semi in
+                               vcat $ map fieldField (consArgs c0)
+                       else errorWithoutStackTrace $ "Unsupported type " ++ show t
+        _           -> errorWithoutStackTrace $ "Unsupported type " ++ show t
 
 -- generates an enum mapping table names to table ids
 genEnum :: DatalogProgram -> Doc
 genEnum d =
   let relNames = map fst (M.toList $ progRelations d)
-      addToIds r = pp $ "idToName.put(TableIds." ++ r ++ ", \"" ++ r ++ "\");"
-      addToNames r = pp $ "nameToId.put(\"" ++ r ++ "\", TableIds." ++ r ++ ");"
+      addToIds r = pp $ "idToName.put(TableId_" ++ r ++ ", \"" ++ r ++ "\");"
+      addToNames r = pp $ "nameToId.put(\"" ++ r ++ "\", TableId_" ++ r ++ ");"
+      makeTableId (t,i) = pp $ "public static final int TableId_" ++ (makeIdentifier t) ++ " = " ++ show(i) ++ ";"
+      indexedTables = zip relNames [0..]
   in
-  pp ("public static enum TableIds " :: String) $+$
-  (braces' $ commaSep $ map (pp . makeIdentifier) relNames) $+$
-  "public static HashMap<TableIds, String> idToName = new HashMap<TableIds, String>();" $+$
-  "public static HashMap<String, TableIds> nameToId = new HashMap<String, TableIds>();" $+$
-  "static" $+$ (braces' $ vcat $ (map addToIds relNames) ++ (map addToNames relNames))
+      (vcat $ map makeTableId indexedTables) $+$
+      "public static HashMap<Integer, String> idToName = new HashMap<Integer, String>();" $+$
+      "public static HashMap<String, Integer> nameToId = new HashMap<String, Integer>();" $+$
+      "static" $+$ (braces' $ vcat $ (map addToIds relNames) ++ (map addToNames relNames))
 
 -- given a relation name this creates a function to construct a DDlogRecord that can be inserted or
 -- deleted in the relation
@@ -125,8 +263,8 @@ genRecord d relationName =
         rel = fromJust $ M.lookup relationName relations
         rtype = relType rel in
       pp ("public static DDlogRecord create_" ++ makeIdentifier relationName) <>
-        (parens $ arguments d rtype) $+$
-        (braces' $ funcBody d rtype $+$ "return r;")
+        (parens $ parameters d rtype) $+$
+        (braces' $ genRecordBody d rtype $+$ "return r;")
 
 -- convert a DDlog string into an identifier
 makeIdentifier :: String -> String
@@ -144,23 +282,22 @@ legalize n = map legalizeChar n
 legalizeChar :: Char -> Char
 legalizeChar c = if isAlpha c then c else '_'
 
--- generate arguments
-arguments :: DatalogProgram -> Type -> Doc
-arguments d t =
+-- generate parameters for the function that creates a DDlogRecord for a specific relation
+-- t is the relation type
+parameters :: DatalogProgram -> Type -> Doc
+parameters d t =
     case t of
         TBool{..}   -> simpleType t <+> "a0"
         TInt{..}    -> simpleType t <+> "a0"
         TString{..} -> simpleType t <+> "a0"
         TSigned{..} -> simpleType t <+> "a0"
-        TUser{..}   -> arguments d (resolveType d t)
+        TUser{..}   -> parameters d (resolveType d t)
         TTuple{..}  -> commaSep $ map (\(i,t) -> (simpleType $ resolveType d t) <+> pp ("a" ++ (show i))) (zip [0..] typeTupArgs)
         TStruct{..} -> let c0:tail = typeCons in
                        if tail == [] then
-                           let fieldArg f = (simpleType $ resolveType d $ fieldType f) <+> (pp $ fieldName f) in
-                               commaSep $ map fieldArg (consArgs c0)
-                       -- we do not support multiple constructors
+                           let fieldParam f = (simpleType $ resolveType d $ fieldType f) <+> (pp $ fieldName f) in
+                               commaSep $ map fieldParam (consArgs c0)
                        else errorWithoutStackTrace $ "Unsupported type " ++ show t
-        -- Java has no support for unsigned, so we don't accept TBit
         _           -> errorWithoutStackTrace $ "Unsupported type " ++ show t
 
 -- convert a simple type to a Java type
@@ -168,9 +305,23 @@ simpleType :: Type -> Doc
 simpleType TBool{..} = "boolean"
 simpleType TInt{..} = "BigInt"
 simpleType TString{..} = "String"
+simpleType TSigned{..} | typeWidth == 16 = "short"
 simpleType TSigned{..} | typeWidth == 32 = "int"
 simpleType TSigned{..} | typeWidth == 64 = "long"
+-- for unsigned values we use the next largest value.
+-- that is not entirely correct, since truncation will behave differently
+simpleType TBit{..}    | typeWidth == 16 = "int"
+simpleType TBit{..}    | typeWidth == 32 = "long"
 simpleType t = errorWithoutStackTrace $ "Unsupported type " ++ show t
+
+-- given a simple type returns the accessor for a DDlogRecord to extract a field of this type
+getRecord :: Type -> Doc
+getRecord TBool{..}   = "getBoolean()"
+getRecord TInt{..}    = "getU128()"
+getRecord TString{..} = "getString()"
+getRecord TSigned{..} = "getLong()"
+getRecord TBit{..}    = "getLong()"
+getRecord t = errorWithoutStackTrace $ "Unsupported type " ++ show t
 
 -- resolves a TypeDef to its underlying type
 resolveType :: DatalogProgram -> Type -> Type
@@ -185,20 +336,27 @@ resolveType d t =
                                 Just something -> something
         _         -> t
 
-funcBody :: DatalogProgram -> Type -> Doc
-funcBody d t =
+-- generates the body of a function which creates a DDlogRecord from an object
+genRecordBody :: DatalogProgram -> Type -> Doc
+genRecordBody d t =
     case t of
         TBool{..}   -> "DDlogRecord r = new DDlogRecord(a0);"
         TInt{..}    -> "DDlogRecord r = new DDlogRecord(a0);"
+        TBit{..}    -> "DDlogRecord r = new DDlogRecord(a0);"
         TString{..} -> "DDlogRecord r = new DDlogRecord(a0);"
         TSigned{..} -> "DDlogRecord r = new DDlogRecord(a0);"
-        TUser{..}   -> funcBody d (resolveType d t)
+        TUser{..}   -> genRecordBody d (resolveType d t)
+        TTuple{..}  -> (vcat $ map (\i -> pp $ "DDlogRecord r" ++ (show i) ++ " = new DDlogRecord(a" ++ (show i) ++ ")")
+                                   [0..(length typeTupArgs)]) $+$
+                       "DDlogRecord[] a = " <> (braces $ commaSep $ map (\i -> pp $ "r" ++ (show i))
+                                                                        [0..(length typeTupArgs)]) <> semi $$
+                       "DDlogRecord r = DDlogRecord.makeTuple(a);"
         TStruct{..} -> let c0:tail = typeCons in
                        if tail == [] then
                          let fieldRec f = "DDlogRecord r" <> (pp $ fieldName f) <+>
                                "= new DDlogRecord" <> (parens $ pp $ fieldName f) <> semi in
                            (vcat $ map fieldRec (consArgs c0)) $$
-                         "DDlogRecord[] a = " <> (braces $ commaSep $ map (pp . fieldName) (consArgs c0)) <> semi $$
+                         "DDlogRecord[] a = " <> (braces $ commaSep $ map (pp . ((++) "r") . fieldName) (consArgs c0)) <> semi $$
                          "DDlogRecord r = DDlogRecord.makeStruct" <> (parens $ commaSep [doubleQuotes $ pp $ consName c0, "a"]) <> semi
                          -- we do not support multiple constructors
                        else errorWithoutStackTrace $ "Unsupported type " ++ show t

--- a/src/Language/DifferentialDatalog/Expr.hs
+++ b/src/Language/DifferentialDatalog/Expr.hs
@@ -56,7 +56,6 @@ import Data.List
 import Data.Maybe
 import Control.Monad
 import Control.Monad.Identity
-import Control.Monad.State
 --import Debug.Trace
 
 import Language.DifferentialDatalog.Ops

--- a/src/Language/DifferentialDatalog/Type.hs
+++ b/src/Language/DifferentialDatalog/Type.hs
@@ -58,7 +58,6 @@ module Language.DifferentialDatalog.Type(
 import Data.Maybe
 import Data.List
 import Control.Monad.Except
-import Control.Monad.State
 import qualified Data.Graph.Inductive as G
 import qualified Data.Map as M
 --import Debug.Trace

--- a/test/datalog_tests/redist.dl
+++ b/test/datalog_tests/redist.dl
@@ -16,7 +16,7 @@ input relation DdlogDependency(parent: entid_t, child: entid_t)
 relation BiEdge(parent: entid_t, child: entid_t)
 BiEdge(parent, child) :- DdlogDependency(parent, child), DdlogDependency(child, parent).
 
-/* Compute connected components by propagating node id's along biditectional edges.
+/* Compute connected components by propagating node id's along bidirectional edges.
  */
 function edge_parent(e: BiEdge): entid_t = e.parent
 function edge_child(e: BiEdge): entid_t = e.child


### PR DESCRIPTION
The -j option of ddlog will cause it to generate a .java file which contains useful classes and method for interacting more efficiently with the generated code. Currently we only support base types for relation elements.

We generate:
* constants corresponding to table ids
* HashMaps mapping table ids to strings and viceversa
* functions that create DDlogRecords for each relation from raw column values
* one class for each relation with multiple methods:
  * constructor from DDlogRecord
  * toString matching the Rust string serialization used by the CLI
  * createCommand - creates an insert/delete command for the corresponding row
  * constructor from raw field values

Here is an example:
```Java
import java.util.*;
import ddlogapi.DDlogRecord;

import ddlogapi.DDlogCommand;

class Span_string
{
    public static final int TableId_Binding = 0;
    public static HashMap<Integer, String> idToName = new HashMap<Integer, String>();
    public static HashMap<String, Integer> nameToId = new HashMap<String, Integer>();
    static
    {
        idToName.put(TableId_Binding, "Binding");
        nameToId.put("Binding", TableId_Binding);
    }
    public static DDlogRecord create_Binding(String entity, String tn)
    {
        DDlogRecord rentity = new DDlogRecord(entity);
        DDlogRecord rtn = new DDlogRecord(tn);
        DDlogRecord[] a = {rentity, rtn};
        DDlogRecord r = DDlogRecord.makeStruct("Binding", a);
        return r;
    }
    public static class Binding
    {
        public String entity;
        public String tn;
        public Binding(DDlogRecord r)
        {
            this.entity = r.getStructField(0).getString();
            this.tn = r.getStructField(1).getString();
        }
        public Binding(String entity, String tn)
        {
            this.entity = entity;
            this.tn = tn;
        }
        public DDlogRecord asRecord()
        {
            return create_Binding(this.entity, this.tn);
        }
        @Override public String toString()
        {
            return "Binding" + "{" + this.entity.toString() + "," + 
                                     this.tn.toString() + "}";
        }
        public DDlogCommand createCommand(boolean insert)
        {
            return new DDlogCommand(insert ? DDlogCommand.Kind.Insert : DDlogCommand.Kind.DeleteVal,
            TableId_Binding,
            this.asRecord());
        }
    }
}
```


