### PR TITLE
std.rs: Rust function name did not match DDlog declaration

### DIFF
--- a/lib/std.rs
+++ b/lib/std.rs
@@ -183,7 +183,7 @@ pub fn std_vec_push<X: Ord+Clone>(v: &mut std_Vec<X>, x: &X) {
     v.push((*x).clone());
 }
 
-pub fn std_vec_insert_imm<X: Ord+Clone>(v: &std_Vec<X>, x: &X) -> std_Vec<X> {
+pub fn std_vec_push_imm<X: Ord+Clone>(v: &std_Vec<X>, x: &X) -> std_Vec<X> {
     let mut v2 = v.clone();
     v2.push((*x).clone());
     v2

--- a/test/datalog_tests/simple.ast.expected
+++ b/test/datalog_tests/simple.ast.expected
@@ -101,6 +101,7 @@ typedef Ttxt = intern.IString
 typedef UMinus_bigint = UMinus_bigint{description: string, n: bigint}
 typedef UMinus_s32 = UMinus_s32{description: string, n: signed<32>}
 typedef ValidDestination = ValidDestination{addr: ip_addr_t}
+typedef VecTest = VecTest{x: std.Vec<string>}
 typedef W = W{f1: bigint, f2: bigint, f3: bigint}
 typedef WithKey = WithKey{key: bit<128>, val: string}
 typedef WithKeyDbg = WithKeyDbg{key: bit<128>, val: string}
@@ -580,6 +581,7 @@ relation ToAllocate [ToAllocate]
 output relation UMinus_bigint [UMinus_bigint]
 output relation UMinus_s32 [UMinus_s32]
 output relation ValidDestination [ValidDestination]
+output relation VecTest [VecTest]
 output relation W [W]
 input relation WithKey [WithKey] primary key (x) x.key
 output relation WithKeyDbg [WithKeyDbg]
@@ -595,6 +597,11 @@ Sib(.s1=x, .s2=y) :- Parent(.child=x, .parent=z), Parent(.child=y, .parent=z), (
 Parent(.child="Alice", .parent="Bob").
 Parent(.child="Ben", .parent="Bob").
 Parent(.child="Bob", .parent="Bob").
+VecTest(.x=std.vec_empty()).
+VecTest(.x=((var v: std.Vec<string>) = std.vec_empty();
+            (std.vec_push(v, "Hello,");
+             v))).
+VecTest(.x=std.vec_push_imm(std.vec_push_imm((std.vec_empty(): std.Vec<string>), "Hello, "), "world!")).
 Reach(.s1=x, .s2=y) :- Links(.l=l, .s1=x, .s2=y).
 Reach(.s1=x, .s2=y) :- Links(.l=l, .s1=y, .s2=x).
 Reach(.s1=x, .s2=y) :- Links(.l=l, .s1=x, .s2=z), Reach(.s1=z, .s2=y).

--- a/test/datalog_tests/simple.dl
+++ b/test/datalog_tests/simple.dl
@@ -186,6 +186,16 @@ typedef string_syn = string
 function use_parameterized(x: string, y: string_syn): string =
     parameterized(x, y)
 
+output relation VecTest(x: Vec<string>)
+
+VecTest(vec_empty()).
+VecTest({
+    var v: Vec<string> = vec_empty();
+    vec_push(v, "Hello,");
+    v
+}).
+VecTest(vec_push_imm(vec_push_imm(vec_empty(): Vec<string>, "Hello, "), "world!")).
+
 // metro: graph reachability
 
 typedef line = bigint

--- a/test/datalog_tests/simple.dump.expected
+++ b/test/datalog_tests/simple.dump.expected
@@ -194,6 +194,11 @@ UMinus_s32{"-(-32'sd100)",100}
 UMinus_s32{"-32'sd100",-100}
 UMinus_s32{"-32768",-32768}
 
+VecTest:
+VecTest{std_Vec { x: [] }}
+VecTest{std_Vec { x: ["Hello,"] }}
+VecTest{std_Vec { x: ["Hello, ", "world!"] }}
+
 Rules test
 R4:
 R3{0,true}: 1
@@ -401,6 +406,11 @@ UMinus_s32:
 UMinus_s32{"-(-32'sd100)",100}
 UMinus_s32{"-32'sd100",-100}
 UMinus_s32{"-32768",-32768}
+
+VecTest:
+VecTest{std_Vec { x: [] }}
+VecTest{std_Vec { x: ["Hello,"] }}
+VecTest{std_Vec { x: ["Hello, ", "world!"] }}
 
 Table12:
 Table12{20695836920908937261915266253713563738,"foo",S{(true, true),5}}: 1


### PR DESCRIPTION
Rust implementation of `vec_push_imm` was called `std_vec_insert_imm`
instead of `std_vec_push_imm`.

Addresses #284 