### PR TITLE
Fix dependencies for "unit tests"

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -98,7 +98,7 @@ tests:
     - -Werror
     dependencies:
     - differential-datalog
-    - tasty
+    - tasty >= 1.2
     - tasty-hunit
     - tasty-golden
     - filepath

--- a/stack.yaml
+++ b/stack.yaml
@@ -42,9 +42,11 @@ packages:
 # extra-deps: []
 
 extra-deps:
-# We need githash 0.1.3.3 in order to have git-worktree(1) support. It
-# needs to be whitelisted here until we upgrade our resolver.
+- ansi-terminal-0.10
+- ansi-wl-pprint-0.6.9
 - githash-0.1.3.3
+- graphviz-2999.20.0.3
+- tasty-1.2.3
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -224,7 +224,7 @@ compilerTest progress file cli_args = do
     (ccode, cstdo, cstde) <- withProgress progress $ readCreateProcessWithExitCode cargo_proc ""
     when (ccode /= ExitSuccess) $ do
         errorWithoutStackTrace $ "cargo build failed with exit code " ++ show ccode ++
-                                 "\nstdout:\n" ++ cstde ++
+                                 "\nstderr:\n" ++ cstde ++
                                  "\n\nstdout:\n" ++ cstdo
 
     cliTest progress fname specname dir cli_args

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -57,15 +57,15 @@ import Language.DifferentialDatalog.FlatBuffer
 main :: IO ()
 main = do
     progress <- isJust <$> lookupEnv "DDLOG_TEST_PROGRESS"
-    tests <- goldenTests progress
+    tests <- allTests progress
     defaultMain tests
 
 cargo_build_flags :: IO [[Char]]
 cargo_build_flags = do
   (maybe [] (return)) <$> lookupEnv "STACK_CARGO_FLAGS"
 
-goldenTests :: Bool -> IO TestTree
-goldenTests progress = do
+allTests :: Bool -> IO TestTree
+allTests progress = do
   -- locate datalog files
   dlFiles <- findByExtensionNonRec [".dl"] "./test/datalog_tests"
   -- some of the tests may have accompanying .dat files


### PR DESCRIPTION
The recently introduced unit test feature for DDLog Rust projects has a
flaw: there is an implicit dependency on the corresponding *_ddlog
directory having been created first (which is done by the compiler
tests) and if that is not the case the test will just fail.
We need to make this dependency explicit such that running the unit
tests also causes generation of the *_ddlog project.
This change does exactly that. We factor out the Rust project generation
into a separate "test" and then make use of tasty's "after" feature in
order to make this test a dependency of the unit tests and the compiler
tests. The "after" feature got introduced with tasty 1.2, which
therefore is added as an extra dependency.
With this change, running of only the unit tests for server_api, for
example, could be accomplished using this mouthful:
  > $ stack test --ta
  >   '--pattern "$(NF) == \"generate server_api\" ||
  >              ($(NF-1) == \"unit tests\" && $(NF) == \"server_api\")"'

(we need to explicitly match the "generate server_api" test because of
 the way tasty implements dependency handling, see its [README][])

[README]: https://github.com/feuerbach/tasty/blob/master/README.md#dependencies
