### PR TITLE
DDlogAPI.java: Validate DDlog handle in API methods

### DIFF
--- a/java/test_flatbuf1/Test.java
+++ b/java/test_flatbuf1/Test.java
@@ -438,7 +438,7 @@ public class Test {
         } catch (IllegalStateException e) {}
     }
 
-    void clear() {
+    void clear() throws DDlogException {
         this.api.clearRelation(flatbufTestRelation.BI);
         this.api.clearRelation(flatbufTestRelation.CI);
         this.api.clearRelation(flatbufTestRelation.DI);


### PR DESCRIPTION
The DDlog handle becomes invalid after `DDlogAPI.stop()`.  Subsequent
attempts to invoke methods on this handle are unsafe.

To avoid crashes and confusing error messages, we zero the handle
in `stop()` and validate it in all `DDlogAPI` methods.

Fixes #371 