### PR TITLE
Topic/various

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,30 +88,7 @@ script:
       (cd rust/template/ && cargo fmt --all -- --check)
   fi
 - if [ -n "${CLIPPY}" -a "${TRAVIS_OS_NAME}" = "linux" ]; then
-      CLIPPYFLAGS="
-          -A clippy::char_lit_as_u8
-          -A clippy::many_single_char_names
-          -A clippy::enum_variant_names
-          -A clippy::expect_fun_call
-          -A clippy::extra_unused_lifetimes
-          -A clippy::for_kv_map
-          -A clippy::get_unwrap
-          -A clippy::into_iter_on_ref
-          -A clippy::just_underscores_and_digits
-          -A clippy::let_and_return
-          -A clippy::map_clone
-          -A clippy::needless_return
-          -A clippy::new_without_default
-          -A clippy::ptr_arg
-          -A clippy::ptr_offset_with_cast
-          -A clippy::redundant_closure
-          -A clippy::should_implement_trait
-          -A clippy::trivially_copy_pass_by_ref
-          -A clippy::type_complexity
-          -A clippy::unreadable_literal
-          -D warnings"
-
-      (cd rust/template/ && cargo clippy --all -- ${CLIPPYFLAGS})
+      (cd rust/template/ && cargo clippy --all -- -D warnings)
   fi
 - if [ -n "${CARGO_TEST}" -a "${TRAVIS_OS_NAME}" = "linux" ]; then
       (cd rust/template/ && cargo test --all)

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,11 +85,7 @@ script:
 #- DDLOG_TEST_PROGRESS=1 stack --no-terminal test --haddock --no-haddock-deps
 #- DDLOG_TEST_PROGRESS=1 stack --no-terminal test --ta "$TEST_SUITE"  --haddock --no-haddock-deps
 - if [ -n "${RUSTFMT}" -a "${TRAVIS_OS_NAME}" = "linux" ]; then
-      (cd rust/template/ && cargo fmt --all -- --check) &&
-      (cd rust/template/cmd_parser/ && cargo fmt --all -- --check) &&
-      (cd rust/template/differential_datalog/ && cargo fmt --all -- --check) &&
-      (cd rust/template/observe/ && cargo fmt --all -- --check) &&
-      (cd rust/template/ovsdb/ && cargo fmt --all -- --check)
+      (cd rust/template/ && cargo fmt --all -- --check)
   fi
 - if [ -n "${CLIPPY}" -a "${TRAVIS_OS_NAME}" = "linux" ]; then
       CLIPPYFLAGS="
@@ -116,11 +112,7 @@ script:
           -A clippy::unreadable_literal
           -D warnings"
 
-      (cd rust/template/ && cargo clippy -- ${CLIPPYFLAGS}) &&
-      (cd rust/template/cmd_parser/ && cargo clippy -- ${CLIPPYFLAGS}) &&
-      (cd rust/template/differential_datalog/ && cargo clippy -- ${CLIPPYFLAGS}) &&
-      (cd rust/template/observe/ && cargo clippy -- ${CLIPPYFLAGS}) &&
-      (cd rust/template/ovsdb/ && cargo clippy -- ${CLIPPYFLAGS})
+      (cd rust/template/ && cargo clippy --all -- ${CLIPPYFLAGS})
   fi
 - if [ x${TOOL} = xstack ]; then DDLOG_TEST_PROGRESS=1 stack --no-terminal test --ta "$TEST_SUITE"; fi
 - if [ x${TOOL} = xrun_souffle_tests ]; then cd test && travis_wait 30 ./run-souffle-tests.py  ackermann andersen bigrams cba_expr_value centroids clique cliquer comp-parametrized-inherit comp-parametrized-multilvl degree dfa dfa_min disconnected dominance double_tree earley equal factoring family fib; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,7 +107,6 @@ script:
           -A clippy::redundant_closure
           -A clippy::should_implement_trait
           -A clippy::trivially_copy_pass_by_ref
-          -A clippy::single_match
           -A clippy::type_complexity
           -A clippy::unreadable_literal
           -D warnings"

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ env:
    - TOOL=stack TEST_SUITE='-p tutorial' BUILD_BINARY=1
      # We piggy back on what has historically been one of the shorter
      # runs to also check formatting of the Rust code.
