### PR TITLE
Optionally disable input caching

### DIFF
--- a/java/ddlogapi.c
+++ b/java/ddlogapi.c
@@ -101,12 +101,12 @@ void commit_callback(void* callbackInfo, table_id tableid, const ddlog_record* r
 }
 
 JNIEXPORT jlong JNICALL Java_ddlogapi_DDlogAPI_ddlog_1run(
-    JNIEnv *env, jobject obj, jboolean storeData, jint workers, jstring callback) {
+    JNIEnv *env, jobject obj, jboolean storeInputs, jboolean storeOutputs, jint workers, jstring callback) {
     if (workers <= 0)
         workers = 1;
 
     if (callback == NULL)
-        return (jlong)ddlog_run((unsigned)workers, storeData, NULL, 0, NULL);
+        return (jlong)ddlog_run((unsigned)workers, storeInputs, storeOutputs, NULL, 0, NULL);
 
     struct CallbackInfo* cbinfo = createCallback(env, obj, callback, "(IJZ)V");
     if (cbinfo == NULL)
@@ -119,7 +119,7 @@ JNIEXPORT jlong JNICALL Java_ddlogapi_DDlogAPI_ddlog_1run(
         return 0;
     (*env)->SetLongField(env, obj, callbackHandle, (jlong)cbinfo);
 
-    void* handle = ddlog_run((unsigned)workers, storeData, commit_callback, (uintptr_t)cbinfo, NULL);
+    void* handle = ddlog_run((unsigned)workers, storeInputs, storeOutputs, commit_callback, (uintptr_t)cbinfo, NULL);
     return (jlong)handle;
 }
 

--- a/java/ddlogapi/DDlogAPI.java
+++ b/java/ddlogapi/DDlogAPI.java
@@ -15,7 +15,7 @@ public class DDlogAPI {
     /**
      * The C ddlog API
      */
-    native long ddlog_run(boolean storeData, int workers, String callbackName);
+    native long ddlog_run(boolean storeInputs, boolean storeOutputs, int workers, String callbackName);
     static native int ddlog_record_commands(long hprog, String filename, boolean append);
     static native int ddlog_stop_recording(long hprog, int fd);
     static native int ddlog_dump_input_snapshot(long hprog, String filename, boolean append);
@@ -115,11 +115,11 @@ public class DDlogAPI {
      *                  many times, on potentially different threads, when the "commit"
      *                  API function is called.
      */
-    public DDlogAPI(int workers, Consumer<DDlogCommand> callback, boolean storeData) {
+    public DDlogAPI(int workers, Consumer<DDlogCommand> callback, boolean storeInputs, boolean storeOutputs) {
         this.tableId = new HashMap<String, Integer>();
         String onCommit = callback == null ? null : "onCommit";
         this.commitCallback = callback;
-        this.hprog = this.ddlog_run(storeData, workers, onCommit);
+        this.hprog = this.ddlog_run(storeInputs, storeOutputs, workers, onCommit);
     }
 
     /// Callback invoked from commit.

--- a/java/test/SpanTest.java
+++ b/java/test/SpanTest.java
@@ -134,13 +134,13 @@ public class SpanTest {
                     100/*log4j.FATAL*/);
             if (localTables) {
                 //this.api = new DDlogAPI(1, r -> this.onCommit(r));
-                this.api = new DDlogAPI(1, r -> this.onCommitDirect(r), false);
+                this.api = new DDlogAPI(1, r -> this.onCommitDirect(r), false, false);
                 this.ruleSpanTableId = this.api.getTableId("RuleSpan");
                 this.containerSpanTableId = this.api.getTableId("ContainerSpan");
                 this.ruleSpan = new TreeSet<RuleSpan>(new SpanComparator());
                 this.containerSpan = new TreeSet<ContainerSpan>(new SpanComparator());
             } else {
-                this.api = new DDlogAPI(1, null, true);
+                this.api = new DDlogAPI(1, null, false, true);
             }
             this.command = null;
             this.exitCode = -1;

--- a/java/test1/RedistTest.java
+++ b/java/test1/RedistTest.java
@@ -244,12 +244,12 @@ public class RedistTest {
 
         SpanParser() {
             if (localTables) {
-                this.api = new DDlogAPI(2, r -> this.onCommit(r), false);
+                this.api = new DDlogAPI(2, r -> this.onCommit(r), true, false);
                 this.spanTableId = this.api.getTableId("Span");
                 if (debug)
                     System.err.println("Span table id " + this.spanTableId);
             } else {
-                this.api = new DDlogAPI(2, null, true);
+                this.api = new DDlogAPI(2, null, true, true);
             }
             this.command = null;
             this.exitCode = -1;

--- a/java/test2/TwoTest.java
+++ b/java/test2/TwoTest.java
@@ -11,8 +11,8 @@ public class TwoTest {
     private final DDlogAPI api2;
 
     TwoTest() {
-        this.api1 = new DDlogAPI(1, r -> this.onCommit(r), false);
-        this.api2 = new DDlogAPI(1, r -> this.onCommit(r), false);
+        this.api1 = new DDlogAPI(1, r -> this.onCommit(r), true, false);
+        this.api2 = new DDlogAPI(1, r -> this.onCommit(r), true, false);
     }
 
     synchronized void onCommit(DDlogCommand command) {

--- a/java/test3/SpanTest.java
+++ b/java/test3/SpanTest.java
@@ -10,7 +10,7 @@ public class SpanTest {
     private final DDlogAPI api;
 
     SpanTest() {
-        this.api = new DDlogAPI(1, null, false);
+        this.api = new DDlogAPI(1, null, true, false);
     }
 
     void onCommit(DDlogCommand command) {

--- a/java/test4/XTest.java
+++ b/java/test4/XTest.java
@@ -7,7 +7,7 @@ public class XTest {
     private final DDlogAPI api;
 
     XTest() {
-        this.api = new DDlogAPI(1, null, false);
+        this.api = new DDlogAPI(1, null, true, false);
     }
 
     void onCommit(DDlogCommand command) {

--- a/rust/template/differential_datalog/test.rs
+++ b/rust/template/differential_datalog/test.rs
@@ -235,7 +235,7 @@ fn test_one_relation(nthreads: usize) {
         init_data: vec![]
     };
 
-    let mut running = prog.run(nthreads);
+    let mut running = prog.run(nthreads, true);
 
     /* 1. Insertion */
     let vals:Vec<u64> = (0..TEST_SIZE).collect();
@@ -344,7 +344,7 @@ fn test_two_relations(nthreads: usize) {
         init_data: vec![]
     };
 
-    let mut running = prog.run(nthreads);
+    let mut running = prog.run(nthreads, true);
 
     /* 1. Populate T1 */
     let vals:Vec<u64> = (0..TEST_SIZE).collect();
@@ -490,7 +490,7 @@ fn test_semijoin(nthreads: usize) {
         init_data: vec![]
     };
 
-    let mut running = prog.run(nthreads);
+    let mut running = prog.run(nthreads, true);
 
     let vals:Vec<u64> = (0..TEST_SIZE).collect();
     let set = FnvHashSet::from_iter(vals.iter().map(|x| Value::Tuple2(Box::new(Value::u64(*x)),Box::new(Value::u64(*x)))));
@@ -633,7 +633,7 @@ fn test_join(nthreads: usize) {
     };
 
 
-    let mut running = prog.run(nthreads);
+    let mut running = prog.run(nthreads, true);
 
     let vals:Vec<u64> = (0..TEST_SIZE).collect();
     let set = FnvHashSet::from_iter(vals.iter().map(|x| Value::Tuple2(Box::new(Value::u64(*x)),Box::new(Value::u64(*x)))));
@@ -792,7 +792,7 @@ fn test_antijoin(nthreads: usize) {
         init_data: vec![]
     };
 
-    let mut running = prog.run(nthreads);
+    let mut running = prog.run(nthreads, true);
 
     let vals:Vec<u64> = (0..TEST_SIZE).collect();
     let set = FnvHashSet::from_iter(vals.iter().map(|x| Value::Tuple2(Box::new(Value::u64(*x)),Box::new(Value::u64(*x)))));
@@ -1002,7 +1002,7 @@ fn test_map(nthreads: usize) {
         init_data: vec![]
     };
 
-    let mut running = prog.run(nthreads);
+    let mut running = prog.run(nthreads, true);
 
     let vals:Vec<u64> = (0..TEST_SIZE).collect();
     let set = FnvHashSet::from_iter(vals.iter().map(|x| Value::u64(*x)));
@@ -1205,7 +1205,7 @@ fn test_recursion(nthreads: usize) {
         init_data: vec![]
     };
 
-    let mut running = prog.run(nthreads);
+    let mut running = prog.run(nthreads, true);
 
     /* 1. Populate parent relation */
     /*

--- a/rust/template/main.rs
+++ b/rust/template/main.rs
@@ -178,7 +178,7 @@ pub fn main() {
         opt store_inputs:bool=true,  desc:"Do not store input relation state.",  long:"no-store-inputs";
         opt store_delta:bool=true,   desc:"Do not record changes.",              long:"no-store-delta";
         opt print:bool=false,        desc:"Print changes during commit.";
-        opt workers:usize=4,         desc:"The number of worker threads.",       short:'w';
+        opt workers:usize=2,         desc:"The number of worker threads (default: 2).",       short:'w';
     };
     let (args, rest) = parser.parse_or_exit();
 

--- a/rust/template/main.rs
+++ b/rust/template/main.rs
@@ -174,10 +174,11 @@ pub fn main() {
     let parser = opts! {
         synopsis "DDlog CLI interface.";
         auto_shorts false;
-        opt store:bool=true, desc:"Do not store relation state (for benchmarking only)."; // --no-store
-        opt delta:bool=true, desc:"Do not record changes.";                               // --no-delta
-        opt print:bool=true, desc:"Do not print deltas.";                                 // --no-print
-        opt workers:usize=4, short:'w', desc:"The number of worker threads.";             // --workers or -w
+        opt store_outputs:bool=true, desc:"Do not store output relation state.", long:"no-store-outputs";
+        opt store_inputs:bool=true,  desc:"Do not store input relation state.",  long:"no-store-inputs";
+        opt store_delta:bool=true,   desc:"Do not record changes.",              long:"no-store-delta";
+        opt print:bool=false,        desc:"Print changes during commit.";
+        opt workers:usize=4,         desc:"The number of worker threads.",       short:'w';
     };
     let (args, rest) = parser.parse_or_exit();
 
@@ -192,9 +193,10 @@ pub fn main() {
     let cb = if args.print { record_upd } else { no_op };
 
     let hddlog = HDDlog::run(args.workers,
-                             args.store,
+                             args.store_inputs,
+                             args.store_outputs,
                              cb);
 
-    let ret = run_interactive(hddlog, args.delta);
+    let ret = run_interactive(hddlog, args.store_delta);
     exit(ret);
 }

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -108,7 +108,7 @@ souffleTest testdir progress =
         [ goldenVsFiles testdir
           [testdir </> "souffle.dump.expected.gz"]
           [testdir </> "souffle.dump"]
-          $ do {convertSouffle testdir progress; compilerTest progress (testdir </> "souffle.dl") ["--no-print", "-w", "1"] ["cdylib"]}]
+          $ do {convertSouffle testdir progress; compilerTest progress (testdir </> "souffle.dl") ["-w", "1"] ["cdylib"]}]
 
 convertSouffle :: String -> Bool -> IO ()
 convertSouffle testdir progress = do

--- a/test/run-souffle-tests.py
+++ b/test/run-souffle-tests.py
@@ -235,7 +235,7 @@ def run_merged_test(filename):
         lines = f.read()
     print "Running program at", datetime.datetime.now().time()
     code, result = run_command(["./" + filename + "_ddlog/target/debug/" + filename +
-                                "_cli", "--no-print"], lines)
+                                "_cli"], lines)
     if code != 0:
         print "Error running ddlog program", code
     with open(filename + ".dump", "w") as dump:


### PR DESCRIPTION
Do not merge this PR until we've fixed OVN to work with it.

-------------------

Until now, DDlog stored copies of all input relations.  These are
primarily used to filter out duplicate insertions and deletions, as well
as to implement `ddlog_clear_relation()` and
`ddlog_dump_input_snapshot()` APIs.  In applications where these
features are not required, this behavior introduces unnecessary memory
overhead.

This commit introduces a new flag (available in Rust, Java, and C APIs and
in the CLI) that controls caching of input relations.  This is similar
to how we've had a flag to control caching of output tables for a while.
We now have a pair of flags: `store_inputs` and `store_outputs`.

In the CLI, we now have the `--no-store-inputs` flag, which disables
input relation caching and `--no-store-outputs`, which is equivalent to
the old `--no-store` flag.

While we're at it, change CLI behavior so that printing of updates is
disabled by default (no more need for the `--no-print` switch). Here is
a summary of new DDlog CLI flags:

```
DDlog CLI interface.

Options:
  --no-store-outputs    Do not store output relation state.
  --no-store-inputs     Do not store input relation state.
  --no-store-delta      Do not record changes.
  --print               Print changes during commit.
  -w, --workers         The number of worker threads. (default: 4)
  -h, --help            Show this help message.
```