### PR TITLE
More tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -178,4 +178,8 @@ test-ovn-northd:
           ./configure --with-ddlog=/root/.local/ddlog/lib --with-ovs-source=/root/ovs --enable-ddlog-northd-cli &&
           make check -j1 TESTSUITEFLAGS="117-135 138-141 143-145 147-149 151-152 154-161 167-169 172 174-181 183-185 187-189 191 193-196 198-199 201-202")
         - (git clone https://github.com/ddlog-dev/ovn-test-data.git &&
-          /usr/bin/time /root/ovn/northd/ovn_northd_ddlog/target/release/ovn_northd_cli -w 2 --no-store --no-print --no-delta < ovn-test-data/ovn_scale_test_short.dat)
+          /usr/bin/time /root/ovn/northd/ovn_northd_ddlog/target/release/ovn_northd_cli -w 2 --no-store --no-print < ovn-test-data/ovn_scale_test_short.dat > ovn_scale_test_short.dump &&
+          sed -n '/^Profile:$/,$p' ovn_scale_test_short.dump &&
+          sed -n '/Profile:/q;p' ovn_scale_test_short.dump > ovn_scale_test_short.dump.truncated &&
+          sed -n '/Profile:/q;p' ovn-test-data/ovn_scale_test_short.dump.expected > ovn_scale_test_short.dump.expected.truncated &&
+          diff -q ovn_scale_test_short.dump.truncated ovn_scale_test_short.dump.expected.truncated)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -72,7 +72,7 @@ test-redist:
     tags:
         - ddlog-ci-1
     script:
-        - STACK_CARGO_FLAGS='--release' stack --no-terminal test --ta "-p redist"
+        - STACK_CARGO_FLAGS='--release' stack test --ta '-p "$(NF) == \"generate redist\" || ($(NF-1) == \"compiler tests\" && $(NF) == \"redist\")"'
         - (cd java/test1 && ./run.sh)
         - (cd java/test_flatbuf && ./run.sh)
 
@@ -151,6 +151,16 @@ test-imported-souffle-tests7:
     extends: .test-imported-souffle
     script:
         - (cd test && ./run-souffle-tests-in-batches.py 150 175)
+
+# Torture-test optimized version of redist
+test-redist_opt:
+    extends: .install-ddlog
+    tags:
+        - ddlog-ci-2
+    script:
+        - (cd test/datalog_tests &&
+          git clone https://github.com/ddlog-dev/redist_opt-test-data.git &&
+          ./test-redist_opt.sh)
 
 # Test ovn-northd-ddlog
 test-ovn-northd:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,6 +35,8 @@ test-tutorial:
 
 test-server_api:
     script:
+    # The NF variable is defined by the Haskell tasty package, documented here:
+    # http://hackage.haskell.org/package/tasty
     - stack --no-terminal test --ta '-p "$(NF) == \"generate server_api\" || ($(NF-1) == \"compiler tests\" && $(NF) == \"server_api\")"';
     - cd test/datalog_tests/server_api/;
       i=0;

--- a/lib/graph.rs
+++ b/lib/graph.rs
@@ -21,8 +21,8 @@ where
     S: Scope,
     S::Timestamp: Lattice + Ord,
     V: Val,
