### PR TITLE
Topic/debug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ env:
    - TOOL=stack TEST_SUITE='-p redist' JAVA=1
    - TOOL=stack TEST_SUITE='-p span_uuid'
    - TOOL=stack TEST_SUITE='-p souffle0'
-   - TOOL=stack TEST_SUITE='-p simple'
+   - TOOL=stack TEST_SUITE='-p simple' STACK_CARGO_FLAGS='--release'
    - TOOL=stack TEST_SUITE='-p path'
    - TOOL=stack TEST_SUITE='-p ovn'
    - TOOL=stack TEST_SUITE='-p modules'

--- a/java/test_flatbuf/run.sh
+++ b/java/test_flatbuf/run.sh
@@ -26,8 +26,8 @@ CLASSPATH=`pwd`/../../test/datalog_tests/${PROG}_ddlog/flatbuf/java:`pwd`/../ddl
 # Compile the ${PROG}.dl DDlog program; use -j switch to generate FlatBuffers schema and Java bindings for it
 ddlog -i ../../test/datalog_tests/${PROG}.dl -j -L../../lib
 
-# Compile the rust program; generates ../test/datalog_tests/${PROG}_ddlog/target/release/lib${PROG}_ddlog.a
-(cd ../../test/datalog_tests/${PROG}_ddlog; cargo build --features=flatbuf --release)
+# Compile the rust program; generates ../test/datalog_tests/${PROG}_ddlog/target/debug/lib${PROG}_ddlog.a
+(cd ../../test/datalog_tests/${PROG}_ddlog; cargo build --features=flatbuf)
 
 # Compile generated Java classes (the FlatBuffer Java package must be compiled first and must be in the
 # $CLASSPATH)
@@ -37,7 +37,7 @@ ddlog -i ../../test/datalog_tests/${PROG}.dl -j -L../../lib
 javac Test.java
 
 # Create a shared library containing all the native code: ddlogapi.c, lib${PROG}_ddlog.a
-${CC} -shared -fPIC -I${JAVA_HOME}/include -I${JAVA_HOME}/include/${JDK_OS} -I../../rust/template -I../../lib ../ddlogapi.c -L../../test/datalog_tests/${PROG}_ddlog/target/release/ -l${PROG}_ddlog -o libddlogapi.${SHLIBEXT}
+${CC} -shared -fPIC -I${JAVA_HOME}/include -I${JAVA_HOME}/include/${JDK_OS} -I../../rust/template -I../../lib ../ddlogapi.c -L../../test/datalog_tests/${PROG}_ddlog/target/debug/ -l${PROG}_ddlog -o libddlogapi.${SHLIBEXT}
 
 # Run the java program pointing to the created shared library
 java -Djava.library.path=. Test > test.dump

--- a/rust/template/cmd_parser/lib.rs
+++ b/rust/template/cmd_parser/lib.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::char_lit_as_u8)]
-
 extern crate libc;
 extern crate nom;
 extern crate num;

