### PR TITLE
Topic/non consuming drop

### DIFF
--- a/rust/template/differential_datalog/test.rs
+++ b/rust/template/differential_datalog/test.rs
@@ -9,7 +9,7 @@
     clippy::cmp_owned,
     clippy::nonminimal_bool,
     clippy::toplevel_ref_arg,
-    clippy::trivially_copy_pass_by_ref,
+    clippy::trivially_copy_pass_by_ref
 )]
 
 use abomonation::Abomonation;
@@ -333,6 +333,18 @@ fn set_update(_rel: &str, s: &Arc<Mutex<Delta>>, x: &Value, w: Weight) {
     };
 
     //println!("set_update({}) {:?} {}", rel, *x, insert);
+}
+
+#[test]
+fn test_multiple_stops() {
+    let prog: Program<Value> = Program {
+        nodes: vec![],
+        init_data: vec![],
+    };
+
+    let mut running = prog.run(2);
+    running.stop().unwrap();
+    running.stop().unwrap();
 }
 
 /* Test insertion/deletion into a database with a single table and no rules

--- a/rust/template/src/api.rs
+++ b/rust/template/src/api.rs
@@ -982,8 +982,11 @@ pub unsafe extern "C" fn ddlog_profile(prog: *const HDDlog) -> *const raw::c_cha
     let res = {
         let profile = prog.profile();
         ffi::CString::new(profile)
-            .expect("Failed to convert profile string to C")
-            .into_raw()
+            .map(ffi::CString::into_raw)
+            .unwrap_or_else(|e| {
+                prog.eprintln(&format!("Failed to convert profile string to C: {}", e));
+                ptr::null_mut()
+            })
     };
     Arc::into_raw(prog);
     res

--- a/rust/template/src/api.rs
+++ b/rust/template/src/api.rs
@@ -89,8 +89,8 @@ impl HDDlog {
         Ok(())
     }
 
-    pub fn stop(self) -> Result<(), String> {
-        self.prog.into_inner().map(RunningProgram::stop).unwrap()
+    pub fn stop(&mut self) -> Result<(), String> {
+        self.prog.lock().unwrap().stop()
     }
 
     pub fn transaction_start(&self) -> Result<(), String> {
@@ -662,7 +662,7 @@ pub unsafe extern "C" fn ddlog_stop(prog: *const HDDlog) -> raw::c_int {
             prog, print_err, ..
         }) => prog
             .into_inner()
-            .map(|p| {
+            .map(|mut p| {
                 p.stop().map(|_| 0).unwrap_or_else(|e| {
                     HDDlog::print_err(print_err, &format!("ddlog_stop(): error: {}", e));
                     -1

--- a/rust/template/src/main.rs
+++ b/rust/template/src/main.rs
@@ -166,7 +166,7 @@ fn is_upd_cmd(c: &Command) -> bool {
     }
 }
 
-fn run(hddlog: HDDlog, print_deltas: bool) -> i32 {
+fn run(mut hddlog: HDDlog, print_deltas: bool) -> i32 {
     let upds = Arc::new(Mutex::new(Vec::new()));
     let ret = interact(|cmd, interactive| {
         handle_cmd(

--- a/rust/template/src/server.rs
+++ b/rust/template/src/server.rs
@@ -86,7 +86,7 @@ impl DDlogServer {
 
     /// Shutdown the DDlog program and notify listeners of completion.
     pub fn shutdown(&mut self) -> Response<()> {
-        if let Some(prog) = self.prog.take() {
+        if let Some(mut prog) = self.prog.take() {
             prog.stop()?;
         }
         for outlet in &self.outlets {

--- a/test/datalog_tests/server_api/tests/test.rs
+++ b/test/datalog_tests/server_api/tests/test.rs
@@ -95,6 +95,15 @@ fn start_commit_on_no_updates() -> Result<(), String> {
         assert_eq!(mock.called_on_completed, 1);
         assert_eq!(mock.called_on_error.get(), 0);
     }
+
+    server.shutdown()?;
+
+    // But only once!
+    {
+        let mock = observable.0.lock().unwrap();
+        assert_eq!(mock.called_on_completed, 1);
+        assert_eq!(mock.called_on_error.get(), 0);
+    }
     Ok(())
 }
 
@@ -205,12 +214,10 @@ fn multiple_transactions() -> Result<(), String> {
         assert_eq!(mock.called_on_commit, 1);
     }
 
-    let updates = &[
-        UpdCmd::Delete(
-            RelIdentifier::RelId(P1In as usize),
-            Record::String("first".to_string()),
-        ),
-    ];
+    let updates = &[UpdCmd::Delete(
+        RelIdentifier::RelId(P1In as usize),
+        Record::String("first".to_string()),
+    )];
 
     server.on_start()?;
     server.on_updates(Box::new(


### PR DESCRIPTION
This pull request implements automatic cleanup for `RunningProgram` and `DDlogServer` by running the respective shutdown code in `drop`. Aside from general niceness (by not having to worry about manual cleanup), it makes the recently added unit tests a bit more sane because now they actually clean up (beforehand we saw "worker hang" messages occasionally.