### PR TITLE
Topic/txnmux

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,7 +29,13 @@ test-tutorial:
     script: stack --no-terminal test --ta "-p tutorial"
 
 test-server_api:
-    script: stack --no-terminal test --ta '-p "$(NF) == \"generate server_api\" || (($(NF-1) == \"compiler tests\" || $(NF-1) == \"unit tests\") && $(NF) == \"server_api\")"'
+    script:
+    - i=0;
+      true;
+      while [ $? -eq 0 -a $i -lt 100 ]; do
+        i=$((i+1));
+        stack --no-terminal test --ta '-p "$(NF) == \"generate server_api\" || (($(NF-1) == \"compiler tests\" || $(NF-1) == \"unit tests\") && $(NF) == \"server_api\")"';
+      done
 
 test-simple:
     script: stack --no-terminal test --ta "-p simple"

--- a/doc/tutorial/tutorial.md
+++ b/doc/tutorial/tutorial.md
@@ -41,8 +41,8 @@ Installation instructions are found in the [README](../../README.md#Installation
 ## "Hello, World!" in DDlog
 
 Files storing DDlog programs have the `.dl` suffix.
-[dl.vim](../../tools/dl.vim) is a file that offers syntax highlighting
-support for the vim editor.
+[dl.vim](../../tools/vim/syntax/dl.vim) is a file that offers syntax
+highlighting support for the vim editor.
 
 If you add a file called `playpen.dl`, in the `test/datalog_tests`
 directory, it will be executed automatically when you run the DDlog tests, by

--- a/rust/template/Cargo.toml
+++ b/rust/template/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "datalog_example"
 version = "0.1.0"
+edition = "2018"
 autobins = false
 build = "src/build.rs"
 

--- a/rust/template/cmd_parser/Cargo.toml
+++ b/rust/template/cmd_parser/Cargo.toml
@@ -1,15 +1,16 @@
 [package]
 name = "cmd_parser"
 version = "0.1.0"
+edition = "2018"
 
 [dependencies.differential_datalog]
 path = "../differential_datalog"
 
 [dependencies]
+libc = "0.2.42"
 nom = "4.0"
 num = "0.2"
 rustyline = "1.0.0"
-libc = "0.2.42"
 
 [lib]
 name = "cmd_parser"

--- a/rust/template/cmd_parser/lib.rs
+++ b/rust/template/cmd_parser/lib.rs
@@ -1,21 +1,15 @@
 #![warn(missing_debug_implementations)]
 
-extern crate libc;
-extern crate nom;
-extern crate num;
-extern crate rustyline;
-
-extern crate differential_datalog;
-
 mod parse;
+
+use std::io;
+use std::io::{BufRead, BufReader};
 
 pub use parse::*;
 
 use nom::*;
 use rustyline::error::ReadlineError;
 use rustyline::Editor;
-use std::io;
-use std::io::{BufRead, BufReader};
 
 const HISTORY_FILE: &str = "cmd_parser_history.txt";
 

--- a/rust/template/differential_datalog/Cargo.toml
+++ b/rust/template/differential_datalog/Cargo.toml
@@ -1,21 +1,22 @@
 [package]
 name = "differential_datalog"
 version = "0.1.0"
+edition = "2018"
 
 [dependencies.graph_map]
-git="https://github.com/frankmcsherry/graph-map.git"
+git = "https://github.com/frankmcsherry/graph-map.git"
 
 [dev-dependencies]
-byteorder="0.4.2"
-getopts="0.2.14"
-itertools="^0.6"
-rand="0.3.13"
+byteorder = "0.4.2"
+getopts = "0.2.14"
+itertools = "^0.6"
+rand = "0.3.13"
 serde_derive = "1.0"
 
 [dependencies]
 abomonation = "0.7"
 differential-dataflow = "0.9"
-fnv="1.0.2"
+fnv = "1.0.2"
 libc = "0.2"
 num = { version = "0.2", features = ["serde"] }
 sequence_trie = "0.3"

--- a/rust/template/differential_datalog/lib.rs
+++ b/rust/template/differential_datalog/lib.rs
@@ -1,20 +1,5 @@
 #![allow(clippy::get_unwrap, clippy::type_complexity)]
 
-extern crate abomonation;
-extern crate num;
-
-#[cfg(test)]
-#[macro_use]
-extern crate serde_derive;
-extern crate libc;
-extern crate serde;
-
-extern crate timely;
-//extern crate timely_communication;
-extern crate differential_dataflow;
-extern crate fnv;
-extern crate sequence_trie;
-
 mod profile;
 #[cfg(test)]
 mod test;

--- a/rust/template/differential_datalog/program.rs
+++ b/rust/template/differential_datalog/program.rs
@@ -49,7 +49,6 @@ use differential_dataflow::trace::TraceReader;
 use differential_dataflow::AsCollection;
 use differential_dataflow::Collection;
 use differential_dataflow::Data;
-use timely;
 use timely::communication::initialize::Configuration;
 use timely::communication::Allocator;
 use timely::dataflow::operators::*;
@@ -61,9 +60,9 @@ use timely::progress::timestamp::Refines;
 use timely::progress::{PathSummary, Timestamp};
 use timely::worker::Worker;
 
-use profile::*;
-use record::Mutator;
-use variable::*;
+use crate::profile::*;
+use crate::record::Mutator;
+use crate::variable::*;
 
 type TValAgent<S, V> = TraceAgent<
     V,

--- a/rust/template/differential_datalog/test.rs
+++ b/rust/template/differential_datalog/test.rs
@@ -12,19 +12,23 @@
     clippy::trivially_copy_pass_by_ref
 )]
 
