### PR TITLE
Remove TODO referencing issue #64

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,14 +65,15 @@ changes to the relational schema or rules require re-compilation.
 [Differential Datalog](doc/datalog2.0-workshop/paper.pdf), Leonid Ryzhyk and Mihai Budiu
 Datalog 2.0, Philadelphia, PA, June 4-5, 2019.
 
-## Installing from sources
+## Installation
 
+### From sources
 To install the required dependencies for buidling DDlog run
 `. ./install-dependencies.sh` (If you want to use other versions of
 the Rust or Haskell tools you can manually install the required
 dependencies, as described below.)
 
-### Prerequisites
+#### Prerequisites
 
 This section describes the manual installation of dependencies.
 We have tested our software on Ubuntu Linux and MacOS.
@@ -104,7 +105,7 @@ FlatBuffers library.  Download and build FlatBuffers release 1.11.0 from
 that the `flatc` tool is in your `$PATH`.  Additionally, make sure that FlatBuffers
 Java classes are in your `$CLASSPATH`.
 
-### Building
+#### Building
 
 To build the software:
 
@@ -133,11 +134,11 @@ of disk space):
 stack test
 ```
 
-## Binary installation
+### Binary
 
 To install a precompiled version of DDlog, download the [latest binary release](https://github.com/ryzhyk/differential-datalog/releases), extract it from archive and add `ddlog/bin` to your `$PATH`. You will also need to install the Rust toolchain (see instructions [above](#prerequisites))
 
-## vim syntax highlighting
+### vim syntax highlighting
 
 Create a symlink to `tools/dl.vim` from the `~/.vim/syntax/` directory to enable differential
 datalog syntax highlighting in `.dl` files.

--- a/doc/tutorial/tutorial.md
+++ b/doc/tutorial/tutorial.md
@@ -36,7 +36,7 @@ program -> | compiler |-> code -> | compiler |--> executable
 
 ## Installing DDlog
 
-Installation instructions are found in the [README](../../README.md).
+Installation instructions are found in the [README](../../README.md#Installation).
 
 ## "Hello, World!" in DDlog
 
@@ -48,8 +48,6 @@ If you add a file called `playpen.dl`, in the `test/datalog_tests`
 directory, it will be executed automatically when you run the DDlog tests, by
 typing `stack test`.  You can execute just this file by typing `stack
 test --ta '-p playpen'`.
-
-**TODO: replace these instructions once issue #64 has been fixed**
 
 You should create the following `playpen.dl` file:
 


### PR DESCRIPTION
Issue #64 has been resolved but the Tutorial still mentions it in a TODO. I
don't see much need for adjustment as testing using the stack program is already
covered (which is what was added as part of said issue). However, I restructured
the README a bit and added a direct link to the installation section as a
reference on how to install ddlog.