### PR TITLE
test-redist_opt.sh: Strengthen the test suite.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,8 +9,6 @@ variables:
 .install-ddlog:
     before_script:
         - stack install
-        - mkdir -p /root/.local/ddlog
-        - ln -s $(pwd)/lib /root/.local/ddlog/lib
 
 # Test Rust template only.
 test-rust:
@@ -173,25 +171,8 @@ test-ovn-northd:
     tags:
         - ddlog-ci-2
     script:
-        # TODO: OVS master once these changes are there.
-        - (cd /root &&
-          git clone https://github.com/openvswitch/ovs.git &&
-          cd ovs && git checkout ovn-ddlog-patches &&
-          ./boot.sh &&
-          ./configure  &&
-          make -j6)
-        # TODO: maintain and eventually remove the list of tests.
-        # TODO: use -j6 once build script is fixed
-        # TODO: use primary OVN repo
-        - (cd /root &&
-          git clone https://github.com/ryzhyk/ovn.git &&
-          cd ovn && git checkout ddlog-dev-v2 &&
-          ./boot.sh &&
-          ./configure --with-ddlog=/root/.local/ddlog/lib --with-ovs-source=/root/ovs --enable-ddlog-northd-cli &&
-          make check -j1 TESTSUITEFLAGS="117-135 138-141 143-145 147-149 151-152 154-161 167-169 172 174-181 183-185 187-189 191 193-196 198-199 201-202")
-        - (git clone https://github.com/ddlog-dev/ovn-test-data.git &&
-          /usr/bin/time /root/ovn/northd/ovn_northd_ddlog/target/release/ovn_northd_cli -w 2 --no-store --no-print < ovn-test-data/ovn_scale_test_short.dat > ovn_scale_test_short.dump &&
-          sed -n '/^Profile:$/,$p' ovn_scale_test_short.dump &&
-          sed -n '/Profile:/q;p' ovn_scale_test_short.dump > ovn_scale_test_short.dump.truncated &&
-          sed -n '/Profile:/q;p' ovn-test-data/ovn_scale_test_short.dump.expected > ovn_scale_test_short.dump.expected.truncated &&
-          diff -q ovn_scale_test_short.dump.truncated ovn_scale_test_short.dump.expected.truncated)
+        - cd test
+        - git clone https://github.com/openvswitch/ovs.git
+        - git clone https://github.com/ryzhyk/ovn.git
+        - git clone https://github.com/ddlog-dev/ovn-test-data.git
+        - ./test-ovn.sh

--- a/test/datalog_tests/test-redist_opt.sh
+++ b/test/datalog_tests/test-redist_opt.sh
@@ -48,39 +48,58 @@ run_memleak_test 100000
 
 # $1 - number of iterations
 # $2 - number of workers
