### PR TITLE
Fix race condition causing unrelated socket closures

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,6 +14,14 @@ test-rust:
         - (cd rust/template/ && cargo fmt --all -- --check)
         - (cd rust/template/ && cargo clippy --all -- -D warnings)
         - (cd rust/template/ && cargo test --all)
+        - (cd rust/template/ && (
+            i=0;
+            true;
+            while [ $? -eq 0 -a $i -lt 100 ]; do
+              i=$((i+1));
+              cargo test --package tcp_channel;
+            done
+          ))
 
 # Run individual stack-based tests, when possible combining them with Java tests
 # that depend on the same DDlog program.


### PR DESCRIPTION
Our tests have found a race condition which manifests in broken pipe or
connection refused errors when running tests concurrently. The
explanation, in a nutshell, is that with the current code we may issue a
close(2) on one file descriptor twice and any multiple closes, given the
right timing, could actually close an unrelated file descriptor if the
number has been reused by the system.
To fix this problem, this change introduces a second mutex to the
TcpReceiver's file descriptor state that synchronizes system calls with
respect to closes.
I verified the fix by running our unit tests for half an hour or so.
Previously, such a race condition would be hit after less than 10s in
most cases.
This change fixes #427.