### PR TITLE
 Added `--version` and `--box-threshold` compiler flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ To download stack (if you don't already have it) use:
 wget -qO- https://get.haskellstack.org/ | sh
 ```
 
-You will also need to install the Rust toolchain v1.32 or later:
+You will also need to install the Rust toolchain v1.34 or later:
 
 ```
 curl https://sh.rustup.rs -sSf | sh

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -21,7 +21,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -}
 
-{-# LANGUAGE RecordWildCards, ImplicitParams, LambdaCase, FlexibleContexts #-}
+{-# LANGUAGE RecordWildCards, ImplicitParams, LambdaCase, FlexibleContexts, TemplateHaskell #-}
 
 import System.Environment
 import System.FilePath.Posix
@@ -31,14 +31,12 @@ import Control.Monad
 import Data.List
 import Text.PrettyPrint
 
+import Language.DifferentialDatalog.Version
 import Language.DifferentialDatalog.Syntax
 import Language.DifferentialDatalog.Module
 import Language.DifferentialDatalog.Validate
 import Language.DifferentialDatalog.Compile
 import Language.DifferentialDatalog.CompileJava
-
--- Keep this in sync with the binary release version on github
-dDLOG_VERSION = "v0.6.2"
 
 data TOption = Help
              | Version
@@ -135,7 +133,7 @@ main = do
                    _ -> errorWithoutStackTrace $ usageInfo ("Usage: " ++ prog ++ " [OPTION...]") options
     case confAction config of
          ActionHelp -> putStrLn $ usageInfo ("Usage: " ++ prog ++ " [OPTION...]") options
-         ActionVersion -> do putStrLn $ "DDlog " ++ dDLOG_VERSION
+         ActionVersion -> do putStrLn $ "DDlog " ++ dDLOG_VERSION ++ " (" ++ gitHash ++ ")"
                              putStrLn $ "Copyright (c) 2019 VMware, Inc. (MIT License)"
          ActionValidate -> do { parseValidate config; return () }
          ActionCompile -> compileProg config

--- a/package.yaml
+++ b/package.yaml
@@ -35,6 +35,7 @@ dependencies:
 - wide-word
 - graphviz
 - text
+- githash
 
 library:
   source-dirs: src

--- a/rust/template/Cargo.toml
+++ b/rust/template/Cargo.toml
@@ -19,7 +19,7 @@ path = "./ovsdb"
 [dependencies]
 differential-dataflow = "0.9"
 timely = "0.9"
-abomonation= "0.7.2"
+abomonation= "0.7"
 serde = "1.0"
 serde_derive = "1.0"
 fnv="1.0.2"

--- a/rust/template/differential_datalog/Cargo.toml
+++ b/rust/template/differential_datalog/Cargo.toml
@@ -13,7 +13,7 @@ itertools="^0.6"
 
 [dependencies]
 differential-dataflow = "0.9"
-abomonation = "0.7.2"
+abomonation = "0.7"
 timely = "0.9"
 fnv="1.0.2"
 num = "0.2"

--- a/src/Language/DifferentialDatalog/Version.hs
+++ b/src/Language/DifferentialDatalog/Version.hs
@@ -1,0 +1,37 @@
+{-
+Copyright (c) 2018 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-}
+
+{-# LANGUAGE TemplateHaskell #-}
+
+module Language.DifferentialDatalog.Version (
+    dDLOG_VERSION,
+    gitHash)
+where
+ 
+import GitHash
+
+-- Keep this in sync with the binary release version on github
+dDLOG_VERSION = "v0.6.2"
+
+gitHash :: String
+gitHash = giHash $$tGitInfoCwd

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -21,7 +21,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -}
 
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleContexts, ImplicitParams #-}
 
 import Test.Tasty
 import Test.Tasty.Golden
@@ -180,7 +180,8 @@ compilerTest progress fname cli_args crate_types = do
     (prog, rs_code, toml_code) <- parseValidate fname body
     -- generate Rust project
     let rust_dir = takeDirectory fname
-    compile prog specname rs_code toml_code rust_dir crate_types
+    let ?cfg = defaultCompilerConfig in
+        compile prog specname rs_code toml_code rust_dir crate_types
     -- compile it with Cargo
     let cargo_proc = (proc "cargo" (["build"] ++ cargo_build_flag)) {
                           cwd = Just $ rust_dir </> rustProjectDir specname


### PR DESCRIPTION
`--box-threshold` makes the tradeoff between allocating records on the
heap and storing them inline (and potentially wasting memory by
increasing Value size) user-configurable.  The default is 16, but we've
seen use cases where we can save memory by reducing it to 8.

`--version` prints DDlog version and copyright as expected

Addresses #300 and #299 