### PR TITLE
Logging API

### DIFF
--- a/java/ddlogapi.c
+++ b/java/ddlogapi.c
@@ -75,8 +75,6 @@ static struct CallbackInfo* createCallback(JNIEnv* env, jobject obj, jstring met
     return cbinfo;
 }
 
-
-
 static void deleteCallback(struct CallbackInfo* cbinfo) {
     if (cbinfo == NULL)
         return;
@@ -282,6 +280,9 @@ void log_callback(uintptr_t callbackInfo, int level, const char *msg) {
 
 /* This function sets up a new logging callback for the given module and
  * then deallocates the old `CallbackInfo`, if any.
+ *
+ * Returns 0 if either `callback` is NULL or `callback` is not NULL and
+ * installing the new callback fails.
  */
 JNIEXPORT jlong JNICALL Java_ddlogapi_DDlogAPI_ddlog_1log_1replace_1callback(
     JNIEnv *env, jobject obj, jint module, jlong old_cbinfo, jobject callback, jint max_level) {

--- a/java/test/run.sh
+++ b/java/test/run.sh
@@ -29,10 +29,10 @@ rm -f ../../test/datalog_tests/span_uuid_ddlog/target/release/libspan_uuid_ddlog
 # Compile SpanTest.java
 javac -cp .. SpanTest.java
 # Create a shared library containing all the native code: ddlogapi.c, libspan_uuid_ddlog.a
-${CC} -shared -fPIC -I${JAVA_HOME}/include -I${JAVA_HOME}/include/${JDK_OS} -I../../rust/template ../ddlogapi.c -L../../test/datalog_tests/span_uuid_ddlog/target/release/ -lspan_uuid_ddlog -o libddlogapi.${SHLIBEXT}
+${CC} -shared -fPIC -I${JAVA_HOME}/include -I${JAVA_HOME}/include/${JDK_OS} -I../../rust/template -I../../lib ../ddlogapi.c -L../../test/datalog_tests/span_uuid_ddlog/target/release/ -lspan_uuid_ddlog -o libddlogapi.${SHLIBEXT}
 # Run the java program pointing to the created shared library
 #java -Xcheck:jni -Djava.library.path=. -jar span.jar ../../test/datalog_tests/span_uuid.dat >span_uuid.java.dump
-java -Djava.library.path=. -cp ../ddlogapi.jar:. SpanTest ../../test/datalog_tests/span_uuid.dat > span_uuid.java.dump
+java -Djava.library.path=. -cp ../ddlogapi.jar:. SpanTest ../../test/datalog_tests/span_uuid.dat > span_uuid.java.dump 2> span_uuid.log
 # Compare outputs
 diff -q span_uuid.java.dump ../../test/datalog_tests/span_uuid.dump.expected
 

--- a/lib/ddlog_log.h
+++ b/lib/ddlog_log.h
@@ -1,0 +1,19 @@
+/*
+ * C prototypes for the logging API (see `log.dl`, `log.rs`)
+ */
+
+/*
+ * Set logging callback and log level for a given module.
+ *
+ * `module`    - Opaque module identifier.  Can represent module, subsystem, log
+ *               stream, etc.
+ * `cb`        - Callback to be invoked for each log message with the given module
+ *               id and log level `<= max_level`.
+ * `max_level` - Don't invoke the callback for messages whoe log level is
+ *               `> max_level`.
+ */
+extern void ddlog_log_set_callback(
+        int module,
+        void (*cb)(uintptr_t arg, int level, const char* msg),
+        uintptr_t cb_arg,
+        int max_level);

--- a/lib/ddlog_log.h
+++ b/lib/ddlog_log.h
@@ -8,7 +8,8 @@
  * `module`    - Opaque module identifier.  Can represent module, subsystem, log
  *               stream, etc.
  * `cb`        - Callback to be invoked for each log message with the given module
- *               id and log level `<= max_level`.
+ *               id and log level `<= max_level`.  Passing `NULL` disables
+ *               logging for the given module.
  * `max_level` - Don't invoke the callback for messages whoe log level is
  *               `> max_level`.
  */

--- a/lib/log.dl
+++ b/lib/log.dl
@@ -1,0 +1,89 @@
+/*
+ * Logging API.
+ *
+ * This API has two facets.  First, it provides the `log()` function that can
+ * be invoked from a DDlog rule to provide more visibility into the rule's
+ * evaluation.  In addition to the usual log level and log message arguments,
+ * this function takes a `module` argument, which identifies the module or
+ * subsystem that this log message is associated with.
+ *
+ * Second, it provides a Rust configuration API that can only be invoked by the
+ * "host" program to set log level for individual modules and to supply a
+ * logging callback for each module (see `log.rs`).  This way, different
+ * modules can produce separate log streams or even use different logging
+ * mechanisms.
+ *
+ * NOTE: DDlog guarantees that the log callback function will be invoked at least
+ * once for each evaluated rule prefix.  But this is the only guarantee it
+ * provides.  It might invoke the callback multiple times per each evaluated rule,
+ * and it can invoke callbacks in arbitrary order.  It may further invoke the
+ * callback both during insertion and deletion operations (i.e., rule inputs can
+ * have positive or negative polarity), and there is currently no way
+ * to tell which one it is.
+ *
+ * NOTE: Internally, this library maintains a global module-to-log_callback
+ * map shared by all DDlog instances running in the same address space.  The host
+ * program is responsible for maintaining this mapping via the Rust API in
+ * `log.rs`.
+ *
+ * NOTE (Logging overhead): Even when logging is disabled for a particular
+ * module, log statements still have a small cost.  It is therefore recommended
+ * to comment out unused log statements when possible.  Specifically, depending
+ * on the context, the log statement may end up being compiled into a separate
+ * dataflow operator.  It is a light-weight operator that does not cost much
+ * to evaluate, but it nevertheless increases the size of the control flow
+ * graph.  In addition, the log function evaluates its argument eagerly even
+ * when not invoking the callback.  In particular, string operations can
+ * be expensive.
+ *
+ * Other related files:
+ * `log4j.dl`    - specializes the logging API for using log4j loggers
+ * `log.rs`      - Rust logging API
+ * `ddlog_log.h` - matching C bindings
+ * `DDlogAPI.java (DDlogAPI.log_set_callback method)` - Java API to control
+ * logging
+ *
+ * === Example ===
+ *
+ * In DDlog:
+ * ```
+ * // Declare module id's for logging purposes
+ * function mod_SPAN_UUID(): log.module_t = 100
+ *
+ * // Use log() function in a rule
+ * Span(entity, tn) :- Binding(entity, tn),
+ *                     log(mod_SPAN_UUID(), 5, "Span(entity,tn) :- Binding(.entity=${deref(entity)},.tn=${deref(tn)}))").
+ * ```
+ *
+ * In Java:
+ * ```
+ * // Module id declarations must match DDlog values:
+ * static int MOD_SPAN_UUID1 = 100;
+ * // Set logging callback and log level from Java
+ * DDlogAPI.log_set_callback(
+ *     MOD_SPAN_UUID1,
+ *     (msg, level) -> System.err.println("Log msg from module1 (" + level + "): " + msg),
+ *     5);
+ * ```
+ * ===============
+ *
+ */
+
+/* `module_t` type identifies the subsystem or component for logging purposes.
+ */
+typedef module_t = signed<32>
+
+typedef log_level_t = signed<32>
+
+/*
+ * Write to a log stream
+ *
+ * `module` - Identifies the subsystem writing to the log.  A log record is only
+ *            produced if logging has been enabled for this subsystem (see
+ *            `log.rs`)
+ * `level`  - log level
+ * `msg`    - error message (UTF-8)
+ *
+ * Always returns `true`.
+ */
+extern function log(module: module_t, level: log_level_t, msg: string): bool

--- a/lib/log.dl
+++ b/lib/log.dl
@@ -84,6 +84,7 @@ typedef log_level_t = signed<32>
  * `level`  - log level
  * `msg`    - error message (UTF-8)
  *
- * Always returns `true`.
+ * This function returns a `bool` so that it can be used as a filter inside
+ * DDlog rules.  It always returns `true`.
  */
 extern function log(module: module_t, level: log_level_t, msg: string): bool

--- a/lib/log.rs
+++ b/lib/log.rs
@@ -15,6 +15,7 @@ lazy_static! {
 
 /*
  * Logging API exposed to the DDlog program.
+ * (see detailed documentation in `log.dl`)
  */
 pub fn log_log(module: &log_module_t, level: &log_log_level_t, msg: &String) -> bool
 {
@@ -27,7 +28,10 @@ pub fn log_log(module: &log_module_t, level: &log_log_level_t, msg: &String) -> 
 }
 
 /*
- * Configuration API.
+ * Configuration API
+ * (detailed documentation in `ddlog_log.h`)
+ *
+ * `cb = None` - disables logging for the given module.
  *
  * NOTE: we set callback and log level simultaneously.  A more flexible API
  * would allow changing log level without changing the callback.

--- a/lib/log.rs
+++ b/lib/log.rs
@@ -1,0 +1,74 @@
+use std::sync;
+use std::collections;
+use std::ffi;
+
+type log_callback_t = Box<dyn Fn(log_log_level_t, &str) + Send + Sync>;
+
+lazy_static! {
+    /* Logger configuration for each module consists of the maximal enabled
+     * log level (messages above this level are ignored) and callback.
+     */
+    static ref LOG_CONFIG: sync::RwLock<collections::HashMap<log_module_t, (log_callback_t, log_log_level_t)>> = {
+        sync::RwLock::new(collections::HashMap::new())
+    };
+}
+
+/*
+ * Logging API exposed to the DDlog program.
+ */
+pub fn log_log(module: &log_module_t, level: &log_log_level_t, msg: &String) -> bool
+{
+    if let Some((cb, current_level)) = LOG_CONFIG.read().unwrap().get(&module) {
+        if *level <= *current_level {
+            cb(*level, msg.as_str());
+        }
+    };
+    true
+}
+
+/*
+ * Configuration API.
+ *
+ * NOTE: we set callback and log level simultaneously.  A more flexible API
+ * would allow changing log level without changing the callback.
+ */
+pub fn log_set_callback(module: log_module_t, cb: Option<log_callback_t>, max_level: log_log_level_t)
+{
+    match cb {
+        Some(cb) => {
+            LOG_CONFIG.write().unwrap().insert(module, (cb, max_level));
+        },
+        None => {
+            LOG_CONFIG.write().unwrap().remove(&module);
+        }
+    }
+}
+
+/*
+ * C bindings for the config API
+ */
+#[no_mangle]
+pub unsafe extern "C" fn ddlog_log_set_callback(module: raw::c_int,
+                                                cb: Option<extern "C" fn(arg: libc::uintptr_t,
+                                                                         level: raw::c_int,
+                                                                         msg: *const raw::c_char)>,
+                                                cb_arg: libc::uintptr_t,
+                                                max_level: raw::c_int)
+{
+    match cb {
+        Some(cb) => {
+            log_set_callback(module as log_module_t,
+                             Some(Box::new(move |level, msg| {
+                                 cb(cb_arg,
+                                    level as raw::c_int,
+                                    ffi::CString::new(msg).unwrap_or_default().as_ptr())
+                             })),
+                             max_level as log_log_level_t)
+        },
+        None => {
+            log_set_callback(module as log_module_t,
+                             None,
+                             max_level as log_log_level_t)
+        }
+    }
+}

--- a/lib/log4j.dl
+++ b/lib/log4j.dl
@@ -1,0 +1,12 @@
+/*
+ * Convenience functions for using the logging API with log4j.
+ */
+
+import log
+
+function trace(module: module_t, msg: string): bool = log(module, 600/*TRACE*/, msg)
+function debug(module: module_t, msg: string): bool = log(module, 500/*DEBUG*/, msg)
+function info (module: module_t, msg: string): bool = log(module, 400/*INFO*/,  msg)
+function warn (module: module_t, msg: string): bool = log(module, 300/*WARN*/,  msg)
+function error(module: module_t, msg: string): bool = log(module, 200/*ERROR*/, msg)
+function fatal(module: module_t, msg: string): bool = log(module, 100/*FATAL*/, msg)

--- a/rust/template/differential_datalog/program.rs
+++ b/rust/template/differential_datalog/program.rs
@@ -145,7 +145,7 @@ pub type Weight = isize;
 const MSG_BUF_SIZE: usize = 500;
 
 /* Message buffer for profiling messages */
-const PROF_MSD_BUF_SIZE: usize = 10000;
+const PROF_MSG_BUF_SIZE: usize = 10000;
 
 /// Result type returned by this library
 pub type Response<X> = Result<X, String>;
@@ -839,7 +839,7 @@ impl<V:Val> Program<V>
         let flush_ack_send = flush_ack_send.clone();
 
         /* Profiling channel */
-        let (prof_send, prof_recv) = mpsc::sync_channel::<ProfMsg>(PROF_MSD_BUF_SIZE);
+        let (prof_send, prof_recv) = mpsc::sync_channel::<ProfMsg>(PROF_MSG_BUF_SIZE);
 
         /* Profile data structure */
         let profile = Arc::new(Mutex::new(Profile::new()));

--- a/test/datalog_tests/span_uuid.ast.expected
+++ b/test/datalog_tests/span_uuid.ast.expected
@@ -8,6 +8,8 @@ typedef Source = Source{parent: entid_t, child: entid_t}
 typedef SourceSpan = SourceSpan{entity: uuid_t, tn: tnid_t}
 typedef Span = Span{entity: uuid_t, tn: tnid_t}
 typedef entid_t = uuid_t
+typedef log.log_level_t = signed<32>
+typedef log.module_t = signed<32>
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
 extern type std.Group<'A>
 extern type std.Map<'K,'V>
@@ -18,6 +20,23 @@ extern type std.Set<'A>
 extern type std.Vec<'A>
 typedef tnid_t = uuid_t
 typedef uuid_t = std.Ref<bit<128>>
+extern function log.log (module: log.module_t, level: log.log_level_t, msg: string): bool
+function log4j.debug (module: log.module_t, msg: string): bool =
+    log.log(module, 32'sd500, msg)
+function log4j.error (module: log.module_t, msg: string): bool =
+    log.log(module, 32'sd200, msg)
+function log4j.fatal (module: log.module_t, msg: string): bool =
+    log.log(module, 32'sd100, msg)
+function log4j.info (module: log.module_t, msg: string): bool =
+    log.log(module, 32'sd400, msg)
+function log4j.trace (module: log.module_t, msg: string): bool =
+    log.log(module, 32'sd600, msg)
+function log4j.warn (module: log.module_t, msg: string): bool =
+    log.log(module, 32'sd300, msg)
+function mod_SPAN_UUID1 (): log.module_t =
+    32'sd100
+function mod_SPAN_UUID2 (): log.module_t =
+    32'sd200
 extern function std.__builtin_2string (x: 'X): string
 extern function std.deref (x: std.Ref<'A>): 'A
 extern function std.group2map (g: std.Group<('K, 'V)>): std.Map<'K,'V>
@@ -108,9 +127,9 @@ output relation RuleSpan [RuleSpan]
 input relation Source [Source]
 relation SourceSpan [SourceSpan]
 relation Span [Span]
-Span(.entity=entity, .tn=tn) :- Binding(.entity=entity, .tn=tn).
-Span(.entity=parent, .tn=tn) :- Dependency(.parent=parent, .child=child), Span(.entity=child, .tn=tn).
+Span(.entity=entity, .tn=tn) :- Binding(.entity=entity, .tn=tn), log4j.trace(mod_SPAN_UUID1(), (((("Span(entity,tn) :- Binding(.entity=" ++ std.__builtin_2string(std.deref(entity))) ++ ",.tn=") ++ std.__builtin_2string(std.deref(tn))) ++ "))")).
+Span(.entity=parent, .tn=tn) :- Dependency(.parent=parent, .child=child), log4j.trace(mod_SPAN_UUID1(), (((("Span recursive step: Dependency(.parent=" ++ std.__builtin_2string(std.deref(parent))) ++ ",.child=") ++ std.__builtin_2string(std.deref(child))) ++ "))")), Span(.entity=child, .tn=tn), log4j.trace(mod_SPAN_UUID1(), (((((("Span(parent, tn) :- Dependency(.parent=" ++ std.__builtin_2string(std.deref(parent))) ++ ",.child=") ++ std.__builtin_2string(std.deref(child))) ++ ")), Span(.child, .tn=") ++ std.__builtin_2string(std.deref(tn))) ++ ")")).
 RuleSpan(.entity=entity, .tn=tn) :- Span(.entity=entity, .tn=tn), FWRule(.id=entity).
 SourceSpan(.entity=parent, .tn=tn) :- RuleSpan(.entity=child, .tn=tn), Source(.parent=parent, .child=child).
 SourceSpan(.entity=parent, .tn=tn) :- SourceSpan(.entity=child, .tn=tn), Source(.parent=parent, .child=child).
-ContainerSpan(.entity=entity, .tn=tn) :- SourceSpan(.entity=entity, .tn=tn), Container(.id=entity).
+ContainerSpan(.entity=entity, .tn=tn) :- SourceSpan(.entity=entity, .tn=tn), Container(.id=entity), log4j.debug(mod_SPAN_UUID2(), (((("ContainerSpan(.entity=" ++ std.__builtin_2string(std.deref(entity))) ++ ",.tn=") ++ std.__builtin_2string(std.deref(tn))) ++ "))")).

--- a/test/datalog_tests/span_uuid.dl
+++ b/test/datalog_tests/span_uuid.dl
@@ -1,3 +1,14 @@
+/* LOGGING */
+import log as log
+import log4j
+
+/* LOGGING:
+ * Module id's for logging purposes.
+ * Pretend that we have two modules.
+ */
+function mod_SPAN_UUID1(): log.module_t = 100
+function mod_SPAN_UUID2(): log.module_t = 200
+
 typedef uuid_t = Ref<bit<128>>
 
 /* entity id */
@@ -25,9 +36,13 @@ input relation Source(parent: entid_t, child: entid_t)
 relation Span(entity: uuid_t, tn: tnid_t)
 
 // base case
-Span(entity, tn) :- Binding(entity, tn).
+Span(entity, tn) :- Binding(entity, tn),
+                    trace(mod_SPAN_UUID1(), "Span(entity,tn) :- Binding(.entity=${deref(entity)},.tn=${deref(tn)}))").
 // recursive step: propagate bindings along the dependency graph
-Span(parent, tn) :- Dependency(parent, child), Span(child, tn).
+Span(parent, tn) :- Dependency(parent, child),
+                    trace(mod_SPAN_UUID1(), "Span recursive step: Dependency(.parent=${deref(parent)},.child=${deref(child)}))"),
+                    Span(child, tn),
+                    trace(mod_SPAN_UUID1(), "Span(parent, tn) :- Dependency(.parent=${deref(parent)},.child=${deref(child)})), Span(.child, .tn=${deref(tn)})").
 
 /* RuleSpan: restriction of the Span relation to Rule nodes.
  */
@@ -50,7 +65,8 @@ output relation ContainerSpan(entity: uuid_t, tn: tnid_t /*, explanation: string
 
 ContainerSpan(entity, tn /*, explanation*/) :-
     SourceSpan(entity, tn /*, explanation*/),
-    Container(entity).
+    Container(entity),
+    debug(mod_SPAN_UUID2(), "ContainerSpan(.entity=${deref(entity)},.tn=${deref(tn)}))").
 
 /* For container nodes, add span computed over the source graph to
    container's normal span.


### PR DESCRIPTION
This PR introduces a logging library that provides additional visibility
into DDlog rule evaluation. The logging API has two facets.  First, it provides
the `log()` function that can be invoked from a DDlog rule to write a message
into a log whenever the rule is evaluated.  In addition to the usual log level
and log message arguments, this function takes a `module` argument, which
identifies the module or subsystem that this log message is associated with.
The API is defined in the new `lib/log.dl` library:

```
typedef module_t = signed<32>
typedef log_level_t = signed<32>
extern function log(module: module_t, level: log_level_t, msg: string): bool
```

Convenience wrappers for using the logging API with log4j are in
`lib/log4j.dl`:

```
function trace(module: module_t, msg: string): bool = log(module, 600/*TRACE*/, msg)
function debug(module: module_t, msg: string): bool = log(module, 500/*DEBUG*/, msg)
function info (module: module_t, msg: string): bool = log(module, 400/*INFO*/,  msg)
function warn (module: module_t, msg: string): bool = log(module, 300/*WARN*/,  msg)
function error(module: module_t, msg: string): bool = log(module, 200/*ERROR*/, msg)
function fatal(module: module_t, msg: string): bool = log(module, 100/*FATAL*/, msg)
```

The second facet of this API is a logging configuration function (in Rust) that can
only be invoked by the "host" program to set log levels and logging callbacks for
individual modules.  This way, different modules can produce separate log streams or
even use different logging mechanisms. It is declared in `lib/log.rs`:

```
type log_callback_t = Box<dyn Fn(log_log_level_t, &str) + Send + Sync>;
pub fn log_set_callback(module: log_module_t, cb: Option<log_callback_t>, max_level: log_log_level_t)
```

Matching C bindings are in `lib/ddlog_log.h`; Java bindings are in
`DDlogAPI.java` (see `DDlogAPI.log_set_callback()`).

The current implementation does some caveats:

- DDlog guarantees that the log callback function will be invoked at least
  once for each evaluated rule prefix.  But this is the only guarantee it
  provides.  It might invoke the callback multiple times per each evaluated rule,
  and it can invoke callbacks in arbitrary order.  It may further invoke the
  callback both during insertion and deletion operations (i.e., rule inputs can
  have positive or negative polarity), and there is currently no way
  to tell which one it is.

  The last limitation could be addressed by using the differential
  `inspect` operator for logging.  However, this would introduce
  some additional overhead.  In addition, doing this cleanly requires
  first adding support for lambdas in DDlog.

- Internally, this library maintains a global module-to-log_callback
  map **shared by all DDlog instances running in the same address space**.  The host
  program is responsible for maintaining this mapping via the Rust or Java API.

- Logging overhead: Even when logging is disabled for a particular
  module, log statements still have a small cost.  It is therefore recommended
  to comment out unused log statements when possible.  Specifically, depending
  on the context, the log statement may end up being compiled into a separate
  dataflow operator.  It is a light-weight operator that does not cost much
  to evaluate, but it nevertheless increases the size of the control flow
  graph.  In addition, the log function evaluates its argument eagerly even
  when not invoking the callback.  In particular, string operations can
  be expensive.

=== Example ===

In DDlog:
```
// Declare module id's for logging purposes
function mod_SPAN_UUID(): log.module_t = 100

// Use log() function in a rule
Span(entity, tn) :- Binding(entity, tn),
                    log(mod_SPAN_UUID(), 5, "Span(entity,tn) :- Binding(.entity=${deref(entity)},.tn=${deref(tn)}))").
```

In Java:
```
// Module id declarations must match DDlog values:
static int MOD_SPAN_UUID1 = 100;
// Set logging callback and log level from Java
DDlogAPI.log_set_callback(
    MOD_SPAN_UUID1,
    (msg, level) -> System.err.println("Log msg from module1 (" + level + "): " + msg),
    5);
```
===============