### PR TITLE
Topic/interactive

### DIFF
--- a/rust/template/cmd_parser/lib.rs
+++ b/rust/template/cmd_parser/lib.rs
@@ -32,17 +32,13 @@ where
 {
     let mut buf: Vec<u8> = Vec::new();
 
-    let mut input = if unsafe { libc::isatty(libc::STDIN_FILENO as i32) } != 0 {
+    let istty = unsafe { libc::isatty(libc::STDIN_FILENO as i32) } != 0;
+    let mut input = if istty {
         let mut rl = Editor::<()>::new();
         let _ = rl.load_history(HISTORY_FILE);
         Input::TTY(rl)
     } else {
         Input::Pipe(BufReader::new(io::stdin()))
-    };
-
-    let istty = match &input {
-        Input::TTY(_) => true,
-        _ => false,
     };
 
     loop {
@@ -128,10 +124,7 @@ where
 
 fn err_str<E>(e: &Err<&[u8], E>) -> String {
     match e {
-        Err::Error(Context::Code(s, _)) => {
-            String::from_utf8(s.to_vec()).unwrap_or_else(|_| "not a UTF8 string".to_string())
-        }
-        Err::Failure(Context::Code(s, _)) => {
+        Err::Error(Context::Code(s, _)) | Err::Failure(Context::Code(s, _)) => {
             String::from_utf8(s.to_vec()).unwrap_or_else(|_| "not a UTF8 string".to_string())
         }
         _ => "".to_string(),

--- a/rust/template/cmd_parser/lib.rs
+++ b/rust/template/cmd_parser/lib.rs
@@ -133,18 +133,3 @@ fn err_str<E>(e: &Err<&[u8], E>) -> String {
         _ => "".to_string(),
     }
 }
-
-// uncomment to test command line interaction
-
-/*
-#[cfg(test)]
-fn echo_cb(cmd: Command) {
-    eprintln!("Command: {:?}", cmd)
-}
-
-#[test]
-fn test_interactive() {
-    let res = interact(echo_cb);
-    assert_eq!(res, 0);
-}
-*/

--- a/rust/template/tests/common/mod.rs
+++ b/rust/template/tests/common/mod.rs
@@ -1,0 +1,38 @@
+extern crate cmd_parser;
+
+use std::env::current_exe;
+use std::env::var_os;
+use std::io::Write;
+use std::process::exit;
+use std::process::Command as Process;
+use std::process::Stdio;
+
+use cmd_parser::interact;
+use cmd_parser::Command;
+
+const CHILD_MARKER: &str = "CHILD";
+
+/// Run a test of the `interact` function. The function reads from the
+/// processes stdin and so we spin up a dedicated process for it (and
+/// require the caller to effectively be a dedicated integration test).
+pub fn run_interact_test<F>(input: &[u8], callback: F) -> i32
+where
+    F: Fn(Command, bool) -> (i32, bool),
+{
+    if var_os(CHILD_MARKER).is_none() {
+        let mut child = Process::new(current_exe().unwrap())
+            .arg("--nocapture")
+            .env_clear()
+            .env(CHILD_MARKER, "true")
+            .stdin(Stdio::piped())
+            .spawn()
+            .unwrap();
+
+        child.stdin.as_mut().unwrap().write_all(input).unwrap();
+
+        let status = child.wait().unwrap();
+        status.code().unwrap()
+    } else {
+        exit(interact(callback))
+    }
+}

--- a/rust/template/tests/interact_dump_error.rs
+++ b/rust/template/tests/interact_dump_error.rs
@@ -1,0 +1,28 @@
+// Note that this file should only contain a single test. The test in
+// here invokes itself and having multiple test running in parallel
+// while that is happening is probably a bad idea.
+
+extern crate cmd_parser;
+
+use cmd_parser::Command;
+
+mod common;
+
+fn handler(command: Command, interactive: bool) -> (i32, bool) {
+    match command {
+        // We return `true` ("continue") on this path and verify that we
+        // actually hit the exit command (i.e., we don't exit when
+        // returning an error.
+        Command::Dump(_) => (-1, true),
+        Command::Exit => (42, false),
+        _ => (0, interactive),
+    }
+}
+
+#[test]
+fn interact_dump_error() {
+    let input = b"\
+dump NonExistantRelation;
+exit;";
+    assert_eq!(common::run_interact_test(input, handler), 42)
+}

--- a/rust/template/tests/interact_exit.rs
+++ b/rust/template/tests/interact_exit.rs
@@ -1,0 +1,21 @@
+// Note that this file should only contain a single test. The test in
+// here invokes itself and having multiple test running in parallel
+// while that is happening is probably a bad idea.
+
+extern crate cmd_parser;
+
+use cmd_parser::Command;
+
+mod common;
+
+fn handler(command: Command, interactive: bool) -> (i32, bool) {
+    match command {
+        Command::Exit => (42, false),
+        _ => (0, interactive),
+    }
+}
+
+#[test]
+fn interact_exit() {
+    assert_eq!(common::run_interact_test(br#"exit;"#, handler), 42)
+}


### PR DESCRIPTION
When using the CLI that is provided with each generated ddlog program,
some errors are effectively ignored (in the sense that they don't
terminate the program; arguably sensible behavior), while others cause
program exit. E.g.,
```
  >> list;
  Invalid input: list;,
  >> hello;
  Invalid input: hello;,
```
  (we can just continue)

But:
```
  >> dump Left;
  Error: Unknown output relation Left
  $
```
  (we exit on this path)

The latter behavior can be very frustrating, as it can mean that an
interactive session into which data was fed manually can accidentally be
terminated just by virtue of misspelling a relation, for example.

This pull request addresses the problem.