### PR TITLE
`lib/std.dl`: always import the `log` library.

### DIFF
--- a/java/test1/run.sh
+++ b/java/test1/run.sh
@@ -31,7 +31,7 @@ rm -f ../../test/datalog_tests/redist_ddlog/target/release/libredist_ddlog.so
 # Compile RedistTest.java
 javac -cp ..:fastutil-8.2.2.jar RedistTest.java
 # Create a shared library containing all the native code: ddlogapi.c, libredist_ddlog.a
-${CC} -shared -fPIC -I${JAVA_HOME}/include -I${JAVA_HOME}/include/${JDK_OS} -I../../rust/template ../ddlogapi.c -L../../test/datalog_tests/redist_ddlog/target/release/ -lredist_ddlog -o libddlogapi.${SHLIBEXT}
+${CC} -shared -fPIC -I${JAVA_HOME}/include -I${JAVA_HOME}/include/${JDK_OS} -I../../rust/template ../ddlogapi.c -I../../lib -L../../test/datalog_tests/redist_ddlog/target/release/ -lredist_ddlog -o libddlogapi.${SHLIBEXT}
 # Run the java program pointing to the created shared library
 # Note: this assumes that the fastutil-8.2.2.jar is in the current folder
 java -Djava.library.path=. -cp ./fastutil-8.2.2.jar:../ddlogapi.jar:. RedistTest ../../test/datalog_tests/redist.dat > redist.java.dump

--- a/java/test2/run.sh
+++ b/java/test2/run.sh
@@ -29,7 +29,7 @@ rm -f two_ddlog/target/debug/libtwo_ddlog.so
 # Compile TwoTest.java
 javac -cp .. TwoTest.java
 # Create a shared library containing all the native code: ddlogapi.c, libtwo_ddlog.a
-${CC} -shared -fPIC -I${JAVA_HOME}/include -I${JAVA_HOME}/include/${JDK_OS} -I../../rust/template ../ddlogapi.c -Ltwo_ddlog/target/debug/ -ltwo_ddlog -o libddlogapi.${SHLIBEXT}
+${CC} -shared -fPIC -I${JAVA_HOME}/include -I${JAVA_HOME}/include/${JDK_OS} -I../../rust/template -I../../lib ../ddlogapi.c -Ltwo_ddlog/target/debug/ -ltwo_ddlog -o libddlogapi.${SHLIBEXT}
 # Run the java program pointing to the created shared library
 java -Djava.library.path=. -cp ../ddlogapi.jar:. TwoTest
 

--- a/lib/std.dl
+++ b/lib/std.dl
@@ -1,5 +1,10 @@
 /* Description: DDlog "standard library" automatically imported into every module */
 
+/* Ensure that `log.rs` gets linked into the program even if noone imports
+ * its functionality, as it exports the `ddlog_log_set_callback`, expected, e.g., 
+ * by Java bindings. */
+import log
+
 /*
  * Ref
  */

--- a/test/datalog_tests/copy.ast.expected
+++ b/test/datalog_tests/copy.ast.expected
@@ -1,5 +1,7 @@
 typedef Rin = Rin{b: bool}
 typedef Rout = Rout{b: bool}
+typedef log.log_level_t = signed<32>
+typedef log.module_t = signed<32>
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
 extern type std.Group<'A>
 extern type std.Map<'K,'V>
@@ -8,6 +10,7 @@ typedef std.Option<'A> = std.Some{x: 'A} | std.None{}
 extern type std.Ref<'A>
 extern type std.Set<'A>
 extern type std.Vec<'A>
