### PR TITLE
Topic/tcp channel tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,6 +20,9 @@ test-rust:
 test-tutorial:
     script: stack --no-terminal test --ta "-p tutorial"
 
+test-server_api:
+    script: stack --no-terminal test --ta "-p server_api"
+
 test-simple:
     script: stack --no-terminal test --ta "-p simple"
 

--- a/rust/template/tcp_channel/Cargo.toml
+++ b/rust/template/tcp_channel/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 bincode = "1.2"
 libc = "0.2"
 observe = {path = "../observe"}
-serde = "1.0"
+serde = {version = "1.0", features = ["derive"]}
 
 [lib]
 name = "tcp_channel"

--- a/rust/template/tcp_channel/receiver.rs
+++ b/rust/template/tcp_channel/receiver.rs
@@ -1,5 +1,6 @@
 use std::fmt::Debug;
 use std::io::BufReader;
+use std::io::Error;
 use std::net::SocketAddr;
 use std::net::TcpListener;
 use std::net::ToSocketAddrs;
@@ -14,9 +15,10 @@ use std::thread::JoinHandle;
 use bincode::deserialize_from;
 
 use libc::close;
+use libc::shutdown;
+use libc::SHUT_RDWR;
 
 use observe::Observable;
-use observe::Observer;
 use observe::ObserverBox;
 use observe::Subscription;
 use observe::UpdatesSubscription;
@@ -25,15 +27,54 @@ use serde::de::DeserializeOwned;
 
 use crate::message::Message;
 
+#[derive(Copy, Clone, Debug)]
+enum Fd {
+    /// We are still listening for an incoming connection and
+    /// this is the corresponding file descriptor.
+    Listening(RawFd),
+    /// We have accepted a connection and read data from it.
+    Accepted(RawFd),
+    /// The listener/accepted connection has been closed.
+    Closed,
+}
+
+impl Fd {
+    fn close(&mut self) -> Result<(), Error> {
+        match *self {
+            Fd::Listening(fd) | Fd::Accepted(fd) => {
+                let rc = unsafe { shutdown(fd, SHUT_RDWR) };
+                if rc != 0 {
+                    return Err(Error::last_os_error());
+                }
+
+                // Bad luck if we fail the close. There is not much we
+                // can do about that.
+                *self = Fd::Closed;
+
+                let rc = unsafe { close(fd) };
+                if rc != 0 {
+                    return Err(Error::last_os_error());
+                }
+                Ok(())
+            }
+            Fd::Closed => Ok(()),
+        }
+    }
+}
+
 /// The receiving end of a TCP channel has an address
 /// and streams data to an observer.
 #[derive(Debug)]
 pub struct TcpReceiver<T> {
+    /// The address we are listening on.
     addr: SocketAddr,
-    listener: RawFd,
-    stream: Arc<Mutex<Option<RawFd>>>,
-    thread: JoinHandle<Result<(), String>>,
-    observer: Arc<Mutex<Option<Box<dyn Observer<T, String> + Send>>>>,
+    /// Our listener/connection file descriptor state; shared with the
+    /// thread accepting connections and reading streamed data.
+    fd: Arc<Mutex<Fd>>,
+    /// Handle to the thread accepting a connection and processing data.
+    thread: Option<JoinHandle<Result<(), String>>>,
+    /// The connected observer, if any.
+    observer: Arc<Mutex<Option<ObserverBox<T, String>>>>,
 }
 
 impl<T> TcpReceiver<T>
@@ -60,15 +101,13 @@ where
         let addr = listener
             .local_addr()
             .map_err(|e| format!("failed to inquire local address: {}", e))?;
-        let listener_fd = listener.as_raw_fd();
-        let stream_fd = Arc::new(Mutex::new(None));
+        let fd = Arc::new(Mutex::new(Fd::Listening(listener.as_raw_fd())));
         let observer = Arc::new(Mutex::new(None));
-        let thread = Self::accept(stream_fd.clone(), listener, observer.clone());
+        let thread = Some(Self::accept(listener, fd.clone(), observer.clone()));
 
         Ok(Self {
             addr,
-            listener: listener_fd,
-            stream: stream_fd,
+            fd,
             thread,
             observer,
         })
