### PR TITLE
Manage Rust template in a cargo workspace

### DIFF
--- a/rust/template/Cargo.toml
+++ b/rust/template/Cargo.toml
@@ -4,6 +4,14 @@ version = "0.1.0"
 autobins = false
 build = "src/build.rs"
 
+[workspace]
+members = [
+  "cmd_parser",
+  "differential_datalog",
+  "observe",
+  "ovsdb",
+]
+
 [build-dependencies]
 libtool = "0.1"
 

--- a/rust/template/cmd_parser/Cargo.toml
+++ b/rust/template/cmd_parser/Cargo.toml
@@ -11,13 +11,6 @@ num = "0.2"
 rustyline = "1.0.0"
 libc = "0.2.42"
 
-[profile.release]
-opt-level = 2
-debug = false
-rpath = false
-lto = false
-debug-assertions = false
-
 [lib]
 name = "cmd_parser"
 path = "./lib.rs"

--- a/rust/template/differential_datalog/Cargo.toml
+++ b/rust/template/differential_datalog/Cargo.toml
@@ -25,13 +25,6 @@ timely = "0.9"
 [features]
 default = []
 
-[profile.release]
-opt-level = 2
-debug = false
-rpath = false
-lto = false
-debug-assertions = false
-
 [lib]
 name = "differential_datalog"
 path = "./lib.rs"


### PR DESCRIPTION
Manage Rust template in a cargo workspace

[Cargo workspaces][cargo-ws] are a relatively new addition to Cargo's
functionality which allow related projects to share build artifacts.
That is, dependencies used by multiple crates in the workspace will be
compiled only once.
For us that can provide benefits because the individual crates actually
share a good amount of dependencies, which would otherwise be compiled
repeatedly. What's more, it also simplifies working with those crates as
cargo test, for example, will now recognize the individual sub-crates
and test everything with a single command (which will simplify the
Travis configuration).
On the downside, it means that profile settings (such as optimizations
or emitting of debug symbols) are now the same for all crates in the
workspace. Concretely, it means that all crates in the template will now
use `opt-level = 2`, `debug = false`, `lto = false` etc.
With this change we put the template into such a workspace. The
difference in compile times is as follows:

- cargo build in all Rust crates in template/:
  - with workspace:
    real time:       1m40.852s
    crates compiled: 84
  - without workspace:
    real time:       3m17.451s
    crates compiled: 196

That is we roughly half the duration for the task of compiling all cates
below template/. When including tests -- which is exactly what our CI
will do once we hook up unit tests -- we see a similar decrease in
overall time.

[cargo-ws]: https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html