-use abomonation::Abomonation;
-use program::*;
-use uint::*;
-
-use differential_dataflow::operators::Join;
-use differential_dataflow::Collection;
-use fnv::FnvHashMap;
 use std::collections::btree_map::{BTreeMap, Entry};
 use std::iter::FromIterator;
 use std::sync::{Arc, Mutex};
+
+use abomonation::Abomonation;
+use fnv::FnvHashMap;
+use serde::Deserialize;
+use serde::Serialize;
 use timely::communication::Allocator;
 use timely::dataflow::scopes::*;
 use timely::worker::Worker;
+
+use differential_dataflow::operators::Join;
+use differential_dataflow::Collection;
+
+use crate::program::*;
+use crate::uint::*;
 
 const TEST_SIZE: u64 = 1000;
 

--- a/rust/template/differential_datalog/test_record.rs
+++ b/rust/template/differential_datalog/test_record.rs
@@ -1,13 +1,15 @@
 //! Tests for functions and macros in `record.rs`
 
-use num::bigint::{ToBigInt, ToBigUint};
-use num::{BigInt, BigUint};
-use record::*;
 use std::borrow;
 use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
 use std::iter::FromIterator;
 use std::vec;
+
+use num::bigint::{ToBigInt, ToBigUint};
+use num::{BigInt, BigUint};
+
+use crate::record::*;
 
 #[test]
 fn test_u8() {

--- a/rust/template/differential_datalog/variable.rs
+++ b/rust/template/differential_datalog/variable.rs
@@ -9,8 +9,8 @@ use timely::dataflow::scopes::Child;
 use timely::dataflow::*;
 use timely::order::Product;
 
-use profile::*;
-use program::{TSNested, Weight};
+use crate::profile::*;
+use crate::program::{TSNested, Weight};
 
 /// A collection defined by multiple mutually recursive rules.
 ///

--- a/rust/template/distributed_datalog/Cargo.toml
+++ b/rust/template/distributed_datalog/Cargo.toml
@@ -3,6 +3,9 @@ name = "distributed_datalog"
 version = "0.1.0"
 edition = "2018"
 
+[dev-dependencies]
+observe = {path = "observe", features = ["test"]}
+
 [dependencies]
 observe = {path = "observe"}
 tcp_channel = {path = "tcp_channel"}

--- a/rust/template/distributed_datalog/observe/src/lib.rs
+++ b/rust/template/distributed_datalog/observe/src/lib.rs
@@ -16,7 +16,6 @@ pub use observable::Observable;
 pub use observable::ObservableAny;
 pub use observable::ObservableBox;
 pub use observable::UpdatesObservable;
-pub use observer::CachingObserver;
 pub use observer::Observer;
 pub use observer::ObserverBox;
 pub use observer::OptionalObserver;

--- a/rust/template/distributed_datalog/observe/src/observer.rs
+++ b/rust/template/distributed_datalog/observe/src/observer.rs
@@ -1,6 +1,4 @@
-use std::collections::LinkedList;
 use std::fmt::Debug;
-use std::mem::replace;
 use std::ops::Deref;
 use std::ops::DerefMut;
 use std::sync::Arc;
@@ -115,70 +113,6 @@ where
     }
 }
 
