### PR TITLE
run-souffle-tests.py: Return a list on all paths

### DIFF
--- a/test/run-souffle-tests.py
+++ b/test/run-souffle-tests.py
@@ -177,10 +177,10 @@ def run_remote_tests():
     for tg in testgroups:
         code, _ = run_command(["mkdir", "-p", tg])
         if code != 0:
-            return
+            return []
         code, dirs = run_command(["svn", "ls", url + tg])
         if code != 0:
-            return
+            return []
         for test in dirs.split("/\n"):
             directory = tg + "/" + test
             if not should_run(test):


### PR DESCRIPTION
run-souffle-tests.py returns an implicit None on two error (?) paths which
callers simply don't expect (see [job 582855296][job-582855296] for an
instance of this problem). While the intention of returning from those
paths is not 100% clear to me (wouldn't an exception be more
appropriate?), let's at least fix the mixed return type issue.

[job-582855296]: https://travis-ci.org/d-e-s-o/differential-datalog/jobs/582855296