### PR TITLE
Topic/should fail

### DIFF
--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -80,18 +80,22 @@ allTests progress = do
             , let expect = file -<.> "ast.expected"
             , let output = file -<.> "ast"]
   let generated_tests = testGroup "generated tests" $ concat $
-          [ [testCase generate_name $ generateDDLogRust True file ["staticlib"]
-            , after AllSucceed generate_pattern $ compilerTests progress file files
-            , after AllSucceed generate_pattern $ unitTests (dropExtension file)]
-            | (file:files) <- inFiles
-            , let base = dropExtension (takeBaseName file)
-              -- the name of the "test" generating the DDLog Rust project,
-              -- which is a dependency used by other tests
-            , let generate_name = "generate " ++ base
-            , let generate_pattern = "$(NF) == \"" ++ generate_name ++ "\""
-          ]
+          [ generatedTests progress file files
+            | (file:files) <- inFiles]
 
   return $ testGroup "ddlog tests" [parser_tests, generated_tests, souffleTests progress]
+
+generatedTests :: Bool -> FilePath -> [FilePath] -> [TestTree]
+generatedTests progress file files = do
+    let base = dropExtension (takeBaseName file)
+    -- the name of the "test" generating the DDLog Rust project,
+    -- which is a dependency used by other tests
+    let generate_name = "generate " ++ base
+    let generate_pattern = "$(NF) == \"" ++ generate_name ++ "\""
+
+    [testCase generate_name $ generateDDLogRust True file ["staticlib"]
+          , after AllSucceed generate_pattern $ compilerTests progress file files
+          , after AllSucceed generate_pattern $ unitTests (dropExtension file)]
 
 compilerTests :: Bool -> FilePath -> [FilePath] -> TestTree
 compilerTests progress file files = do

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -80,7 +80,9 @@ allTests progress = do
             , let expect = file -<.> "ast.expected"
             , let output = file -<.> "ast"]
   let generated_tests = testGroup "generated tests" $ concat $
-          [ generatedTests progress file files
+          [ if shouldFail $ file
+               then []
+               else generatedTests progress file files
             | (file:files) <- inFiles]
 
   return $ testGroup "ddlog tests" [parser_tests, generated_tests, souffleTests progress]
@@ -99,10 +101,8 @@ generatedTests progress file files = do
 
 compilerTests :: Bool -> FilePath -> [FilePath] -> TestTree
 compilerTests progress file files = do
-    testGroup "compiler tests" $ catMaybes $
-          [ if shouldFail $ file
-               then Nothing
-               else Just $ goldenVsFiles (takeBaseName file) expect output (compilerTest progress file [])
+    testGroup "compiler tests" $
+          [ goldenVsFiles (takeBaseName file) expect output (compilerTest progress file [])
             | let expect = map (uncurry replaceExtension) $ zip files [".dump.expected"]
             , let output = map (uncurry replaceExtension) $ zip files [".dump"]]
 


### PR DESCRIPTION
This change fixes an issue causing `stack test` to fail. In a nutshell, we should not attempt to generate a Rust DDLog project for the negative tests.

Fixes #399