@@ -78,20 +117,49 @@ where
     /// it, and dispatch that to the subscribed observer, if any. If no
     /// observer is subscribed, data will be silently dropped.
     fn accept(
-        stream: Arc<Mutex<Option<RawFd>>>,
         listener: TcpListener,
-        observer: Arc<Mutex<Option<Box<dyn Observer<T, String> + Send>>>>,
+        fd: Arc<Mutex<Fd>>,
+        observer: Arc<Mutex<Option<ObserverBox<T, String>>>>,
     ) -> JoinHandle<Result<(), String>> {
         spawn(move || {
-            let (socket, _) = listener
-                .accept()
-                .map_err(|e| format!("failed to accept connection: {}", e))?;
-            *stream.lock().unwrap() = Some(socket.as_raw_fd());
+            let socket = match listener.accept() {
+                Ok((s, _)) => {
+                    let mut guard = fd.lock().unwrap();
+                    // The user may have closed the receiver shortly
+                    // after us accepting a connection. If that is the
+                    // case do not continue.
+                    if let Fd::Closed = *guard {
+                        return Ok(());
+                    }
+                    *guard = Fd::Accepted(s.as_raw_fd());
+                    s
+                }
+                Err(e) => {
+                    // If the stream has been closed errors are expected
+                    // and we just return to terminate the thread. We
+                    // could alternatively check for a specific error
+                    // return that occurs when the listener socket is
+                    // closed concurrently but that seems less portable.
+                    if let Fd::Closed = *fd.lock().unwrap() {
+                        return Ok(());
+                    } else {
+                        return Err(format!("failed to accept connection: {}", e));
+                    }
+                }
+            };
 
             let mut reader = BufReader::new(socket);
             loop {
-                let message = deserialize_from(&mut reader)
-                    .map_err(|e| format!("failed to deserialize message: {}", e))?;
+                let message = match deserialize_from(&mut reader) {
+                    Ok(m) => m,
+                    Err(_) => {
+                        if let Fd::Closed = *fd.lock().unwrap() {
+                            return Ok(());
+                        }
+                        // TODO: Can/should we log the error?
+                        continue;
+                    }
+                };
 
                 // If there is no observer we just drop the data, which
                 // is seemingly the only reasonable behavior given that
@@ -122,14 +190,17 @@ where
 
 impl<T> Drop for TcpReceiver<T> {
     fn drop(&mut self) {
-        // We can't really handle any errors here.
-        // The order of operations is important. First close the
-        // listener to be sure that a no new stream will be accepted,
-        // then close the stream itself.
-        unsafe {
-            let _ = close(self.listener);
-            let _ = self.stream.lock().unwrap().map(|fd| close(fd));
-        }
+        // TODO: We probably want to just log failures.
+        self.fd.lock().unwrap().close().unwrap();
+        // TODO: We probably want to log any errors reported by the
+        //       thread being joined.
+        self.thread
+            .take()
+            .map(JoinHandle::join)
+            .unwrap()
+            .unwrap()
+            .unwrap();
+
         // The remaining members will be destroyed automatically, no
         // need to bother here.
     }

--- a/test/datalog_tests/server_api/Cargo.toml
+++ b/test/datalog_tests/server_api/Cargo.toml
@@ -9,3 +9,6 @@ differential_datalog = {path = "../server_api_ddlog/differential_datalog"}
 maplit = "1.0"
 observe = {path = "../server_api_ddlog/observe"}
 server_api = {path = "../server_api_ddlog"}
+
+[dev-dependencies]
+lazy_static = "1.4"

--- a/test/datalog_tests/server_api/Cargo.toml
+++ b/test/datalog_tests/server_api/Cargo.toml
@@ -9,6 +9,8 @@ differential_datalog = {path = "../server_api_ddlog/differential_datalog"}
 maplit = "1.0"
 observe = {path = "../server_api_ddlog/observe"}
 server_api = {path = "../server_api_ddlog"}
+tcp_channel = {path = "../server_api_ddlog/tcp_channel"}
 
 [dev-dependencies]
 lazy_static = "1.4"
+waitfor = "0.1"

--- a/test/datalog_tests/server_api/tests/deltas.rs
+++ b/test/datalog_tests/server_api/tests/deltas.rs
@@ -93,7 +93,7 @@ fn single_delta_tcp() -> Result<(), String> {
         observer: SharedObserver<DDlogServer>,
     ) -> Result<Box<dyn Any>, String> {
         let mut recv = TcpReceiver::new("127.0.0.1:0").unwrap();
-        let send = TcpSender::new(*recv.addr()).unwrap();
+        let send = TcpSender::connect(*recv.addr()).unwrap();
 
         recv.subscribe(Box::new(observer));
         observable.subscribe(Box::new(send));

--- a/test/datalog_tests/server_api/tests/deltas.rs
+++ b/test/datalog_tests/server_api/tests/deltas.rs
@@ -1,20 +1,26 @@
+use std::any::Any;
 use std::sync::Mutex;
+use std::time::Duration;
 
 use differential_datalog::program::Update;
 use differential_datalog::record::{Record, RelIdentifier, UpdCmd};
 use observe::Observable;
 use observe::Observer;
 use observe::SharedObserver;
+use tcp_channel::TcpReceiver;
+use tcp_channel::TcpSender;
 
 use server_api_ddlog::api::*;
-use server_api_ddlog::Relations::*;
 use server_api_ddlog::server::*;
+use server_api_ddlog::Relations::*;
 use server_api_ddlog::Value;
 
 use lazy_static::lazy_static;
 
 use maplit::hashmap;
 use maplit::hashset;
+
+use waitfor::wait_for;
 
 macro_rules! DeltaTest {
     ( $($setup_fn:tt)* ) => {{
@@ -35,7 +41,7 @@ macro_rules! DeltaTest {
         let server2 = DDlogServer::new(program2, hashmap! {P1Out => P2In});
 
         let mut stream = server1.add_stream(hashset! {P1Out});
-        ($($setup_fn)*)(&mut stream, SharedObserver::new(server2))?;
+        let _data = ($($setup_fn)*)(&mut stream, SharedObserver::new(server2))?;
 
         let updates = &[UpdCmd::Insert(
             RelIdentifier::RelId(P1In as usize),
@@ -48,10 +54,17 @@ macro_rules! DeltaTest {
         ))?;
         server1.on_commit()?;
 
-        let deltas = DELTAS.lock().unwrap();
-        let actual = deltas.as_slice();
-        let expected = &[(P2Out as usize, Record::String("delta-me-now".to_string()))];
-        assert_eq!(actual, expected);
+        let result = wait_for::<_, _, ()>(Duration::from_secs(5), Duration::from_millis(10), || {
+            let deltas = DELTAS.lock().unwrap();
+            if deltas.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(deltas.clone()))
+            }
+        });
+
+        let expected = vec![(P2Out as usize, Record::String("delta-me-now".to_string()))];
+        assert_eq!(result, Ok(Some(expected)));
         Ok(())
     }}
 }
@@ -63,9 +76,32 @@ fn single_delta_direct() -> Result<(), String> {
     fn do_test(
         observable: &mut dyn Observable<Update<Value>, String>,
         observer: SharedObserver<DDlogServer>,
-    ) -> Result<(), String> {
+    ) -> Result<Box<dyn Any>, String> {
         observable.subscribe(Box::new(observer));
-        Ok(())
+        Ok(Box::new(()))
+    }
+
+    DeltaTest!(do_test)
+}
+
+/// Verify that deltas from one program are reported properly in another
+/// that is observing, using a TCP channel to transfer them over.
+#[test]
+fn single_delta_tcp() -> Result<(), String> {
+    fn do_test(
+        observable: &mut dyn Observable<Update<Value>, String>,
+        observer: SharedObserver<DDlogServer>,
+    ) -> Result<Box<dyn Any>, String> {
+        let mut recv = TcpReceiver::new("127.0.0.1:0").unwrap();
+        let send = TcpSender::new(*recv.addr()).unwrap();
+
+        recv.subscribe(Box::new(observer));
+        observable.subscribe(Box::new(send));
+
+        // We need to pass our receiver out so that it doesn't get
+        // dropped immediately, which would result in a broken
+        // connection.
+        Ok(Box::new(recv))
     }
 
     DeltaTest!(do_test)

--- a/test/datalog_tests/server_api/tests/deltas.rs
+++ b/test/datalog_tests/server_api/tests/deltas.rs
@@ -8,6 +8,8 @@ use server_api_ddlog::api::*;
 use server_api_ddlog::server;
 use server_api_ddlog::Relations::*;
 
+use lazy_static::lazy_static;
+
 use maplit::hashmap;
 use maplit::hashset;
 
@@ -15,18 +17,12 @@ use maplit::hashset;
 /// that is observing.
 #[test]
 fn single_delta() -> Result<(), String> {
-    // We need a global here (and cannot, say, close over some local
-    // from a lambda expression) because our callback has to implement
-    // Clone and that is not possible for a closure capturing its
-    // environment in a mutable way.
-    // We need an option because Vec::new is not const and so we can't
-    // use it to initialize a static.
-    static mut DELTAS: Option<Mutex<Vec<(usize, Record)>>> = None;
-    unsafe { DELTAS = Some(Mutex::new(Vec::new())) };
+    lazy_static! {
+        static ref DELTAS: Mutex<Vec<(usize, Record)>> = { Mutex::new(Vec::new()) };
+    }
 
     fn collect_deltas(relation_id: usize, record: &Record, _weight: isize) {
-        let deltas = unsafe { DELTAS.as_mut().unwrap() };
-        deltas.lock().unwrap().push((relation_id, record.clone()));
+        DELTAS.lock().unwrap().push((relation_id, record.clone()));
     }
 
     let program1 = HDDlog::run(1, false, |_, _: &Record, _| {});
@@ -49,8 +45,7 @@ fn single_delta() -> Result<(), String> {
     ))?;
     server1.on_commit()?;
 
-    let mutex = unsafe { DELTAS.as_mut().unwrap() };
-    let deltas = mutex.lock().unwrap();
+    let deltas = DELTAS.lock().unwrap();
     let actual = deltas.as_slice();
     let expected = &[(P2Out as usize, Record::String("delta-me-now".to_string()))];
     assert_eq!(actual, expected);

--- a/test/datalog_tests/server_api/tests/deltas.rs
+++ b/test/datalog_tests/server_api/tests/deltas.rs
@@ -1,53 +1,72 @@
 use std::sync::Mutex;
 
+use differential_datalog::program::Update;
 use differential_datalog::record::{Record, RelIdentifier, UpdCmd};
 use observe::Observable;
 use observe::Observer;
+use observe::SharedObserver;
 
 use server_api_ddlog::api::*;
-use server_api_ddlog::server;
 use server_api_ddlog::Relations::*;
+use server_api_ddlog::server::*;
+use server_api_ddlog::Value;
 
 use lazy_static::lazy_static;
 
 use maplit::hashmap;
 use maplit::hashset;
 
+macro_rules! DeltaTest {
+    ( $($setup_fn:tt)* ) => {{
+        lazy_static! {
+            static ref DELTAS: Mutex<Vec<(usize, Record)>> = {
+                Mutex::new(Vec::new())
+            };
+        }
+
+        fn collect_deltas(relation_id: usize, record: &Record, _weight: isize) {
+            DELTAS.lock().unwrap().push((relation_id, record.clone()));
+        }
+
+        let program1 = HDDlog::run(1, false, |_, _: &Record, _| {});
+        let mut server1 = DDlogServer::new(program1, hashmap! {});
+
+        let program2 = HDDlog::run(1, false, collect_deltas);
+        let server2 = DDlogServer::new(program2, hashmap! {P1Out => P2In});
+
+        let mut stream = server1.add_stream(hashset! {P1Out});
+        ($($setup_fn)*)(&mut stream, SharedObserver::new(server2))?;
+
+        let updates = &[UpdCmd::Insert(
+            RelIdentifier::RelId(P1In as usize),
+            Record::String("delta-me-now".to_string()),
+        )];
+
+        server1.on_start()?;
+        server1.on_updates(Box::new(
+            updates.into_iter().map(|cmd| updcmd2upd(cmd).unwrap()),
+        ))?;
+        server1.on_commit()?;
+
+        let deltas = DELTAS.lock().unwrap();
+        let actual = deltas.as_slice();
+        let expected = &[(P2Out as usize, Record::String("delta-me-now".to_string()))];
+        assert_eq!(actual, expected);
+        Ok(())
+    }}
+}
+
 /// Verify that deltas from one program are reported properly in another
 /// that is observing.
 #[test]
-fn single_delta() -> Result<(), String> {
-    lazy_static! {
-        static ref DELTAS: Mutex<Vec<(usize, Record)>> = { Mutex::new(Vec::new()) };
+fn single_delta_direct() -> Result<(), String> {
+    fn do_test(
+        observable: &mut dyn Observable<Update<Value>, String>,
+        observer: SharedObserver<DDlogServer>,
+    ) -> Result<(), String> {
+        observable.subscribe(Box::new(observer));
+        Ok(())
     }
 
-    fn collect_deltas(relation_id: usize, record: &Record, _weight: isize) {
-        DELTAS.lock().unwrap().push((relation_id, record.clone()));
-    }
-
-    let program1 = HDDlog::run(1, false, |_, _: &Record, _| {});
-    let mut server1 = server::DDlogServer::new(program1, hashmap! {});
-
-    let program2 = HDDlog::run(1, false, collect_deltas);
-    let server2 = server::DDlogServer::new(program2, hashmap! {P1Out => P2In});
-
-    let mut stream = server1.add_stream(hashset! {P1Out});
-    let _ = stream.subscribe(Box::new(server2));
-
-    let updates = &[UpdCmd::Insert(
-        RelIdentifier::RelId(P1In as usize),
-        Record::String("delta-me-now".to_string()),
-    )];
-
-    server1.on_start()?;
-    server1.on_updates(Box::new(
-        updates.into_iter().map(|cmd| updcmd2upd(cmd).unwrap()),
-    ))?;
-    server1.on_commit()?;
-
-    let deltas = DELTAS.lock().unwrap();
-    let actual = deltas.as_slice();
-    let expected = &[(P2Out as usize, Record::String("delta-me-now".to_string()))];
-    assert_eq!(actual, expected);
-    Ok(())
+    DeltaTest!(do_test)
 }


### PR DESCRIPTION
This change concludes the TCP channel infrastructure. Most importantly we run the existing tests for the observable-observer infrastructure to also test TCP channel based observers. Also, run the test in the GitLab CI/CD pipeline.