### PR TITLE
Remove most tests from Travis

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,6 +19,8 @@ test-tutorial:
     script: stack --no-terminal test --ta "-p tutorial"
 
 test-simple:
+    # TODO: add release builds when we have more powerful workers
+    #script: STACK_CARGO_FLAGS='--release' stack --no-terminal test --ta "-p simple"
     script: stack --no-terminal test --ta "-p simple"
 
 test-modules:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,13 +43,13 @@ env:
      # We piggy back on what has historically been one of the shorter
      # runs to also check formatting of the Rust code.
    - TOOL=run_souffle_tests RUSTFMT=1 CLIPPY=1 CARGO_TEST=1
-   - TOOL=stack TEST_SUITE='-p redist' JAVA=1
-   - TOOL=stack TEST_SUITE='-p span_uuid'
-   - TOOL=stack TEST_SUITE='-p souffle0'
+   # - TOOL=stack TEST_SUITE='-p redist' JAVA=1
+   # - TOOL=stack TEST_SUITE='-p span_uuid'
+   # - TOOL=stack TEST_SUITE='-p souffle0'
    - TOOL=stack TEST_SUITE='-p simple' STACK_CARGO_FLAGS='--release'
-   - TOOL=stack TEST_SUITE='-p path'
-   - TOOL=stack TEST_SUITE='-p ovn'
-   - TOOL=stack TEST_SUITE='-p modules'
+   # - TOOL=stack TEST_SUITE='-p path'
+   # - TOOL=stack TEST_SUITE='-p ovn'
+   # - TOOL=stack TEST_SUITE='-p modules'
 
 #addons: {apt: {packages: [ghc-8.2.2], sources: [hvr-ghc]}}
 

--- a/gitlab-ci/README.md
+++ b/gitlab-ci/README.md
@@ -1,8 +1,7 @@
 # GitLab CI setup
 
 - GitLab mirror of the DDlog repo (required for integration with GitLab CI):
-    - https://gitlab.com/ryzhyk/differential-datalog
-    - TODO: create a GitLab org to host the repo instead
+    - https://gitlab.com/ddlog/differential-datalog
     - TODO: Add a webhook to the github repo to trigger GitLab sync
 
 - Docker container for GitLab CI
@@ -25,3 +24,21 @@
 
 - GitLab CI script:
     - `.gitlab-ci.yml`
+
+## Creating a GitLab mirror for your own fork of DDlog
+
+Follow these steps to connect your fork of the DDlog repo to GitLab CI,
+so that you can test your changes, e.g., before submitting a PR against
+the main DDlog repo.
+
+- You will need a [gitlab.com](https://gitlab.com) account.
+- Log into your GitLab account.
+- Click `New Project`.
+- Choose `CI/CD for external repo` project type.
+- Specify your fork of `differential-datalog` as the repository to import.
+- That's it. GitLab should now automatically pick up your changes during
+  the next periodic scan (every 30 minutes).  To kick off the CI pipeline
+  instantly, go to `Settings->Repository->Mirroring repositories` and click
+  `Update now`.  You can see the status of the CI pipeline under the `CI/CD`
+  tab.
+- TODO: Figure out how to add a webhook to start GitLab CI tests instantly.


### PR DESCRIPTION
GitLab is proving to be a way more scalable CI platform than Travis.
So, in the interests of speeding up test runs we remove most tests,
which are now redundant, from Travis.

We still want to use Travis for:
- MacOS tests
- Release builds
- Tests using newer versions of rustc/clippy/rustfmt than GitLab
  (although there is no reason we couldn't test those in GitLab)