### PR TITLE
Exclude 'pull-request/*' branches from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,15 @@ dist: trusty
 jdk: oraclejdk8
 osx_image: xcode9.3
 
-# build this branch in the gitlab CI
+# 'gitlab-ci' is meant for testing GitLab CI integration and not build
+# by Travis.
+# Branches starting with 'pull-request' are used by our pull-request
+# "mirroring" infrastructure and can safely be ignored by Travis as
+# well.
 branches:
   except:
   - gitlab-ci
+  - /^pull-request\/.*/
 
 # Do not choose a language; we provide our own build tools.
 language: rust


### PR DESCRIPTION
We have enabled GitHub pull request "mirroring" recently (through
github-pull-request-mirror [1]), which, whenever a pull request comes in
through GitHub, will ensure that a corresponding branch is created in
GitLab. Doing so will trigger a GitLab CI build which in turn will make
this build appear as a "check" in the pull request on the GitHub UI.

Because a Travis build is triggered irrespective of this infrastructure,
and because such a new branch also triggers a Travis build, we
explicitly disable Travis builds for all branches matching the
'^pull-request/.*' pattern used by this infrastructure, for they would
just result in duplicated work.

[1]: https://github.com/d-e-s-o/github-pull-request-mirror