--- a/rust/template/cmd_parser/parse.rs
+++ b/rust/template/cmd_parser/parse.rs
@@ -476,7 +476,7 @@ named!(int_val<&[u8], Record>,
 named!(hex_val<&[u8], BigInt>,
     do_parse!(tag_no_case!("0x") >>
               bs1: take_while1!(|x|is_hex_digit(x)) >>
-              bs2: take_while!(|x|is_hex_digit(x) || x == '_' as u8) >>
+              bs2: take_while!(|x|is_hex_digit(x) || x == b'_') >>
               spaces >>
               ({let mut bs = bs1.to_vec();
                 bs.extend_from_slice(bs2);
@@ -485,7 +485,7 @@ named!(hex_val<&[u8], BigInt>,
 
 named!(dec_val<&[u8], BigInt>,
     do_parse!(bs1: take_while1!(|x| is_digit(x)) >>
-              bs2: take_while!(|x| is_digit(x) || x == '_' as u8) >>
+              bs2: take_while!(|x| is_digit(x) || x == b'_') >>
               spaces >>
               ({let mut bs = bs1.to_vec();
                 bs.extend_from_slice(bs2);

--- a/rust/template/src/lib.rs
+++ b/rust/template/src/lib.rs
@@ -10,8 +10,7 @@
     clippy::extra_unused_lifetimes,
     clippy::ptr_arg,
     clippy::ptr_offset_with_cast,
-    clippy::redundant_closure,
-    clippy::type_complexity
+    clippy::redundant_closure
 )]
 
 extern crate differential_dataflow;

--- a/rust/template/src/server.rs
+++ b/rust/template/src/server.rs
@@ -9,10 +9,12 @@ use std::fmt;
 use std::fmt::{Debug, Formatter};
 use std::sync::{Arc, Mutex};
 
+type ObserverBox = Box<dyn Observer<Update<super::Value>, String>>;
+
 pub struct UpdatesSubscription {
     /// A pointer to the observer field in the outlet, and sets it to
     /// `None` upon unsubscribing.
-    observer: Arc<Mutex<Option<Box<dyn Observer<Update<super::Value>, String>>>>>,
+    observer: Arc<Mutex<Option<ObserverBox>>>,
 }
 
 impl Subscription for UpdatesSubscription {
@@ -25,7 +27,7 @@ impl Subscription for UpdatesSubscription {
 }
 
 pub struct UpdatesObservable {
-    observer: Arc<Mutex<Option<Box<dyn Observer<Update<super::Value>, String>>>>>,
+    observer: Arc<Mutex<Option<ObserverBox>>>,
 }
 
 impl Observable<Update<super::Value>, String> for UpdatesObservable {
@@ -94,7 +96,7 @@ impl DDlogServer {
 /// An outlet streams a subset of DDlog tables to an observer.
 pub struct Outlet {
     tables: HashSet<super::Relations>,
-    observer: Arc<Mutex<Option<Box<dyn Observer<Update<super::Value>, String>>>>>,
+    observer: Arc<Mutex<Option<ObserverBox>>>,
 }
 
 /// Newtype for interior mutability of the observer.

--- a/test/datalog_tests/api_test/run.sh
+++ b/test/datalog_tests/api_test/run.sh
@@ -5,5 +5,5 @@
 # `stack test --ta "-p copy"` with the following commands to compile the DDlog program:
 #   > ddlog -i copy.dl -L../../lib
 #   > cd copy_ddlog
-#   > cargo build --release
+#   > cargo build
 stack test --ta "-p copy" && cargo run


### PR DESCRIPTION
Use debug build instead of release

I performed some comparison of the run times of the Rust tests that take
up the majority of our pipeline's time, focusing on the different build
types available. In the past the argument has come up that while release
builds take longer, they execute faster and make up for that, which is
also the main reason we use release builds in those tests to begin with.

I performed two runs, one using `cargo test --release`, the other using
`cargo test` (which defaults to debug build).

debug: https://travis-ci.org/d-e-s-o/differential-datalog/builds/585822177
release: https://travis-ci.org/d-e-s-o/differential-datalog/builds/585822065

The results are as follows. Shown is the run time of the compile time
test in seconds for Mac (mac) and Linux (lin) and the change in run time
when switching from release to debug builds.

| Test            | Runtime Release | Runtime Debug | Change   |
| --------------- | --------------- | ------------- | -------- |
| tutorial (mac)  | 1418.48s        | 456.24s       | -68%     |
| tutorial (lin)  | 1324.71s        | 319.96s       | -76%     |
| redist (mac)    | 1780.83s        | 1590.56s      | -11%     |
| redist (lin)    | 1501.80s        | 1213.07s      | -19%     |
| span_uuid (mac) | 1390.25s        | 557.00s       | -60%     |
| span_uuid (lin) | 1228.94s        | 386.98s       | -69%     |
| simple (mac)    | 1980.93s        | timeout       | N/A      |
| simple (lin)    | 1673.17s        | timeout       | N/A      |
| path (mac)      | 1325.78s        | 378.96s       | -71%     |
| path (lin)      | 1240.93s        | 301.83s       | -76%     |
| ovn (mac)       | timeout         | 587.29s       | N/A      |
| ovn (lin)       | 2025.68s        | 503.90s       | -75%     |
| modules (mac)   | 1434.49s        | 463.38s       | -68%     |
| modules (lin)   | 1308.62s        | 338.31s       | -74%     |

As can be seen from the results, the difference between the two variants
is rather big. The only test that regressed is `simple`, which
consistently timed out for debug builds, confirming that some tests'
runtime may in fact regress more than the reduction in compile time
decreases (at least that is a possible interpretation, I haven't look at
the reasons in that detail).
While a mere two runs may not be considered enough, the difference in
runtime is so severe that I don't think there is much doubt about the
effect overall (and we can always revert). I also performed some more
runs locally (although only with the `path` test) and the results are
similar in nature.

Given those results, this change proposes to switch to using debug
builds for testing by default, which will save us in the order of 2h per
test run (this time is calculated not from the above numbers but from
looking at the actual end-to-end test runtime in Travis, which includes
setup and more; given the stark decrease in individual test run time we
may even think about running fast tests on the same VM to cut down on
setup time, but I did not go down that route).
In order to accommodate for the `simple` test, I make the stack testing
framework honor an environment variable, STACK_CARGO_FLAGS, that is set
to "--release" for this test (in Travis).

--- >8 ------ >8 ------ >8 (cut here)

- I am clubbing two more minor clippy cleanup changes in this pull request.

- I am not very familiar with Haskell and the list function introduced in
`Spec.hs` seems very much like a kludge. I am sure there is a more
elegant syntax to accomplish the same. If you know, please let me know.