### PR TITLE
Change `HDDlog::commit_dump_changes ` to return the delta DB

### DIFF
--- a/rust/template/api.rs
+++ b/rust/template/api.rs
@@ -111,9 +111,7 @@ impl HDDlog {
             Ok(()) => {
                 self.update_handler.after_commit(true);
                 let mut delta = self.deltadb.lock().unwrap();
-                let res = delta.take();
-                // *delta = None;
-                Ok(res.unwrap())
+                Ok(delta.take().unwrap())
             },
             Err(e) => {
                 self.update_handler.after_commit(false);
@@ -255,16 +253,6 @@ impl HDDlog {
             print_err,
             replay_file:    None}
     }
-
-    // fn dump_delta(db: &mut DeltaMap) -> impl iter::Iterator<Item=(usize, &record::Record, bool)>
-    // {
-    //     db.as_ref().iter().map(|(table_id, table_data)| {
-    //         table_data.iter().map(|(val, weight)| {
-    //             debug_assert!(*weight == 1 || *weight == -1);
-    //             (*table_id, &val.clone().into_record(), *weight == 1)
-    //         })
-    //     }).flatten()
-    // }
 
     fn db_dump_table<F>(db: &mut ValMap,
                         table: libc::size_t,

--- a/rust/template/main.rs
+++ b/rust/template/main.rs
@@ -50,23 +50,20 @@ fn handle_cmd(hddlog: &HDDlog,
         Command::Commit(record_delta) => {
             // uncomment to enable profiling
             // PROFILER.lock().unwrap().start("./prof.profile").expect("Couldn't start profiling");
-            let mut current_table = None;
             let res = if record_delta {
-                hddlog.transaction_commit_dump_changes().map(|changes| if print_deltas {
-                    for (table_id, table_data) in changes.as_ref().iter() {
-                        for (val, weight) in table_data.iter() {
-                            debug_assert!(*weight == 1 || *weight == -1);
-                            if current_table != Some(*table_id) {
-                                let _ = writeln!(stdout(), "{}:", relid2name(*table_id).unwrap());
-                                current_table = Some(*table_id);
-                            };
-                            let _ = writeln!(stdout(),
-                                             "{}: {}",
-                                             val,
-                                             if *weight == 1 { "+1" } else { "-1" });
+                hddlog.transaction_commit_dump_changes()
+                    .map(|changes| if print_deltas {
+                        for (table_id, table_data) in changes.as_ref().iter() {
+                            let _ = writeln!(stdout(), "{}:", relid2name(*table_id).unwrap());
+                            for (val, weight) in table_data.iter() {
+                                debug_assert!(*weight == 1 || *weight == -1);
+                                let _ = writeln!(stdout(),
+                                                 "{}: {:+}",
+                                                 val,
+                                                 *weight);
+                            }
                         }
-                    }
-                })
+                    })
             } else {
                 hddlog.transaction_commit()
             };

--- a/rust/template/main.rs
+++ b/rust/template/main.rs
@@ -59,7 +59,7 @@ fn handle_cmd(hddlog: &HDDlog,
                                 debug_assert!(*weight == 1 || *weight == -1);
                                 let _ = writeln!(stdout(),
                                                  "{}: {:+}",
-                                                 val,
+                                                 val.clone().into_record(),
                                                  *weight);
                             }
                         }

--- a/rust/template/main.rs
+++ b/rust/template/main.rs
@@ -50,25 +50,61 @@ fn handle_cmd(hddlog: &HDDlog,
         Command::Commit(record_delta) => {
             // uncomment to enable profiling
             //PROFILER.lock().unwrap().start("./prof.profile").expect("Couldn't start profiling");
-            let mut current_table = None;
-            let res = if record_delta {
-                let cb = if print_deltas {
-                    Some(|table, val: &Record, pol: bool| {
-                        if current_table != Some(table) {
-                            let _ = writeln!(stdout(), "{}:", relid2name(table).unwrap());
-                            current_table = Some(table);
-                        };
-                        let _ = writeln!(stdout(), "{}: {}", *val, if pol { "+1" } else { "-1" });
-                    })
-                } else {
-                    None
-                };
-                hddlog.transaction_commit_dump_changes(cb)
+            if record_delta {
+                match hddlog.transaction_commit_dump_changes() {
+                    Ok(changes) => {
+                        let mut current_table = None;
+                        for (table_id, table_data) in changes.as_ref().iter() {
+                            for (val, weight) in table_data.iter() {
+                                debug_assert!(*weight == 1 || *weight == -1);
+                                if current_table != Some(*table_id) {
+                                    let _ = writeln!(stdout(), "{}:", relid2name(*table_id).unwrap());
+                                    current_table = Some(*table_id);
+                                };
+                                let _ = writeln!(stdout(),
+                                                 "{}: {}",
+                                                 val.clone().into_record(),
+                                                 if *weight == 1 { "+1" } else { "-1" });
+                            }
+                        }
+                        Ok(())
+                    },
+                    Err(e) => {
+                        Err(e)
+                    }
+                }
             } else {
                 hddlog.transaction_commit()
-            };
-            //PROFILER.lock().unwrap().stop().expect("Couldn't stop profiler");
-            res
+            }
+            // let res = if record_delta {
+
+
+            //     let cb = if print_deltas {
+            //         Some(|table, val: &Record, pol: bool| {
+            //             if current_table != Some(table) {
+            //                 let _ = writeln!(stdout(), "{}:", relid2name(table).unwrap());
+            //                 current_table = Some(table);
+            //             };
+            //             let _ = writeln!(stdout(), "{}: {}", *val, if pol { "+1" } else { "-1" });
+            //         })
+            //     } else {
+            //         None
+            //     };
+
+            //     if let Some(f) = cb {
+            //         for (table_id, table_data) in changes.as_ref().iter() {
+            //             for (val, weight) in table_data.iter() {
+            //                 debug_assert!(*weight == 1 || *weight == -1);
+            //                 f(*table_id as libc::size_t,
+            //                   &val.clone().into_record(),
+            //                   *weight == 1);
+            //             }
+            //         }
+            //     };
+            // } else {
+            // };
+            // //PROFILER.lock().unwrap().stop().expect("Couldn't stop profiler");
+            // res
         },
         Command::Comment => {
             Ok(())


### PR DESCRIPTION
This is for #287 . However, we can't return iterators since the lifetime won't work out. I tried refactoring `HDDlog::dump_table`, but since we don't want to move out the DB I don't see a good solution without cloning a lot. Since `dump_table` is not on the critical path now I'm leaving it alone. 