### PR TITLE
Introduce profile Cargo feature

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,7 +38,11 @@ test-server_api:
       done
 
 test-simple:
-    script: stack --no-terminal test --ta "-p simple"
+    script:
+    - stack --no-terminal test --ta "-p simple"
+    - apt-get update
+    - apt-get install --assume-yes libgoogle-perftools-dev
+    - cd test/datalog_tests/simple_ddlog/ && LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/ cargo build --features='profile'
 
 test-modules:
     script: stack --no-terminal test --ta "-p modules"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,8 +40,6 @@ test-server_api:
 test-simple:
     script:
     - stack --no-terminal test --ta "-p simple"
-    - apt-get update
-    - apt-get install --assume-yes libgoogle-perftools-dev
     - cd test/datalog_tests/simple_ddlog/ && LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/ cargo build --features='profile'
 
 test-modules:

--- a/rust/template/Cargo.toml
+++ b/rust/template/Cargo.toml
@@ -31,9 +31,9 @@ path = "./ovsdb"
 
 [dependencies]
 abomonation = "0.7"
-cpuprofiler = "0.0.3"
+cpuprofiler = {version = "0.0.3", optional = true}
 differential-dataflow = "0.9"
-fnv="1.0.2"
+fnv = "1.0.2"
 lazy_static = "1.3"
 libc = "0.2"
 num-traits = "0.2"
@@ -52,6 +52,7 @@ flatbuffers = {version = "0.6", optional = true}
 default = []
 d3log = ["distributed_datalog"]
 flatbuf = ["flatbuffers"]
+profile = ["cpuprofiler"]
 
 [profile.release]
 opt-level = 2

--- a/rust/template/src/main.rs
+++ b/rust/template/src/main.rs
@@ -18,8 +18,8 @@ use differential_datalog::record::*;
 use rustop::opts;
 use time::precise_time_ns;
 
-// uncomment to enable profiling
-//use cpuprofiler::PROFILER;
+#[cfg(feature = "profile")]
+use cpuprofiler::PROFILER;
 
 #[allow(clippy::let_and_return)]
 fn handle_cmd(
@@ -37,8 +37,15 @@ fn handle_cmd(
     .and(match cmd {
         Command::Start => hddlog.transaction_start(),
         Command::Commit(record_delta) => {
-            // uncomment to enable profiling
-            // PROFILER.lock().unwrap().start("./prof.profile").expect("Couldn't start profiling");
+            #[cfg(feature = "profile")]
+            {
+                PROFILER
+                    .lock()
+                    .unwrap()
+                    .start("./prof.profile")
+                    .expect("Couldn't start profiling");
+            }
+
             let res = if record_delta {
                 hddlog.transaction_commit_dump_changes().map(|changes| {
                     if print_deltas {
@@ -59,7 +66,15 @@ fn handle_cmd(
             } else {
                 hddlog.transaction_commit()
             };
-            //PROFILER.lock().unwrap().stop().expect("Couldn't stop profiler");
+
+            #[cfg(feature = "profile")]
+            {
+                PROFILER
+                    .lock()
+                    .unwrap()
+                    .stop()
+                    .expect("Couldn't stop profiler");
+            }
             res
         }
         Command::Comment => Ok(()),

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -14,7 +14,8 @@ RUN apt-get update &&   \
     python-pip          \
     autoconf            \
     libtool             \
-    libssl-dev
+    libssl-dev          \
+    libgoogle-perftools-dev
 
 # Install haskell stack
 RUN wget -qO- https://get.haskellstack.org/ | sh


### PR DESCRIPTION
We have two ways to profile programs, that serve slightly different
purposes and work differently: the `enable_cpu_profiling` API enables
profiling of differential operators and the cpuprofiler based approach
allows for creating a detailed callstack-style profile eligible to be
analyzed with pprof.
While we want to keep the two, the cpuprofiler infrastructure has a few
disadvantages in the way it is hooked up:
1) It is hard to find because all references to it are a dependency to
   the cpuprofiler crate and a few comments in some source file
2) It is cumbersome to enable because various lines have to be commented
   out. Those lines are also not compiled, making them an easy target
   for bit rot.
3) The cpuprofiler crate (and its dependencies) are compiled
   unconditionally, for the case that a user would use this
   functionality.

This patch addresses those three problems (to varying degrees) by
introducing another Cargo feature, `profile`. With it, we can compile the
dependent upon crate conditionally, have a clearly visible and fairly
easily discoverable switch, and don't need to do anything else than
enable the feature to make this functionality available.
According to my testing this feature switch reduces the number of crates
we compile by default from 79 down to 68.