### PR TITLE
Eliminate triple-buffering in the DDlog API

### DIFF
--- a/rust/template/ddlog.h
+++ b/rust/template/ddlog.h
@@ -295,7 +295,7 @@ extern void ddlog_free_json(char *json);
  *
  * Whether the function succeeds or fails, it consumes all commands in
  * the `upds` array (but not the array itself), so they can no longer be
- * accessed by the called after the function returns.
+ * accessed by the caller after the function returns.
  */
 extern int ddlog_apply_updates(ddlog_prog prog, ddlog_cmd **upds, size_t n);
 

--- a/rust/template/differential_datalog/record.rs
+++ b/rust/template/differential_datalog/record.rs
@@ -562,7 +562,7 @@ pub unsafe extern "C" fn ddlog_delete_key_cmd(table: libc::size_t, rec: *mut Rec
 
 /// `Mutator` trait represents an object that can be used to mutate a value (e.g., change some of
 /// its fields).
-pub trait Mutator<V> {
+pub trait Mutator<V>: fmt::Display {
     /// Consumes a value and returns an updated value.
     fn mutate(&self, v: &mut V) -> Result<(), String>;
 }

--- a/rust/template/ovsdb.rs
+++ b/rust/template/ovsdb.rs
@@ -52,7 +52,7 @@ fn apply_updates(prog: &sync::Arc<HDDlog>, prefix: *const c_char, updates_str: *
     record_updatecmds(prog, &commands);
 
     let updates: Result<Vec<Update<Value>>, String> = commands.iter().map(|c|updcmd2upd(c)).collect();
-    prog.prog.lock().unwrap().apply_updates(updates?)
+    prog.prog.lock().unwrap().apply_updates(updates?.into_iter())
 }
 
 fn record_updatecmds(prog: &sync::Arc<HDDlog>, upds: &Vec<UpdCmd>)


### PR DESCRIPTION
The `HDDlog::apply_updates()` method used to convert array of `*UpdCmd`
to `Vec<Box<UpdCmd>>` and then to `Vec<Update<Value>>` before passing
commands down to `RunningProgram::apply_updates()`.  This increased peak
memory consumption on the `redist` test by 30%.

This commit eliminates the tripple buffering by instead using a
streaming interface based on iterators in both `HDDlog` and `RunningProgram`.
As part of this transformation, we introduce a version of
`HDDlog::apply_updates`, called `HDDlog::apply_valupdates` that takes an
iterator over `Update<Value>`.   It is invoked internally by `apply_updates`
and is also used directly by `main.rs`.  This is a more efficient
interface and should be preferred going forward.  In particular, we will
use it in Java bindings once we generate FlatBuffer
serialization/deserialization directly to/from the `Value` type.