### PR TITLE
Compile.hs: Export type aliases from generated code.

### DIFF
--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -526,7 +526,7 @@ mkTypedef d tdef@TypeDef{..} =
                              mkEnumMutator tdef                                                        $$
                              display                                                                   $$
                              default_enum
-         Just t           -> "type" <+> rname tdefName <+> targs <+> "=" <+> mkType t <> ";"
+         Just t           -> "pub type" <+> rname tdefName <+> targs <+> "=" <+> mkType t <> ";"
          Nothing          -> empty -- The user must provide definitions of opaque types
     where
     derive_struct = "#[derive(Eq, Ord, Clone, Hash, PartialEq, PartialOrd, Serialize, Deserialize, Default)]"


### PR DESCRIPTION
In the past,
```
typedef t02 = string
```
compiled to
```
type t01 = bool;
```

This commit changes it to
```
pub type t01 = bool;
```
so that clients written in Rust can refer to it.