### PR TITLE
Generic deltamap

### DIFF
--- a/rust/template/differential_datalog/program.rs
+++ b/rust/template/differential_datalog/program.rs
@@ -13,7 +13,7 @@
 // TODO: single input relation
 
 use std::collections::hash_map;
-use std::fmt::{self, Debug, Formatter};
+use std::fmt::{self, Debug, Display, Formatter};
 use std::hash::Hash;
 use std::ops::{Add, Deref, Mul};
 use std::result::Result;
@@ -192,6 +192,7 @@ pub trait Val:
     + Serialize
     + DeserializeOwned
     + Debug
+    + Display
     + Abomonation
     + Default
     + Sync
@@ -209,6 +210,7 @@ impl<T> Val for T where
         + Serialize
         + DeserializeOwned
         + Debug
+        + Display
         + Abomonation
         + Default
         + Sync

--- a/rust/template/differential_datalog/test.rs
+++ b/rust/template/differential_datalog/test.rs
@@ -13,6 +13,9 @@
 )]
 
 use std::collections::btree_map::{BTreeMap, Entry};
+use std::fmt;
+use std::fmt::Display;
+use std::fmt::Formatter;
 use std::iter::FromIterator;
 use std::sync::{Arc, Mutex};
 
@@ -98,6 +101,12 @@ impl Abomonation for Value {}
 impl Default for Value {
     fn default() -> Value {
         Value::bool(false)
+    }
+}
+
+impl Display for Value {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str("test::Value")
     }
 }
 

--- a/rust/template/src/flatbuf.rs
+++ b/rust/template/src/flatbuf.rs
@@ -539,7 +539,7 @@ pub fn updates_from_flatbuf<'a>(
     }
 }
 
-pub fn updates_to_flatbuf(delta: &DeltaMap) -> (Vec<u8>, usize) {
+pub fn updates_to_flatbuf(delta: &DeltaMap<Value>) -> (Vec<u8>, usize) {
     /* Pre-compute size of delta. */
     let mut delta_size: usize = 0;
 

--- a/rust/template/src/ovsdb.rs
+++ b/rust/template/src/ovsdb.rs
@@ -118,8 +118,8 @@ pub unsafe extern "C" fn ddlog_dump_ovsdb_delta(
     res
 }
 
-fn dump_delta(
-    db: &mut valmap::DeltaMap,
+fn dump_delta<V: Val + IntoRecord>(
+    db: &mut valmap::DeltaMap<V>,
     module: *const c_char,
     table: *const c_char,
 ) -> Result<CString, String> {

--- a/rust/template/src/valmap.rs
+++ b/rust/template/src/valmap.rs
@@ -14,25 +14,25 @@ use super::*;
 /* Stores a set of changes to output tables.
  */
 #[derive(Debug, Default)]
-pub struct DeltaMap {
-    map: BTreeMap<RelId, BTreeMap<Value, isize>>,
+pub struct DeltaMap<V> {
+    map: BTreeMap<RelId, BTreeMap<V, isize>>,
 }
 
-impl AsMut<BTreeMap<RelId, BTreeMap<Value, isize>>> for DeltaMap {
-    fn as_mut(&mut self) -> &mut BTreeMap<RelId, BTreeMap<Value, isize>> {
+impl<V> AsMut<BTreeMap<RelId, BTreeMap<V, isize>>> for DeltaMap<V> {
+    fn as_mut(&mut self) -> &mut BTreeMap<RelId, BTreeMap<V, isize>> {
         &mut self.map
     }
 }
 
-impl AsRef<BTreeMap<RelId, BTreeMap<Value, isize>>> for DeltaMap {
-    fn as_ref(&self) -> &BTreeMap<RelId, BTreeMap<Value, isize>> {
+impl<V> AsRef<BTreeMap<RelId, BTreeMap<V, isize>>> for DeltaMap<V> {
+    fn as_ref(&self) -> &BTreeMap<RelId, BTreeMap<V, isize>> {
         &self.map
     }
 }
 
-impl DeltaMap {
-    pub fn new() -> DeltaMap {
-        DeltaMap {
+impl<V: Val> DeltaMap<V> {
+    pub fn new() -> Self {
+        Self {
             map: BTreeMap::default(),
         }
     }
@@ -77,11 +77,11 @@ impl DeltaMap {
         Ok(())
     }
 
-    pub fn get_rel(&mut self, relid: RelId) -> &BTreeMap<Value, isize> {
+    pub fn get_rel(&mut self, relid: RelId) -> &BTreeMap<V, isize> {
         self.map.entry(relid).or_insert_with(BTreeMap::default)
     }
 
-    pub fn update(&mut self, relid: RelId, x: &Value, diff: isize) {
+    pub fn update(&mut self, relid: RelId, x: &V, diff: isize) {
         //println!("set_update({}) {:?} {}", rel, *x, insert);
         let entry = self
             .map


### PR DESCRIPTION
The changes contained in this pull request mark the next step towards making `DDlogServer` independent of the generated code.

#### Require Display to be implemented for Val

In order to remove dependencies between DDlogServer and the generated
code we want to make the struct generic over the value type to use. That
in turns requires making generic a bunch of other structs, most
importantly DeltaMap.
As it turns out DeltaMap, by virtue of hard coding Value, made the
implicit assumption that Val: Display. However, when we switch it over
to using any Val instead, that constraint is not fulfilled. This change
adds the requirement that everything claiming to implement Val also
needs to implement Display.

---
#### Make DeltaMap generic over the value type it uses

In order to disentangle DDlogServer from the generated code we need to
make it generic over the value type to use. Because DDlogServer
indirectly works with a DeltaMap, which assumes a fixed Value type, we
also need to make this type generic over the value type to use.
This change does exactly that.

