### PR TITLE
Update Haskell resolver to 14.7

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -35,7 +35,7 @@ dependencies:
 - wide-word
 - graphviz
 - text
-- githash >= 0.1.3.3
+- githash
 - process
 - casing
 
@@ -98,7 +98,7 @@ tests:
     - -Werror
     dependencies:
     - differential-datalog
-    - tasty >= 1.2
+    - tasty
     - tasty-hunit
     - tasty-golden
     - filepath

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -1547,7 +1547,7 @@ mkAntijoin d input_filters input_val Atom{..} rl@Rule{..} ajoin_idx = do
     let (arr, _) = normalizeArrangement d ctx atomVal
     -- Filter inputs using 'input_filters'
     ffun <- mkFFun d rl input_filters
-    Just aid <- getAntijoinArrangement atomRelation arr
+    aid <- fromJust <$> getAntijoinArrangement atomRelation arr
     next <- compileRule d rl ajoin_idx input_val
     return $ "XFormArrangement::Antijoin {"                                                                   $$
              "    description:" <+> (pp $ show $ show $ rulePPPrefix rl $ ajoin_idx + 1) <> ".to_string(),"   $$

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-12.26
+resolver: lts-14.7
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -40,13 +40,6 @@ packages:
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
 # extra-deps: []
-
-extra-deps:
-- ansi-terminal-0.10
-- ansi-wl-pprint-0.6.9
-- githash-0.1.3.3
-- graphviz-2999.20.0.3
-- tasty-1.2.3
 
 # Override default flag values for local packages and extra-deps
 # flags: {}


### PR DESCRIPTION
Updates to a more recent LTS release of Haskell to reduce the need for
manual management of dependencies.

Resolves #370 

