### PR TITLE
Topic/txnmux

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,7 +29,7 @@ test-tutorial:
     script: stack --no-terminal test --ta "-p tutorial"
 
 test-server_api:
-    script: stack --no-terminal test --ta "-p server_api"
+    script: stack --no-terminal test --ta '-p "$(NF) == \"generate server_api\" || (($(NF-1) == \"compiler tests\" || $(NF-1) == \"unit tests\") && $(NF) == \"server_api\")"'
 
 test-simple:
     script: stack --no-terminal test --ta "-p simple"
@@ -41,7 +41,7 @@ test-ovn-ftl:
     script: stack --no-terminal test --ta "-p ovn_ftl"
 
 test-ovn:
-    script: stack test --ta '--pattern "$(NF) == \"generate ovn\" || ($(NF-1) == \"compiler tests\" && $(NF) == \"ovn\")"'
+    script: stack test --ta '-p "$(NF) == \"generate ovn\" || ($(NF-1) == \"compiler tests\" && $(NF) == \"ovn\")"'
 
 test-path:
     script:

--- a/rust/template/differential_datalog/program.rs
+++ b/rust/template/differential_datalog/program.rs
@@ -1811,7 +1811,7 @@ impl<V: Val> RunningProgram<V> {
                         if let Some(thread) = self.prof_thread_handle.take() {
                             match thread.join() {
                                 Err(_) => {
-                                    Err("profiling thread terminated with an error".to_string())?
+                                    Err("profiling thread terminated with an error".to_string())
                                 }
                                 Ok(_) => Ok(()),
                             }

--- a/rust/template/distributed_datalog/Cargo.toml
+++ b/rust/template/distributed_datalog/Cargo.toml
@@ -6,3 +6,8 @@ edition = "2018"
 [dependencies]
 observe = {path = "observe"}
 tcp_channel = {path = "tcp_channel"}
+
+[features]
+# The 'test' feature set on this crate requires the 'test' feature of
+# the `observe` crate being enabled as well.
+test = ["observe/test"]

--- a/rust/template/distributed_datalog/README.md
+++ b/rust/template/distributed_datalog/README.md
@@ -36,6 +36,9 @@ As it stands that means we have the following components:
   comprised of a `TcpSender` (an `Observer`) and a `TcpReceiver` (an
   `Observable) that can connect two `ddlog` programs (wrapped in
   `DDlogServer` objects) and transfer deltas produced
+- a transaction multiplexer (`TxnMux`) that allows for serializing
+  transactions as emitted by multiple `Observables` such that no two
+  transactions interleave
 
 ### Examples & Tests
 **D3log** has unit as well as integration style tests using an actual

--- a/rust/template/distributed_datalog/observe/Cargo.toml
+++ b/rust/template/distributed_datalog/observe/Cargo.toml
@@ -2,3 +2,7 @@
 name = "observe"
 version = "0.1.0"
 edition = "2018"
+
+[features]
+# Expose additional types commonly used only for testing purposes.
+test = []

--- a/rust/template/distributed_datalog/observe/src/lib.rs
+++ b/rust/template/distributed_datalog/observe/src/lib.rs
@@ -9,9 +9,14 @@
 
 mod observable;
 mod observer;
+#[cfg(any(test, feature = "test"))]
+mod test;
 
 pub use observable::Observable;
 pub use observable::UpdatesObservable;
 pub use observer::Observer;
 pub use observer::ObserverBox;
 pub use observer::SharedObserver;
+
+#[cfg(feature = "test")]
+pub use test::MockObserver;

--- a/rust/template/distributed_datalog/observe/src/lib.rs
+++ b/rust/template/distributed_datalog/observe/src/lib.rs
@@ -14,6 +14,7 @@ mod test;
 
 pub use observable::Observable;
 pub use observable::ObservableAny;
+pub use observable::ObservableBox;
 pub use observable::UpdatesObservable;
 pub use observer::CachingObserver;
 pub use observer::Observer;

--- a/rust/template/distributed_datalog/observe/src/lib.rs
+++ b/rust/template/distributed_datalog/observe/src/lib.rs
@@ -13,6 +13,7 @@ mod observer;
 mod test;
 
 pub use observable::Observable;
+pub use observable::ObservableAny;
 pub use observable::UpdatesObservable;
 pub use observer::CachingObserver;
 pub use observer::Observer;

--- a/rust/template/distributed_datalog/observe/src/lib.rs
+++ b/rust/template/distributed_datalog/observe/src/lib.rs
@@ -17,6 +17,7 @@ pub use observable::UpdatesObservable;
 pub use observer::CachingObserver;
 pub use observer::Observer;
 pub use observer::ObserverBox;
+pub use observer::OptionalObserver;
 pub use observer::SharedObserver;
 
 #[cfg(feature = "test")]

--- a/rust/template/distributed_datalog/observe/src/lib.rs
+++ b/rust/template/distributed_datalog/observe/src/lib.rs
@@ -14,6 +14,7 @@ mod test;
 
 pub use observable::Observable;
 pub use observable::UpdatesObservable;
+pub use observer::CachingObserver;
 pub use observer::Observer;
 pub use observer::ObserverBox;
 pub use observer::SharedObserver;

--- a/rust/template/distributed_datalog/observe/src/observable.rs
+++ b/rust/template/distributed_datalog/observe/src/observable.rs
@@ -34,7 +34,7 @@ where
 /// observer.
 #[derive(Debug)]
 pub struct UpdatesObservable<T, E> {
-    /// A reference to the `Observer` we subscribed to.
+    /// A reference to the `Observer` subscribed to us, if any.
     pub observer: Arc<Mutex<Option<ObserverBox<T, E>>>>,
 }
 

--- a/rust/template/distributed_datalog/observe/src/observable.rs
+++ b/rust/template/distributed_datalog/observe/src/observable.rs
@@ -5,6 +5,9 @@ use crate::observer::ObserverBox;
 use crate::observer::OptionalObserver;
 use crate::observer::SharedObserver;
 
+/// A boxed up `ObservableAny`.
+pub type ObservableBox<T, E> = Box<dyn ObservableAny<T, E> + Send>;
+
 /// A trait for objects that can be observed.
 pub trait Observable<T, E>: Debug
 where

--- a/rust/template/distributed_datalog/observe/src/observable.rs
+++ b/rust/template/distributed_datalog/observe/src/observable.rs
@@ -72,36 +72,15 @@ where
 mod tests {
     use super::*;
 
-    use crate::Observer;
-
-    #[derive(Debug)]
-    struct DummyObserver(());
-
-    impl Observer<(), ()> for DummyObserver {
-        fn on_start(&mut self) -> Result<(), ()> {
-            Ok(())
-        }
-
-        fn on_commit(&mut self) -> Result<(), ()> {
-            Ok(())
-        }
-
-        fn on_updates<'a>(&mut self, _: Box<dyn Iterator<Item = ()> + 'a>) -> Result<(), ()> {
-            Ok(())
-        }
-
-        fn on_completed(&mut self) -> Result<(), ()> {
-            Ok(())
-        }
-    }
+    use crate::test::MockObserver;
 
     /// Test subscribing and unsubscribing for an `UpdatesObservable`.
     #[test]
     fn subscribe_unsubscribe() {
-        let mut observable = UpdatesObservable {
+        let mut observable = UpdatesObservable::<(), ()> {
             observer: Arc::new(Mutex::new(None)),
         };
-        let observer = Box::new(DummyObserver(()));
+        let observer = Box::new(MockObserver::new());
 
         assert!(observable.subscribe(observer).is_ok());
         assert!(observable.unsubscribe(&()).is_some());
@@ -110,11 +89,11 @@ mod tests {
     /// Test multiple subscriptions to an `UpdatesObservable`.
     #[test]
     fn multiple_subscribe() {
-        let mut observable = UpdatesObservable {
+        let mut observable = UpdatesObservable::<(), ()> {
             observer: Arc::new(Mutex::new(None)),
         };
-        let observer1 = Box::new(DummyObserver(()));
-        let observer2 = Box::new(DummyObserver(()));
+        let observer1 = Box::new(MockObserver::new());
+        let observer2 = Box::new(MockObserver::new());
 
         assert!(observable.subscribe(observer1).is_ok());
         assert!(observable.subscribe(observer2).is_err());

--- a/rust/template/distributed_datalog/observe/src/observer.rs
+++ b/rust/template/distributed_datalog/observe/src/observer.rs
@@ -31,7 +31,7 @@ where
 
 /// Wrapper around an `Observer` that allows for it to be shared by
 /// wrapping it into a combination of `Arc` & `Mutex`.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct SharedObserver<O>(pub Arc<Mutex<O>>);
 
 impl<O> SharedObserver<O> {
@@ -39,6 +39,12 @@ impl<O> SharedObserver<O> {
     /// provided `Observer` as necessary.
     pub fn new(observer: O) -> Self {
         SharedObserver(Arc::new(Mutex::new(observer)))
+    }
+}
+
+impl<O> Clone for SharedObserver<O> {
+    fn clone(&self) -> Self {
+        SharedObserver(self.0.clone())
     }
 }
 

--- a/rust/template/distributed_datalog/observe/src/observer.rs
+++ b/rust/template/distributed_datalog/observe/src/observer.rs
@@ -1,4 +1,6 @@
+use std::collections::LinkedList;
 use std::fmt::Debug;
+use std::mem::replace;
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -68,5 +70,97 @@ where
 
     fn on_completed(&mut self) -> Result<(), E> {
         self.0.lock().unwrap().on_completed()
+    }
+}
+
+/// Wrapper around an `Observer` that stores updates and pushes them
+/// forward only when an `on_commit` is received.
+#[derive(Debug)]
+pub struct CachingObserver<O, T> {
+    /// The observer we ultimately push our data to when we received the
+    /// `on_commit` event.
+    observer: O,
+    /// The data we accumulated so far.
+    data: Option<LinkedList<Vec<T>>>,
+}
+
+impl<O, T> CachingObserver<O, T> {
+    /// Create a new `CachingObserver` wrapping the provided observer.
+    pub fn new(observer: O) -> Self {
+        Self {
+            observer,
+            data: None,
+        }
+    }
+}
+
+impl<O, T, E> Observer<T, E> for CachingObserver<O, T>
+where
+    O: Observer<T, E>,
+    T: Send + Debug,
+    E: Send,
+{
+    fn on_start(&mut self) -> Result<(), E> {
+        if self.data.is_none() {
+            self.data = Some(LinkedList::new());
+        } else {
+            panic!("received multiple on_start events")
+        }
+        Ok(())
+    }
+
+    fn on_commit(&mut self) -> Result<(), E> {
+        if let Some(ref mut data) = self.data.take() {
+            self.observer.on_start()?;
+            let updates_list = replace(data, LinkedList::new());
+            for updates in updates_list.into_iter() {
+                self.observer.on_updates(Box::new(updates.into_iter()))?;
+            }
+            self.observer.on_commit()?;
+        } else {
+            panic!("on_commit was not preceded by an on_start event")
+        }
+        Ok(())
+    }
+
+    fn on_updates<'a>(&mut self, updates: Box<dyn Iterator<Item = T> + 'a>) -> Result<(), E> {
+        if let Some(ref mut data) = self.data {
+            data.push_back(updates.collect());
+        } else {
+            panic!("on_updates was not preceded by an on_start event")
+        }
+        Ok(())
+    }
+
+    fn on_completed(&mut self) -> Result<(), E> {
+        self.observer.on_completed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::test::MockObserver;
+
+    /// Test caching of transactions via a `CachingObserver`.
+    #[test]
+    fn transaction_caching() {
+        let mock = SharedObserver::new(MockObserver::new());
+        let observer = &mut CachingObserver::new(mock.clone()) as &mut dyn Observer<_, ()>;
+
+        assert_eq!(observer.on_start(), Ok(()));
+        assert_eq!(mock.0.lock().unwrap().called_on_start, 0);
+
+        assert_eq!(observer.on_updates(Box::new([1, 3, 2].iter())), Ok(()));
+        assert_eq!(mock.0.lock().unwrap().called_on_updates, 0);
+
+        assert_eq!(observer.on_updates(Box::new([6, 4, 5].iter())), Ok(()));
+        assert_eq!(mock.0.lock().unwrap().called_on_updates, 0);
+
+        assert_eq!(observer.on_commit(), Ok(()));
+        assert_eq!(mock.0.lock().unwrap().called_on_start, 1);
+        assert_eq!(mock.0.lock().unwrap().called_on_updates, 6);
+        assert_eq!(mock.0.lock().unwrap().called_on_commit, 1);
     }
 }

--- a/rust/template/distributed_datalog/observe/src/observer.rs
+++ b/rust/template/distributed_datalog/observe/src/observer.rs
@@ -179,6 +179,64 @@ where
     }
 }
 
+/// An `Observer` that wraps an inner, optional `Observer`. If the inner
+/// one is unset all events will just be dropped.
+#[derive(Debug)]
+pub struct OptionalObserver<O>(Option<O>);
+
+impl<O> OptionalObserver<O> {
+    /// Create a new `OptionalObserver` object, automatically wrapping the
+    /// provided `Observer` as necessary.
+    pub fn new(observer: O) -> Self {
+        Self(Some(observer))
+    }
+
+    /// Replace the existing `Observer` (if any) with the given optional
+    /// one, returning the previous one.
+    pub fn replace(&mut self, value: O) -> Option<O> {
+        self.0.replace(value)
+    }
+
+    /// Take the inner observer, if any, replacing it with none.
+    pub fn take(&mut self) -> Option<O> {
+        self.0.take()
+    }
+
+    /// Check whether an actual observer is present or not.
+    pub fn is_some(&self) -> bool {
+        self.0.is_some()
+    }
+}
+
+impl<O> Default for OptionalObserver<O> {
+    fn default() -> Self {
+        Self(None)
+    }
+}
+
+impl<O, T, E> Observer<T, E> for OptionalObserver<O>
+where
+    O: Observer<T, E>,
+    T: Send,
+    E: Send,
+{
+    fn on_start(&mut self) -> Result<(), E> {
+        self.0.as_mut().map_or(Ok(()), Observer::on_start)
+    }
+
+    fn on_commit(&mut self) -> Result<(), E> {
+        self.0.as_mut().map_or(Ok(()), Observer::on_commit)
+    }
+
+    fn on_updates<'a>(&mut self, updates: Box<dyn Iterator<Item = T> + 'a>) -> Result<(), E> {
+        self.0.as_mut().map_or(Ok(()), |o| o.on_updates(updates))
+    }
+
+    fn on_completed(&mut self) -> Result<(), E> {
+        self.0.as_mut().map_or(Ok(()), Observer::on_completed)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -203,6 +261,34 @@ mod tests {
         assert_eq!(observer.on_commit(), Ok(()));
         assert_eq!(mock.0.lock().unwrap().called_on_start, 1);
         assert_eq!(mock.0.lock().unwrap().called_on_updates, 6);
+        assert_eq!(mock.0.lock().unwrap().called_on_commit, 1);
+    }
+
+    /// Test the workings of an `OptionalObserver` with no actual
+    /// observer present.
+    #[test]
+    fn no_optional_observer() {
+        let observer = &mut OptionalObserver::<MockObserver>::default() as &mut dyn Observer<_, ()>;
+
+        assert_eq!(observer.on_start(), Ok(()));
+        assert_eq!(observer.on_updates(Box::new([1, 3, 2].iter())), Ok(()));
+        assert_eq!(observer.on_commit(), Ok(()));
+    }
+
+    /// Test the workings of an `OptionalObserver` with an observer
+    /// present.
+    #[test]
+    fn with_optional_observer() {
+        let mock = SharedObserver::new(MockObserver::new());
+        let observer = &mut OptionalObserver::new(mock.clone()) as &mut dyn Observer<_, ()>;
+
+        assert_eq!(observer.on_start(), Ok(()));
+        assert_eq!(mock.0.lock().unwrap().called_on_start, 1);
+
+        assert_eq!(observer.on_updates(Box::new([1, 3, 2].iter())), Ok(()));
+        assert_eq!(mock.0.lock().unwrap().called_on_updates, 3);
+
+        assert_eq!(observer.on_commit(), Ok(()));
         assert_eq!(mock.0.lock().unwrap().called_on_commit, 1);
     }
 }

--- a/rust/template/distributed_datalog/observe/src/test.rs
+++ b/rust/template/distributed_datalog/observe/src/test.rs
@@ -1,0 +1,46 @@
+use crate::Observer;
+
+#[derive(Clone, Debug, Default)]
+pub struct MockObserver {
+    pub called_on_start: usize,
+    pub called_on_commit: usize,
+    pub called_on_updates: usize,
+    pub called_on_completed: usize,
+}
+
+impl MockObserver {
+    pub fn new() -> Self {
+        Self {
+            called_on_start: 0,
+            called_on_commit: 0,
+            called_on_updates: 0,
+            called_on_completed: 0,
+        }
+    }
+}
+
+impl<T, E> Observer<T, E> for MockObserver
+where
+    T: Send,
+    E: Send,
+{
+    fn on_start(&mut self) -> Result<(), E> {
+        self.called_on_start += 1;
+        Ok(())
+    }
+
+    fn on_commit(&mut self) -> Result<(), E> {
+        self.called_on_commit += 1;
+        Ok(())
+    }
+
+    fn on_updates<'a>(&mut self, updates: Box<dyn Iterator<Item = T> + 'a>) -> Result<(), E> {
+        self.called_on_updates += updates.count();
+        Ok(())
+    }
+
+    fn on_completed(&mut self) -> Result<(), E> {
+        self.called_on_completed += 1;
+        Ok(())
+    }
+}

--- a/rust/template/distributed_datalog/src/lib.rs
+++ b/rust/template/distributed_datalog/src/lib.rs
@@ -1,4 +1,7 @@
+mod txnmux;
+
 pub use observe::Observable;
+pub use observe::ObservableBox;
 pub use observe::Observer;
 pub use observe::ObserverBox;
 pub use observe::OptionalObserver;
@@ -6,6 +9,7 @@ pub use observe::SharedObserver;
 pub use observe::UpdatesObservable;
 pub use tcp_channel::TcpReceiver;
 pub use tcp_channel::TcpSender;
+pub use txnmux::TxnMux;
 
 #[cfg(feature = "test")]
 pub use observe::MockObserver;

--- a/rust/template/distributed_datalog/src/lib.rs
+++ b/rust/template/distributed_datalog/src/lib.rs
@@ -5,3 +5,6 @@ pub use observe::SharedObserver;
 pub use observe::UpdatesObservable;
 pub use tcp_channel::TcpReceiver;
 pub use tcp_channel::TcpSender;
+
+#[cfg(feature = "test")]
+pub use observe::MockObserver;

--- a/rust/template/distributed_datalog/src/lib.rs
+++ b/rust/template/distributed_datalog/src/lib.rs
@@ -1,6 +1,7 @@
 pub use observe::Observable;
 pub use observe::Observer;
 pub use observe::ObserverBox;
+pub use observe::OptionalObserver;
 pub use observe::SharedObserver;
 pub use observe::UpdatesObservable;
 pub use tcp_channel::TcpReceiver;

--- a/rust/template/distributed_datalog/src/txnmux.rs
+++ b/rust/template/distributed_datalog/src/txnmux.rs
@@ -1,0 +1,97 @@
+use std::any::Any;
+use std::fmt::Debug;
+
+use observe::CachingObserver;
+use observe::Observable;
+use observe::ObservableBox;
+use observe::ObserverBox;
+use observe::OptionalObserver;
+use observe::SharedObserver;
+
+/// A multiplexer for transactions. In a nutshell, this is an object
+/// that tracks a set of `Observable`s and implements the `Observable`
+/// interface (i.e., can be subscribed to) itself. It will ensure that
+/// the registered `Observable`'s transactions are serialized, meaning
+/// the concurrent transactions will be submitted one after the other
+/// without interleaving.
+#[derive(Debug, Default)]
+pub struct TxnMux<T, E>
+where
+    T: Debug + Send,
+    E: Debug + Send,
+{
+    /// The observables we track and our subscriptions to them.
+    subscriptions: Vec<(ObservableBox<T, E>, Box<dyn Any>)>,
+    /// A reference to the `Observer` subscribed to us, if any.
+    observer: SharedObserver<OptionalObserver<ObserverBox<T, E>>>,
+}
+
+impl<T, E> TxnMux<T, E>
+where
+    T: Debug + Send + 'static,
+    E: Debug + Send + 'static,
+{
+    /// Create a new `TxnMux`, without any observables.
+    pub fn new() -> Self {
+        Self {
+            subscriptions: Vec::new(),
+            observer: SharedObserver::new(OptionalObserver::default()),
+        }
+    }
+
+    /// Add an `Observable` to track to the multiplexer.
+    pub fn add_observable(
+        &mut self,
+        mut observable: ObservableBox<T, E>,
+    ) -> Result<(), ObservableBox<T, E>> {
+        // Each observable gets its own `CachingObserver`, which will
+        // take care of applying transactions in one go (serialized by
+        // the shared observer's lock).
+        let cacher = CachingObserver::new(self.observer.clone());
+        match observable.subscribe_any(Box::new(cacher)) {
+            Ok(subscription) => {
+                self.subscriptions.push((observable, subscription));
+                Ok(())
+            }
+            Err(_) => Err(observable),
+        }
+    }
+}
+
+impl<T, E> Drop for TxnMux<T, E>
+where
+    T: Debug + Send,
+    E: Debug + Send,
+{
+    fn drop(&mut self) {
+        for (mut observable, subscription) in self.subscriptions.drain(..).rev() {
+            let _result = observable.unsubscribe_any(subscription.as_ref());
+            debug_assert!(_result.is_some(), "{:?}", subscription);
+        }
+    }
+}
+
+impl<T, E> Observable<T, E> for TxnMux<T, E>
+where
+    T: Debug + Send + 'static,
+    E: Debug + Send + 'static,
+{
+    type Subscription = ();
+
+    fn subscribe(
+        &mut self,
+        observer: ObserverBox<T, E>,
+    ) -> Result<Self::Subscription, ObserverBox<T, E>> {
+        let mut guard = self.observer.lock().unwrap();
+        if guard.is_some() {
+            Err(observer)
+        } else {
+            guard.replace(observer);
+            Ok(())
+        }
+    }
+
+    fn unsubscribe(&mut self, _subscription: &Self::Subscription) -> Option<ObserverBox<T, E>> {
+        self.observer.lock().unwrap().take()
+    }
+}

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -164,6 +164,7 @@ rustLibFiles specname =
         , (dir </> "distributed_datalog/observe/src/lib.rs"          , $(embedFile "rust/template/distributed_datalog/observe/src/lib.rs"))
         , (dir </> "distributed_datalog/observe/src/observable.rs"   , $(embedFile "rust/template/distributed_datalog/observe/src/observable.rs"))
         , (dir </> "distributed_datalog/observe/src/observer.rs"     , $(embedFile "rust/template/distributed_datalog/observe/src/observer.rs"))
+        , (dir </> "distributed_datalog/observe/src/test.rs"         , $(embedFile "rust/template/distributed_datalog/observe/src/test.rs"))
         , (dir </> "distributed_datalog/tcp_channel/Cargo.toml"      , $(embedFile "rust/template/distributed_datalog/tcp_channel/Cargo.toml"))
         , (dir </> "distributed_datalog/tcp_channel/src/lib.rs"      , $(embedFile "rust/template/distributed_datalog/tcp_channel/src/lib.rs"))
         , (dir </> "distributed_datalog/tcp_channel/src/message.rs"  , $(embedFile "rust/template/distributed_datalog/tcp_channel/src/message.rs"))

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -160,6 +160,7 @@ rustLibFiles specname =
         , (dir </> "cmd_parser/parse.rs"                             , $(embedFile "rust/template/cmd_parser/parse.rs"))
         , (dir </> "distributed_datalog/Cargo.toml"                  , $(embedFile "rust/template/distributed_datalog/Cargo.toml"))
         , (dir </> "distributed_datalog/src/lib.rs"                  , $(embedFile "rust/template/distributed_datalog/src/lib.rs"))
+        , (dir </> "distributed_datalog/src/txnmux.rs"               , $(embedFile "rust/template/distributed_datalog/src/txnmux.rs"))
         , (dir </> "distributed_datalog/observe/Cargo.toml"          , $(embedFile "rust/template/distributed_datalog/observe/Cargo.toml"))
         , (dir </> "distributed_datalog/observe/src/lib.rs"          , $(embedFile "rust/template/distributed_datalog/observe/src/lib.rs"))
         , (dir </> "distributed_datalog/observe/src/observable.rs"   , $(embedFile "rust/template/distributed_datalog/observe/src/observable.rs"))

--- a/test/datalog_tests/server_api.dl
+++ b/test/datalog_tests/server_api.dl
@@ -1,13 +1,6 @@
 // A simple test for multiple DDlog programs communicating
 // with each other.
 
-input relation P1In[string]
-output relation P1Out[string]
-
-P1Out[s] :- P1In[s].
-
-
-input relation P2In[string]
-output relation P2Out[string]
-
-P2Out[s] :- P2In[s].
+import server_api_1 as p1
+import server_api_2 as p2
+import server_api_3 as p3

--- a/test/datalog_tests/server_api/Cargo.toml
+++ b/test/datalog_tests/server_api/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 differential_datalog = {path = "../server_api_ddlog/differential_datalog"}
-distributed_datalog = {path = "../server_api_ddlog/distributed_datalog"}
+distributed_datalog = {path = "../server_api_ddlog/distributed_datalog", features=["test"]}
 maplit = "1.0"
 server_api = {path = "../server_api_ddlog"}
 

--- a/test/datalog_tests/server_api/Cargo.toml
+++ b/test/datalog_tests/server_api/Cargo.toml
@@ -11,6 +11,5 @@ server_api = {path = "../server_api_ddlog"}
 
 [dev-dependencies]
 env_logger = {version = "0.6", default_features = false, features = ["humantime"]}
-lazy_static = "1.4"
 test-env-log = "0.1"
 waitfor = "0.1"

--- a/test/datalog_tests/server_api/tests/deltas.rs
+++ b/test/datalog_tests/server_api/tests/deltas.rs
@@ -33,13 +33,13 @@ where
     let program2 = HDDlog::run(1, false, move |relation_id, record: &Record, _| {
         deltas2.lock().unwrap().push((relation_id, record.clone()));
     });
-    let server2 = DDlogServer::new(program2, hashmap! {P1Out => P2In});
+    let server2 = DDlogServer::new(program2, hashmap! {server_api_1_P1Out => server_api_2_P2In});
 
-    let mut stream = server1.add_stream(hashset! {P1Out});
+    let mut stream = server1.add_stream(hashset! {server_api_1_P1Out});
     let _data = setup(&mut stream, SharedObserver::new(server2))?;
 
     let updates = &[UpdCmd::Insert(
-        RelIdentifier::RelId(P1In as usize),
+        RelIdentifier::RelId(server_api_1_P1In as usize),
         Record::String("delta-me-now".to_string()),
     )];
 
@@ -58,7 +58,10 @@ where
         }
     });
 
-    let expected = vec![(P2Out as usize, Record::String("delta-me-now".to_string()))];
+    let expected = vec![(
+        server_api_2_P2Out as usize,
+        Record::String("delta-me-now".to_string()),
+    )];
     assert_eq!(result, Ok(Some(expected)));
     Ok(())
 }

--- a/test/datalog_tests/server_api/tests/deltas.rs
+++ b/test/datalog_tests/server_api/tests/deltas.rs
@@ -1,6 +1,7 @@
 use std::any::Any;
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::thread::spawn;
 use std::time::Duration;
 
 use differential_datalog::record::{Record, RelIdentifier, UpdCmd};
@@ -9,6 +10,7 @@ use distributed_datalog::Observer;
 use distributed_datalog::SharedObserver;
 use distributed_datalog::TcpReceiver;
 use distributed_datalog::TcpSender;
+use distributed_datalog::TxnMux;
 
 use server_api_ddlog::api::*;
 use server_api_ddlog::server::*;
@@ -102,4 +104,148 @@ fn single_delta_tcp() -> Result<(), String> {
     }
 
     single_delta_test(do_test)
+}
+
+fn multi_transaction_test<F>(setup: F) -> Result<(), String>
+where
+    F: FnOnce(
+        UpdatesObservable,
+        UpdatesObservable,
+        SharedObserver<DDlogServer>,
+    ) -> Result<Box<dyn Any>, String>,
+{
+    // The setup we build is as follows:
+    //
+    //       P3[s1 ++ s2]
+    //         /      \
+    //        /        \
+    //     P1[s1]     P2[s2]
+    //
+    let program1 = HDDlog::run(1, false, |_, _: &Record, _| {});
+    let mut server1 = DDlogServer::new(program1, hashmap! {});
+
+    let program2 = HDDlog::run(1, false, |_, _: &Record, _| {});
+    let mut server2 = DDlogServer::new(program2, hashmap! {});
+
+    let deltas = Arc::new(Mutex::new(Vec::new()));
+    let deltas2 = deltas.clone();
+    let program3 = HDDlog::run(1, false, move |relation_id, record: &Record, _| {
+        deltas2.lock().unwrap().push((relation_id, record.clone()));
+    });
+    let redirect = hashmap! {
+        server_api_1_P1Out => server_api_3_P1Out,
+        server_api_2_P2Out => server_api_3_P2Out,
+    };
+    let server3 = DDlogServer::new(program3, redirect);
+
+    let stream1 = server1.add_stream(hashset! {server_api_1_P1Out});
+    let stream2 = server2.add_stream(hashset! {server_api_2_P2Out});
+    let _data = setup(stream1, stream2, SharedObserver::new(server3))?;
+
+    // Insert updates concurrently to test serialization of
+    // transactions.
+    let t1 = spawn(move || {
+        let updates1 = &[UpdCmd::Insert(
+            RelIdentifier::RelId(server_api_1_P1In as usize),
+            Record::String("p1-entry".to_string()),
+        )];
+
+        server1.on_start().unwrap();
+        server1
+            .on_updates(Box::new(
+                updates1.into_iter().map(|cmd| updcmd2upd(cmd).unwrap()),
+            ))
+            .unwrap();
+        server1.on_commit().unwrap();
+    });
+
+    let t2 = spawn(move || {
+        let updates2 = &[UpdCmd::Insert(
+            RelIdentifier::RelId(server_api_2_P2In as usize),
+            Record::String("p2-entry".to_string()),
+        )];
+
+        server2.on_start().unwrap();
+        server2
+            .on_updates(Box::new(
+                updates2.into_iter().map(|cmd| updcmd2upd(cmd).unwrap()),
+            ))
+            .unwrap();
+        server2.on_commit().unwrap();
+    });
+
+    let result = wait_for::<_, _, ()>(Duration::from_secs(5), Duration::from_millis(10), || {
+        let deltas = deltas.lock().unwrap();
+        if deltas.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(deltas.clone()))
+        }
+    });
+
+    t1.join().unwrap();
+    t2.join().unwrap();
+
+    let expected = vec![(
+        server_api_3_P3Out as usize,
+        Record::String("p1-entryp2-entry".to_string()),
+    )];
+    assert_eq!(result, Ok(Some(expected)));
+    Ok(())
+}
+
+/// Test delta retrieval in the face of two concurrent transactions.
+#[test]
+fn multi_transaction_direct() -> Result<(), String> {
+    fn do_test(
+        observable1: UpdatesObservable,
+        observable2: UpdatesObservable,
+        observer: SharedObserver<DDlogServer>,
+    ) -> Result<Box<dyn Any>, String> {
+        let mut mux = TxnMux::new();
+        let _ = mux.subscribe(Box::new(observer)).unwrap();
+        let _ = mux.add_observable(Box::new(observable1)).unwrap();
+        let _ = mux.add_observable(Box::new(observable2)).unwrap();
+
+        Ok(Box::new(mux))
+    }
+
+    multi_transaction_test(do_test)
+}
+
+/// Test delta retrieval in the face of two concurrent transactions over
+/// a TCP channel.
+#[test]
+fn multi_transaction_tcp() -> Result<(), String> {
+    fn do_test(
+        mut observable1: UpdatesObservable,
+        mut observable2: UpdatesObservable,
+        observer: SharedObserver<DDlogServer>,
+    ) -> Result<Box<dyn Any>, String> {
+        // We create the following setup:
+        // o1 -> s1 --(TCP)-> r1 \
+        //                        -- mux -> observer
+        // o2 -> s2 --(TCP)-> r2 /
+        //
+        // (where oX=observableX, sX=sendX, and rX=recvX)
+
+        let mut mux = TxnMux::new();
+        let _ = mux.subscribe(Box::new(observer)).unwrap();
+
+        let recv1 = TcpReceiver::new("127.0.0.1:0").unwrap();
+        let send1 = TcpSender::connect(*recv1.addr()).unwrap();
+
+        let recv2 = TcpReceiver::new("127.0.0.1:0").unwrap();
+        let send2 = TcpSender::connect(*recv2.addr()).unwrap();
+
+        let _ = observable1.subscribe(Box::new(send1)).unwrap();
+        let _ = observable2.subscribe(Box::new(send2)).unwrap();
+
+        let _ = mux.add_observable(Box::new(recv1)).unwrap();
+        let _ = mux.add_observable(Box::new(recv2)).unwrap();
+
+        Ok(Box::new(mux))
+    }
+
+    multi_transaction_test(do_test)
 }

--- a/test/datalog_tests/server_api/tests/events.rs
+++ b/test/datalog_tests/server_api/tests/events.rs
@@ -66,7 +66,7 @@ fn start_commit_on_no_updates(
 
     await_expected(|| {
         let (on_start, on_updates, on_commit) = {
-            let mock = observer.0.lock().unwrap();
+            let mock = observer.lock().unwrap();
             (
                 mock.called_on_start,
                 mock.called_on_updates,
@@ -85,7 +85,7 @@ fn start_commit_on_no_updates(
     // procedure.
     await_expected(|| {
         let on_completed = {
-            let mock = observer.0.lock().unwrap();
+            let mock = observer.lock().unwrap();
             mock.called_on_completed
         };
         assert!(on_completed >= 1, "{}", on_completed);
@@ -96,7 +96,7 @@ fn start_commit_on_no_updates(
     // But only once!
     await_expected(|| {
         let on_completed = {
-            let mock = observer.0.lock().unwrap();
+            let mock = observer.lock().unwrap();
             mock.called_on_completed
         };
         assert!(on_completed >= 1, "{}", on_completed);
@@ -124,7 +124,7 @@ fn start_commit_with_updates(
 
     await_expected(|| {
         let (on_start, on_updates, on_commit) = {
-            let mock = observer.0.lock().unwrap();
+            let mock = observer.lock().unwrap();
             (
                 mock.called_on_start,
                 mock.called_on_updates,
@@ -156,7 +156,7 @@ fn unsubscribe(
 
     await_expected(|| {
         let (on_start, on_commit) = {
-            let mock = observer.0.lock().unwrap();
+            let mock = observer.lock().unwrap();
             (mock.called_on_start, mock.called_on_commit)
         };
 
@@ -197,7 +197,7 @@ fn multiple_mergable_updates(
 
     await_expected(|| {
         let (on_start, on_updates, on_commit) = {
-            let mock = observer.0.lock().unwrap();
+            let mock = observer.lock().unwrap();
             (
                 mock.called_on_start,
                 mock.called_on_updates,
@@ -238,7 +238,7 @@ fn multiple_transactions(
 
     await_expected(|| {
         let (on_start, on_updates, on_commit) = {
-            let mock = observer.0.lock().unwrap();
+            let mock = observer.lock().unwrap();
             (
                 mock.called_on_start,
                 mock.called_on_updates,
@@ -264,7 +264,7 @@ fn multiple_transactions(
 
     await_expected(|| {
         let (on_start, on_updates, on_commit) = {
-            let mock = observer.0.lock().unwrap();
+            let mock = observer.lock().unwrap();
             (
                 mock.called_on_start,
                 mock.called_on_updates,

--- a/test/datalog_tests/server_api/tests/events.rs
+++ b/test/datalog_tests/server_api/tests/events.rs
@@ -8,6 +8,7 @@ use differential_datalog::program::Update;
 use differential_datalog::record::Record;
 use differential_datalog::record::RelIdentifier;
 use differential_datalog::record::UpdCmd;
+use distributed_datalog::MockObserver as Mock;
 use distributed_datalog::Observable;
 use distributed_datalog::Observer;
 use distributed_datalog::SharedObserver;
@@ -27,51 +28,6 @@ use maplit::hashset;
 use test_env_log::test;
 
 use waitfor::wait_for;
-
-#[derive(Clone, Debug)]
-struct Mock {
-    called_on_start: usize,
-    called_on_commit: usize,
-    called_on_updates: usize,
-    called_on_completed: usize,
-}
-
-impl Mock {
-    fn new() -> Self {
-        Self {
-            called_on_start: 0,
-            called_on_commit: 0,
-            called_on_updates: 0,
-            called_on_completed: 0,
-        }
-    }
-}
-
-impl<T, E> Observer<T, E> for Mock
-where
-    T: Send,
-    E: Send,
-{
-    fn on_start(&mut self) -> Result<(), E> {
-        self.called_on_start += 1;
-        Ok(())
-    }
-
-    fn on_commit(&mut self) -> Result<(), E> {
-        self.called_on_commit += 1;
-        Ok(())
-    }
-
-    fn on_updates<'a>(&mut self, updates: Box<dyn Iterator<Item = T> + 'a>) -> Result<(), E> {
-        self.called_on_updates += updates.count();
-        Ok(())
-    }
-
-    fn on_completed(&mut self) -> Result<(), E> {
-        self.called_on_completed += 1;
-        Ok(())
-    }
-}
 
 type MockObserver = SharedObserver<Mock>;
 

--- a/test/datalog_tests/server_api/tests/events.rs
+++ b/test/datalog_tests/server_api/tests/events.rs
@@ -155,7 +155,7 @@ fn start_commit_with_updates(
     observer: MockObserver,
 ) -> Result<(), String> {
     let updates = &[UpdCmd::Insert(
-        RelIdentifier::RelId(P1In as usize),
+        RelIdentifier::RelId(server_api_1_P1In as usize),
         Record::String("test".to_string()),
     )];
 
@@ -219,15 +219,15 @@ fn multiple_mergable_updates(
 ) -> Result<(), String> {
     let updates = &[
         UpdCmd::Insert(
-            RelIdentifier::RelId(P1In as usize),
+            RelIdentifier::RelId(server_api_1_P1In as usize),
             Record::String("42".to_string()),
         ),
         UpdCmd::Insert(
-            RelIdentifier::RelId(P1In as usize),
+            RelIdentifier::RelId(server_api_1_P1In as usize),
             Record::String("here-to-stay".to_string()),
         ),
         UpdCmd::Delete(
-            RelIdentifier::RelId(P1In as usize),
+            RelIdentifier::RelId(server_api_1_P1In as usize),
             Record::String("42".to_string()),
         ),
     ];
@@ -265,11 +265,11 @@ fn multiple_transactions(
 ) -> Result<(), String> {
     let updates = &[
         UpdCmd::Insert(
-            RelIdentifier::RelId(P1In as usize),
+            RelIdentifier::RelId(server_api_1_P1In as usize),
             Record::String("first".to_string()),
         ),
         UpdCmd::Insert(
-            RelIdentifier::RelId(P1In as usize),
+            RelIdentifier::RelId(server_api_1_P1In as usize),
             Record::String("second".to_string()),
         ),
     ];
@@ -296,7 +296,7 @@ fn multiple_transactions(
     });
 
     let updates = &[UpdCmd::Delete(
-        RelIdentifier::RelId(P1In as usize),
+        RelIdentifier::RelId(server_api_1_P1In as usize),
         Record::String("first".to_string()),
     )];
 
@@ -330,7 +330,7 @@ fn setup() -> (DDlogServer, UpdatesObservable, MockObserver) {
     let mut server = DDlogServer::new(program, hashmap! {});
 
     let observer = SharedObserver::new(Mock::new());
-    let mut stream = server.add_stream(hashset! {P1Out});
+    let mut stream = server.add_stream(hashset! {server_api_1_P1Out});
     let _ = stream.subscribe(Box::new(observer.clone())).unwrap();
 
     (server, stream, observer)
@@ -341,7 +341,7 @@ fn setup_tcp() -> (DDlogServer, UpdatesObservable, MockObserver, Box<dyn Any>) {
     let mut server = DDlogServer::new(program, hashmap! {});
 
     let observer = SharedObserver::new(Mock::new());
-    let mut stream = server.add_stream(hashset! {P1Out});
+    let mut stream = server.add_stream(hashset! {server_api_1_P1Out});
 
     let mut recv = TcpReceiver::<Update<Value>>::new("127.0.0.1:0").unwrap();
     let send = TcpSender::connect(*recv.addr()).unwrap();

--- a/test/datalog_tests/server_api_1.ast.expected
+++ b/test/datalog_tests/server_api_1.ast.expected
@@ -90,13 +90,6 @@ extern function std.vec_nth (v: std.Vec<'X>, n: bit<64>): std.Option<'X>
 extern function std.vec_push (v: mut std.Vec<'X>, x: 'X): ()
 extern function std.vec_push_imm (v: std.Vec<'X>, x: 'X): std.Vec<'X>
 extern function std.vec_singleton (x: 'X): std.Vec<'X>
-input relation server_api_1.P1In [string]
-output relation server_api_1.P1Out [string]
-input relation server_api_2.P2In [string]
-output relation server_api_2.P2Out [string]
-input relation server_api_3.P1Out [string]
-input relation server_api_3.P2Out [string]
-output relation server_api_3.P3Out [string]
-server_api_1.P1Out[s] :- server_api_1.P1In[s].
-server_api_2.P2Out[s] :- server_api_2.P2In[s].
-server_api_3.P3Out[(s1 ++ s2)] :- server_api_3.P1Out[s1], server_api_3.P2Out[s2].
+input relation P1In [string]
+output relation P1Out [string]
+P1Out[s] :- P1In[s].

--- a/test/datalog_tests/server_api_1.dl
+++ b/test/datalog_tests/server_api_1.dl
@@ -1,0 +1,4 @@
+input relation P1In[string]
+output relation P1Out[string]
+
+P1Out[s] :- P1In[s].

--- a/test/datalog_tests/server_api_2.ast.expected
+++ b/test/datalog_tests/server_api_2.ast.expected
@@ -90,13 +90,6 @@ extern function std.vec_nth (v: std.Vec<'X>, n: bit<64>): std.Option<'X>
 extern function std.vec_push (v: mut std.Vec<'X>, x: 'X): ()
 extern function std.vec_push_imm (v: std.Vec<'X>, x: 'X): std.Vec<'X>
 extern function std.vec_singleton (x: 'X): std.Vec<'X>
-input relation server_api_1.P1In [string]
-output relation server_api_1.P1Out [string]
-input relation server_api_2.P2In [string]
-output relation server_api_2.P2Out [string]
-input relation server_api_3.P1Out [string]
-input relation server_api_3.P2Out [string]
-output relation server_api_3.P3Out [string]
-server_api_1.P1Out[s] :- server_api_1.P1In[s].
-server_api_2.P2Out[s] :- server_api_2.P2In[s].
-server_api_3.P3Out[(s1 ++ s2)] :- server_api_3.P1Out[s1], server_api_3.P2Out[s2].
+input relation P2In [string]
+output relation P2Out [string]
+P2Out[s] :- P2In[s].

--- a/test/datalog_tests/server_api_2.dl
+++ b/test/datalog_tests/server_api_2.dl
@@ -1,0 +1,4 @@
+input relation P2In[string]
+output relation P2Out[string]
+
+P2Out[s] :- P2In[s].

--- a/test/datalog_tests/server_api_3.ast.expected
+++ b/test/datalog_tests/server_api_3.ast.expected
@@ -90,13 +90,7 @@ extern function std.vec_nth (v: std.Vec<'X>, n: bit<64>): std.Option<'X>
 extern function std.vec_push (v: mut std.Vec<'X>, x: 'X): ()
 extern function std.vec_push_imm (v: std.Vec<'X>, x: 'X): std.Vec<'X>
 extern function std.vec_singleton (x: 'X): std.Vec<'X>
-input relation server_api_1.P1In [string]
-output relation server_api_1.P1Out [string]
-input relation server_api_2.P2In [string]
-output relation server_api_2.P2Out [string]
-input relation server_api_3.P1Out [string]
-input relation server_api_3.P2Out [string]
-output relation server_api_3.P3Out [string]
-server_api_1.P1Out[s] :- server_api_1.P1In[s].
-server_api_2.P2Out[s] :- server_api_2.P2In[s].
-server_api_3.P3Out[(s1 ++ s2)] :- server_api_3.P1Out[s1], server_api_3.P2Out[s2].
+input relation P1Out [string]
+input relation P2Out [string]
+output relation P3Out [string]
+P3Out[(s1 ++ s2)] :- P1Out[s1], P2Out[s2].

--- a/test/datalog_tests/server_api_3.dl
+++ b/test/datalog_tests/server_api_3.dl
@@ -1,0 +1,6 @@
+input relation P1Out[string]
+input relation P2Out[string]
+
+output relation P3Out[string]
+
+P3Out[s1 ++ s2] :- P1Out[s1], P2Out[s2].


### PR DESCRIPTION
This change implements a transaction multiplexer for observables. Basically the moment we have `n` observables pushing updates to a single observer (e.g., datalog server/program) we may run into problems because only a single transaction can be active on an `HDDlog`.
To handle those cases we need to ensure that transactions don't interleave, buffering updates as required and then pushing them atomically.