### PR TITLE
Remove usage of unsafe_abomonate

### DIFF
--- a/rust/template/Cargo.toml
+++ b/rust/template/Cargo.toml
@@ -32,7 +32,7 @@ path = "./observe"
 path = "./tcp_channel"
 
 [dependencies]
-abomonation= "0.7"
+abomonation = "0.7"
 cpuprofiler = "0.0.3"
 differential-dataflow = "0.9"
 fnv="1.0.2"

--- a/rust/template/differential_datalog/int.rs
+++ b/rust/template/differential_datalog/int.rs
@@ -29,7 +29,8 @@ impl Default for Int {
         }
     }
 }
-unsafe_abomonate!(Int);
+
+impl Abomonation for Int {}
 
 impl Int {
     pub fn from_bigint(v: BigInt) -> Int {

--- a/rust/template/differential_datalog/lib.rs
+++ b/rust/template/differential_datalog/lib.rs
@@ -1,6 +1,5 @@
 #![allow(clippy::get_unwrap, clippy::type_complexity)]
 
-#[macro_use]
 extern crate abomonation;
 extern crate num;
 

--- a/rust/template/differential_datalog/program.rs
+++ b/rust/template/differential_datalog/program.rs
@@ -94,7 +94,7 @@ pub struct TS16 {
     pub x: u16,
 }
 
-unsafe_abomonate!(TS16);
+impl Abomonation for TS16 {}
 
 impl Mul for TS16 {
     type Output = TS16;

--- a/rust/template/differential_datalog/test.rs
+++ b/rust/template/differential_datalog/test.rs
@@ -33,14 +33,16 @@ struct P {
     f1: Q,
     f2: bool,
 }
-unsafe_abomonate!(P);
+
+impl Abomonation for P {}
 
 #[derive(Eq, Ord, Clone, Hash, PartialEq, PartialOrd, Serialize, Deserialize, Debug)]
 struct Q {
     f1: bool,
     f2: String,
 }
-unsafe_abomonate!(Q);
+
+impl Abomonation for Q {}
 
 #[derive(Eq, Ord, Clone, Hash, PartialEq, PartialOrd, Serialize, Deserialize, Debug)]
 enum S {
@@ -58,7 +60,8 @@ enum S {
         g2: Q,
     },
 }
-unsafe_abomonate!(S);
+
+impl Abomonation for S {}
 
 impl S {
     fn f1(&mut self) -> &mut u32 {
@@ -85,7 +88,8 @@ enum Value {
     Q(Q),
     S(S),
 }
-unsafe_abomonate!(Value);
+
+impl Abomonation for Value {}
 
 impl Default for Value {
     fn default() -> Value {

--- a/rust/template/differential_datalog/uint.rs
+++ b/rust/template/differential_datalog/uint.rs
@@ -27,7 +27,8 @@ impl Default for Uint {
         }
     }
 }
-unsafe_abomonate!(Uint);
+
+impl Abomonation for Uint {}
 
 impl Uint {
     pub fn from_biguint(v: BigUint) -> Uint {

--- a/rust/template/src/lib.rs
+++ b/rust/template/src/lib.rs
@@ -29,7 +29,6 @@ extern crate twox_hash;
 #[macro_use]
 extern crate differential_datalog;
 
-#[macro_use]
 extern crate abomonation;
 extern crate ddlog_ovsdb_adapter;
 
@@ -109,13 +108,15 @@ pub enum Value {
     empty(),
     bool(bool),
 }
-unsafe_abomonate!(Value);
+
+impl Abomonation for Value {}
 
 impl Default for Value {
     fn default() -> Value {
         Value::bool(false)
     }
 }
+
 impl fmt::Display for Value {
     fn fmt(&self, _f: &mut fmt::Formatter) -> fmt::Result {
         panic!("Value::fmt not implemented")

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -917,7 +917,7 @@ mkValType d types =
     "pub enum Value {"                                                                      $$
     (nest' $ vcat $ punctuate comma $ map mkValCons $ S.toList types)                       $$
     "}"                                                                                     $$
-    "unsafe_abomonate!(Value);"                                                             $$
+    "impl Abomonation for Value {}"                                                         $$
     "impl Default for Value {"                                                              $$
     "    fn default() -> Value {" <> tuple0 <> "}"                                          $$
     "}"                                                                                     $$


### PR DESCRIPTION
The unsafe_abomonate macro has been deprecated in version 0.5 of the
crate and so we should probably refrain from using it. The
recommendation is to use abomonate_derive but the way we used the macro
we should just be able to directly implement the Abomonation trait for
the types we used the macro for previously, as that is exactly what the
macro did. This change fixes #409.