### PR TITLE
Initial GitLab CI integration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,116 @@
+default:
+    image: ddlog/gitlab-ci:latest
+
+# Template for tests that expect ddlog to be in the $PATH.
+.install-ddlog:
+    before_script:
+        - stack install
+
+# Test Rust template only.
+test-rust:
+    script:
+        - (cd rust/template/ && cargo fmt --all -- --check)
+        - (cd rust/template/ && cargo clippy --all -- -D warnings)
+        - (cd rust/template/ && cargo test --all)
+
+# Run individual stack-based tests, when possible combining them with Java tests
+# that depend on the same DDlog program.
+test-tutorial:
+    script: stack --no-terminal test --ta "-p tutorial"
+
+test-simple:
+    script: stack --no-terminal test --ta "-p simple"
+
+test-modules:
+    script: stack --no-terminal test --ta "-p modules"
+
+test-ovn-ftl:
+    script: stack --no-terminal test --ta "-p ovn_ftl"
+
+test-ovn:
+    script: stack test --ta '--pattern "$(NF) == \"generate ovn\" || ($(NF-1) == \"compiler tests\" && $(NF) == \"ovn\")"'
+
+test-path:
+    script:
+        - stack --no-terminal test --ta "-p fail"
+        - stack --no-terminal test --ta "-p path"
+
+test-souffle0:
+    script:
+        - stack --no-terminal test --ta "-p souffle0"
+
+test-redist:
+    extends: .install-ddlog
+    script:
+        - stack --no-terminal test --ta "-p redist"
+        - (cd java/test1 && ./run.sh)
+        - (cd java/test_flatbuf && ./run.sh)
+
+test-redist:
+    extends: .install-ddlog
+    script:
+        - stack --no-terminal test --ta "-p span_string"
+        - (cd java/test3 && ./run.sh)
+
+# All other Java tests.
+test-redist:
+    extends: .install-ddlog
+    script:
+        - stack --no-terminal test --ta "-p span_uuid"
+        - (cd java/test && ./run.sh)
+
+test-java1:
+    extends: .install-ddlog
+    script:
+        - (cd java/test2 && ./run.sh)
+        - (cd java/test4 && ./run.sh)
+
+# these tests are currently failing (#372)
+#test-java2:
+#    extends: .install-ddlog
+#    script:
+#        - (cd java/test5 && ./run.sh)
+#        - (cd java/test6 && ./run.sh)
+
+test-flatbuf:
+    extends: .install-ddlog
+    script:
+        - (cd java/test_flatbuf1 && ./run.sh)
+
+# Tests from the souffle github repo.
+test-imported-souffle-tests1:
+    extends: .install-ddlog
+    script:
+        - (cd test && ./run-souffle-tests-in-batches.py 0 24)
+
+# Slow
+#test-imported-souffle-tests2:
+#    extends: .install-ddlog
+#    script:
+#        - (cd test && ./run-souffle-tests-in-batches.py 25 49)
+
+# Times out or runs out of memory on gitlab
+#test-imported-souffle-tests3:
+#    extends: .install-ddlog
+#    script:
+#        - (cd test && ./run-souffle-tests-in-batches.py 50 74)
+
+test-imported-souffle-tests4:
+    extends: .install-ddlog
+    script:
+        - (cd test && ./run-souffle-tests-in-batches.py 75 99)
+
+test-imported-souffle-tests5:
+    extends: .install-ddlog
+    script:
+        - (cd test && ./run-souffle-tests-in-batches.py 100 124)
+
+test-imported-souffle-tests6:
+    extends: .install-ddlog
+    script:
+        - (cd test && ./run-souffle-tests-in-batches.py 125 149)
+
+test-imported-souffle-tests7:
+    extends: .install-ddlog
+    script:
+        - (cd test && ./run-souffle-tests-in-batches.py 150 175)

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,11 @@ dist: trusty
 jdk: oraclejdk8
 osx_image: xcode9.3
 
