### PR TITLE
Revert "clippy: Fix occurrences of map_clone lint"

### DIFF
--- a/rust/template/ovsdb/lib.rs
+++ b/rust/template/ovsdb/lib.rs
@@ -1,5 +1,6 @@
 //! Parse OVSDB database update messages and convert them into DDlog table update commands
 
+#![allow(clippy::map_clone)]
 #![warn(missing_copy_implementations, missing_debug_implementations)]
 extern crate differential_datalog;
 extern crate num;
@@ -32,7 +33,7 @@ fn parse_uuid(s: &str) -> Result<BigInt, String> {
     let digits: Vec<u8> = s
         .as_bytes()
         .iter()
-        .copied()
+        .map(|x| *x)
         .filter(|x| *x != b'-')
         .collect();
     BigInt::parse_bytes(digits.as_slice(), 16)


### PR DESCRIPTION
This change reverts commit 91713b7ddfeef9c7ad72bd585b879499cf1de043. The
change makes use of a feature that has only been stabilized in version
1.36+ of Rust, breaking our support for 1.34.