### PR TITLE
Fix Rust code generation for iteration over maps.

### DIFF
--- a/lib/std.rs
+++ b/lib/std.rs
@@ -567,11 +567,11 @@ impl<'a, K: Ord, V> MapIter<'a, K, V> {
     }
 }
 
-impl<'a, K, V> Iterator for MapIter<'a, K, V> {
-    type Item = (&'a K, &'a V);
+impl<'a, K: Clone, V: Clone> Iterator for MapIter<'a, K, V> {
+    type Item = (K, V);
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next()
+        self.iter.next().map(|(k, v)| (k.clone(), v.clone()))
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -691,7 +691,7 @@ where
     fn to_flatbuf(&self, fbb: &mut fbrt::FlatBufferBuilder<'b>) -> Self::Target {
         let vec: Vec<<(K, V) as ToFlatBufferVectorElement<'b>>::Target> = self
             .iter()
-            .map(|(k, v)| ((*k).clone(), (*v).clone()).to_flatbuf_vector_element(fbb))
+            .map(|(k, v)| (k, v).to_flatbuf_vector_element(fbb))
             .collect();
         fbb.create_vector(vec.as_slice())
     }

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -2081,8 +2081,8 @@ mkExpr' _ _ EITE{..} = (doc, EVal)
 mkExpr' d ctx e@EFor{..} = (doc, EVal)
     where
     e' = exprMap (E . sel3) e
-    -- Iterator over group produces owned values, not references
-    opt_ref = if isGroup d $ exprType d (CtxForIter e' ctx) (E $ sel3 exprIter)
+    -- Iterators over groups and maps produces owned values, not references
+    opt_ref = if (\t -> isGroup d t || isMap d t) $ exprType d (CtxForIter e' ctx) (E $ sel3 exprIter)
                  then "ref"
                  else empty
     doc = ("for" <+> opt_ref <+> pp exprLoopVar <+> "in" <+> sel1 exprIter <> ".iter() {") $$

--- a/src/Language/DifferentialDatalog/Type.hs
+++ b/src/Language/DifferentialDatalog/Type.hs
@@ -35,7 +35,7 @@ module Language.DifferentialDatalog.Type(
     exprNodeType,
     relKeyType,
     typ', typ'',
-    isBool, isBit, isSigned, isInt, isString, isStruct, isTuple, isGroup,
+    isBool, isBit, isSigned, isInt, isString, isStruct, isTuple, isGroup, isMap,
     checkTypesMatch,
     typesMatch,
     typeNormalize,
@@ -438,6 +438,11 @@ isGroup :: (WithType a) => DatalogProgram -> a -> Bool
 isGroup d a = case typ' d a of
                    TOpaque _ t _ | t == gROUP_TYPE -> True
                    _                               -> False
+
+isMap :: (WithType a) => DatalogProgram -> a -> Bool
+isMap d a = case typ' d a of
+                 TOpaque _ t _ | t == mAP_TYPE -> True
+                 _                             -> False
 
 -- | Check if 'a' and 'b' have idential types up to type aliasing;
 -- throw exception if they don't.


### PR DESCRIPTION
For-loop that iterates over maps, e.g.:

```
for (x in m) { ... }
```

used to compile into:

```
for x in m.iter() { ... }
```

where `m.iter()` returns our custom `MapIter`, defined in `std.rs`,
which used to have `Iterator::Target=(&K, &V)`. As a result, type of the
Rust variable `x` is `(&K, &V)`.  Our current naive model of Rust cannot
represent such types, instead treating `x` as if it was `&(K,V)`, which
could lead to compiler errors when we manipulate `x` in the body of the
loop.

A long-term solution is to model Rust's dataflow more accurately
(https://github.com/vmware/differential-datalog/issues/422).  The
short-term fix I implemented is to re-define `MapIter` to have
`Iterator::Target = (K, V)`, which involves cloning `K` and `V`
internally, but at least it's correct.