### PR TITLE
DatalogProgram.hs: Broken visitor

### DIFF
--- a/test/datalog_tests/constr.fail.ast.expected
+++ b/test/datalog_tests/constr.fail.ast.expected
@@ -20,4 +20,6 @@ expecting function name
 
 error: ./test/datalog_tests/constr.fail.dl:4:15-7:1: Field x is declared with different types
 
-error: ./test/datalog_tests/constr.fail.dl:4:1-6:1: The following type variables are not used in type definition: D
+error: ./test/datalog_tests/constr.fail.dl:4:1-7:1: The following type variables are not used in type definition: D
+
+./test/datalog_tests/constr.fail.dl:6:54-7:1: Unknown module vm.  Did you forget to import it?

--- a/test/datalog_tests/constr.fail.dl
+++ b/test/datalog_tests/constr.fail.dl
@@ -33,3 +33,10 @@ typedef Alt = C0{x: bit<16>}
 // type argument 'D not used in type definition
 typedef Parameterized<'A,'B,'C,'D> = Option1{x: 'A}
                                    | Option2{y: 'B, z: 'C}
+
+//---
+
+typedef VIP  = string
+typedef UUID = string
+
+input relation VM_Host[(VIP, UUID)] primary key (vm) vm.VIP


### PR DESCRIPTION
The expression visitor implementation, which is supposed to visit all
expressions in the program, ignored primary key expressions.

Resolves #398