-/// Wrapper around an `Observer` that stores updates and pushes them
-/// forward only when an `on_commit` is received.
-#[derive(Debug)]
-pub struct CachingObserver<O, T> {
-    /// The observer we ultimately push our data to when we received the
-    /// `on_commit` event.
-    observer: O,
-    /// The data we accumulated so far.
-    data: Option<LinkedList<Vec<T>>>,
-}
-
-impl<O, T> CachingObserver<O, T> {
-    /// Create a new `CachingObserver` wrapping the provided observer.
-    pub fn new(observer: O) -> Self {
-        Self {
-            observer,
-            data: None,
-        }
-    }
-}
-
-impl<O, T, E> Observer<T, E> for CachingObserver<O, T>
-where
-    O: Observer<T, E>,
-    T: Send + Debug,
-    E: Send,
-{
-    fn on_start(&mut self) -> Result<(), E> {
-        if self.data.is_none() {
-            self.data = Some(LinkedList::new());
-        } else {
-            panic!("received multiple on_start events")
-        }
-        Ok(())
-    }
-
-    fn on_commit(&mut self) -> Result<(), E> {
-        if let Some(ref mut data) = self.data.take() {
-            self.observer.on_start()?;
-            let updates_list = replace(data, LinkedList::new());
-            for updates in updates_list.into_iter() {
-                self.observer.on_updates(Box::new(updates.into_iter()))?;
-            }
-            self.observer.on_commit()?;
-        } else {
-            panic!("on_commit was not preceded by an on_start event")
-        }
-        Ok(())
-    }
-
-    fn on_updates<'a>(&mut self, updates: Box<dyn Iterator<Item = T> + 'a>) -> Result<(), E> {
-        if let Some(ref mut data) = self.data {
-            data.push_back(updates.collect());
-        } else {
-            panic!("on_updates was not preceded by an on_start event")
-        }
-        Ok(())
-    }
-
-    fn on_completed(&mut self) -> Result<(), E> {
-        self.observer.on_completed()
-    }
-}
-
 /// An `Observer` that wraps an inner, optional `Observer`. If the inner
 /// one is unset all events will just be dropped.
 #[derive(Debug)]
@@ -205,6 +139,11 @@ impl<O> OptionalObserver<O> {
     /// Check whether an actual observer is present or not.
     pub fn is_some(&self) -> bool {
         self.0.is_some()
+    }
+
+    /// Retrieve an `Option` referencing the inner `Observer`.
+    pub fn as_ref(&self) -> Option<&O> {
+        self.0.as_ref()
     }
 }
 