-# $3 - DIFFERENTIAL_EAGER_MERGE value
+# $3 - data file
+# $4 - expected output file
+# $5 - DIFFERENTIAL_EAGER_MERGE value
 run_test() {
-    echo Correctness test with $1 iterations, $2 workers, and DIFFERENTIAL_EAGER_MERGE=$3
-    if [ $# == 3 ]; then
-        export DIFFERENTIAL_EAGER_MERGE=$3
+    echo Correctness test with $1 iterations, $2 workers, input file \"$3\", reference file \"$4\" and DIFFERENTIAL_EAGER_MERGE=$5
+    if [ $# == 5 ]; then
+        export DIFFERENTIAL_EAGER_MERGE=$5
     else
         unset DIFFERENTIAL_EAGER_MERGE
     fi
     # Feed $1 copies of data to DDlog
     ( for (( i=1; i<=$1; i++ ))
     do
-        cat redist_opt-test-data/redist_opt.dat
+        cat $3
     done) |
         /usr/bin/time ./redist_opt_ddlog/target/release/redist_opt_cli -w $2 --no-print --no-store > redist_opt.dump
 
     # The output should be $1 copies of redist_opt.dump.expected
     (for (( i=1; i<=$1; i++ ))
     do
-        cat redist_opt-test-data/redist_opt.dump.expected
+        cat $4
     done) > redist_opt.dump.expected
 
     diff -q redist_opt.dump.expected redist_opt.dump
 }
 
-run_test 5 1
-run_test 5 1 100000
-run_test 3 2
-run_test 3 2 100000
-run_test 3 4
-run_test 3 4 100000
-run_test 3 8
-run_test 3 8 100000
-run_test 3 16
-run_test 3 16 100000
-run_test 3 40
-run_test 3 40 100000
+run_test 5 1 "redist_opt-test-data/redist_opt.dat" "redist_opt-test-data/redist_opt.dump.expected"
+run_test 5 1 "redist_opt-test-data/redist_opt.dat" "redist_opt-test-data/redist_opt.dump.expected" 10
+run_test 5 1 "redist_opt-test-data/redist_opt.dat" "redist_opt-test-data/redist_opt.dump.expected" 100
+run_test 5 1 "redist_opt-test-data/redist_opt.dat" "redist_opt-test-data/redist_opt.dump.expected" 100000
+run_test 3 2 "redist_opt-test-data/redist_opt.dat" "redist_opt-test-data/redist_opt.dump.expected"
+run_test 3 2 "redist_opt-test-data/redist_opt.dat" "redist_opt-test-data/redist_opt.dump.expected" 10
+run_test 3 2 "redist_opt-test-data/redist_opt.dat" "redist_opt-test-data/redist_opt.dump.expected" 100
+run_test 3 2 "redist_opt-test-data/redist_opt.dat" "redist_opt-test-data/redist_opt.dump.expected" 100000
+run_test 3 4 "redist_opt-test-data/redist_opt.dat" "redist_opt-test-data/redist_opt.dump.expected"
+run_test 3 4 "redist_opt-test-data/redist_opt.dat" "redist_opt-test-data/redist_opt.dump.expected" 10
+run_test 3 4 "redist_opt-test-data/redist_opt.dat" "redist_opt-test-data/redist_opt.dump.expected" 100
+run_test 3 4 "redist_opt-test-data/redist_opt.dat" "redist_opt-test-data/redist_opt.dump.expected" 100000
+run_test 3 40 "redist_opt-test-data/redist_opt.dat" "redist_opt-test-data/redist_opt.dump.expected"
+run_test 3 40 "redist_opt-test-data/redist_opt.dat" "redist_opt-test-data/redist_opt.dump.expected" 10
+run_test 3 40 "redist_opt-test-data/redist_opt.dat" "redist_opt-test-data/redist_opt.dump.expected" 100
+run_test 3 40 "redist_opt-test-data/redist_opt.dat" "redist_opt-test-data/redist_opt.dump.expected" 100000
+
+run_test 1 1 "redist_opt-test-data/query.dat" "redist_opt-test-data/query.dump.expected"
+run_test 1 1 "redist_opt-test-data/query.dat" "redist_opt-test-data/query.dump.expected" 10
+run_test 1 1 "redist_opt-test-data/query.dat" "redist_opt-test-data/query.dump.expected" 100
+
+run_test 1 2 "redist_opt-test-data/query.dat" "redist_opt-test-data/query.dump.expected"
+run_test 1 2 "redist_opt-test-data/query.dat" "redist_opt-test-data/query.dump.expected" 10
+run_test 1 2 "redist_opt-test-data/query.dat" "redist_opt-test-data/query.dump.expected" 100
+run_test 1 2 "redist_opt-test-data/query.dat" "redist_opt-test-data/query.dump.expected" 1000
+
+run_test 1 4 "redist_opt-test-data/query.dat" "redist_opt-test-data/query.dump.expected"
+run_test 1 4 "redist_opt-test-data/query.dat" "redist_opt-test-data/query.dump.expected" 10
+run_test 1 4 "redist_opt-test-data/query.dat" "redist_opt-test-data/query.dump.expected" 100

--- a/test/test-ovn.sh
+++ b/test/test-ovn.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+
+# TODO: use OVS master once these changes are there.
+(cd ovs &&
+ git checkout ovn-ddlog-patches &&
+ ./boot.sh &&
+ ./configure  &&
+ make -j6)
+
+# TODO: maintain and eventually remove the list of tests.
+# TODO: use -j6 once build script is fixed
+# TODO: use primary OVN repo
+(cd ovn &&
+ git checkout ddlog-dev-v2 &&
+ ./boot.sh &&
+ ./configure --with-ddlog=../../lib --with-ovs-source=../ovs --enable-ddlog-northd-cli &&
+ (make check -j1 TESTSUITEFLAGS="117-135 138-141 143-145 147-149 151-152 154-161 167-169 172 174-181 183-185 187-189 191 193-196 198-199 201-202" ||
+ (find tests/testsuite.dir/ \( -name testsuite.log -o -name ovn-northd.log \) -exec echo '{}' \; -exec cat '{}' \; && false))
+)
+
+/usr/bin/time ovn/northd/ovn_northd_ddlog/target/release/ovn_northd_cli -w 2 --no-store --no-print < ovn-test-data/ovn_scale_test_short.dat > ovn_scale_test_short.dump
+sed -n '/^Profile:$/,$p' ovn_scale_test_short.dump
+sed -n '/Profile:/q;p' ovn_scale_test_short.dump > ovn_scale_test_short.dump.truncated
+sed -n '/Profile:/q;p' ovn-test-data/ovn_scale_test_short.dump.expected > ovn_scale_test_short.dump.expected.truncated
+diff -q ovn_scale_test_short.dump.truncated ovn_scale_test_short.dump.expected.truncated


### PR DESCRIPTION
- Run with additional `DIFFERENTIAL_EAGER_MERGE` values (10 and
  100).
- Add a dataset that populates input tables and then performs many small
  queries.  This clearly shows the advantages of smaller
  `DIFFERENTIAL_EAGER_MERGE` values.