### PR TITLE
Upgrade rustc dependency to 1.37.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ rust:
   # documented as supported in README.md!). Newer releases are (supposed to
   # be) backwards compatible and so we do not test everything on them as well
   # (to not artificially blow up CI/CD times).
-  - 1.34.0
+  - 1.37.0
 
 # Caching so the next build will be fast too.
 cache:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.com/vmware/differential-datalog.svg?branch=master)](https://travis-ci.com/vmware/differential-datalog)
-[![rustc](https://img.shields.io/badge/rustc-1.34+-blue.svg)](https://blog.rust-lang.org/2019/04/11/Rust-1.34.0.html)
+[![rustc](https://img.shields.io/badge/rustc-1.37+-blue.svg)](https://blog.rust-lang.org/2019/08/15/Rust-1.37.0.html)
 
 # Differential Datalog (DDlog)
 
@@ -89,7 +89,7 @@ To download `stack` (if you don't already have it) use:
 wget -qO- https://get.haskellstack.org/ | sh
 ```
 
-You will also need to install the Rust toolchain v1.34 or later:
+You will also need to install the Rust toolchain v1.37 or later:
 
 ```
 curl https://sh.rustup.rs -sSf | sh


### PR DESCRIPTION
Because our travis setup expects `vendor` tool to be integrated into
`cargo`.