@@ -242,27 +181,6 @@ mod tests {
     use super::*;
 
     use crate::test::MockObserver;
-
-    /// Test caching of transactions via a `CachingObserver`.
-    #[test]
-    fn transaction_caching() {
-        let mock = SharedObserver::new(MockObserver::new());
-        let observer = &mut CachingObserver::new(mock.clone()) as &mut dyn Observer<_, ()>;
-
-        assert_eq!(observer.on_start(), Ok(()));
-        assert_eq!(mock.0.lock().unwrap().called_on_start, 0);
-
-        assert_eq!(observer.on_updates(Box::new([1, 3, 2].iter())), Ok(()));
-        assert_eq!(mock.0.lock().unwrap().called_on_updates, 0);
-
-        assert_eq!(observer.on_updates(Box::new([6, 4, 5].iter())), Ok(()));
-        assert_eq!(mock.0.lock().unwrap().called_on_updates, 0);
-
-        assert_eq!(observer.on_commit(), Ok(()));
-        assert_eq!(mock.0.lock().unwrap().called_on_start, 1);
-        assert_eq!(mock.0.lock().unwrap().called_on_updates, 6);
-        assert_eq!(mock.0.lock().unwrap().called_on_commit, 1);
-    }
 
     /// Test the workings of an `OptionalObserver` with no actual
     /// observer present.

--- a/rust/template/distributed_datalog/observe/src/test.rs
+++ b/rust/template/distributed_datalog/observe/src/test.rs
@@ -1,14 +1,20 @@
 use crate::Observer;
 
-#[derive(Clone, Debug, Default)]
+/// A dummy observer merely counting method invocations.
+#[derive(Copy, Clone, Debug, Default)]
 pub struct MockObserver {
+    /// The number of `on_start` calls the observer has seen.
     pub called_on_start: usize,
+    /// The number of `on_commit` calls the observer has seen.
     pub called_on_commit: usize,
+    /// The number of updates the observer has received.
     pub called_on_updates: usize,
+    /// The number of `on_completed` calls the observer has seen.
     pub called_on_completed: usize,
 }
 
 impl MockObserver {
+    /// Create a new `MockObserver`.
     pub fn new() -> Self {
         Self {
             called_on_start: 0,

--- a/rust/template/distributed_datalog/src/lib.rs
+++ b/rust/template/distributed_datalog/src/lib.rs
@@ -11,5 +11,5 @@ pub use tcp_channel::TcpReceiver;
 pub use tcp_channel::TcpSender;
 pub use txnmux::TxnMux;
 
-#[cfg(feature = "test")]
+#[cfg(any(test, feature = "test"))]
 pub use observe::MockObserver;

--- a/rust/template/distributed_datalog/src/txnmux.rs
+++ b/rust/template/distributed_datalog/src/txnmux.rs
@@ -1,12 +1,77 @@
 use std::any::Any;
+use std::collections::LinkedList;
 use std::fmt::Debug;
+use std::mem::replace;
 
-use observe::CachingObserver;
 use observe::Observable;
 use observe::ObservableBox;
+use observe::Observer;
 use observe::ObserverBox;
 use observe::OptionalObserver;
 use observe::SharedObserver;
+
+/// Wrapper around a `SharedObserver` that stores updates and pushes them
+/// forward only when an `on_commit` is received.
+#[derive(Debug)]
+struct CachingObserver<O, T> {
+    /// The observer we ultimately push our data to when we received the
+    /// `on_commit` event.
+    observer: SharedObserver<OptionalObserver<O>>,
+    /// The data we accumulated so far.
+    data: Option<LinkedList<Vec<T>>>,
+}
+
+impl<O, T> CachingObserver<O, T> {
+    /// Create a new `CachingObserver` wrapping the provided observer.
+    pub fn new(observer: SharedObserver<OptionalObserver<O>>) -> Self {
+        Self {
+            observer,
+            data: None,
+        }
+    }
+}
+
+impl<O, T, E> Observer<T, E> for CachingObserver<O, T>
+where
+    O: Observer<T, E>,
+    T: Send + Debug,
+    E: Send,
+{
+    fn on_start(&mut self) -> Result<(), E> {
+        if self.data.is_none() {
+            self.data = Some(LinkedList::new());
+        } else {
+            panic!("received multiple on_start events")
+        }
+        Ok(())
+    }
+
+    fn on_commit(&mut self) -> Result<(), E> {
+        if let Some(ref mut data) = self.data.take() {
+            let updates = replace(data, LinkedList::new());
+            let mut guard = self.observer.lock().unwrap();
+            guard.on_start()?;
+            guard.on_updates(Box::new(updates.into_iter().flatten()))?;
+            guard.on_commit()?;
+        } else {
+            panic!("on_commit was not preceded by an on_start event")
+        }
+        Ok(())
+    }
+
+    fn on_updates<'a>(&mut self, updates: Box<dyn Iterator<Item = T> + 'a>) -> Result<(), E> {
+        if let Some(ref mut data) = self.data {
+            data.push_back(updates.collect());
+        } else {
+            panic!("on_updates was not preceded by an on_start event")
+        }
+        Ok(())
+    }
+
+    fn on_completed(&mut self) -> Result<(), E> {
+        self.observer.on_completed()
+    }
+}
 
 /// A multiplexer for transactions. In a nutshell, this is an object
 /// that tracks a set of `Observable`s and implements the `Observable`
@@ -35,7 +100,7 @@ where
     pub fn new() -> Self {
         Self {
             subscriptions: Vec::new(),
-            observer: SharedObserver::new(OptionalObserver::default()),
+            observer: SharedObserver::default(),
         }
     }
 
@@ -93,5 +158,33 @@ where
 
     fn unsubscribe(&mut self, _subscription: &Self::Subscription) -> Option<ObserverBox<T, E>> {
         self.observer.lock().unwrap().take()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::MockObserver;
+
+    /// Test caching of transactions via a `CachingObserver`.
+    #[test]
+    fn transaction_caching() {
+        let mock = SharedObserver::new(OptionalObserver::new(MockObserver::new()));
+        let observer = &mut CachingObserver::new(mock.clone()) as &mut dyn Observer<_, ()>;
+
+        assert_eq!(observer.on_start(), Ok(()));
+        assert_eq!(mock.lock().unwrap().as_ref().unwrap().called_on_start, 0);
+
+        assert_eq!(observer.on_updates(Box::new([1, 3, 2].iter())), Ok(()));
+        assert_eq!(mock.lock().unwrap().as_ref().unwrap().called_on_updates, 0);
+
+        assert_eq!(observer.on_updates(Box::new([6, 4, 5].iter())), Ok(()));
+        assert_eq!(mock.lock().unwrap().as_ref().unwrap().called_on_updates, 0);
+
+        assert_eq!(observer.on_commit(), Ok(()));
+        assert_eq!(mock.lock().unwrap().as_ref().unwrap().called_on_start, 1);
+        assert_eq!(mock.lock().unwrap().as_ref().unwrap().called_on_updates, 6);
+        assert_eq!(mock.lock().unwrap().as_ref().unwrap().called_on_commit, 1);
     }
 }

--- a/rust/template/ovsdb/Cargo.toml
+++ b/rust/template/ovsdb/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "ddlog_ovsdb_adapter"
 version = "0.1.0"
+edition = "2018"
 
 [dependencies.differential_datalog]
 path = "../differential_datalog"
 
 [dependencies]
-serde_json="1.0"
 num = "0.2"
+serde_json = "1.0"
 
 [dependencies.uuid]
 version = "0.7"

--- a/rust/template/ovsdb/lib.rs
+++ b/rust/template/ovsdb/lib.rs
@@ -2,20 +2,18 @@
 
 #![allow(clippy::map_clone)]
 #![warn(missing_copy_implementations, missing_debug_implementations)]
-extern crate differential_datalog;
-extern crate num;
-extern crate serde_json;
-extern crate uuid;
 
-use differential_datalog::record::*;
+#[cfg(test)]
+mod test;
+
+use std::borrow::Cow;
+
 use num::{BigInt, Signed, ToPrimitive};
 use serde_json::map::Map;
 use serde_json::Number;
 use serde_json::Value;
-use std::borrow::Cow;
 
-#[cfg(test)]
-mod test;
+use differential_datalog::record::*;
 
 /*
  * Functions to parse JSON into DDlog commands

--- a/rust/template/src/main.rs
+++ b/rust/template/src/main.rs
@@ -4,18 +4,8 @@
 
 #![allow(dead_code, non_snake_case)]
 
-//#![feature(alloc_system)]
-//extern crate alloc_system;
-
-extern crate cmd_parser;
-extern crate datalog_example_ddlog;
-extern crate differential_datalog;
-extern crate time;
-
-#[macro_use]
-extern crate rustop;
-
 use std::io::stdout;
+use std::io::Write;
 use std::process::exit;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -25,11 +15,10 @@ use cmd_parser::*;
 use datalog_example_ddlog::*;
 use differential_datalog::program::*;
 use differential_datalog::record::*;
-use std::io::Write;
+use rustop::opts;
 use time::precise_time_ns;
 
 // uncomment to enable profiling
-//extern crate cpuprofiler;
 //use cpuprofiler::PROFILER;
 
 #[allow(clippy::let_and_return)]

--- a/rust/template/src/server.rs
+++ b/rust/template/src/server.rs
@@ -3,7 +3,6 @@ use std::fmt;
 use std::fmt::{Debug, Formatter};
 use std::sync::{Arc, Mutex};
 
-use api::HDDlog;
 use differential_datalog::program::{RelId, Response, Update};
 use differential_datalog::record::{Record, RelIdentifier, UpdCmd};
 use distributed_datalog::Observer;
@@ -11,6 +10,8 @@ use distributed_datalog::ObserverBox as ObserverBoxT;
 use distributed_datalog::OptionalObserver;
 use distributed_datalog::SharedObserver;
 use distributed_datalog::UpdatesObservable as UpdatesObservableT;
+
+use crate::api::HDDlog;
 
 pub type ObserverBox = ObserverBoxT<Update<super::Value>, String>;
 pub type UpdatesObservable = UpdatesObservableT<Update<super::Value>, String>;

--- a/test/datalog_tests/server_api/tests/deltas.rs
+++ b/test/datalog_tests/server_api/tests/deltas.rs
@@ -108,11 +108,7 @@ fn single_delta_tcp() -> Result<(), String> {
 
 fn multi_transaction_test<F>(setup: F) -> Result<(), String>
 where
-    F: FnOnce(
-        UpdatesObservable,
-        UpdatesObservable,
-        SharedObserver<DDlogServer>,
-    ) -> Result<Box<dyn Any>, String>,
+    F: FnOnce(UpdatesObservable, UpdatesObservable, DDlogServer) -> Result<Box<dyn Any>, String>,
 {
     // The setup we build is as follows:
     //
@@ -140,7 +136,7 @@ where
 
     let stream1 = server1.add_stream(hashset! {server_api_1_P1Out});
     let stream2 = server2.add_stream(hashset! {server_api_2_P2Out});
-    let _data = setup(stream1, stream2, SharedObserver::new(server3))?;
+    let _data = setup(stream1, stream2, server3)?;
 
     // Insert updates concurrently to test serialization of
     // transactions.
@@ -200,7 +196,7 @@ fn multi_transaction_direct() -> Result<(), String> {
     fn do_test(
         observable1: UpdatesObservable,
         observable2: UpdatesObservable,
-        observer: SharedObserver<DDlogServer>,
+        observer: DDlogServer,
     ) -> Result<Box<dyn Any>, String> {
         let mut mux = TxnMux::new();
         let _ = mux.subscribe(Box::new(observer)).unwrap();
@@ -220,7 +216,7 @@ fn multi_transaction_tcp() -> Result<(), String> {
     fn do_test(
         mut observable1: UpdatesObservable,
         mut observable2: UpdatesObservable,
-        observer: SharedObserver<DDlogServer>,
+        observer: DDlogServer,
     ) -> Result<Box<dyn Any>, String> {
         // We create the following setup:
         // o1 -> s1 --(TCP)-> r1 \


### PR DESCRIPTION
When run frequently, the "deltas" test fails on occasion with an error
indicating that an attempt was made to start a new transaction when one
is already in progress.
The problem here is that the initial idea was to have the
CachingObserver be invoked while holding a mutex protecting the overall
observer. However, that turned out to be not possible and so we ended up
invoking methods on the inner observer that by themselves were protected
by a lock but not as a whole -- so interleaving of transactions was
still possible.
This pull request fixes the problem by making the CachingObserver aware that
it contains a SharedObserver inside and protecting the overall
transaction by its lock. Because it is less general now I decided to
make it private to the txnmux module.
It also includes changes to update all our template's crates to use Rust Edition 2018.