### PR TITLE
Use wrapping unary negation (addresses #294)

### DIFF
--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -2094,11 +2094,14 @@ mkExpr' d ctx e@EUnOp{..} = (v, EVal)
     where
     arg =  val exprOp
     e' = exprMap (E . sel3) e
+    t = exprType' d ctx (E e')
+    uint = (not $ isInt d t) && (typeWidth (typ' d t) <= 128)
     v = case exprUOp of
              Not    -> parens $ "!" <> arg
-             BNeg   -> mkTruncate (parens $ "!" <> arg) $ exprType' d ctx (E e')
-             UMinus -> mkTruncate (parens $ "-" <> arg) $ exprType' d ctx (E e')
-
+             BNeg   -> mkTruncate (parens $ "!" <> arg) t
+             UMinus | uint
+                    -> mkTruncate (parens $ arg <> ".wrapping_neg()") t
+             UMinus -> mkTruncate (parens $ "-" <> arg) t
 mkExpr' _ _ EPHolder{} = ("_", ELVal)
 
 -- keep type ascriptions in LHS of assignment and in integer constants

--- a/test/datalog_tests/simple.ast.expected
+++ b/test/datalog_tests/simple.ast.expected
@@ -788,6 +788,7 @@ Signed(.n=(32'sd28 / 32'sd4)).
 Signed(.n=(32'sd24 % 32'sd16)).
 Signed(.n=(32'sd18 >> 32'd1)).
 Signed(.n=(32'sd5 << 32'd1)).
+Signed(.n=(- 32'sd2147483648)).
 Cast_u32(.description="32'd100  as bit<32>", .actual=(32'd100 as bit<32>), .expected=32'd100).
 Cast_u32(.description="16'd100  as bit<32>", .actual=(16'd100 as bit<32>), .expected=32'd100).
 Cast_u32(.description="8'd100   as bit<32>", .actual=(8'd100 as bit<32>), .expected=32'd100).

--- a/test/datalog_tests/simple.dl
+++ b/test/datalog_tests/simple.dl
@@ -909,6 +909,7 @@ Signed(32'sd28 / 32'sd4).
 Signed(32'sd24 % 32'sd16).
 Signed(32'sd18 >> 1).
 Signed(32'sd5 << 1).
+Signed(- (2147483648)).
 
 /* Type casts */
 output relation Cast_u32(description: string, actual: bit<32>, expected: bit<32>)

--- a/test/datalog_tests/simple.dump.expected
+++ b/test/datalog_tests/simple.dump.expected
@@ -170,6 +170,7 @@ Sib{"Bob","Alice"}
 Sib{"Bob","Ben"}
 
 Signed:
+Signed{-2147483648}
 Signed{0}
 Signed{1}
 Signed{2}
@@ -380,6 +381,7 @@ Sib{"Bob","Alice"}
 Sib{"Bob","Ben"}
 
 Signed:
+Signed{-2147483648}
 Signed{0}
 Signed{1}
 Signed{2}
@@ -861,6 +863,7 @@ Arithm{12}
 Arithm{13}
 Arithm{14}
 Signed
+Signed{-2147483648}
 Signed{0}
 Signed{1}
 Signed{2}

--- a/test/run-souffle-tests.py
+++ b/test/run-souffle-tests.py
@@ -28,7 +28,6 @@ xfail = [
     "aggregates2", # aggregation used in head
     "aggregates_complex", # cannot be evalated bottom-up; issue 293
     "aggregates",  # issue 227 - count of empty group
-    "number_constants", # overflow of negation; issue 294
     "magic_aggregates",  # 227
     "count",       # 227
     "magic_count", # 227


### PR DESCRIPTION
Some time ago, we converted DDlog to use wrapping arithmetic for
integers.  This ensures that all arithmetic operations have well-defined
semantics that does not involve crashing due to integer overflows.  The
unary minus operation was left out in that conversion, causing
expressions like `-(2147483648:signed<32>)` to crash.

The fix is to compile unary minus for bit vectors as `x.wrapping_neg()`
instead of `-x`.