-   - TOOL=run_souffle_tests RUSTFMT=1 CLIPPY=1
+   - TOOL=run_souffle_tests RUSTFMT=1 CLIPPY=1 CARGO_TEST=1
    - TOOL=stack TEST_SUITE='-p redist' JAVA=1
    - TOOL=stack TEST_SUITE='-p span_uuid'
    - TOOL=stack TEST_SUITE='-p souffle0'
@@ -113,6 +113,9 @@ script:
           -D warnings"
 
       (cd rust/template/ && cargo clippy --all -- ${CLIPPYFLAGS})
+  fi
+- if [ -n "${CARGO_TEST}" -a "${TRAVIS_OS_NAME}" = "linux" ]; then
+      (cd rust/template/ && cargo test --all)
   fi
 - if [ x${TOOL} = xstack ]; then DDLOG_TEST_PROGRESS=1 stack --no-terminal test --ta "$TEST_SUITE"; fi
 - if [ x${TOOL} = xrun_souffle_tests ]; then cd test && travis_wait 30 ./run-souffle-tests.py  ackermann andersen bigrams cba_expr_value centroids clique cliquer comp-parametrized-inherit comp-parametrized-multilvl degree dfa dfa_min disconnected dominance double_tree earley equal factoring family fib; fi

--- a/rust/template/cmd_parser/lib.rs
+++ b/rust/template/cmd_parser/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::char_lit_as_u8)]
+
 extern crate libc;
 extern crate nom;
 extern crate num;

--- a/rust/template/cmd_parser/lib.rs
+++ b/rust/template/cmd_parser/lib.rs
@@ -107,9 +107,8 @@ where
                     //return -1;
                 }
             };
-            match rest {
-                Some(rest) => buf = rest,
-                _ => {}
+            if let Some(rest) = rest {
+                buf = rest
             };
             if !more {
                 break;

--- a/rust/template/differential_datalog/lib.rs
+++ b/rust/template/differential_datalog/lib.rs
@@ -1,3 +1,17 @@
+#![allow(
+    clippy::expect_fun_call,
+    clippy::for_kv_map,
+    clippy::get_unwrap,
+    clippy::into_iter_on_ref,
+    clippy::let_and_return,
+    clippy::needless_return,
+    clippy::new_without_default,
+    clippy::ptr_arg,
+    clippy::ptr_offset_with_cast,
+    clippy::should_implement_trait,
+    clippy::type_complexity
+)]
+
 #[macro_use]
 extern crate abomonation;
 extern crate num;

