### PR TITLE
Introduce facilities to communicate DDlog deltas

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,6 +88,7 @@ script:
       (cd rust/template/ && cargo fmt --all -- --check) &&
       (cd rust/template/cmd_parser/ && cargo fmt --all -- --check) &&
       (cd rust/template/differential_datalog/ && cargo fmt --all -- --check) &&
+      (cd rust/template/observe/ && cargo fmt --all -- --check) &&
       (cd rust/template/ovsdb/ && cargo fmt --all -- --check)
   fi
 - if [ -n "${CLIPPY}" ]; then
@@ -118,6 +119,7 @@ script:
       (cd rust/template/ && cargo clippy --all-targets -- ${CLIPPYFLAGS}) &&
       (cd rust/template/cmd_parser/ && cargo clippy --all-targets -- ${CLIPPYFLAGS}) &&
       (cd rust/template/differential_datalog/ && cargo clippy --all-targets -- ${CLIPPYFLAGS}) &&
+      (cd rust/template/observe/ && cargo clippy --all-targets -- ${CLIPPYFLAGS}) &&
       (cd rust/template/ovsdb/ && cargo clippy --all-targets -- ${CLIPPYFLAGS})
   fi
 - if [ x${TOOL} = xstack ]; then DDLOG_TEST_PROGRESS=1 stack --no-terminal test --ta "$TEST_SUITE"; fi

--- a/rust/template/Cargo.toml
+++ b/rust/template/Cargo.toml
@@ -16,12 +16,14 @@ path = "./cmd_parser"
 [dependencies.ddlog_ovsdb_adapter]
 path = "./ovsdb"
 
+[dependencies.observe]
+path = "./observe"
+
 [dependencies]
 differential-dataflow = "0.9"
 timely = "0.9"
 abomonation= "0.7"
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 fnv="1.0.2"
 libc="0.2"
 time="0.1"

--- a/rust/template/differential_datalog/Cargo.toml
+++ b/rust/template/differential_datalog/Cargo.toml
@@ -6,21 +6,21 @@ version = "0.1.0"
 git="https://github.com/frankmcsherry/graph-map.git"
 
 [dev-dependencies]
-getopts="0.2.14"
-rand="0.3.13"
 byteorder="0.4.2"
+getopts="0.2.14"
 itertools="^0.6"
+rand="0.3.13"
+serde_derive = "1.0"
 
 [dependencies]
-differential-dataflow = "0.9"
 abomonation = "0.7"
-timely = "0.9"
+differential-dataflow = "0.9"
 fnv="1.0.2"
-num = "0.2"
-serde = "1.0"
-serde_derive = "1.0"
 libc = "0.2"
+num = { version = "0.2", features = ["serde"] }
 sequence_trie = "0.3"
+serde = { version = "1.0", features = ["derive"] }
+timely = "0.9"
 
 [features]
 default = []

--- a/rust/template/differential_datalog/record.rs
+++ b/rust/template/differential_datalog/record.rs
@@ -14,6 +14,9 @@ use std::slice;
 use std::string::ToString;
 use std::vec;
 
