### PR TITLE
Topic/multi receiver

### DIFF
--- a/rust/template/distributed_datalog/Cargo.toml
+++ b/rust/template/distributed_datalog/Cargo.toml
@@ -9,6 +9,7 @@ path = "../differential_datalog"
 [dev-dependencies]
 env_logger = {version = "0.6", default_features = false, features = ["humantime"]}
 test-env-log = "0.1"
+waitfor = "0.1"
 
 [dependencies]
 bincode = "1.2"

--- a/rust/template/distributed_datalog/src/observe/mod.rs
+++ b/rust/template/distributed_datalog/src/observe/mod.rs
@@ -8,6 +8,7 @@ mod test;
 pub use observable::Observable;
 pub use observable::ObservableAny;
 pub use observable::ObservableBox;
+pub use observable::SharedObservable;
 pub use observable::UpdatesObservable;
 pub use observer::Observer;
 pub use observer::ObserverBox;

--- a/rust/template/distributed_datalog/src/observe/observable.rs
+++ b/rust/template/distributed_datalog/src/observe/observable.rs
@@ -45,7 +45,7 @@ where
     fn subscribe_any(
         &mut self,
         observer: ObserverBox<T, E>,
-    ) -> Result<Box<dyn Any>, ObserverBox<T, E>>;
+    ) -> Result<Box<dyn Any + Send>, ObserverBox<T, E>>;
 
     /// Unsubscribe an `Observer` from this `Observable` using a
     /// previously handed out subscription.
@@ -58,15 +58,15 @@ impl<T, E, S, O> ObservableAny<T, E> for O
 where
     T: Send,
     E: Send,
-    S: Any,
+    S: Any + Send,
     O: Observable<T, E, Subscription = S>,
 {
     fn subscribe_any(
         &mut self,
         observer: ObserverBox<T, E>,
-    ) -> Result<Box<dyn Any>, ObserverBox<T, E>> {
+    ) -> Result<Box<dyn Any + Send>, ObserverBox<T, E>> {
         self.subscribe(observer)
-            .map(|s| Box::new(s) as Box<dyn Any>)
+            .map(|s| Box::new(s) as Box<dyn Any + Send>)
     }
 
     fn unsubscribe_any(&mut self, subscription: &dyn Any) -> Option<ObserverBox<T, E>> {

--- a/rust/template/distributed_datalog/src/observe/observer.rs
+++ b/rust/template/distributed_datalog/src/observe/observer.rs
@@ -113,45 +113,9 @@ where
     }
 }
 
-/// An `Observer` that wraps an inner, optional `Observer`. If the inner
-/// one is unset all events will just be dropped.
-#[derive(Debug)]
-pub struct OptionalObserver<O>(Option<O>);
-
-impl<O> OptionalObserver<O> {
-    /// Create a new `OptionalObserver` object, automatically wrapping the
-    /// provided `Observer` as necessary.
-    pub fn new(observer: O) -> Self {
-        Self(Some(observer))
-    }
-
-    /// Replace the existing `Observer` (if any) with the given optional
-    /// one, returning the previous one.
-    pub fn replace(&mut self, value: O) -> Option<O> {
-        self.0.replace(value)
-    }
-
-    /// Take the inner observer, if any, replacing it with none.
-    pub fn take(&mut self) -> Option<O> {
-        self.0.take()
-    }
-
-    /// Check whether an actual observer is present or not.
-    pub fn is_some(&self) -> bool {
-        self.0.is_some()
-    }
-
-    /// Retrieve an `Option` referencing the inner `Observer`.
-    pub fn as_ref(&self) -> Option<&O> {
-        self.0.as_ref()
-    }
-}
-
-impl<O> Default for OptionalObserver<O> {
-    fn default() -> Self {
-        Self(None)
-    }
-}
+/// An optional `Observer`. If set to `None` all events will just be
+/// dropped.
+pub type OptionalObserver<O> = Option<O>;
 
 impl<O, T, E> Observer<T, E> for OptionalObserver<O>
 where
@@ -160,19 +124,19 @@ where
     E: Send,
 {
     fn on_start(&mut self) -> Result<(), E> {
-        self.0.as_mut().map_or(Ok(()), Observer::on_start)
+        self.as_mut().map_or(Ok(()), Observer::on_start)
     }
 
     fn on_commit(&mut self) -> Result<(), E> {
-        self.0.as_mut().map_or(Ok(()), Observer::on_commit)
+        self.as_mut().map_or(Ok(()), Observer::on_commit)
     }
 
     fn on_updates<'a>(&mut self, updates: Box<dyn Iterator<Item = T> + 'a>) -> Result<(), E> {
-        self.0.as_mut().map_or(Ok(()), |o| o.on_updates(updates))
+        self.as_mut().map_or(Ok(()), |o| o.on_updates(updates))
     }
 
     fn on_completed(&mut self) -> Result<(), E> {
-        self.0.as_mut().map_or(Ok(()), Observer::on_completed)
+        self.as_mut().map_or(Ok(()), Observer::on_completed)
     }
 }
 
