### PR TITLE
Consume githash in version 0.1.3.3

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -35,7 +35,7 @@ dependencies:
 - wide-word
 - graphviz
 - text
-- githash
+- githash >= 0.1.3.3
 - process
 - casing
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -41,6 +41,11 @@ packages:
 # (e.g., acme-missiles-0.3)
 # extra-deps: []
 
+extra-deps:
+# We need githash 0.1.3.3 in order to have git-worktree(1) support. It
+# needs to be whitelisted here until we upgrade our resolver.
+- githash-0.1.3.3
+
 # Override default flag values for local packages and extra-deps
 # flags: {}
 


### PR DESCRIPTION
differential-datalog fails to build in a git-worktree(1) environment.
The reason is that githash, the package we use for inferring the commit
we built at in order to embed it into the binary, does not work with
git-worktree style repositories.
This functionality got [added upstream][githash-14] and version 0.1.3.3
now includes support for it. This change adds an explicit constraint to
ensure we consume this or a higher version. This change fixes #345.

[githash-14]: https://github.com/snoyberg/githash/pull/14