### PR TITLE
Bug in handling of updates from differential.

### DIFF
--- a/java/ddlogapi/DDlogAPI.java
+++ b/java/ddlogapi/DDlogAPI.java
@@ -20,7 +20,7 @@ public class DDlogAPI {
     static native int ddlog_stop_recording(long hprog, int fd);
     static native int ddlog_dump_input_snapshot(long hprog, String filename, boolean append);
     native int dump_table(long hprog, int table, String callbackMethod);
-    static native int  ddlog_stop(long hprog, long callbackHandle);
+    static native int ddlog_stop(long hprog, long callbackHandle);
     static native int ddlog_transaction_start(long hprog);
     static native int ddlog_transaction_commit(long hprog);
     native int ddlog_transaction_commit_dump_changes(long hprog, String callbackName);
@@ -123,12 +123,14 @@ public class DDlogAPI {
     }
 
     /// Callback invoked from commit.
-    void onCommit(int tableid, long handle, boolean polarity) {
+    void onCommit(int tableid, long handle, long w) {
         if (this.commitCallback != null) {
-            DDlogCommand.Kind kind = polarity ? DDlogCommand.Kind.Insert : DDlogCommand.Kind.DeleteVal;
-            DDlogRecord record = DDlogRecord.fromSharedHandle(handle);
-            DDlogCommand command = new DDlogCommand(kind, tableid, record);
-            this.commitCallback.accept(command);
+            DDlogCommand.Kind kind = w > 0 ? DDlogCommand.Kind.Insert : DDlogCommand.Kind.DeleteVal;
+            for (long i = 0; i < java.lang.Math.abs(w); i++) {
+                DDlogRecord record = DDlogRecord.fromSharedHandle(handle);
+                DDlogCommand command = new DDlogCommand(kind, tableid, record);
+                this.commitCallback.accept(command);
+            }
         }
     }
 

--- a/rust/template/ddlog.h
+++ b/rust/template/ddlog.h
@@ -87,8 +87,14 @@ extern table_id ddlog_get_table_id(const char* tname);
  *	- `arg`	     - opaque used-defined value
  *	- `table`    - table being modified
  *	- `rec`	     - record that has been inserted or deleted
- *	- `polarity` - `true` - record has been added
- *		       `false` - record has been deleted
+ *	- `weight`   - change in the multiplicity of the record.  The same record can
+ *	               be inserted (callback invoked with positive weight) and deleted
+ *	               (callback invoked with negative weight) multiple times during
+ *                 transaction commit.  In order to determine how the membership of
+ *                 the value in the relation was changed by the transaction, sum up
+ *                 all its weights.  The result of +1 means that the record was
+ *                 inserted; -1 - record was deleted; 0 - record's membership
+ *                 did not change.
  *
  * IMPORTANT: Thread safety: DDlog invokes the callback from its worker threads
  * without any serialization to avoid contention. Hence, if the `workers` argument
@@ -117,7 +123,7 @@ extern ddlog_prog ddlog_run(unsigned int workers,
                             void (*cb)(void *arg,
                                        table_id table,
                                        const ddlog_record *rec,
-                                       bool polarity),
+                                       ssize_t weight),
 			    uintptr_t cb_arg,
 			    void (*print_err_msg)(const char *msg));
 

--- a/rust/template/main.rs
+++ b/rust/template/main.rs
@@ -90,7 +90,7 @@ fn handle_cmd(hddlog: &HDDlog,
             Ok(())
         },
         Command::Dump(None) => {
-            let _ = hddlog.db.as_ref().map(|db|db.lock().unwrap().format(&mut stdout()));
+            let _ = hddlog.db.as_ref().map(|db|db.lock().unwrap().format_as_sets(&mut stdout()));
             Ok(())
         },
         Command::Dump(Some(rname)) => {
@@ -101,7 +101,7 @@ fn handle_cmd(hddlog: &HDDlog,
                 },
                 Some(rid) => rid as RelId
             };
-            let _ = hddlog.db.as_ref().map(|db|db.lock().unwrap().format_rel(relid, &mut stdout()));
+            let _ = hddlog.db.as_ref().map(|db|db.lock().unwrap().format_rel_as_set(relid, &mut stdout()));
             Ok(())
         },
         Command::Clear(rname) => {
@@ -185,10 +185,10 @@ pub fn main() {
         panic!("Invalid command line arguments; try -h for help");
     }
 
-    fn record_upd(table:usize, rec: &Record, pol: bool) {
-        eprintln!("{} {:?} {}", if pol { "insert" } else { "delete" }, table, *rec);
+    fn record_upd(table:usize, rec: &Record, w: isize) {
+        eprintln!("{}({:+}) {:?} {}", if w >= 0 { "insert" } else { "delete" }, w, table, *rec);
     }
-    fn no_op(_table:usize, _rec: &Record, _pol: bool) {}
+    fn no_op(_table:usize, _rec: &Record, _w: isize) {}
     let cb = if args.print { record_upd } else { no_op };
 
     let hddlog = HDDlog::run(args.workers,

--- a/rust/template/valmap.rs
+++ b/rust/template/valmap.rs
@@ -11,50 +11,6 @@ use std::collections::BTreeSet;
 
 use super::*;
 
-/* Stores the snapshot of output tables.
- */
-#[derive(Default)]
-pub struct ValMap{map: BTreeMap<RelId, BTreeSet<Value>>}
-
-impl ValMap {
-    pub fn new() -> ValMap {
-        ValMap{map: BTreeMap::default()}
-    }
-
-    pub fn format(&self, w: &mut io::Write) -> io::Result<()> {
-       for (relid, relset) in &self.map {
-           w.write_fmt(format_args!("{:?}:\n", relid2rel(*relid).unwrap()))?;
-           for val in relset {
-                w.write_fmt(format_args!("{}\n", *val))?;
-           };
-           w.write_fmt(format_args!("\n"))?;
-       };
-       Ok(())
-    }
-
-    pub fn format_rel(&mut self, relid: RelId, w: &mut io::Write) -> io::Result<()> {
-        let set = self.get_rel(relid);
-        for val in set {
-            w.write_fmt(format_args!("{}\n", *val))?;
-        };
-        Ok(())
-    }
-
-    pub fn get_rel(&mut self, relid: RelId) -> &BTreeSet<Value> {
-        self.map.entry(relid).or_insert_with(BTreeSet::default)
-    }
-
-    pub fn update(&mut self, relid: RelId, x : &Value, insert: bool)
-    {
-        //println!("set_update({}) {:?} {}", rel, *x, insert);
-        if insert {
-            self.map.entry(relid).or_insert_with(BTreeSet::default).insert(x.clone());
-        } else {
-            self.map.entry(relid).or_insert_with(BTreeSet::default).remove(x);
-        }
-    }
-}
-
 /* Stores a set of changes to output tables.
  */
 #[derive(Default)]
@@ -121,9 +77,8 @@ impl DeltaMap {
         self.map.entry(relid).or_insert_with(BTreeMap::default)
     }
 
-    pub fn update(&mut self, relid: RelId, x : &Value, insert: bool)
+    pub fn update(&mut self, relid: RelId, x : &Value, diff: isize)
     {
-        let diff = if insert { 1 } else { -1 };
         //println!("set_update({}) {:?} {}", rel, *x, insert);
         let entry = self.map.entry(relid)
             .or_insert_with(BTreeMap::default)

--- a/rust/template/valmap.rs
+++ b/rust/template/valmap.rs
@@ -96,6 +96,27 @@ impl DeltaMap {
         Ok(())
     }
 
+    pub fn format_as_sets(&self, w: &mut io::Write) -> io::Result<()> {
+       for (relid, map) in &self.map {
+           w.write_fmt(format_args!("{:?}:\n", relid2rel(*relid).unwrap()))?;
+           for (val,weight) in map {
+                w.write_fmt(format_args!("{}\n", *val))?;
+                assert_eq!(*weight, 1, "val={}, weight={}", *val, *weight);
+           };
+           w.write_fmt(format_args!("\n"))?;
+       };
+       Ok(())
+    }
+
+    pub fn format_rel_as_set(&mut self, relid: RelId, w: &mut io::Write) -> io::Result<()> {
+        let map = self.get_rel(relid);
+        for (val, weight) in map {
+            w.write_fmt(format_args!("{}\n", *val))?;
+            assert_eq!(*weight, 1, "val={}, weight={}", *val, *weight);
+        };
+        Ok(())
+    }
+
     pub fn get_rel(&mut self, relid: RelId) -> &BTreeMap<Value, isize> {
         self.map.entry(relid).or_insert_with(BTreeMap::default)
     }

--- a/src/Language/DifferentialDatalog/Expr.hs
+++ b/src/Language/DifferentialDatalog/Expr.hs
@@ -349,6 +349,9 @@ exprIsInjective d vs e =
 exprIsInjective' :: DatalogProgram -> ExprNode Bool -> Bool
 exprIsInjective' _ EVar{}        = True
 exprIsInjective' d EApply{..}    =
+    -- FIXME: once we add support for recursive functions, be careful to avoid
+    -- infinite recursion.  The simple thing to do is just to return False for
+    -- recursive functions, as reasoning about them seems tricky otherwise.
     and exprArgs && (maybe False (exprIsInjective d (S.fromList $ map name funcArgs)) $ funcDef)
     where Function{..} = getFunc d exprFunc
 exprIsInjective' _ EBool{}       = True

--- a/src/Language/DifferentialDatalog/Relation.hs
+++ b/src/Language/DifferentialDatalog/Relation.hs
@@ -36,6 +36,7 @@ module Language.DifferentialDatalog.Relation (
 ) 
 where
 
+import qualified Data.Set                       as S
 import qualified Data.Graph.Inductive           as G
 import qualified Data.Graph.Inductive.Query.DFS as G
 import Data.Maybe
@@ -80,8 +81,8 @@ relIsDistinctByConstruction d rel
      length rules == 1 && length heads == 1 &&
      -- The first atom in the body of the rule is a distinct relation and does not contain wildcards
      length (ruleRHS rule) >= 1 && relIsDistinct d baserel && (not $ exprContainsPHolders $ atomVal atom1) &&
-     -- The head of the rule contains all the variables from the first atom
-     (null $ (nub $ atomVars $ atomVal atom1) \\ (nub $ atomVars $ atomVal head_atom)) &&
+     -- The head of the rule is an injective function of all the variables from the first atom
+     exprIsInjective d (S.fromList $ atomVars $ atomVal atom1) (atomVal head_atom) && 
      -- The rule only contains clauses that filter the collection
      all (\case
            RHSLiteral True a -> relIsDistinct d (getRelation d $ atomRelation a) &&

--- a/src/Language/DifferentialDatalog/Rule.hs
+++ b/src/Language/DifferentialDatalog/Rule.hs
@@ -129,12 +129,11 @@ atomVarOccurrences ctx e =
 
 atomVars :: Expr -> [String]
 atomVars e =
-    exprCollect (\e' ->
-                  case e' of
-                       EVar _ v       -> [v]
-                       EBinding _ v _ -> [v]
-                       _              -> [])
-                   (++) e
+    exprCollect (\case
+                  EVar _ v       -> [v]
+                  EBinding _ v _ -> [v]
+                  _              -> [])
+                (++) e
 
 atomVarDecls :: DatalogProgram -> Rule -> Int -> S.Set Field
 atomVarDecls d rl i = S.fromList $ atomVarTypes d (CtxRuleRAtom rl i) (atomVal $ rhsAtom $ ruleRHS rl !! i)

--- a/test/datalog_tests/simple.ast.expected
+++ b/test/datalog_tests/simple.ast.expected
@@ -29,6 +29,9 @@ typedef Cast_u256 = Cast_u256{description: string, expected: bit<256>, actual: b
 typedef Cast_u32 = Cast_u32{description: string, actual: bit<32>, expected: bit<32>}
 typedef ConcatString = ConcatString{s: string}
 typedef DMethod = DMethod{c1: Symbol, c2: Symbol}
+typedef DdlogBinding = DdlogBinding{tn: tnid_t, entity: entid_t}
+typedef DdlogDependency = DdlogDependency{parent: entid_t, child: entid_t}
+typedef DdlogNode = DdlogNode{id: entid_t}
 typedef Disaggregate = Disaggregate{x: string, y: string}
 typedef Edge = Edge{from: bigint, to: bigint}
 typedef ExternalId = ExternalId{host: bit<64>, id: (string, string)}
@@ -78,6 +81,7 @@ typedef Ris_true = Ris_true{_s: TB}
 typedef S = S{f1: (bool, bool), f2: bit<32>}
 typedef Sib = Sib{s1: person, s2: person}
 typedef Signed = Signed{n: signed<32>}
+typedef Span = Span{entity: entid_t, tns: std.Set<tnid_t>}
 typedef String2 = String2{s: string}
 typedef StringOrd = StringOrd{s: string, ord: bit<32>}
 typedef Strings = Strings{s: string}
@@ -113,6 +117,7 @@ typedef YX = YX{y: bigint, x: bigint}
 typedef YZX = YZX{y: bigint, z: bigint, x: bigint}
 typedef Z = Z{field: bigint}
 typedef ZZ = ZZ{x: bigint, y: R3}
+typedef entid_t = bit<32>
 #[size = 4]
 extern type intern.IObj<'A>
 typedef intern.IString = intern.IObj<string>
@@ -155,6 +160,7 @@ typedef t15 = Const15{f: bigint}
 typedef t18 = Const18{f0: bigint, f1: string, f2: t00}
 typedef t19 = C000{f0: bigint} | C111{f0: bigint} | C222{f0: bigint}
 typedef t20 = signed<32>
+typedef tnid_t = bit<16>
 function a0 (): bigint =
     1
 function a1 (): bigint =
@@ -524,6 +530,9 @@ output relation Cast_u256 [Cast_u256]
 output relation Cast_u32 [Cast_u32]
 output relation ConcatString [ConcatString]
 output relation DMethod [DMethod]
+input relation DdlogBinding [DdlogBinding]
+input relation DdlogDependency [DdlogDependency]
+input relation DdlogNode [DdlogNode]
 output relation Disaggregate [Disaggregate]
 input relation Edge [Edge]
 output relation ExternalId [ExternalId]
@@ -571,6 +580,7 @@ relation Ris_true [Ris_true]
 output relation SCCLabel [(bigint, bigint)]
 output relation Sib [Sib]
 output relation Signed [Signed]
+output relation Span [Span]
 input relation String2 [String2]
 output relation StringOrd [StringOrd]
 input relation Strings [Strings]
@@ -843,4 +853,6 @@ UMinus_s32(.description="-32768", .n=(- 32'sd32768)).
 UMinus_bigint(.description="-100", .n=(- 100)).
 UMinus_bigint(.description="- -100", .n=(- (- 100))).
 UMinus_bigint(.description="-32768", .n=(- 32768)).
+Span(.entity=(entity: entid_t), .tns=bindings) :- DdlogNode(.id=entity), DdlogBinding(.tn=tn, .entity=entity), var bindings = Aggregate((entity), std.group2set(tn)).
+Span(.entity=parent, .tns=tns) :- DdlogNode(.id=parent), DdlogDependency(.parent=child, .child=parent), Span(.entity=child, .tns=child_tns), var tns = Aggregate((parent), std.group_set_unions(child_tns)).
 apply graph.SCC(Edge, edge_from, edge_to) -> (SCCLabel)

--- a/test/datalog_tests/simple.dat
+++ b/test/datalog_tests/simple.dat
@@ -554,3 +554,51 @@ dump UMinus_s32;
 
 echo UMinus_bigint;
 dump UMinus_bigint;
+
+
+start;
+insert DdlogNode[DdlogNode{0}],
+insert DdlogNode[DdlogNode{1}],
+insert DdlogNode[DdlogNode{2}],
+insert DdlogNode[DdlogNode{3}],
+insert DdlogNode[DdlogNode{4}],
+insert DdlogNode[DdlogNode{5}],
+insert DdlogNode[DdlogNode{6}],
+insert DdlogNode[DdlogNode{7}],
+insert DdlogNode[DdlogNode{8}],
+insert DdlogNode[DdlogNode{9}],
+insert DdlogBinding[DdlogBinding{0, 9}],
+insert DdlogNode[DdlogNode{10}],
+insert DdlogBinding[DdlogBinding{1, 10}],
+insert DdlogNode[DdlogNode{11}],
+insert DdlogBinding[DdlogBinding{2, 11}],
+insert DdlogNode[DdlogNode{12}],
+insert DdlogBinding[DdlogBinding{3, 12}],
+insert DdlogNode[DdlogNode{13}],
+insert DdlogBinding[DdlogBinding{4, 13}],
+insert DdlogDependency[DdlogDependency{1, 2}],
+insert DdlogDependency[DdlogDependency{2, 1}],
+insert DdlogDependency[DdlogDependency{3, 4}],
+insert DdlogDependency[DdlogDependency{4, 3}],
+insert DdlogDependency[DdlogDependency{5, 6}],
+insert DdlogDependency[DdlogDependency{6, 5}],
+insert DdlogDependency[DdlogDependency{7, 8}],
+insert DdlogDependency[DdlogDependency{8, 7}],
+insert DdlogDependency[DdlogDependency{0, 1}],
+insert DdlogDependency[DdlogDependency{1, 0}],
+insert DdlogDependency[DdlogDependency{2, 3}],
+insert DdlogDependency[DdlogDependency{3, 2}],
+insert DdlogDependency[DdlogDependency{6, 7}],
+insert DdlogDependency[DdlogDependency{7, 6}],
+insert DdlogDependency[DdlogDependency{0, 8}],
+insert DdlogDependency[DdlogDependency{11, 1}],
+insert DdlogDependency[DdlogDependency{3, 5}],
+insert DdlogDependency[DdlogDependency{9, 0}],
+insert DdlogDependency[DdlogDependency{10, 4}],
+insert DdlogDependency[DdlogDependency{12, 5}],
+insert DdlogDependency[DdlogDependency{13, 7}];
+commit dump_changes;
+start;
+insert DdlogDependency[DdlogDependency{1, 6}],
+insert DdlogDependency[DdlogDependency{6, 1}];
+commit dump_changes;

--- a/test/datalog_tests/simple.dl
+++ b/test/datalog_tests/simple.dl
@@ -999,3 +999,25 @@ output relation UMinus_bigint(description: string, n: bigint)
 UMinus_bigint("-100", -100).
 UMinus_bigint("- -100", - -100).
 UMinus_bigint("-32768", -32768).
+
+typedef entid_t = bit<32>
+typedef tnid_t = bit<16>
+
+/* Recursion + aggregation */
+input relation DdlogNode(id: entid_t)
+input relation DdlogBinding(tn: tnid_t, entity: entid_t)
+input relation DdlogDependency(parent: entid_t, child: entid_t)
+
+output relation Span(entity: entid_t, tns: Set<tnid_t>)
+
+Span(entity: entid_t, bindings) :-
+    DdlogNode(entity),
+    DdlogBinding(tn, entity),
+    var bindings = Aggregate((entity), group2set(tn)).
+
+/* Recursive step: propagate span along graph edges */
+Span(parent, tns) :-
+    DdlogNode(parent),
+    DdlogDependency(child, parent),
+    Span(child, child_tns),
+    var tns = Aggregate((parent), group_set_unions(child_tns)).

--- a/test/datalog_tests/simple.dump.expected
+++ b/test/datalog_tests/simple.dump.expected
@@ -936,3 +936,29 @@ UMinus_bigint
 UMinus_bigint{"- -100",100}
 UMinus_bigint{"-100",-100}
 UMinus_bigint{"-32768",-32768}
+Span:
+Span{.entity = 0, .tns = [0, 1, 2]}: +1
+Span{.entity = 1, .tns = [0, 1, 2]}: +1
+Span{.entity = 2, .tns = [0, 1, 2]}: +1
+Span{.entity = 3, .tns = [0, 1, 2]}: +1
+Span{.entity = 4, .tns = [0, 1, 2]}: +1
+Span{.entity = 5, .tns = [0, 1, 2, 3, 4]}: +1
+Span{.entity = 6, .tns = [0, 1, 2, 3, 4]}: +1
+Span{.entity = 7, .tns = [0, 1, 2, 3, 4]}: +1
+Span{.entity = 8, .tns = [0, 1, 2, 3, 4]}: +1
+Span{.entity = 9, .tns = [0]}: +1
+Span{.entity = 10, .tns = [1]}: +1
+Span{.entity = 11, .tns = [2]}: +1
+Span{.entity = 12, .tns = [3]}: +1
+Span{.entity = 13, .tns = [4]}: +1
+Span:
+Span{.entity = 0, .tns = [0, 1, 2]}: -1
+Span{.entity = 0, .tns = [0, 1, 2, 3, 4]}: +1
+Span{.entity = 1, .tns = [0, 1, 2]}: -1
+Span{.entity = 1, .tns = [0, 1, 2, 3, 4]}: +1
+Span{.entity = 2, .tns = [0, 1, 2]}: -1
+Span{.entity = 2, .tns = [0, 1, 2, 3, 4]}: +1
+Span{.entity = 3, .tns = [0, 1, 2]}: -1
+Span{.entity = 3, .tns = [0, 1, 2, 3, 4]}: +1
+Span{.entity = 4, .tns = [0, 1, 2]}: -1
+Span{.entity = 4, .tns = [0, 1, 2, 3, 4]}: +1


### PR DESCRIPTION
I wrongly assumed that, because output collections are distinct,
the `inspect()` operator attached to them only sees unit weights.
However, while these collections logically represent distinct records,
they can emerge as updates with varying counts that add up to 0, +1, or
-1.  Thus the entire logic based on representing updates as Booleans was
wrong.

The fix is to use the `consolidate()` operator to get DD to
consolidate all updates to the same record to at most 1 update with
multiplicity of +1 or -1.

This commit also introduces a degree of future-proofness by refactoring
the callback API to take `isize` instead of `bool` weights.