### PR TITLE
Read and write ovsdb2ddlog configuration files from json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ tags
 *.jar
 java/test/span_uuid.java.dump
 java/test*/*_ddlog
+java/webserver/apache-tomcat-8.5.2
 *.pyc
 souffle-grammar.pgt
 # idea project files

--- a/package.yaml
+++ b/package.yaml
@@ -37,6 +37,7 @@ dependencies:
 - githash
 - process
 - casing
+- aeson
 
 library:
   source-dirs: src


### PR DESCRIPTION
Fixes #393 
I have tested this by generating json files for ovn and using them in the Makefiles.
For example, this is the nb file generated:
```json
{
  "proxyTables": [],
  "keys": {
    "Logical_Switch_Port": [
      "name"
    ]
  },
  "outputTables": [
    [
      "NB_Global",
      [
        "ssl",
        "connections",
        "external_ids",
        "nb_cfg"
      ]
    ],
    [
      "Logical_Switch_Port",
      []
    ]
  ],
  "ovsFile": "ovn-nb.ovsschema"
}
```
