### PR TITLE
Retry tcp_channel::receiver::never_accepted on successful connection

### DIFF
--- a/rust/template/differential_datalog/program.rs
+++ b/rust/template/differential_datalog/program.rs
@@ -259,7 +259,8 @@ type TransformerMap<'a, V> =
 /// set, adding new collections.  Note that the transformer can only be applied in the top scope
 /// (`Child<'a, Worker<Allocator>, TS>`), as we currently don't have a way to ensure that the
 /// transformer is monotonic and thus it may not converge if used in a nested scope.
-pub type TransformerFunc<V> = fn() -> Box<dyn for<'a> Fn(&mut TransformerMap<'a, V>)>;
+pub type TransformerFuncRes<V> = Box<dyn for<'a> Fn(&mut TransformerMap<'a, V>)>;
+pub type TransformerFunc<V> = fn() -> TransformerFuncRes<V>;
 
 /// Program node is either an individual non-recursive relation, a transformer application or
 /// a vector of one or more mutually recursive relations.


### PR DESCRIPTION
GitLab has found a case (and @ryzhyk reported it) where the
never_accepted test fails because the connection succeeded. The only
explanation I can come up with that would cause this behavior is, if
right after the drop of the TcpReceiver object and the
TcpStream::connect attempt a test running in parallel opens a listener
socket and gets assigned the very same port by random chance.

To prevent this problem from causing instability in the pipeline, let's
retry up to ten times if we actually succeed to connect. The chances of
such an even occurring ten times in a row should be extremely small.