-    N: Val,
-    E: Val,
+    N: differential_dataflow::ExchangeData + std::hash::Hash,
+    E: differential_dataflow::ExchangeData,
     EF: Fn(V) -> E + 'static,
     LF: Fn((N, N)) -> V + 'static,
 {
@@ -54,8 +54,8 @@ where
     S: Scope,
     S::Timestamp: Lattice + Ord,
     V: Val,
-    N: Val,
-    E: Val,
+    N: differential_dataflow::ExchangeData + std::hash::Hash,
+    E: differential_dataflow::ExchangeData,
     EF: Fn(V) -> E + 'static,
     LF: Fn((N, N)) -> V + 'static,
 {
@@ -82,8 +82,8 @@ where
     S::Timestamp: Lattice + Ord,
     u64: From<N>,
     V: Val,
-    N: Val + Clone,
-    E: Val,
+    N: differential_dataflow::ExchangeData + std::hash::Hash,
+    E: differential_dataflow::ExchangeData,
     EF: Fn(V) -> E + 'static,
     LF: Fn((N, N)) -> V + 'static,
 {
@@ -115,8 +115,8 @@ where
     S: Scope,
     S::Timestamp: TotalOrder + Lattice + Ord,
     V: Val,
-    N: Val,
-    E: Val,
+    N: differential_dataflow::ExchangeData + std::hash::Hash,
+    E: differential_dataflow::ExchangeData,
     EF: Fn(V) -> E + 'static,
     LF: Fn((N, N)) -> V + 'static,
 {

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -125,6 +125,7 @@ cargo specname toml_code crate_types =
 rustProjectDir :: String -> String
 rustProjectDir specname = specname ++ "_ddlog"
 
+-- IMPORTANT: KEEP THIS IN SYNC WITH FILE LIST IN 'build.rs'.
 templateFiles :: String -> [(String, String)]
 templateFiles specname =
     map (mapSnd (BS.unpack)) $

--- a/test/datalog_tests/redist_opt.dl
+++ b/test/datalog_tests/redist_opt.dl
@@ -1,0 +1,142 @@
+import tinyset as TS
+import graph as graph
+
+/* entity id */
+typedef entid_t = bit<32>
+
+/* transport node id */
+typedef tnid_t = bit<16>
+
+typedef EntityType =
+    EntityLS |
+    EntityLSP{connected_to_dr: bool} |
+    EntityLRP |
+    EntityRDS{routingDomainId: entid_t}|
+    EntityOther
+
+input relation DdlogNode(id: entid_t, etype: EntityType)
+
+input relation DdlogBinding(tn: tnid_t, entity: entid_t)
+
+input relation DdlogDependency(parent: entid_t, child: entid_t)
+
+relation ValidDependency(parent: entid_t, child: entid_t)
+
+ValidDependency(parent, child) :- DdlogDependency(parent, child), DdlogNode(parent, _), DdlogNode(child, _).
+
+relation ExtDdlogDependency(parent: entid_t, child: entid_t)
+
+ExtDdlogDependency(parent, child) :-
+    ValidDependency(parent, child).
+
+ExtDdlogDependency(ls, lsp) :-
+    ValidDependency(lsp, lrp),
+    DdlogNode(lrp, EntityLRP),
+    DdlogNode(lsp, EntityLSP{.connected_to_dr = true}),
+    ValidDependency(lsp, ls),
+    DdlogNode(ls, EntityLS).
+
+
+/* Bi-directional edges.
+ */
+function dep_parent(e: ExtDdlogDependency): entid_t = e.parent
+function dep_child(e: ExtDdlogDependency): entid_t = e.child
+relation BiEdge[(entid_t, entid_t)]
+apply graph.UnsafeBidirectionalEdges(ExtDdlogDependency, dep_parent, dep_child) -> (BiEdge)
+
+/* Compute connected components by propagating node id's along biditectional edges.
+ */
+function edge_parent(e: (entid_t, entid_t)): entid_t =
+     match (e) {
+         (parent,_) -> parent
+     }
+ function edge_child(e: (entid_t, entid_t)): entid_t =
+     match (e) {
+         (_, child) -> child
+     }
+relation SCCLabel[(entid_t, entid_t)]
+apply graph.ConnectedComponents64(BiEdge, edge_child, edge_parent) -> (SCCLabel)
+
+
+/* Label all nodes that don't belong to an SCC with their own ids
+ */
+relation LabeledNode(node: entid_t, scc: entid_t)
+LabeledNode(node, scc) :- SCCLabel[(node, scc)].
+LabeledNode(node, node) :- DdlogNode(node, _), not SCCLabel[(node, _)].
+
+/* Lift the ExtDdlogDependency relation to SCCs:
+ * Two SCCs are connected by an edge iff there exists a pair
+ * of nodes that belong to the first and the second SCC respectively,
+ * connected by a ExtDdlogDependency edge.
+ */
+relation SCCEdge(parent: entid_t, child: entid_t)
+SCCEdge(parentscc,childscc) :-
+    ExtDdlogDependency(parent, child),
+    LabeledNode(parent, parentscc),
+    LabeledNode(child, childscc),
+    childscc != parentscc.
+
+/* Lift the DdlogBinding relation to SCCs:
+ * An SCC is bound to a TN iff at least one of its nodes is bound to this TN.
+ */
+relation SCCBinding(scc: entid_t, bindings: Ref<TS.Set64<tnid_t>>)
+SCCBinding(scc, ref_new(bindings)) :-
+    DdlogBinding(tn, entity),
+    LabeledNode(entity, scc),
+    var bindings = Aggregate((scc), TS.group2set(tn)).
+
+/* Compute SCC span.
+ */
+relation SCCSpan(scc: entid_t, span: Ref<TS.Set64<tnid_t>>)
+/* Base case */
+SCCSpan(scc, bindings) :- SCCBinding(scc, bindings).
+/* Recursive step: propagate span along graph edges */
+SCCSpan(parent, tns) :-
+    SCCEdge(child, parent),
+    SCCSpan(child, child_tns),
+    var tns = Aggregate((parent), TS.group_setref_unions(child_tns)).
+
+/* Flatten the span relation: for each node in an SCC, the node's span is the
+ * same as the SCC span.
+ */
+output relation Span(entity: entid_t, tns: Ref<TS.Set64<tnid_t>>)
+Span(node, span) :- SCCSpan(scc, span), LabeledNode(node, scc).
+
+
+/* used for query all From nodes for a given To node, or query all To nodes for
+ * a given From node
+ */
+input relation ToNode(to: entid_t)
+input relation FromNode(fro: entid_t)
+relation Froms(from :entid_t, to :entid_t )
+relation Tos(from :entid_t, to :entid_t )
+
+Froms(from, to) :- ToNode(to), ExtDdlogDependency(from, to).
+Tos(from, to) :- FromNode(from), ExtDdlogDependency(from, to).
+
+output relation FromsList(froms: Set<entid_t>, to: entid_t)
+FromsList(froms, to) :-
+    Froms(from, to),
+    var froms = Aggregate((to), group2set(from)).
+
+output relation TosList(from: entid_t, tos: Set<entid_t>)
+TosList(from, tos) :-
+    Tos(from, to),
+    var tos = Aggregate((from), group2set(to)).
+
+/* getSpan() */
+input relation QuerySpanNode(entity: entid_t)
+output relation QuerySpan(entity: entid_t, tns: Ref<TS.Set64<tnid_t>>)
+QuerySpan(node, span):- QuerySpanNode(node), Span(node, span).
+
+
+/* dump span table */
+input relation IsDumpSpan()
+output relation DumpSpan(entity: entid_t, tns: Ref<TS.Set64<tnid_t>>)
+DumpSpan(node, span):- IsDumpSpan(), Span(node, span).
+
+/* dump ExtDdlogDependency */
+input relation IsDumpRelation()
+output relation DumpRelation(parent: entid_t, child: entid_t)
+DumpRelation(parent, child):- IsDumpRelation(), ExtDdlogDependency(parent, child).
+

--- a/test/datalog_tests/run-test.sh
+++ b/test/datalog_tests/run-test.sh
@@ -29,7 +29,7 @@ else
     usage
 fi
 
-CARGOFLAGS="--features=flatbuf"
+CARGOFLAGS+=" --features=flatbuf"
 if [ "x${build}" == "xrelease" ]; then
     CARGOFLAGS="--release ${CARGOFLAGS}"
 elif [ "x${build}" == "xdebug" ]; then

--- a/test/datalog_tests/test-redist_opt.sh
+++ b/test/datalog_tests/test-redist_opt.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+set -e
+
+./run-test.sh redist_opt release
+
+# $1 - number of iterations
+# $2 - number of workers
+# $3 - DIFFERENTIAL_EAGER_MERGE value
+run_tiny_test() {
+    if [ $# == 3 ]; then
+        export DIFFERENTIAL_EAGER_MERGE=$3
+    else
+        unset DIFFERENTIAL_EAGER_MERGE
+    fi
+    # Feed $1 copies of data to DDlog
+    ( for (( i=1; i<=$1; i++ ))
+    do
+        echo "start;
+        insert DdlogNode[DdlogNode{0,EntityOther{}}],
+        insert DdlogNode[DdlogNode{1,EntityOther{}}],
+        commit;
+        start;
+        delete DdlogNode[DdlogNode{0,EntityOther{}}],
+        delete DdlogNode[DdlogNode{1,EntityOther{}}],
+        commit;"
+    done) |
+        /usr/bin/time -o redist_mem -f "%M" ./redist_opt_ddlog/target/release/redist_opt_cli -w $2 --no-print --no-store --no-delta
+}
+
+# $1 - DIFFERENTIAL_EAGER_MERGE value
+run_memleak_test() {
+    echo Mem leak test with DIFFERENTIAL_EAGER_MERGE=$1
+    run_tiny_test 10 4 $1
+    mem_short=$(cat redist_mem)
+    run_tiny_test 10000 4 $1
+    mem_long=$(cat redist_mem)
+    echo "mem_short=$mem_short, mem_long=$mem_long"
+    if [ "$mem_long" -gt $(( 2*"$mem_short" )) ]
+    then
+        echo "Possible memory leak: mem_short=$mem_short, mem_long=$mem_long"
+        exit 1
+    fi
+}
+
+run_memleak_test
+run_memleak_test 100000
+
+# $1 - number of iterations
+# $2 - number of workers
+# $3 - DIFFERENTIAL_EAGER_MERGE value
+run_test() {
+    echo Correctness test with $1 iterations, $2 workers, and DIFFERENTIAL_EAGER_MERGE=$3
+    if [ $# == 3 ]; then
+        export DIFFERENTIAL_EAGER_MERGE=$3
+    else
+        unset DIFFERENTIAL_EAGER_MERGE
+    fi
+    # Feed $1 copies of data to DDlog
+    ( for (( i=1; i<=$1; i++ ))
+    do
+        cat redist_opt-test-data/redist_opt.dat
+    done) |
+        /usr/bin/time ./redist_opt_ddlog/target/release/redist_opt_cli -w $2 --no-print --no-store > redist_opt.dump
+
+    # The output should be $1 copies of redist_opt.dump.expected
+    (for (( i=1; i<=$1; i++ ))
+    do
+        cat redist_opt-test-data/redist_opt.dump.expected
+    done) > redist_opt.dump.expected
+
+    diff -q redist_opt.dump.expected redist_opt.dump
+}
+
+run_test 5 1
+run_test 5 1 100000
+run_test 3 2
+run_test 3 2 100000
+run_test 3 4
+run_test 3 4 100000
+run_test 3 8
+run_test 3 8 100000
+run_test 3 16
+run_test 3 16 100000
+run_test 3 40
+run_test 3 40 100000

--- a/tools/prepush.sh
+++ b/tools/prepush.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This script is configured to be run by git pre-push
 
-(cd rust/template/ && \
-cargo fmt --all -- --check && \
-cargo check --all)
+(cd rust/template/ &&
+cargo fmt --all -- --check &&
+cargo clippy --all -- -D warnings)
 (cd lib && rustfmt *.rs --check)


### PR DESCRIPTION
This PR consists of several extensions and improvements on the test suite

## redist_opt

This is an optimized and extended version of the `redist` test along with
a test script designed to torture DDlog by running it with different
number of workers, different settings of DIFFERENTIAL_EAGER_MERGE, and
by feeding the input data file multiple times.  The data for this test
is stored in a separate github repo:
https://github.com/ddlog-dev/redist_opt-test-data

Also contains a memory leak test that runs a simple transaction that
adds and removes a couple of records many times and makes sure that
memory footpring does not increase significantly with the number of
iterations.

## Improved OVN scale test



We used to run the OVN scale test without actually looking at its
results.  This is useful for checking for deadlocks and performance
issues, but can miss correctness bugs.

This commit relies on the modified `ovn-test-data` repo, where the test
script is modified to dump changes on each commit and that also contains
a reference output for the test.

We have to be careful in diffing the expected and actual dumps to ignore
the performance profiles part of the dump, which we want to only keep for
performance tracking.

## Minor improvements

- bug fix in `run-test.sh`
- run `rustfmt` in `lib/`