### PR TITLE
Run CI/CD pipeline with minimum Rust version we claim to support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,12 @@ osx_image: xcode9.3
 
 # Do not choose a language; we provide our own build tools.
 language: rust
+rust:
+  # Test with minimum Rust version we support (keep in sync with what is
+  # documented as supported in README.md!). Newer releases are (supposed to
+  # be) backwards compatible and so we do not test everything on them as well
+  # (to not artificially blow up CI/CD times).
+  - 1.34.0
 
 # Caching so the next build will be fast too.
 cache:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.com/vmware/differential-datalog.svg?branch=master)](https://travis-ci.com/vmware/differential-datalog)
+[![rustc](https://img.shields.io/badge/rustc-1.34+-blue.svg)](https://blog.rust-lang.org/2019/04/11/Rust-1.34.0.html)
 
 # Differential Datalog (DDlog)
 


### PR DESCRIPTION
Travis by default tests the project with the most recent stable version of
Rust. That is not optimal because at any point in time may we inadvertently
use a feature provided by a newer Rust version and, hence, break the contract
we guarantee by virtue of stating what versions we support.
To fix this problem, let's run our pipeline with the minimum Rust version we
claim to support, in order to identify issues. Newer versions of Rust are
supposed to be backwards compatible and tangentially developers are more
likely to use those when running the tests locally.
As a bonus, also add a badge for the minimum Rust version to the README.