### PR TITLE
Use VMware-hosted runners to run more tests in GitLab CI .

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,9 +19,9 @@ test-tutorial:
     script: stack --no-terminal test --ta "-p tutorial"
 
 test-simple:
-    # TODO: add release builds when we have more powerful workers
-    #script: STACK_CARGO_FLAGS='--release' stack --no-terminal test --ta "-p simple"
-    script: stack --no-terminal test --ta "-p simple"
+    tags:
+        - ddlog-ci-1
+    script: STACK_CARGO_FLAGS='--release' stack --no-terminal test --ta "-p simple"
 
 test-modules:
     script: stack --no-terminal test --ta "-p modules"
@@ -79,40 +79,44 @@ test-flatbuf:
     script:
         - (cd java/test_flatbuf1 && ./run.sh)
 
+# Template for souffle tests
+.test-imported-souffle:
+    extends: .install-ddlog
+    tags:
+        - ddlog-ci-1
+
 # Tests from the souffle github repo.
 test-imported-souffle-tests1:
-    extends: .install-ddlog
+    extends: .test-imported-souffle
     script:
         - (cd test && ./run-souffle-tests-in-batches.py 0 24)
 
-# Slow
-#test-imported-souffle-tests2:
-#    extends: .install-ddlog
-#    script:
-#        - (cd test && ./run-souffle-tests-in-batches.py 25 49)
+test-imported-souffle-tests2:
+    extends: .test-imported-souffle
+    script:
+        - (cd test && ./run-souffle-tests-in-batches.py 25 49)
 
-# Times out or runs out of memory on gitlab
-#test-imported-souffle-tests3:
-#    extends: .install-ddlog
-#    script:
-#        - (cd test && ./run-souffle-tests-in-batches.py 50 74)
+test-imported-souffle-tests3:
+    extends: .test-imported-souffle
+    script:
+        - (cd test && ./run-souffle-tests-in-batches.py 50 74)
 
 test-imported-souffle-tests4:
-    extends: .install-ddlog
+    extends: .test-imported-souffle
     script:
         - (cd test && ./run-souffle-tests-in-batches.py 75 99)
 
 test-imported-souffle-tests5:
-    extends: .install-ddlog
+    extends: .test-imported-souffle
     script:
         - (cd test && ./run-souffle-tests-in-batches.py 100 124)
 
 test-imported-souffle-tests6:
-    extends: .install-ddlog
+    extends: .test-imported-souffle
     script:
         - (cd test && ./run-souffle-tests-in-batches.py 125 149)
 
 test-imported-souffle-tests7:
-    extends: .install-ddlog
+    extends: .test-imported-souffle
     script:
         - (cd test && ./run-souffle-tests-in-batches.py 150 175)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,6 +5,8 @@ default:
 .install-ddlog:
     before_script:
         - stack install
+        - mkdir -p /root/.local/ddlog
+        - ln -s $(pwd)/lib /root/.local/ddlog/lib
 
 # Test Rust template only.
 test-rust:
@@ -120,3 +122,25 @@ test-imported-souffle-tests7:
     extends: .test-imported-souffle
     script:
         - (cd test && ./run-souffle-tests-in-batches.py 150 175)
+
+# Test ovn-northd-ddlog
+test-ovn-northd:
+    extends: .install-ddlog
+    tags:
+        - ddlog-ci-2
+    script:
+        # TODO: use main OVS repo once these changes are there.
+        - (cd /root &&
+          git clone https://github.com/numansiddique/ovs.git &&
+          cd ovs && git checkout ovs_ddlog_patches &&
+          ./boot.sh &&
+          ./configure  &&
+          make -j6)
+        # TODO: maintain and eventually remove the list of tests.
+        # TODO: use -j6 once build script is fixed
+        - (cd /root &&
+          git clone https://github.com/ovn-org/ovn.git &&
+          cd ovn && git checkout ddlog-dev-v2 &&
+          ./boot.sh &&
+          ./configure --with-ddlog=/root/.local/ddlog/lib --with-ovs-source=/root/ovs &&
+          make check -j1 TESTSUITEFLAGS="117-135 138-141 143-145 147-149 151-152 154-161 167-169 172 174-181 183-185 187-189 191 193-196 198-199 201-202")

