### PR TITLE
Topic/d3log feature

### DIFF
--- a/rust/template/Cargo.toml
+++ b/rust/template/Cargo.toml
@@ -21,6 +21,7 @@ path = "./differential_datalog"
 
 [dependencies.distributed_datalog]
 path = "./distributed_datalog"
+optional = true
 
 [dependencies.cmd_parser]
 path = "./cmd_parser"
@@ -49,6 +50,7 @@ flatbuffers = {version = "0.6", optional = true}
 
 [features]
 default = []
+d3log = ["distributed_datalog"]
 flatbuf = ["flatbuffers"]
 
 [profile.release]

--- a/rust/template/differential_datalog/record.rs
+++ b/rust/template/differential_datalog/record.rs
@@ -14,7 +14,6 @@ use std::slice;
 use std::string::ToString;
 use std::vec;
 
-extern crate serde;
 use serde::{Deserialize, Serialize};
 
 pub type Name = Cow<'static, str>;

--- a/rust/template/src/build.rs
+++ b/rust/template/src/build.rs
@@ -1,5 +1,3 @@
-extern crate libtool;
-
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/rust/template/src/lib.rs
+++ b/rust/template/src/lib.rs
@@ -58,6 +58,7 @@ use num_traits::identities::One;
 
 pub mod api;
 pub mod ovsdb;
+#[cfg(feature = "d3log")]
 pub mod server;
 pub mod update_handler;
 pub mod valmap;

--- a/rust/template/src/lib.rs
+++ b/rust/template/src/lib.rs
@@ -12,45 +12,6 @@
     clippy::redundant_closure // Broken in 1.34
 )]
 
-extern crate differential_dataflow;
-extern crate fnv;
-extern crate num_traits;
-extern crate timely;
-
-#[macro_use]
-extern crate lazy_static;
-
-#[macro_use]
-extern crate serde;
-extern crate libc;
-extern crate twox_hash;
-
-#[macro_use]
-extern crate differential_datalog;
-extern crate distributed_datalog;
-
-extern crate abomonation;
-extern crate ddlog_ovsdb_adapter;
-
-#[cfg(feature = "flatbuf")]
-extern crate flatbuffers;
-
-use differential_dataflow::collection;
-use timely::communication;
-use timely::dataflow::scopes;
-use timely::worker;
-
-use abomonation::Abomonation;
-use differential_datalog::arcval;
-use differential_datalog::int::*;
-use differential_datalog::program::*;
-use differential_datalog::record;
-use differential_datalog::record::{FromRecord, IntoRecord, Mutator};
-use differential_datalog::uint::*;
-
-use fnv::{FnvHashMap, FnvHashSet};
-use libc::size_t;
-use num_traits::identities::One;
 use std::borrow;
 use std::boxed;
 use std::ffi;
@@ -67,6 +28,33 @@ use std::os::unix;
 use std::os::unix::io::{FromRawFd, IntoRawFd};
 use std::ptr;
 use std::sync;
+
+use differential_dataflow::collection;
+use timely::communication;
+use timely::dataflow::scopes;
+use timely::worker;
+
+use serde::Deserialize;
+use serde::Serialize;
+
+use abomonation::Abomonation;
+use differential_datalog::arcval;
+use differential_datalog::decl_enum_into_record;
+use differential_datalog::decl_record_mutator_enum;
+use differential_datalog::decl_record_mutator_struct;
+use differential_datalog::decl_record_mutator_val_enum;
+use differential_datalog::decl_struct_into_record;
+use differential_datalog::decl_val_enum_into_record;
+use differential_datalog::int::*;
+use differential_datalog::program::*;
+use differential_datalog::record;
+use differential_datalog::record::{FromRecord, IntoRecord, Mutator};
+use differential_datalog::uint::*;
+
+use fnv::{FnvHashMap, FnvHashSet};
+use lazy_static::lazy_static;
+use libc::size_t;
+use num_traits::identities::One;
 
 pub mod api;
 pub mod ovsdb;

--- a/rust/template/tests/common/mod.rs
+++ b/rust/template/tests/common/mod.rs
@@ -1,5 +1,3 @@
-extern crate cmd_parser;
-
 use std::env::current_exe;
 use std::env::var_os;
 use std::io::Write;

--- a/rust/template/tests/interact_dump_error.rs
+++ b/rust/template/tests/interact_dump_error.rs
@@ -2,8 +2,6 @@
 // here invokes itself and having multiple test running in parallel
 // while that is happening is probably a bad idea.
 
-extern crate cmd_parser;
-
 use cmd_parser::Command;
 
 mod common;

--- a/rust/template/tests/interact_exit.rs
+++ b/rust/template/tests/interact_exit.rs
@@ -2,8 +2,6 @@
 // here invokes itself and having multiple test running in parallel
 // while that is happening is probably a bad idea.
 
-extern crate cmd_parser;
-
 use cmd_parser::Command;
 
 mod common;

--- a/test/datalog_tests/server_api/Cargo.toml
+++ b/test/datalog_tests/server_api/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 differential_datalog = {path = "../server_api_ddlog/differential_datalog"}
 distributed_datalog = {path = "../server_api_ddlog/distributed_datalog", features=["test"]}
 maplit = "1.0"
-server_api = {path = "../server_api_ddlog"}
+server_api = {path = "../server_api_ddlog", features=["d3log"]}
 
 [dev-dependencies]
 env_logger = {version = "0.6", default_features = false, features = ["humantime"]}


### PR DESCRIPTION
This pull request introduces a new Cargo feature, `d3log`, for the template. The feature is disabled by default, as it is meant to be completely optional with only a subset of clients expected to use it.

By having this feature disabled we remove the need to compile a total of five crates unless users opt in. This will probably have a small effect on pipeline runs right now and more moving forward (as the code base for the distributed parts continues to grow).

Perhaps more importantly, we isolate the distributed part of the code base from the (stable) core. It is conceivable, for example, that we require a newer Rust version for this functionality (e.g., because Rust 1.39 is slated to stabilize async-await syntax and we may want to use it when working with certain async enabled crates).

This change is also at least somewhat related to issue #411.