+extern crate serde;
+use serde::{Deserialize, Serialize};
+
 pub type Name = Cow<'static, str>;
 
 /* Rust's implementation of `Debug::fmt` for `str` incorrectly escapes
@@ -45,7 +48,7 @@ pub fn format_ddlog_str(s: &str, f: &mut fmt::Formatter) -> fmt::Result {
 /// instance from some external representation, e.g., JSON, one needs to use `String`'s instead.  To
 /// accommodate both options, `Record` uses `Cow` to store names.
 ///
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub enum Record {
     Bool(bool),
     Int(BigInt),
@@ -115,7 +118,7 @@ impl fmt::Display for Record {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub enum CollectionKind {
     Unknown,
     Vector,

--- a/rust/template/observe/Cargo.toml
+++ b/rust/template/observe/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "observe"
+version = "0.1.0"
+authors = ["Remy Wang <remy.sucre@gmail.com>"]
+edition = "2018"
+
+[lib]
+name = "observe"
+path = "./lib.rs"

--- a/rust/template/observe/lib.rs
+++ b/rust/template/observe/lib.rs
@@ -1,0 +1,52 @@
+#[warn(missing_docs)]
+
+/// A trait for objects that can be observed.
+pub trait Observable<T, E>
+where
+    T: Send,
+    E: Send,
+{
+    /// An Observer subscribes to an Observable to listen to data
+    /// emitted by the latter. The Observer stops listening when
+    /// the Subscription returned is cancelled.
+    fn subscribe(&mut self, observer: Box<dyn Observer<T, E> + Send>) -> Box<dyn Subscription>;
+}
+
+/// A trait for objects that can observe an observable one.
+pub trait Observer<T, E>: Send
+where
+    T: Send,
+    E: Send,
+{
+    /// Action to perform before data starts coming in from the
+    /// Observable
+    fn on_start(&mut self) -> Result<(), E>;
+
+    /// Action to perform when a series of incoming data from the
+    /// Observable is committed
+    fn on_commit(&mut self) -> Result<(), E>;
+
+    /// Process an incoming item
+    fn on_next(&mut self, item: T) -> Result<(), E>;
+
+    /// Process a series of incoming items
+    fn on_updates<'a>(&mut self, updates: Box<dyn Iterator<Item = T> + 'a>) -> Result<(), E> {
+        for upd in updates {
+            self.on_next(upd)?;
+        }
+        Ok(())
+    }
+
+    /// Action to perform when the Observable finishes sending
+    /// data
+    fn on_completed(&mut self) -> Result<(), E>;
+
+    /// Action to perform when any error occurs
+    fn on_error(&self, error: E);
+}
+
+pub trait Subscription {
+    /// Cancel the subscription so the corresponding Observer
+    /// stops listening to the corresponding Observable
+    fn unsubscribe(self: Box<Self>);
+}

--- a/rust/template/src/build.rs
+++ b/rust/template/src/build.rs
@@ -19,6 +19,7 @@ fn main() {
     println!("cargo:rerun-if-changed=src/lib.rs");
     println!("cargo:rerun-if-changed=src/main.rs");
     println!("cargo:rerun-if-changed=src/ovsdb.rs");
+    println!("cargo:rerun-if-changed=src/server.rs");
     println!("cargo:rerun-if-changed=src/update_handler.rs");
     println!("cargo:rerun-if-changed=src/valmap.rs");
 

--- a/rust/template/src/lib.rs
+++ b/rust/template/src/lib.rs
@@ -13,15 +13,15 @@
 extern crate differential_dataflow;
 extern crate fnv;
 extern crate num_traits;
+extern crate observe;
 extern crate timely;
 
 #[macro_use]
 extern crate lazy_static;
 
 #[macro_use]
-extern crate serde_derive;
-extern crate libc;
 extern crate serde;
+extern crate libc;
 extern crate twox_hash;
 
 #[macro_use]
@@ -69,6 +69,7 @@ use std::sync;
 
 pub mod api;
 pub mod ovsdb;
+pub mod server;
 pub mod update_handler;
 pub mod valmap;
 

--- a/rust/template/src/server.rs
+++ b/rust/template/src/server.rs
@@ -1,0 +1,257 @@
+use differential_datalog::program::{RelId, Response, Update};
+use differential_datalog::record::{Record, RelIdentifier, UpdCmd};
+
+use api::*;
+use observe::*;
+
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+use std::fmt::{Debug, Formatter};
+use std::sync::{Arc, Mutex};
+
+pub struct UpdatesSubscription {
+    /// A pointer to the observer field in the outlet, and sets it to
+    /// `None` upon unsubscribing.
+    observer: Arc<Mutex<Option<Box<dyn Observer<Update<super::Value>, String>>>>>,
+}
+
+impl Subscription for UpdatesSubscription {
+    /// Cancel a subscription so that the observer stops listening to
+    /// the observable.
+    fn unsubscribe(self: Box<Self>) {
+        let mut observer = self.observer.lock().unwrap();
+        *observer = None;
+    }
+}
+
+pub struct UpdatesObservable {
+    observer: Arc<Mutex<Option<Box<dyn Observer<Update<super::Value>, String>>>>>,
+}
+
+impl Observable<Update<super::Value>, String> for UpdatesObservable {
+    /// An observer subscribes to the delta stream from an outlet.
+    fn subscribe(
+        &mut self,
+        observer: Box<dyn Observer<Update<super::Value>, String> + Send>,
+    ) -> Box<dyn Subscription> {
+        *self.observer.lock().unwrap() = Some(observer);
+        Box::new(UpdatesSubscription {
+            observer: self.observer.clone(),
+        })
+    }
+}
+
+/// A DDlog server wraps a DDlog progam, and writes deltas to the
+/// outlets. The redirect map redirects input deltas to local tables.
+pub struct DDlogServer {
+    prog: Option<HDDlog>,
+    outlets: Vec<Outlet>,
+    redirect: HashMap<super::Relations, super::Relations>,
+}
+
+impl DDlogServer {
+    /// Create a new server with no outlets.
+    pub fn new(prog: HDDlog, redirect: HashMap<super::Relations, super::Relations>) -> Self {
+        DDlogServer {
+            prog: Some(prog),
+            outlets: Vec::new(),
+            redirect,
+        }
+    }
+
+    /// Add a new outlet that streams a subset of the tables.
+    pub fn add_stream(&mut self, tables: HashSet<super::Relations>) -> UpdatesObservable {
+        let observer = Arc::new(Mutex::new(None));
+        let outlet = Outlet {
+            tables,
+            observer: observer.clone(),
+        };
+        self.outlets.push(outlet);
+        UpdatesObservable { observer }
+    }
+
+    /// Remove an outlet.
+    pub fn remove_stream(&mut self, stream: UpdatesObservable) {
+        self.outlets
+            .retain(|o| !Arc::ptr_eq(&o.observer, &stream.observer));
+    }
+
+    /// Shutdown the DDlog program and notify listeners of completion.
+    pub fn shutdown(&mut self) -> Response<()> {
+        if let Some(prog) = self.prog.take() {
+            prog.stop()?;
+        }
+        for outlet in &self.outlets {
+            let mut observer = outlet.observer.lock().unwrap();
+            if let Some(ref mut observer) = *observer {
+                observer.on_completed()?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// An outlet streams a subset of DDlog tables to an observer.
+pub struct Outlet {
+    tables: HashSet<super::Relations>,
+    observer: Arc<Mutex<Option<Box<dyn Observer<Update<super::Value>, String>>>>>,
+}
+
+/// Newtype for interior mutability of the observer.
+pub struct ADDlogServer(pub Arc<Mutex<DDlogServer>>);
+
+impl Observer<Update<super::Value>, String> for ADDlogServer {
+    fn on_start(&mut self) -> Response<()> {
+        let mut s = self.0.lock().unwrap();
+        s.on_start()
+    }
+
+    fn on_commit(&mut self) -> Response<()> {
+        self.0.lock().unwrap().on_commit()
+    }
+
+    fn on_next(&mut self, upd: Update<super::Value>) -> Response<()> {
+        self.0.lock().unwrap().on_next(upd)
+    }
+
+    fn on_updates<'a>(
+        &mut self,
+        updates: Box<dyn Iterator<Item = Update<super::Value>> + 'a>,
+    ) -> Response<()> {
+        self.0.lock().unwrap().on_updates(updates)
+    }
+
+    fn on_error(&self, error: String) {
+        self.0.lock().unwrap().on_error(error)
+    }
+
+    fn on_completed(&mut self) -> Response<()> {
+        self.0.lock().unwrap().on_completed()
+    }
+}
+
+impl Observer<Update<super::Value>, String> for DDlogServer {
+    /// Start a transaction when deltas start coming in.
+    fn on_start(&mut self) -> Response<()> {
+        if let Some(ref mut prog) = self.prog {
+            prog.transaction_start()?;
+
+            for outlet in &self.outlets {
+                let mut observer = outlet.observer.lock().unwrap();
+                if let Some(ref mut observer) = *observer {
+                    observer.on_start()?;
+                }
+            }
+            Ok(())
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Commit input deltas to local tables and pass on output deltas to
+    /// the listeners on the outlets.
+    fn on_commit(&mut self) -> Response<()> {
+        if let Some(ref mut prog) = self.prog {
+            let changes = prog.transaction_commit_dump_changes()?;
+            for outlet in &self.outlets {
+                let mut observer = outlet.observer.lock().unwrap();
+                if let Some(ref mut observer) = *observer {
+                    let mut upds = outlet
+                        .tables
+                        .iter()
+                        .flat_map(|table| {
+                            let table = *table as usize;
+                            changes.as_ref().get(&table).map(|t| {
+                                t.iter().map(move |(val, weight)| {
+                                    debug_assert!(*weight == 1 || *weight == -1);
+                                    if *weight == 1 {
+                                        Update::Insert {
+                                            relid: table,
+                                            v: val.clone(),
+                                        }
+                                    } else {
+                                        Update::DeleteValue {
+                                            relid: table,
+                                            v: val.clone(),
+                                        }
+                                    }
+                                })
+                            })
+                        })
+                        .flatten()
+                        .peekable();
+
+                    if upds.peek().is_some() {
+                        observer.on_updates(Box::new(upds))?;
+                        observer.on_commit()?;
+                    }
+                }
+            }
+            Ok(())
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Apply a single update.
+    fn on_next(&mut self, upd: Update<super::Value>) -> Response<()> {
+        let upd = vec![match upd {
+            Update::Insert { relid: relid, v: v } => {
+                let rel = super::relid2rel(relid).expect("Table not found");
+                Update::Insert {
+                    relid: *self.redirect.get(&rel).unwrap_or(&rel) as usize,
+                    v: v,
+                }
+            }
+            Update::DeleteValue { relid: relid, v: v } => {
+                let rel = super::relid2rel(relid).expect("Table not found");
+                Update::DeleteValue {
+                    relid: *self.redirect.get(&rel).unwrap_or(&rel) as usize,
+                    v: v,
+                }
+            }
+            update => panic!("Operation {:?} not allowed", update),
+        }];
+        if let Some(ref mut prog) = self.prog {
+            prog.apply_valupdates(upd.into_iter())
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Apply a series of updates.
+    fn on_updates<'a>(
+        &mut self,
+        updates: Box<dyn Iterator<Item = Update<super::Value>> + 'a>,
+    ) -> Response<()> {
+        if let Some(ref prog) = self.prog {
+            prog.apply_valupdates(updates.map(|upd| match upd {
+                Update::Insert { relid: relid, v: v } => {
+                    let rel = super::relid2rel(relid).expect("Table not found");
+                    Update::Insert {
+                        relid: *self.redirect.get(&rel).unwrap_or(&rel) as usize,
+                        v,
+                    }
+                }
+                Update::DeleteValue { relid: relid, v: v } => {
+                    let rel = super::relid2rel(relid).expect("Table not found");
+                    Update::DeleteValue {
+                        relid: *self.redirect.get(&rel).unwrap_or(&rel) as usize,
+                        v,
+                    }
+                }
+                update => panic!("Operation {:?} not allowed", update),
+            }))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn on_error(&self, error: String) {
+        println!("error: {:?}", error);
+    }
+
+    fn on_completed(&mut self) -> Response<()> {
+        Ok(())
+    }
+}

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -134,6 +134,7 @@ templateFiles specname =
         , (dir </> "src/ovsdb.rs"               , $(embedFile "rust/template/src/ovsdb.rs"))
         , (dir </> "src/valmap.rs"              , $(embedFile "rust/template/src/valmap.rs"))
         , (dir </> "src/update_handler.rs"      , $(embedFile "rust/template/src/update_handler.rs"))
+        , (dir </> "src/server.rs"              , $(embedFile "rust/template/src/server.rs"))
         , (dir </> "ddlog.h"                    , $(embedFile "rust/template/ddlog.h"))
         , (dir </> "ddlog_ovsdb_test.c"         , $(embedFile "rust/template/ddlog_ovsdb_test.c"))
         ]
@@ -157,6 +158,8 @@ rustLibFiles specname =
         , (dir </> "cmd_parser/Cargo.toml"              , $(embedFile "rust/template/cmd_parser/Cargo.toml"))
         , (dir </> "cmd_parser/lib.rs"                  , $(embedFile "rust/template/cmd_parser/lib.rs"))
         , (dir </> "cmd_parser/parse.rs"                , $(embedFile "rust/template/cmd_parser/parse.rs"))
+        , (dir </> "observe/Cargo.toml"                 , $(embedFile "rust/template/observe/Cargo.toml"))
+        , (dir </> "observe/lib.rs"                     , $(embedFile "rust/template/observe/lib.rs"))
         , (dir </> "ovsdb/Cargo.toml"                   , $(embedFile "rust/template/ovsdb/Cargo.toml"))
         , (dir </> "ovsdb/lib.rs"                       , $(embedFile "rust/template/ovsdb/lib.rs"))
         , (dir </> "ovsdb/test.rs"                      , $(embedFile "rust/template/ovsdb/test.rs"))

--- a/test/datalog_tests/ddd.ast.expected
+++ b/test/datalog_tests/ddd.ast.expected
@@ -1,0 +1,107 @@
+typedef log.log_level_t = signed<32>
+typedef log.module_t = signed<32>
+typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
+extern type std.Group<'A>
+extern type std.Map<'K,'V>
+typedef std.Option<'A> = std.Some{x: 'A} | std.None{}
+#[size = 8]
+extern type std.Ref<'A>
+extern type std.Set<'A>
+extern type std.Vec<'A>
+extern function log.log (module: log.module_t, level: log.log_level_t, msg: string): bool
+extern function std.__builtin_2string (x: 'X): string
+extern function std.deref (x: std.Ref<'A>): 'A
+extern function std.group2map (g: std.Group<('K, 'V)>): std.Map<'K,'V>
+extern function std.group2set (g: std.Group<'A>): std.Set<'A>
+extern function std.group2vec (g: std.Group<'A>): std.Vec<'A>
+extern function std.group_count (g: std.Group<'A>): bit<64>
+extern function std.group_first (g: std.Group<'A>): 'A
+extern function std.group_max (g: std.Group<'A>): 'A
+extern function std.group_min (g: std.Group<'A>): 'A
+extern function std.group_nth (g: std.Group<'A>, n: bit<64>): std.Option<'A>
+extern function std.group_set_unions (g: std.Group<std.Set<'A>>): std.Set<'A>
+extern function std.group_setref_unions (g: std.Group<std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
+extern function std.group_sum (g: std.Group<'A>): 'A
+function std.group_unzip (g: std.Group<('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
+    ((var xs: std.Vec<'X>) = std.vec_empty();
+     ((var ys: std.Vec<'Y>) = std.vec_empty();
+      (for (v in g) {
+           ((var x, var y) = v;
+            (std.vec_push(xs, x);
+             std.vec_push(ys, y)))
+       };
+       (xs, ys))))
+extern function std.hash128 (x: 'X): bit<128>
+extern function std.hash64 (x: 'X): bit<64>
+extern function std.hex (x: 'X): string
+extern function std.htonl (x: bit<32>): bit<32>
+extern function std.htons (x: bit<16>): bit<16>
+function std.is_none (x: std.Option<'A>): bool =
+    match (x) {
+        std.None{} -> true,
+        _ -> false
+    }
+function std.is_some (x: std.Option<'A>): bool =
+    match (x) {
+        std.Some{.x=_} -> true,
+        _ -> false
+    }
+extern function std.map_contains_key (m: std.Map<'K,'V>, k: 'K): bool
+extern function std.map_empty (): std.Map<'K,'V>
+extern function std.map_get (m: std.Map<'K,'V>, k: 'K): std.Option<'V>
+extern function std.map_insert (m: mut std.Map<'K,'V>, k: 'K, v: 'V): ()
+extern function std.map_insert_imm (m: std.Map<'K,'V>, k: 'K, v: 'V): std.Map<'K,'V>
+extern function std.map_is_empty (m: std.Map<'K,'V>): bool
+extern function std.map_remove (m: mut std.Map<'K,'V>, k: 'K): ()
+extern function std.map_singleton (k: 'K, v: 'V): std.Map<'K,'V>
+extern function std.map_union (m1: std.Map<'K,'V>, m2: std.Map<'K,'V>): std.Map<'K,'V>
+extern function std.max (x: 'A, y: 'A): 'A
+extern function std.min (x: 'A, y: 'A): 'A
+extern function std.ntohl (x: bit<32>): bit<32>
+extern function std.ntohs (x: bit<16>): bit<16>
+extern function std.parse_dec_i64 (s: string): std.Option<signed<64>>
+extern function std.parse_dec_u64 (s: string): std.Option<bit<64>>
+extern function std.pow32 (base: 'A, exp: bit<32>): 'A
+extern function std.range (from: 'A, to: 'A, step: 'A): std.Vec<'A>
+extern function std.ref_new (x: 'A): std.Ref<'A>
+extern function std.set2vec (s: std.Set<'A>): std.Vec<'A>
+extern function std.set_contains (s: std.Set<'X>, v: 'X): bool
+extern function std.set_empty (): std.Set<'X>
+extern function std.set_insert (s: mut std.Set<'X>, v: 'X): ()
+extern function std.set_insert_imm (s: std.Set<'X>, v: 'X): std.Set<'X>
+extern function std.set_is_empty (s: std.Set<'X>): bool
+extern function std.set_nth (s: std.Set<'X>, n: bit<64>): std.Option<'X>
+extern function std.set_singleton (x: 'X): std.Set<'X>
+extern function std.set_size (s: std.Set<'X>): bit<64>
+extern function std.set_union (s1: std.Set<'X>, s2: std.Set<'X>): std.Set<'X>
+extern function std.set_unions (sets: std.Vec<std.Set<'X>>): std.Set<'X>
+extern function std.str_to_lower (s: string): string
+extern function std.string_contains (s1: string, s2: string): bool
+extern function std.string_join (strings: std.Vec<string>, sep: string): string
+extern function std.string_len (s: string): bit<64>
+extern function std.string_split (s: string, sep: string): std.Vec<string>
+extern function std.string_substr (s: string, start: bit<64>, end: bit<64>): string
+extern function std.vec2set (s: std.Vec<'A>): std.Set<'A>
+extern function std.vec_contains (v: std.Vec<'X>, x: 'X): bool
+extern function std.vec_empty (): std.Vec<'A>
+extern function std.vec_is_empty (v: std.Vec<'X>): bool
+extern function std.vec_len (v: std.Vec<'X>): bit<64>
+extern function std.vec_nth (v: std.Vec<'X>, n: bit<64>): std.Option<'X>
+extern function std.vec_push (v: mut std.Vec<'X>, x: 'X): ()
+extern function std.vec_push_imm (v: std.Vec<'X>, x: 'X): std.Vec<'X>
+extern function std.vec_singleton (x: 'X): std.Vec<'X>
+input relation lr.down.Left [bool]
+output relation lr.down.Right [bool]
+output relation lr.left.Down [bool]
+input relation lr.left.Left [bool]
+output relation lr.left.Up [bool]
+input relation lr.right.Down [bool]
+output relation lr.right.Right [bool]
+input relation lr.right.Up [bool]
+input relation lr.up.Left [bool]
+output relation lr.up.Right [bool]
+lr.left.Up[b] :- lr.left.Left[b].
+lr.left.Down[b] :- lr.left.Left[b].
+lr.right.Right[b] :- lr.right.Up[b], lr.right.Down[b].
+lr.up.Right[b] :- lr.up.Left[b].
+lr.down.Right[b] :- lr.down.Left[b].

--- a/test/datalog_tests/ddd.dl
+++ b/test/datalog_tests/ddd.dl
@@ -1,0 +1,21 @@
+// A simple test for multiple DDlog programs communicating
+// with each other. Each program is in a file under ../lr/
+
+import lr.left as l
+import lr.right as r
+import lr.up as u
+import lr.down as d
+
+// The tables are connected as follows, where the output
+// of the RHS table is the input of the LHS table
+
+// r.Up   :- u.Right
+// r.Down :- d.Right
+// u.Left :- l.Up
+// d.Left :- l.Down
+
+//     u
+//     |
+// l -< >- r
+//     |
+//     d

--- a/test/datalog_tests/lr/down.dl
+++ b/test/datalog_tests/lr/down.dl
@@ -1,0 +1,5 @@
+// Simple test for distributed DDlog. See ../ddd.dl
+input relation Left[bool]
+output relation Right[bool]
+
+Right[b] :- Left[b].

--- a/test/datalog_tests/lr/left.dl
+++ b/test/datalog_tests/lr/left.dl
@@ -1,0 +1,7 @@
+// Simple test for distributed DDlog. See ../ddd.dl
+input relation Left[bool]
+output relation Up[bool]
+output relation Down[bool]
+
+Up[b] :- Left[b].
+Down[b] :- Left[b].

--- a/test/datalog_tests/lr/right.dl
+++ b/test/datalog_tests/lr/right.dl
@@ -1,0 +1,6 @@
+// Simple test for distributed DDlog. See ../ddd.dl
+input relation Up[bool]
+input relation Down[bool]
+output relation Right[bool]
+
+Right[b] :- Up[b], Down[b].

--- a/test/datalog_tests/lr/up.dl
+++ b/test/datalog_tests/lr/up.dl
@@ -1,0 +1,5 @@
+// Simple test for distributed DDlog. See ../ddd.dl
+input relation Left[bool]
+output relation Right[bool]
+
+Right[b] :- Left[b].

--- a/test/datalog_tests/server_api/Cargo.toml
+++ b/test/datalog_tests/server_api/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "server_api"
+version = "0.1.0"
+authors = ["Remy Wang <remy.sucre@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+ddd = {path = "../ddd_ddlog"}
+differential_datalog = {path = "../ddd_ddlog/differential_datalog"}
+observe = {path = "../ddd_ddlog/observe"}

--- a/test/datalog_tests/server_api/src/main.rs
+++ b/test/datalog_tests/server_api/src/main.rs
@@ -1,0 +1,62 @@
+use differential_datalog::record::{Record, UpdCmd, RelIdentifier};
+use observe::{Observer, Observable};
+
+use ddd_ddlog::api::*;
+use ddd_ddlog::Relations::*;
+use ddd_ddlog::server;
+
+use std::collections::{HashSet, HashMap};
+use std::sync::{Arc, Mutex};
+
+fn main() -> Result<(), String> {
+    // Construct left server with no redirect
+    let prog1 = HDDlog::run(1, false, |_,_:&Record, _| {});
+    let mut s1 = server::DDlogServer::new(prog1, HashMap::new());
+
+    // Construct right server, redirect Up table
+    let prog2 = HDDlog::run(1, false, |_,_:&Record, _| {});
+    let mut redirect2 = HashMap::new();
+    redirect2.insert(lr_left_Up, lr_right_Up);
+    let s2 = server::DDlogServer::new(prog2, redirect2);
+
+    // Stream Up table from left server
+    let mut tables = HashSet::new();
+    tables.insert(lr_left_Up);
+    let mut stream = s1.add_stream(tables);
+
+    // Right server subscribes to the stream
+    let s2 = Arc::new(Mutex::new(s2));
+    let sub = {
+        let s2_a = server::ADDlogServer(s2.clone());
+        stream.subscribe(Box::new(s2_a))
+    };
+
+    // Insert `true` to Left in left server
+    let rec = Record::Bool(true);
+    let table_id = RelIdentifier::RelId(lr_left_Left as usize);
+    let updates = &[UpdCmd::Insert(table_id, rec)];
+
+    // Execute and transmit the update
+    s1.on_start()?;
+    s1.on_updates(Box::new(updates.into_iter().map(|cmd| updcmd2upd(cmd).unwrap())))?;
+    s1.on_commit()?;
+    s1.on_completed()?;
+
+    // Test `unsubscribe`
+    sub.unsubscribe();
+
+    let rec2 = Record::Bool(true);
+    let table_id2 = RelIdentifier::RelId(lr_left_Left as usize);
+    let updates2 = &[UpdCmd::Delete(table_id2, rec2)];
+
+    s1.on_start()?;
+    s1.on_updates(Box::new(updates2.into_iter().map(|cmd| updcmd2upd(cmd).unwrap())))?;
+    s1.on_commit()?;
+    s1.on_completed()?;
+
+    // Shutdown and clean up resources
+    s1.remove_stream(stream);
+    s1.shutdown()?;
+    s2.lock().unwrap().shutdown()?;
+    Ok(())
+}


### PR DESCRIPTION
This pull request is a slightly revamped version of what Remy had sent out earlier as https://github.com/vmware/differential-datalog/pull/333.

I can't update the original pull request because I can't push to his repository. I've mostly addressed the comments I made and fixed a compilation issue with one of the tests.

---

The observer/observable API models a channel that communicates data
streams. For DDlog, we implement a server that is both an observable
(emits) and an observer (consumes) of a stream of updates.

- An observer/observable API, under `rust/template/observe`
- A DDlog server implementing the API, under `rust/template/src/server.rs`
- A test for the server under `tests/datalog_tests/server_api`
- A DDlog program to support the test, under `tests/datalog_tests/ddd.dl`