### PR TITLE
Compile.hs: Avoid name clash in aggregation.

### DIFF
--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -97,7 +97,7 @@ bOX_VAR = "__box"
 
 -- Input argument to aggregation function
 gROUP_VAR :: Doc
-gROUP_VAR = "group"
+gROUP_VAR = "__group__"
 
 -- Functions that return a Rust reference rather than a value.
 -- FIXME: there should be a way to annotate function definitions


### PR DESCRIPTION
We generated variable named `group` when compiling the `Aggregate`
operator, which would clash with a user-defined variable with the same
name in, e.g.,:

```
relation GroupConstraints(group: groupid_t, constraints: Vec<constraint_t>)

GroupConstraints(group, constraints) :-
    GroupConstraint(group, constraint),
    var constraints = Aggregate((group), group2vec(constraint)).
```

Rename the generated variable to `__group__` instead.