### PR TITLE
cmd_parser: Fix parsing of comments in CLI

### DIFF
--- a/rust/template/cmd_parser/lib.rs
+++ b/rust/template/cmd_parser/lib.rs
@@ -50,9 +50,12 @@ where
             Input::TTY(rl) => {
                 let readline = rl.readline(">> ");
                 match readline {
-                    Ok(line) => {
+                    Ok(mut line) => {
                         rl.add_history_entry(line.as_ref());
                         //println!("Line: {}", line);
+                        // If `line` happens to be a comment, it must contain an `\n`, so that the
+                        // parser can recognize its end.
+                        line.push('\n');
                         line
                     }
                     Err(ReadlineError::Interrupted) => {


### PR DESCRIPTION
Fixes #358 

When running from a TTY, we use the `rustyline` crate for interactive
input, which returns strings without the trailing new-line character.
This is ok for all commands, which have explicit delimiters (`,` or
`;`), but not #-comments, which check for the new-line character to
locate the end of the comment.

The fix is to append `\n` to lines returned by `rustyline`.