--- a/rust/template/differential_datalog/record.rs
+++ b/rust/template/differential_datalog/record.rs
@@ -385,9 +385,8 @@ pub unsafe extern "C" fn ddlog_pair(v1: *mut Record, v2: *mut Record) -> *mut Re
 pub unsafe extern "C" fn ddlog_tuple_push(tup: *mut Record, rec: *mut Record) {
     let rec = Box::from_raw(rec);
     let mut tup = Box::from_raw(tup);
-    match tup.as_mut() {
-        Record::Tuple(recs) => recs.push(*rec),
-        _ => {}
+    if let Record::Tuple(recs) = tup.as_mut() {
+        recs.push(*rec)
     };
     Box::into_raw(tup);
 }
@@ -435,9 +434,8 @@ pub unsafe extern "C" fn ddlog_get_vector_elem(
 pub unsafe extern "C" fn ddlog_vector_push(vec: *mut Record, rec: *mut Record) {
     let rec = Box::from_raw(rec);
     let mut vec = Box::from_raw(vec);
-    match vec.as_mut() {
-        Record::Array(CollectionKind::Vector, recs) => recs.push(*rec),
-        _ => {}
+    if let Record::Array(CollectionKind::Vector, recs) = vec.as_mut() {
+        recs.push(*rec)
     };
     Box::into_raw(vec);
 }
@@ -482,9 +480,8 @@ pub unsafe extern "C" fn ddlog_get_set_elem(
 pub unsafe extern "C" fn ddlog_set_push(set: *mut Record, rec: *mut Record) {
     let rec = Box::from_raw(rec);
     let mut set = Box::from_raw(set);
-    match set.as_mut() {
-        Record::Array(CollectionKind::Set, recs) => recs.push(*rec),
-        _ => {}
+    if let Record::Array(CollectionKind::Map, recs) = set.as_mut() {
+        recs.push(*rec)
     };
     Box::into_raw(set);
 }
@@ -545,9 +542,8 @@ pub unsafe extern "C" fn ddlog_map_push(map: *mut Record, key: *mut Record, val:
     let val = Box::from_raw(val);
     let tup = Record::Tuple(vec![*key, *val]);
     let mut map = Box::from_raw(map);
-    match map.as_mut() {
-        Record::Array(CollectionKind::Map, recs) => recs.push(tup),
-        _ => {}
+    if let Record::Array(CollectionKind::Map, recs) = map.as_mut() {
+        recs.push(tup)
     };
     Box::into_raw(map);
 }

--- a/rust/template/ovsdb/lib.rs
+++ b/rust/template/ovsdb/lib.rs
@@ -1,5 +1,6 @@
 //! Parse OVSDB database update messages and convert them into DDlog table update commands
 
+#![allow(clippy::map_clone)]
 extern crate differential_datalog;
 extern crate num;
 extern crate serde_json;

--- a/rust/template/ovsdb/lib.rs
+++ b/rust/template/ovsdb/lib.rs
@@ -95,30 +95,24 @@ fn cmd_from_row_update(
     match update {
         Value::Object(mut m) => {
             /* Handle update-2 format */
-            match m.remove("insert").or_else(|| m.remove("initial")) {
-                Some(v) => {
-                    let mut insert = row_from_obj(v)?;
-                    insert.push((Cow::from("_uuid"), uuid));
-                    cmds.push(UpdCmd::Insert(
-                        RelIdentifier::RelName(Cow::from(table.to_owned())),
-                        Record::NamedStruct(Cow::from(table.to_owned()), insert),
-                    ));
-                    return Ok(());
-                }
-                None => (),
+            if let Some(v) = m.remove("insert").or_else(|| m.remove("initial")) {
+                let mut insert = row_from_obj(v)?;
+                insert.push((Cow::from("_uuid"), uuid));
+                cmds.push(UpdCmd::Insert(
+                    RelIdentifier::RelName(Cow::from(table.to_owned())),
+                    Record::NamedStruct(Cow::from(table.to_owned()), insert),
+                ));
+                return Ok(());
             };
 
-            match m.remove("modify") {
-                Some(v) => {
-                    let insert = row_from_obj(v)?;
-                    cmds.push(UpdCmd::Modify(
-                        RelIdentifier::RelName(Cow::from(table.to_owned())),
-                        uuid,
-                        Record::NamedStruct(Cow::from(table.to_owned()), insert),
-                    ));
-                    return Ok(());
-                }
-                None => (),
+            if let Some(v) = m.remove("modify") {
+                let insert = row_from_obj(v)?;
+                cmds.push(UpdCmd::Modify(
+                    RelIdentifier::RelName(Cow::from(table.to_owned())),
+                    uuid,
+                    Record::NamedStruct(Cow::from(table.to_owned()), insert),
+                ));
+                return Ok(());
             };
 
             if m.contains_key("delete") {

--- a/rust/template/src/lib.rs
+++ b/rust/template/src/lib.rs
@@ -7,7 +7,11 @@
     non_shorthand_field_patterns,
     dead_code,
     overflowing_literals,
-    clippy::ptr_arg
+    clippy::extra_unused_lifetimes,
+    clippy::ptr_arg,
+    clippy::ptr_offset_with_cast,
+    clippy::redundant_closure,
+    clippy::type_complexity
 )]
 
 extern crate differential_dataflow;

--- a/rust/template/src/main.rs
+++ b/rust/template/src/main.rs
@@ -2,7 +2,7 @@
 //! CLI), parsing them with cmd_parser crate, executing commands, and tracking database state in a
 //! map.
 
-#![allow(non_snake_case, dead_code)]
+#![allow(dead_code, non_snake_case, clippy::redundant_closure)]
 
 //#![feature(alloc_system)]
 //extern crate alloc_system;


### PR DESCRIPTION
With this pull request we start running Rust unit tests in Travis. First and foremost, this will prevent them breaking over time by being rarely exercised. Along with that I simplified the `clippy` & `rustfmt` logic in `.travis.yml` and fixed up one more lint `clippy` complained about.

---

It's probably best to make sense of the changes by looking at the individual commits as opposed to reviewing this pull request as a whole. I just clubbed things together to generate less work for the CI.