+extern function log.log (module: log.module_t, level: log.log_level_t, msg: string): bool
 extern function std.__builtin_2string (x: 'X): string
 extern function std.deref (x: std.Ref<'A>): 'A
 extern function std.group2map (g: std.Group<('K, 'V)>): std.Map<'K,'V>

--- a/test/datalog_tests/modules.ast.expected
+++ b/test/datalog_tests/modules.ast.expected
@@ -7,6 +7,8 @@ typedef foolib.ns1.m1.R1 = foolib.ns1.m1.R1{f1: foolib.ns1.m2.T2}
 typedef foolib.ns1.m1.T1 = foolib.ns1.m1.T1{f1: bigint}
 typedef foolib.ns1.m2.R2 = foolib.ns1.m2.R2{f1: bool}
 typedef foolib.ns1.m2.T2 = foolib.ns1.m2.T2{f1: bigint}
+typedef log.log_level_t = signed<32>
+typedef log.module_t = signed<32>
 typedef redist.BiEdge = redist.BiEdge{parent: redist.entid_t, child: redist.entid_t}
 typedef redist.DdlogBinding = redist.DdlogBinding{tn: redist.tnid_t, entity: redist.entid_t}
 typedef redist.DdlogDependency = redist.DdlogDependency{parent: redist.entid_t, child: redist.entid_t}
@@ -31,6 +33,7 @@ function fmain (a1: foolib.lib.Rlib): foolib.ns1.m1.R1 =
     foolib.ns1.m1.R1{.f1=foolib.ns1.m2.T2{.f1=0}}
 function foolib.ns1.m1.fM1 (a1: foolib.ns1.m1.T1): foolib.ns1.m1.R1 =
     foolib.ns1.m1.R1{.f1=foolib.ns1.m2.T2{.f1=a1.f1}}
+extern function log.log (module: log.module_t, level: log.log_level_t, msg: string): bool
 function redist.edge_child (e: redist.BiEdge): redist.entid_t =
     e.child
 function redist.edge_parent (e: redist.BiEdge): redist.entid_t =

--- a/test/datalog_tests/ovn.ast.expected
+++ b/test/datalog_tests/ovn.ast.expected
@@ -66,6 +66,8 @@ typedef ip6_subnet_t = IP6Subnet{addr: ip6_addr_t, mask: ip6_addr_t}
 typedef ip_addr_t = IPAddr4{addr4: ip4_addr_t} | IPAddr6{addr6: ip6_addr_t}
 typedef ip_port_t = IPPort{ip: string, port: std.Option<port_t>}
 typedef ip_subnet_t = IPSubnet4{ip4_subnet: ip4_subnet_t} | IPSubnet6{ip6_subnet: ip6_subnet_t}
+typedef log.log_level_t = signed<32>
+typedef log.module_t = signed<32>
 typedef mac_addr_t = bit<48>
 typedef port_t = bit<16>
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
@@ -86,6 +88,7 @@ extern function in6_generate_lla (mac: mac_addr_t): ip6_addr_t
 extern function ip_address_and_port_from_lb_key (key: string): ip_port_t
 extern function ip_parse (str: string): std.Option<ip_addr_t>
 extern function ipv6_string_mapped (addr: ip6_addr_t): string
+extern function log.log (module: log.module_t, level: log.log_level_t, msg: string): bool
 extern function std.__builtin_2string (x: 'X): string
 extern function std.deref (x: std.Ref<'A>): 'A
 extern function std.group2map (g: std.Group<('K, 'V)>): std.Map<'K,'V>

--- a/test/datalog_tests/ovn_ftl.ast.expected
+++ b/test/datalog_tests/ovn_ftl.ast.expected
@@ -5,6 +5,8 @@ typedef Logical_Router_Port = Logical_Router_Port{name: string, lr: bigint, mac:
 typedef Logical_Switch = Logical_Switch{ls: bigint, has_stateful_acl: bool, has_load_balancer: bool}
 typedef Logical_Switch_Port = Logical_Switch_Port{lsp: bigint, ls: bigint, parent: std.Option<string>, tag_request: std.Option<bigint>, tag: std.Option<bigint>, up: std.Option<bool>, enabled: bool, port_security_not_empty: bool, port_security_l2: string, port_security_ip_ingress: string, port_security_ip_egress: string, port_security_nd: string, name: string, _type: string, macs: string}
 typedef Logical_Switch_Port_IP = Logical_Switch_Port_IP{lspip: bigint, ip_version: bigint, lsp: bigint, lsp_name: string, lsp_enabled: bool, lsp_type: string, ls: bigint, mac: string, ip: string, sn_ip: string, up: bool}
+typedef log.log_level_t = signed<32>
+typedef log.module_t = signed<32>
 typedef stage = LS_IN_ACL{} | LS_OUT_ACL{} | LR_IN_ADMISSION{} | LR_IN_IP_INPUT{} | LR_IN_UNSNAT{} | LR_OUT_SNAT{} | LR_IN_DNAT{} | LR_IN_ARP_RESOLVE{} | LR_IN_ARP_REQUEST{} | LR_IN_DEFRAG{} | LR_OUT_DELIVERY{} | LS_IN_LB{} | LS_OUT_LB{} | LS_IN_PRE_ACL{} | LS_OUT_PRE_ACL{} | LS_IN_PRE_LB{} | LS_OUT_PRE_LB{} | LS_IN_PRE_STATEFUL{} | LS_OUT_PRE_STATEFUL{} | LS_IN_STATEFUL{} | LS_OUT_STATEFUL{} | LS_IN_PORT_SEC_L2{} | LS_IN_PORT_SEC_IP{} | LS_IN_PORT_SEC_ND{} | LS_IN_ARP_RSP{} | LS_IN_DHCP_OPTIONS{} | LS_IN_DHCP_RESPONSE{} | LS_IN_L2_LKUP{} | LS_OUT_PORT_SEC_IP{} | LS_OUT_PORT_SEC_L2{}
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
 extern type std.Group<'A>
@@ -14,6 +16,7 @@ typedef std.Option<'A> = std.Some{x: 'A} | std.None{}
 extern type std.Ref<'A>
 extern type std.Set<'A>
 extern type std.Vec<'A>
+extern function log.log (module: log.module_t, level: log.log_level_t, msg: string): bool
 extern function std.__builtin_2string (x: 'X): string
 extern function std.deref (x: std.Ref<'A>): 'A
 extern function std.group2map (g: std.Group<('K, 'V)>): std.Map<'K,'V>

--- a/test/datalog_tests/path.ast.expected
+++ b/test/datalog_tests/path.ast.expected
@@ -1,5 +1,7 @@
 typedef Edge = Edge{s: node, t: node}
 typedef Path = Path{s1: node, s2: node}
+typedef log.log_level_t = signed<32>
+typedef log.module_t = signed<32>
 typedef node = string
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
 extern type std.Group<'A>
@@ -9,6 +11,7 @@ typedef std.Option<'A> = std.Some{x: 'A} | std.None{}
 extern type std.Ref<'A>
 extern type std.Set<'A>
 extern type std.Vec<'A>
+extern function log.log (module: log.module_t, level: log.log_level_t, msg: string): bool
 extern function std.__builtin_2string (x: 'X): string
 extern function std.deref (x: std.Ref<'A>): 'A
 extern function std.group2map (g: std.Group<('K, 'V)>): std.Map<'K,'V>

--- a/test/datalog_tests/redist.ast.expected
+++ b/test/datalog_tests/redist.ast.expected
@@ -8,6 +8,8 @@ typedef SCCEdge = SCCEdge{parent: entid_t, child: entid_t}
 typedef SCCSpan = SCCSpan{scc: entid_t, span: std.Ref<tinyset.Set64<tnid_t>>}
 typedef Span = Span{entity: entid_t, tns: std.Ref<tinyset.Set64<tnid_t>>}
 typedef entid_t = bit<32>
+typedef log.log_level_t = signed<32>
+typedef log.module_t = signed<32>
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
 extern type std.Group<'A>
 extern type std.Map<'K,'V>
@@ -22,6 +24,7 @@ function edge_child (e: BiEdge): entid_t =
     e.child
 function edge_parent (e: BiEdge): entid_t =
     e.parent
+extern function log.log (module: log.module_t, level: log.log_level_t, msg: string): bool
 extern function std.__builtin_2string (x: 'X): string
 extern function std.deref (x: std.Ref<'A>): 'A
 extern function std.group2map (g: std.Group<('K, 'V)>): std.Map<'K,'V>

--- a/test/datalog_tests/simple.ast.expected
+++ b/test/datalog_tests/simple.ast.expected
@@ -118,6 +118,8 @@ extern type intern.IObj<'A>
 typedef intern.IString = intern.IObj<string>
 typedef ip_addr_t = IPAddr{b3: bit<8>, b2: bit<8>, b1: bit<8>, b0: bit<8>}
 typedef line = bigint
+typedef log.log_level_t = signed<32>
+typedef log.module_t = signed<32>
 typedef nested_t = N{field: C}
 typedef person = string
 typedef serializable_t = ConsInt{x: bigint} | ConsBit{y: bit<32>} | ConsBool{z: bool} | Cons0{}
@@ -284,6 +286,7 @@ extern function h (a: (bigint, bigint)): (bigint, bigint)
 extern function intern.istring_ord (s: intern.IString): bit<32>
 extern function intern.istring_str (s: intern.IString): string
 extern function intern.string_intern (s: string): intern.IString
+extern function log.log (module: log.module_t, level: log.log_level_t, msg: string): bool
 extern function parameterized (x: 'A, y: 'A): 'A
 function parameterized2 (x: 'A, y: 'A): bool =
     (x == y)

--- a/test/datalog_tests/span_string.ast.expected
+++ b/test/datalog_tests/span_string.ast.expected
@@ -8,6 +8,8 @@ typedef Source = Source{parent: entid_t, child: entid_t}
 typedef SourceSpan = SourceSpan{entity: uuid_t, tn: tnid_t}
 typedef Span = Span{entity: uuid_t, tn: tnid_t}
 typedef entid_t = uuid_t
+typedef log.log_level_t = signed<32>
+typedef log.module_t = signed<32>
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
 extern type std.Group<'A>
 extern type std.Map<'K,'V>
@@ -18,6 +20,7 @@ extern type std.Set<'A>
 extern type std.Vec<'A>
 typedef tnid_t = uuid_t
 typedef uuid_t = string
+extern function log.log (module: log.module_t, level: log.log_level_t, msg: string): bool
 extern function std.__builtin_2string (x: 'X): string
 extern function std.deref (x: std.Ref<'A>): 'A
 extern function std.group2map (g: std.Group<('K, 'V)>): std.Map<'K,'V>

--- a/test/datalog_tests/tutorial.ast.expected
+++ b/test/datalog_tests/tutorial.ast.expected
@@ -54,6 +54,8 @@ typedef ip6_addr_t = bit<128>
 typedef ip6_pkt_t = IP6Pkt{ttl: bit<8>, src: ip6_addr_t, dst: ip6_addr_t, payload: ip_payload_t}
 typedef ip_addr_t = IPAddr{addr: bit<32>}
 typedef ip_payload_t = IPTCP{tcp: tcp_pkt_t} | IPUDP{udp: udp_pkt_t} | IPOther{}
+typedef log.log_level_t = signed<32>
+typedef log.module_t = signed<32>
 typedef mac_addr_t = MACAddr{addr: bit<48>}
 typedef nethost_t = NHost{ip: ip_addr_t, mac: mac_addr_t}
 typedef stage = LS_IN_PRE_LB{} | LS_OUT_PRE_LB{}
@@ -102,6 +104,7 @@ function is_multicast_addr (ip: ip_addr_t): bool =
     (ip.addr[31:28] == 4'd14)
 function is_target_audience (person: Person): bool =
     ((person.nationality == "USA") and (person.occupation == "student"))
+extern function log.log (module: log.module_t, level: log.log_level_t, msg: string): bool
 function mac_addr_t2string (mac: mac_addr_t): string =
     ((((((((((("" ++ std.hex(mac.addr[47:40])) ++ ":") ++ std.hex(mac.addr[39:32])) ++ ":") ++ std.hex(mac.addr[31:24])) ++ ":") ++ std.hex(mac.addr[23:16])) ++ ":") ++ std.hex(mac.addr[15:8])) ++ ":") ++ std.hex(mac.addr[7:0]))
 function nethost_t2string (h: nethost_t): string =


### PR DESCRIPTION
Ensure that `log.rs` gets linked into the program even if noone imports
its functionality, as it exports the `ddlog_log_set_callback`, expected, e.g.,
by Java bindings.