+# build this branch in the gitlab CI
+branches:
+  except:
+  - gitlab-ci
+
 # Do not choose a language; we provide our own build tools.
 language: rust
 rust:

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -23,6 +23,7 @@ SOFTWARE.
 
 {-# LANGUAGE RecordWildCards, ImplicitParams, LambdaCase, FlexibleContexts, TemplateHaskell #-}
 
+import Prelude hiding(readFile, writeFile)
 import System.Environment
 import System.FilePath.Posix
 import System.Console.GetOpt
@@ -31,6 +32,7 @@ import Control.Monad
 import Data.List
 import Text.PrettyPrint
 
+import Language.DifferentialDatalog.Util
 import Language.DifferentialDatalog.Version
 import Language.DifferentialDatalog.Syntax
 import Language.DifferentialDatalog.Module

--- a/gitlab-ci/README.md
+++ b/gitlab-ci/README.md
@@ -1,0 +1,27 @@
+# GitLab CI setup
+
+- GitLab mirror of the DDlog repo (required for integration with GitLab CI):
+    - https://gitlab.com/ryzhyk/differential-datalog
+    - TODO: create a GitLab org to host the repo instead
+    - TODO: Add a webhook to the github repo to trigger GitLab sync
+
+- Docker container for GitLab CI
+    - Docker Hub organization to host GitLab CI container images:
+      - https://cloud.docker.com/u/ddlog/repository/docker/ddlog/gitlab-ci
+    - Dockerfile to build GitLab CI container images:
+      - `tools/Dockerfile` (not the best place for it, but it must be in the same
+        directory tree with other installation scripts in `tools`)
+    - Script to compile GitLab CI container image using the Dockerfile
+      - `./gitlab-ci/build-docker-image.sh`
+      - The image only needs to be generated when:
+        - Upgrading to a newer version of Rust
+        - Upgrading to a newer version of Haskell resolver
+        - Upgrading to a newer version of Python
+        - New Java, Python or Haskell dependencies are introduced
+        - Upgrading to a newer version of FlatBuffers
+        - Switching to a different JDK
+      - Upon success, the script prints a command line to upload the image
+        to Docker Hub.
+
+- GitLab CI script:
+    - `.gitlab-ci.yml`

--- a/gitlab-ci/build-docker-image.sh
+++ b/gitlab-ci/build-docker-image.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# Script to compile Docker image for use with GitLab CI
+
+set -e
+
+if [ -z "$1" ]
+then
+    TAG="latest"
+else
+    TAG="$1"
+fi
+
+DIR=$(dirname "$0")
+echo DIR is $DIR
+
+docker build  --network=host -t ddlog/gitlab-ci:$TAG $DIR/../tools
+echo Successfully created docker image.
+echo To upload the image to dockerhub, run \"docker push ddlog/gitlab-ci:$TAG\".
+echo To log into the image: \"docker run --network=host -it ddlog/gitlab-ci:$TAG\".

--- a/java/test/run.sh
+++ b/java/test/run.sh
@@ -17,17 +17,17 @@ case $(uname -s) in
 esac
 
 # Compile the span_uuid.dl DDlog program
-ddlog -i ../../test/datalog_tests/span_uuid.dl -L../../lib
-# Compile the rust program; generates ../test/datalog_tests/span_ddlog/target/release/libspan_ddlog.a
+ddlog -i ../../test/datalog_tests/span_uuid.dl -L../../lib -j
+# Compile the rust program; generates ../test/datalog_tests/span_ddlog/target/debug/libspan_ddlog.a
 pushd ../../test/datalog_tests/span_uuid_ddlog
-cargo build --release
+cargo build --features=flatbuf
 popd
 # Build the Java library with the DDlog API
 make -C ..
 # Compile SpanTest.java
 javac -cp .. SpanTest.java
 # Create a shared library containing all the native code: ddlogapi.c, libspan_uuid_ddlog.a
-${CC} -shared -fPIC -I"${JAVA_HOME}"/include -I"${JAVA_HOME}"/include/${JDK_OS} -I../../rust/template -I../../lib ../ddlogapi.c -L../../test/datalog_tests/span_uuid_ddlog/target/release/ -lspan_uuid_ddlog -o libddlogapi.${SHLIBEXT}
+${CC} -shared -fPIC -I"${JAVA_HOME}"/include -I"${JAVA_HOME}"/include/${JDK_OS} -I../../rust/template -I../../lib ../ddlogapi.c -L../../test/datalog_tests/span_uuid_ddlog/target/debug/ -lspan_uuid_ddlog -o libddlogapi.${SHLIBEXT}
 # Run the java program pointing to the created shared library
 #java -Xcheck:jni -Djava.library.path=. -jar span.jar ../../test/datalog_tests/span_uuid.dat >span_uuid.java.dump
 java -Djava.library.path=. -cp ../ddlogapi.jar:. SpanTest ../../test/datalog_tests/span_uuid.dat > span_uuid.java.dump 2> span_uuid.log

--- a/java/test3/run.sh
+++ b/java/test3/run.sh
@@ -26,12 +26,13 @@ pushd ../../test/datalog_tests/${PROG}_ddlog
 cargo build --release --features=flatbuf
 popd
 
+# Build the Java library with the DDlog API
+make -C ..
+
 # Compile generated Java classes (the FlatBuffer Java package must be compiled first and must be in the
 # $CLASSPATH)
 (cd ../../test/datalog_tests/${PROG}_ddlog/flatbuf/java && javac $(ls ddlog/__"${PROG}"/*.java) && javac $(ls ddlog/"${PROG}"/*.java))
 
-# Build the Java library with the DDlog API
-make -C ..
 # Compile SpanTest.java
 javac SpanTest.java
 # Create a shared library containing all the native code: ddlogapi.c, lib${PROG}_ddlog.a

--- a/java/test4/run.sh
+++ b/java/test4/run.sh
@@ -25,12 +25,13 @@ pushd ${PROG}_ddlog
 cargo build --features=flatbuf
 popd
 
+# Build the Java library with the DDlog API
+make -C ..
+
 # Compile generated Java classes (the FlatBuffer Java package must be compiled first and must be in the
 # $CLASSPATH)
 (cd ${PROG}_ddlog/flatbuf/java && javac $(ls ddlog/__"${PROG}"/*.java) && javac $(ls ddlog/"${PROG}"/*.java))
 
-# Build the Java library with the DDlog API
-make -C ..
 # Compile XTest.java
 javac XTest.java
 # Create a shared library containing all the native code: ddlogapi.c, libspan_string_ddlog.a

--- a/java/test5/run.sh
+++ b/java/test5/run.sh
@@ -25,12 +25,13 @@ pushd ${PROG}_ddlog
 cargo build --features=flatbuf
 popd
 
+# Build the Java library with the DDlog API
+make -C ..
+
 # Compile generated Java classes (the FlatBuffer Java package must be compiled first and must be in the
 # $CLASSPATH)
 (cd ${PROG}_ddlog/flatbuf/java && javac $(ls ddlog/__"${PROG}"/*.java) && javac $(ls ddlog/"${PROG}"/*.java))
 
-# Build the Java library with the DDlog API
-make -C ..
 # Compile XTest.java
 javac XTest.java
 # Create a shared library containing all the native code: ddlogapi.c, libspan_string_ddlog.a

--- a/java/test6/run.sh
+++ b/java/test6/run.sh
@@ -25,12 +25,13 @@ pushd ${PROG}_ddlog
 cargo build --features=flatbuf
 popd
 
+# Build the Java library with the DDlog API
+make -C ..
+
 # Compile generated Java classes (the FlatBuffer Java package must be compiled first and must be in the
 # $CLASSPATH)
 (cd ${PROG}_ddlog/flatbuf/java && javac $(ls ddlog/__"${PROG}"/*.java) && javac $(ls ddlog/"${PROG}"/*.java))
 
-# Build the Java library with the DDlog API
-make -C ..
 # Compile XTest.java
 javac XTest.java
 # Create a shared library containing all the native code: ddlogapi.c, libspan_string_ddlog.a

--- a/java/test_flatbuf1/run.sh
+++ b/java/test_flatbuf1/run.sh
@@ -39,7 +39,7 @@ ddlog -i ${PROG}.dl -j -L../../lib -L.
 (cd ${PROG}_ddlog/flatbuf/java && javac -Xlint:unchecked $(ls ddlog/__${PROG}/*.java) && javac -Xlint:unchecked $(ls ddlog/${PROG}/*.java))
 
 # Compile Test.java and the generated Java file
-javac -Xlint:unchecked Test.java
+javac -encoding utf8 -Xlint:unchecked Test.java
 
 # Create a shared library containing all the native code: ddlogapi.c, lib${PROG}_ddlog.a
 ${CC} -shared -fPIC -I${JAVA_HOME}/include -I${JAVA_HOME}/include/${JDK_OS} -I../../rust/template -I../../lib ../ddlogapi.c -L${PROG}_ddlog/target/release/ -l${PROG}_ddlog -o libddlogapi.${SHLIBEXT}

--- a/rust/template/src/lib.rs
+++ b/rust/template/src/lib.rs
@@ -6,7 +6,8 @@
     unused_parens,
     non_shorthand_field_patterns,
     dead_code,
-    overflowing_literals
+    overflowing_literals,
+    clippy::redundant_closure // Broken in 1.34
 )]
 
 extern crate differential_dataflow;

--- a/rust/template/src/main.rs
+++ b/rust/template/src/main.rs
@@ -187,6 +187,7 @@ fn run(mut hddlog: HDDlog, print_deltas: bool) -> i32 {
     }
 }
 
+#[allow(clippy::redundant_closure)]
 pub fn main() {
     //println!("sizeof(Value) = {}", mem::size_of::<Value>());
     let parser = opts! {

--- a/src/Language/DifferentialDatalog/FlatBuffer.hs
+++ b/src/Language/DifferentialDatalog/FlatBuffer.hs
@@ -36,6 +36,7 @@ where
 -- primary key types; the latter requires adding support for type-erased value
 -- representation (aka `Record`).
 
+import Prelude hiding ((<>), readFile, writeFile)
 import qualified Data.Map as M
 import Data.List
 import Data.Char
@@ -45,7 +46,6 @@ import Data.FileEmbed
 import Control.Monad.State
 import Text.PrettyPrint
 import Control.Monad.Except
-import Prelude hiding((<>))
 import System.FilePath
 import System.Process
 import GHC.IO.Exception

--- a/src/Language/DifferentialDatalog/Module.hs
+++ b/src/Language/DifferentialDatalog/Module.hs
@@ -31,7 +31,7 @@ Description: DDlog's module system implemented as syntactic sugar over core synt
 module Language.DifferentialDatalog.Module(
     parseDatalogProgram) where
 
-import Prelude hiding((<>),mod)
+import Prelude hiding((<>), mod, readFile, writeFile)
 import Control.Monad.State.Lazy
 import Control.Monad.Except
 import qualified Data.Map as M

--- a/src/Language/DifferentialDatalog/OVSDB/Compile.hs
+++ b/src/Language/DifferentialDatalog/OVSDB/Compile.hs
@@ -30,7 +30,7 @@ Description: Compile 'OVSDB schema' to DDlog.
 
 module Language.DifferentialDatalog.OVSDB.Compile (compileSchema, compileSchemaFile) where
 
-import Prelude hiding((<>))
+import Prelude hiding((<>), readFile, writeFile)
 import qualified Data.Map as M
 import Text.PrettyPrint
 import Text.RawString.QQ

--- a/src/Language/DifferentialDatalog/Util.hs
+++ b/src/Language/DifferentialDatalog/Util.hs
@@ -25,6 +25,7 @@ SOFTWARE.
 
 module Language.DifferentialDatalog.Util where
 
+import Prelude hiding(readFile, writeFile)
 import Data.Graph.Inductive
 import Control.Monad.Except
 import Data.List
@@ -36,6 +37,7 @@ import qualified Data.Map as M
 import qualified Data.ByteString.Lazy as BL
 import System.Directory
 import System.FilePath
+import System.IO hiding (readFile, writeFile)
 
 import Language.DifferentialDatalog.Pos
 import Language.DifferentialDatalog.Name
@@ -168,6 +170,21 @@ checksum16BS bs | l `mod` 2 == 0 = checksum16 $ runGet (sequence $ replicate (l 
 removeIndices :: [a] -> [Int] -> [a]
 removeIndices xs indices =
     foldl' (\xs' i -> take i xs' ++ drop (i+1) xs') xs $ reverse $ sort indices
+
+-- Unicode-aware file access.  We deliberately overload standard function names
+-- to force the user to hide non-unicode-aware versions and use these instead.
+
+readFile :: FilePath -> IO String
+readFile path = do
+  h <- openFile path ReadMode
+  hSetEncoding h utf8
+  hGetContents h
+
+writeFile :: FilePath -> String -> IO ()
+writeFile path txt =
+    withFile path WriteMode $ \h -> do
+        hSetEncoding h utf8
+        hPutStr h txt
 
 -- Replace file content if changed
 updateFile :: FilePath -> String -> IO ()

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -209,7 +209,7 @@ compilerTest progress file cli_args = do
     p <- (maybe "" id) <$> lookupEnv "PATH"
     let javac_proc = (shell $ "javac ddlog" </> specname </> "*.java") {
                           cwd = Just $ dir </> rustProjectDir specname </> "flatbuf" </> "java",
-                          env = Just [("CLASSPATH", (dir </> "../../java") ++ classpath),
+                          env = Just [("CLASSPATH", (dir </> "../../java:.") ++ classpath),
                                       ("PATH", p)]
                      }
     (jcode, jstdo, jstde) <- readCreateProcessWithExitCode javac_proc ""

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -23,11 +23,12 @@ SOFTWARE.
 
 {-# LANGUAGE FlexibleContexts, ImplicitParams #-}
 
+import Prelude hiding(readFile, writeFile)
 import Test.Tasty
 import Test.Tasty.Golden
 import Test.Tasty.Golden.Advanced
 import Test.Tasty.HUnit
-import System.IO
+import System.IO hiding(readFile, writeFile)
 import System.FilePath
 import System.Directory
 import System.Process
@@ -47,6 +48,7 @@ import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Set as S
 import qualified Codec.Compression.GZip as GZ
 
+import Language.DifferentialDatalog.Util
 import Language.DifferentialDatalog.Parse
 import Language.DifferentialDatalog.Module
 import Language.DifferentialDatalog.Syntax
@@ -285,9 +287,9 @@ cliTest progress fname specname rust_dir extra_args = do
         hClose herr
         hClose hdat
         when (code /= ExitSuccess) $ do
-            err <- readFile errfile
+            e <- readFile errfile
             errorWithoutStackTrace $ "cargo run cli failed with exit code " ++ show code ++
-                                     "\nstderr:\n" ++ err ++
+                                     "\nstderr:\n" ++ e ++
                                      "\n\nstdout written to:\n" ++ dumpfile
 
 unitTest :: String -> IO ()
@@ -299,11 +301,11 @@ unitTest dir = do
         let test_proc = (proc "cargo" (["test"] ++ cargo_flags)) {
                 cwd = Just $ absdir
             }
-        (code, out, err) <- readCreateProcessWithExitCode test_proc ""
+        (code, out, e) <- readCreateProcessWithExitCode test_proc ""
         when (code /= ExitSuccess) $ do
             errorWithoutStackTrace $ "cargo test failed with exit code " ++ show code ++
                                      "\nstdout:\n" ++ out ++
-                                     "\nstderr:\n" ++ err ++ "\n"
+                                     "\nstderr:\n" ++ e ++ "\n"
 
 -- A version of golden test that supports multiple output files.
 -- Uses strict evaluation to avoid errors lazily reading and then writing the

--- a/test/run-souffle-tests-in-batches.py
+++ b/test/run-souffle-tests-in-batches.py
@@ -10,10 +10,22 @@ def exit(code):
     sys.exit(code)
 
 def main():
-    batchsize = 5
-    start = 190
+    if len(sys.argv) >= 2:
+        start = int(sys.argv[1])
+    else:
+        start = 0
 
-    while True:
+    if len(sys.argv) >= 3:
+        end = int(sys.argv[2])
+    else:
+        end = 0xffffffff
+
+    if len(sys.argv) >= 4:
+        batchsize = int(sys.argv[3])
+    else:
+        batchsize = 5
+
+    while start <= end:
         print "Running from", start
         code = os.system("./run-souffle-tests.py -s " + str(start) + " -r " + str(batchsize))
         if code == (2 << 8):

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,0 +1,41 @@
+FROM ubuntu:18.04
+MAINTAINER DDlog team (https://github.com/vmware/differential-datalog)
+
+RUN apt-get update &&   \
+    apt-get install -y  \
+    wget                \
+    curl                \
+    libc6-dev           \
+    libgmp-dev          \
+    default-jdk         \
+    cmake               \
+    subversion          \
+    python              \
+    python-pip
+
+# Install haskell stack
+RUN wget -qO- https://get.haskellstack.org/ | sh
+
+# Install FlatBuffers
+COPY install-flatbuf.sh /root
+RUN /root/install-flatbuf.sh
+
+ENV PATH=/root/.local/bin:/root/.cargo/bin:$PATH
+ENV CLASSPATH=$CLASSPATH:/flatbuffers/java
+
+# Install Rust
+RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.34.0 -y
+RUN rustup component add rustfmt
+RUN rustup component add clippy
+
+# Install Haskell dependencies to speed up builds
+RUN git clone https://github.com/vmware/differential-datalog.git
+RUN cd differential-datalog && stack --no-terminal --install-ghc test --only-dependencies
+RUN rm -rf differential-datalog
+
+# Python packages needed by souffle scripts
+RUN pip install     \
+    parglare
+
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+ENV JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"

--- a/tools/install-flatbuf.sh
+++ b/tools/install-flatbuf.sh
@@ -22,4 +22,5 @@ if [ "x`flatbuffers/flatc --version`" != "xflatc version 1.11.0" ]; then
     cd ..
 fi
 
+mkdir -p ~/.local/bin/
 ln -f -s `pwd`/flatbuffers/flatc ~/.local/bin/flatc


### PR DESCRIPTION
GitLab CI script that replicates all existing Travis tests (on Linux only) + runs all Java tests and most tests from the Souffle repo. It completes in <30minutes using GitLab shared workers only, which is 4x faster than Travis, while running more tests.