### PR TITLE
Add javac as a prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ curl https://sh.rustup.rs -sSf | sh
 to `~/.profile`, so that it becomes effective at the next login attempt.  To configure your current
 shell run `source $HOME/.cargo/env`.
 
+If you intend to run the test suite or want to generate [Java bindings](doc/java_api.md), you will
+also need a Java installation containing `javac`.
+
 Finally, you will need static versions of the following libraries: `libpthread.a`, `libc.a`, `libm.a`, `librt.a`, `libutil.a`, `libdl.a`, `libgmp.a`, which can be installed from distro-specific packages.
 
 If you plan to use DDlog Java bindings, you will additionally need the Google


### PR DESCRIPTION
It seems that at least for running the tests (and following the tutorial, which
includes a test) `javac` is a requirement, but it is not listed anywhere as
such.
With this change we drop a note about that into the section about prerequisites.
I am not aware of any particular JDK being required, so I kept the text generic.