### PR TITLE
Topic/generic ddlogserver

### DIFF
--- a/test/datalog_tests/server_api/tests/deltas.rs
+++ b/test/datalog_tests/server_api/tests/deltas.rs
@@ -36,9 +36,14 @@ where
         deltas2.lock().unwrap().push((relation_id, record.clone()));
     })
     .unwrap();
-    let server2 = DDlogServer::new(program2, hashmap! {server_api_1_P1Out => server_api_2_P2In});
+    let server2 = DDlogServer::new(
+        program2,
+        hashmap! {
+            server_api_1_P1Out as usize => server_api_2_P2In as usize,
+        },
+    );
 
-    let mut stream = server1.add_stream(hashset! {server_api_1_P1Out});
+    let mut stream = server1.add_stream(hashset! {server_api_1_P1Out as usize});
     let _data = setup(&mut stream, SharedObserver::new(server2))?;
 
     let updates = &[UpdCmd::Insert(
@@ -131,13 +136,13 @@ where
     })
     .unwrap();
     let redirect = hashmap! {
-        server_api_1_P1Out => server_api_3_P1Out,
-        server_api_2_P2Out => server_api_3_P2Out,
+        server_api_1_P1Out as usize => server_api_3_P1Out as usize,
+        server_api_2_P2Out as usize => server_api_3_P2Out as usize,
     };
     let server3 = DDlogServer::new(program3, redirect);
 
-    let stream1 = server1.add_stream(hashset! {server_api_1_P1Out});
-    let stream2 = server2.add_stream(hashset! {server_api_2_P2Out});
+    let stream1 = server1.add_stream(hashset! {server_api_1_P1Out as usize});
+    let stream2 = server2.add_stream(hashset! {server_api_2_P2Out as usize});
     let _data = setup(stream1, stream2, server3)?;
 
     // Insert updates concurrently to test serialization of

--- a/test/datalog_tests/server_api/tests/events.rs
+++ b/test/datalog_tests/server_api/tests/events.rs
@@ -286,7 +286,7 @@ fn setup() -> (DDlogServer, UpdatesObservable, MockObserver) {
     let mut server = DDlogServer::new(program, hashmap! {});
 
     let observer = SharedObserver::new(Mock::new());
-    let mut stream = server.add_stream(hashset! {server_api_1_P1Out});
+    let mut stream = server.add_stream(hashset! {server_api_1_P1Out as usize});
     let _ = stream.subscribe(Box::new(observer.clone())).unwrap();
 
     (server, stream, observer)
@@ -297,7 +297,7 @@ fn setup_tcp() -> (DDlogServer, UpdatesObservable, MockObserver, Box<dyn Any>) {
     let mut server = DDlogServer::new(program, hashmap! {});
 
     let observer = SharedObserver::new(Mock::new());
-    let mut stream = server.add_stream(hashset! {server_api_1_P1Out});
+    let mut stream = server.add_stream(hashset! {server_api_1_P1Out as usize});
 
     let mut recv = TcpReceiver::<Update<Value>>::new("127.0.0.1:0").unwrap();
     let send = TcpSender::connect(*recv.addr()).unwrap();


### PR DESCRIPTION
This PR marks the first step towards decoupling `DDlogServer` from the generated parts of the program. It is comprised of two parts:

#### Remove DDlogServer dependency on differential_datalog::Response

The Response type is just a typedef for Result<T, String> that we used
initially, but there is no real reason to do so. We hardcode the String
part of it elsewhere anyway.
Referencing this type is a dependency in the way of making DDlogServer
independent of the generated program it uses, so remove it.

----

#### Remove DDlogServer dependency on Relations enum

Another dependency that DDlogServer has on the generated code is the usage of
the Relations enum. While it buys us some static guarantees, those
add little value here because we don't work with this type throughout,
and instead now have a fallible conversion somewhere in the middle. With
this change we cut out that dependency and remove the conversion.