@@ -198,7 +162,7 @@ mod tests {
     #[test]
     fn with_optional_observer() {
         let mock = SharedObserver::new(MockObserver::new());
-        let observer = &mut OptionalObserver::new(mock.clone()) as &mut dyn Observer<_, ()>;
+        let observer = &mut Some(mock.clone()) as &mut dyn Observer<_, ()>;
 
         assert_eq!(observer.on_start(), Ok(()));
         assert_eq!(mock.0.lock().unwrap().called_on_start, 1);

--- a/rust/template/distributed_datalog/src/txnmux.rs
+++ b/rust/template/distributed_datalog/src/txnmux.rs
@@ -86,7 +86,7 @@ where
     E: Debug + Send,
 {
     /// The observables we track and our subscriptions to them.
-    subscriptions: Vec<(ObservableBox<T, E>, Box<dyn Any>)>,
+    subscriptions: Vec<(ObservableBox<T, E>, Box<dyn Any + Send>)>,
     /// A reference to the `Observer` subscribed to us, if any.
     observer: SharedObserver<OptionalObserver<ObserverBox<T, E>>>,
 }

--- a/rust/template/distributed_datalog/src/txnmux.rs
+++ b/rust/template/distributed_datalog/src/txnmux.rs
@@ -165,12 +165,15 @@ where
 mod tests {
     use super::*;
 
+    use std::sync::Arc;
+    use std::sync::Mutex;
+
     use crate::observe::MockObserver;
 
     /// Test caching of transactions via a `CachingObserver`.
     #[test]
     fn transaction_caching() {
-        let mock = SharedObserver::new(Some(MockObserver::new()));
+        let mock = Arc::new(Mutex::new(Some(MockObserver::new())));
         let observer = &mut CachingObserver::new(mock.clone()) as &mut dyn Observer<_, ()>;
 
         assert_eq!(observer.on_start(), Ok(()));

--- a/rust/template/distributed_datalog/src/txnmux.rs
+++ b/rust/template/distributed_datalog/src/txnmux.rs
@@ -170,7 +170,7 @@ mod tests {
     /// Test caching of transactions via a `CachingObserver`.
     #[test]
     fn transaction_caching() {
-        let mock = SharedObserver::new(OptionalObserver::new(MockObserver::new()));
+        let mock = SharedObserver::new(Some(MockObserver::new()));
         let observer = &mut CachingObserver::new(mock.clone()) as &mut dyn Observer<_, ()>;
 
         assert_eq!(observer.on_start(), Ok(()));

--- a/test/datalog_tests/server_api/tests/deltas.rs
+++ b/test/datalog_tests/server_api/tests/deltas.rs
@@ -16,8 +16,15 @@ use distributed_datalog::TcpSender;
 use distributed_datalog::TxnMux;
 use distributed_datalog::UpdatesObservable as UpdatesObservableT;
 
-use server_api_ddlog::api::*;
-use server_api_ddlog::Relations::*;
+use server_api_ddlog::api::updcmd2upd;
+use server_api_ddlog::api::HDDlog;
+use server_api_ddlog::Relations::server_api_1_P1In;
+use server_api_ddlog::Relations::server_api_1_P1Out;
+use server_api_ddlog::Relations::server_api_2_P2In;
+use server_api_ddlog::Relations::server_api_2_P2Out;
+use server_api_ddlog::Relations::server_api_3_P1Out;
+use server_api_ddlog::Relations::server_api_3_P2Out;
+use server_api_ddlog::Relations::server_api_3_P3Out;
 use server_api_ddlog::Value;
 
 use maplit::hashmap;
@@ -51,7 +58,7 @@ where
     );
 
     let mut stream = server1.add_stream(hashset! {server_api_1_P1Out as usize});
-    let _data = setup(&mut stream, SharedObserver::new(server2))?;
+    let _data = setup(&mut stream, SharedObserver::new(Mutex::new(server2)))?;
 
     let updates = &[UpdCmd::Insert(
         RelIdentifier::RelId(server_api_1_P1In as usize),

--- a/test/datalog_tests/server_api/tests/events.rs
+++ b/test/datalog_tests/server_api/tests/events.rs
@@ -2,6 +2,7 @@ use std::any::Any;
 use std::panic::catch_unwind;
 use std::panic::AssertUnwindSafe;
 use std::panic::UnwindSafe;
+use std::sync::Mutex;
 use std::time::Duration;
 
 use differential_datalog::program::Update;
@@ -288,7 +289,7 @@ fn setup() -> (DDlogServer, UpdatesObservable, MockObserver) {
     let program = HDDlog::run(1, false, |_, _: &Record, _| {}).unwrap();
     let mut server = DDlogServer::new(program, hashmap! {});
 
-    let observer = SharedObserver::new(Mock::new());
+    let observer = SharedObserver::new(Mutex::new(Mock::new()));
     let mut stream = server.add_stream(hashset! {server_api_1_P1Out as usize});
     let _ = stream.subscribe(Box::new(observer.clone())).unwrap();
 
@@ -299,7 +300,7 @@ fn setup_tcp() -> (DDlogServer, UpdatesObservable, MockObserver, Box<dyn Any>) {
     let program = HDDlog::run(1, false, |_, _: &Record, _| {}).unwrap();
     let mut server = DDlogServer::new(program, hashmap! {});
 
-    let observer = SharedObserver::new(Mock::new());
+    let observer = SharedObserver::new(Mutex::new(Mock::new()));
     let mut stream = server.add_stream(hashset! {server_api_1_P1Out as usize});
 
     let mut recv = TcpReceiver::<Update<Value>>::new("127.0.0.1:0").unwrap();


### PR DESCRIPTION
Make TcpReceiver multi-sender capable

So far any `TcpReceiver` was always in a 1-to-1 relationship with a
`TcpSender` (of course, there could also be no sender), mostly because the
initial design was about a TCP "channel".
That turns out to be not very suitable for our current design, where a
`TcpReceiver` and the one port it exposes is supposed to be the endpoint
for all incoming connections (which conceptually can originate from any
number `TcpSender` objects on any number of nodes).
To fix this problem, this patch adjusts the `TcpReceiver` to support
accepting of multiple incoming connections. We use the previously
written transaction multiplexer to serialize transactions from the
individual connections and multiplex them onto a single observer object.