--- a/gitlab-ci/README.md
+++ b/gitlab-ci/README.md
@@ -45,6 +45,38 @@ mirror of the fork) to the DDlog organization (see below).
 I followed these [instructions](https://docs.gitlab.com/runner/install/linux-manually.html)
 to configure the GitLab runners.
 
+A copy of `/etc/gitlab-runner/config.toml`:
+
+```
+concurrent = 8
+check_interval = 0
+
+[session_server]
+  session_timeout = 1800
+
+[[runners]]
+  name = "ddlog-ci-1"
+  url = "https://gitlab.com"
+  token = "Bjx-aJUGEH6Fp6rBEXkf"
+  executor = "docker"
+  [runners.custom_build_dir]
+  [runners.docker]
+    tls_verify = false
+    image = "ddlog/gitlab-ci:latest"
+    privileged = false
+    disable_entrypoint_overwrite = false
+    oom_kill_disable = false
+    disable_cache = false
+    volumes = ["/cache"]
+    shm_size = 0
+    network_mode = "host"
+    limit = 1
+  [runners.cache]
+    [runners.cache.s3]
+    [runners.cache.gcs]
+
+```
+
 ## Creating a GitLab mirror for your own fork of DDlog
 
 Follow these steps to connect your fork of the DDlog repo to GitLab CI,

--- a/gitlab-ci/README.md
+++ b/gitlab-ci/README.md
@@ -25,6 +25,26 @@
 - GitLab CI script:
     - `.gitlab-ci.yml`
 
+## GitLab runner configuration
+
+Some of the jobs in the CI script require more CPU or memory than available
+to GitLab shared runners.  These jobs are tagged to run on project-specific
+runners hosted by VMware, e.g.:
+
+```
+.test-imported-souffle
+    extends: .install-ddlog
+    tags:
+        - ddlog-ci-1
+```
+
+These runners are attached to the DDlog GitLab organization, so in order to use
+them with your fork of the DDlog repo, you must transfer the fork (or the GitLab
+mirror of the fork) to the DDlog organization (see below).
+
+I followed these [instructions](https://docs.gitlab.com/runner/install/linux-manually.html)
+to configure the GitLab runners.
+
 ## Creating a GitLab mirror for your own fork of DDlog
 
 Follow these steps to connect your fork of the DDlog repo to GitLab CI,
@@ -37,8 +57,17 @@ the main DDlog repo.
 - Choose `CI/CD for external repo` project type.
 - Specify your fork of `differential-datalog` as the repository to import.
 - That's it. GitLab should now automatically pick up your changes during
-  the next periodic scan (every 30 minutes).  To kick off the CI pipeline
+  the next periodic scan (every 30 minutes).
+  <!--To kick off the CI pipeline
   instantly, go to `Settings->Repository->Mirroring repositories` and click
-  `Update now`.  You can see the status of the CI pipeline under the `CI/CD`
-  tab.
-- TODO: Figure out how to add a webhook to start GitLab CI tests instantly.
+  `Update now`.-->
+  You can see the status of the CI pipeline under the `CI/CD` tab.
+- In order to use VMware-hosted GitLab runners, you need to transfer the
+  mirror to the DDlog organization.  To do this, first change the path
+  to the mirror (under `Settings->General->Advanced->Change path`)
+  from `differential-datalog` to, e.g., `differential-datalog-user-name`
+  and then use `Settings->General->Advanced->Transfer project` to move
+  the project to the DDlog org (you must become an owner of the org first).
+
+<!-- TODO: Figure out how to add a webhook to start GitLab CI tests instantly.
+-->

--- a/java/ddlogapi.c
+++ b/java/ddlogapi.c
@@ -265,7 +265,6 @@ JNIEXPORT void JNICALL Java_ddlogapi_DDlogAPI_ddlog_1dump_1input_1snapshot(
     }
     fd = open(c_filename, O_CREAT | O_WRONLY | (append ? O_APPEND : O_TRUNC),
               S_IRUSR | S_IWUSR);
-    (*env)->ReleaseStringUTFChars(env, filename, c_filename);
 
     if (fd < 0) {
         throwIOException(env, "Failed to open file %s. Error code: %d", c_filename, fd);
@@ -275,6 +274,8 @@ JNIEXPORT void JNICALL Java_ddlogapi_DDlogAPI_ddlog_1dump_1input_1snapshot(
         }
         close(fd);
     }
+
+    (*env)->ReleaseStringUTFChars(env, filename, c_filename);
 }
 
 JNIEXPORT void JNICALL Java_ddlogapi_DDlogAPI_ddlog_1stop(

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -11,7 +11,10 @@ RUN apt-get update &&   \
     cmake               \
     subversion          \
     python              \
-    python-pip
+    python-pip          \
+    autoconf            \
+    libtool             \
+    libssl-dev
 
 # Install haskell stack
 RUN wget -qO- https://get.haskellstack.org/ | sh


### PR DESCRIPTION
- Support for project-specif CI runners hosted by VMware (`ddlog-ci-1`, `ddlog-ci-2`)
- Enabled all imported souffle tests (on `ddlog-ci-1`)
- Run the OVN test suite from branch `ddlog-dev-v2` of the `ovn-org` repo
- Unrelated: an ugly use-after-free error in `ddlogapi.c`
  - @mbudiu-vmw, do you think we can have a test case for this?