### PR TITLE
Introduce a file adapter

### DIFF
--- a/rust/template/cmd_parser/lib.rs
+++ b/rust/template/cmd_parser/lib.rs
@@ -120,7 +120,7 @@ where
     }
 }
 
-fn err_str<E>(e: &Err<&[u8], E>) -> String {
+pub fn err_str<E>(e: &Err<&[u8], E>) -> String {
     match e {
         Err::Error(Context::Code(s, _)) | Err::Failure(Context::Code(s, _)) => {
             String::from_utf8(s.to_vec()).unwrap_or_else(|_| "not a UTF8 string".to_string())

--- a/rust/template/differential_datalog/ddlog.rs
+++ b/rust/template/differential_datalog/ddlog.rs
@@ -11,8 +11,13 @@ use crate::valmap::DeltaMap;
 
 /// Convert to and from values/objects of a DDlog program.
 pub trait DDlogConvert: Debug {
+    type Value: Debug;
+
     /// Convert a `RelId` into its symbolic name.
     fn relid2name(rel_id: RelId) -> Option<&'static str>;
+
+    /// Convert an `UpdCmd` into an `Update`.
+    fn updcmd2upd(upd_cmd: &UpdCmd) -> Result<Update<Self::Value>, String>;
 }
 
 /// A trait capturing program instantiation and handling of

--- a/rust/template/distributed_datalog/Cargo.toml
+++ b/rust/template/distributed_datalog/Cargo.toml
@@ -3,11 +3,15 @@ name = "distributed_datalog"
 version = "0.1.0"
 edition = "2018"
 
+[dependencies.cmd_parser]
+path = "../cmd_parser"
+
 [dependencies.differential_datalog]
 path = "../differential_datalog"
 
 [dev-dependencies]
 env_logger = {version = "0.7", default_features = false, features = ["humantime"]}
+tempfile = "3.1"
 test-env-log = "0.1"
 waitfor = "0.1"
 
@@ -15,6 +19,7 @@ waitfor = "0.1"
 bincode = "1.2"
 libc = "0.2"
 log = "0.4"
+nom = "4.0"
 serde = {version = "1.0", features = ["derive"]}
 waitfor = {version = "0.1", optional = true}
 

--- a/rust/template/distributed_datalog/src/lib.rs
+++ b/rust/template/distributed_datalog/src/lib.rs
@@ -14,6 +14,9 @@ mod tcp_channel;
 mod test;
 mod txnmux;
 
+/// A module comprising sources to feed data into a computation.
+pub mod sources;
+
 pub use observe::Observable;
 pub use observe::ObservableBox;
 pub use observe::Observer;

--- a/rust/template/distributed_datalog/src/sources/file.rs
+++ b/rust/template/distributed_datalog/src/sources/file.rs
@@ -1,0 +1,362 @@
+use std::fmt::Debug;
+use std::fs::File as FsFile;
+use std::io::BufRead;
+use std::io::BufReader;
+use std::io::Error;
+use std::io::Read;
+use std::iter::once;
+use std::marker::PhantomData;
+use std::os::unix::io::AsRawFd;
+use std::os::unix::io::RawFd;
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::thread::spawn;
+use std::thread::JoinHandle;
+
+use libc::close;
+use log::error;
+use log::info;
+use nom::Err;
+
+use cmd_parser::err_str;
+use cmd_parser::parse_command;
+use cmd_parser::Command;
+use differential_datalog::program::Update;
+use differential_datalog::DDlogConvert;
+
+use crate::Observable;
+use crate::Observer;
+use crate::ObserverBox;
+
+#[derive(Debug)]
+enum Fd {
+    /// The file descriptor is still active.
+    Active(RawFd),
+    /// The file descriptor has been closed.
+    Closed,
+}
+
+impl Fd {
+    fn close(&mut self) -> Result<(), Error> {
+        match *self {
+            Fd::Active(fd) => {
+                // We don't know of any good reason why a close would
+                // fail. If it did, we are in some pretty funky state
+                // right now and should treat the problem as if the file
+                // descriptor had been closed.
+                *self = Fd::Closed;
+
+                let rc = unsafe { close(fd) };
+                if rc != 0 {
+                    return Err(Error::last_os_error());
+                }
+                Ok(())
+            }
+            Fd::Closed => Ok(()),
+        }
+    }
+}
+
+/// Handle the given command.
+///
+/// `updates` acts as an inter-procedural cache of updates that we will
+/// push into the observer eventually.
+fn handle<C, V>(
+    command: Command,
+    updates: &mut Vec<Update<V>>,
+    observer: &mut dyn Observer<Update<V>, String>,
+) where
+    C: DDlogConvert<Value = V>,
+    V: Debug + Send,
+{
+    match command {
+        Command::Start => {
+            let _ = observer
+                .on_start()
+                .map_err(|e| error!("observer failed on_start: {:?}", e));
+        }
+        Command::Commit(_) => {
+            let _ = observer
+                .on_commit()
+                .map_err(|e| error!("observer failed on_commit: {:?}", e));
+        }
+        Command::Update(upd_cmd, last) => match C::updcmd2upd(&upd_cmd) {
+            Ok(upd) => {
+                if last {
+                    let updates = updates.drain(..).chain(once(upd));
+                    let _ = observer
+                        .on_updates(Box::new(updates))
+                        .map_err(|e| error!("observer failed on_updates: {:?}", e));
+                } else {
+                    updates.push(upd)
+                }
+            }
+            Err(e) => error!("failed to convert UpdCmd to Update: {}", e),
+        },
+        // TODO: Eventually we will need to add support for the 'Clear'
+        //       command.
+        _ => info!("ignoring unsupported command: {:?}", command),
+    }
+}
+
+fn process<C, V, R>(
+    reader: R,
+    fd: Arc<Mutex<Fd>>,
+    mut observer: ObserverBox<Update<V>, String>,
+) -> ObserverBox<Update<V>, String>
+where
+    C: DDlogConvert<Value = V>,
+    V: Debug + Send,
+    R: Read,
+{
+    // TODO: The logic here somewhat resembles that in
+    //       `cmd_parser/lib.rs`. We may want to deduplicate at some
+    //       point.
+    let mut buffer = Vec::new();
+    let mut updates = Vec::new();
+    let mut reader = BufReader::new(reader);
+    loop {
+        let mut line = String::new();
+        match reader.read_line(&mut line) {
+            Ok(_) => {
+                buffer.extend_from_slice(line.as_bytes());
+                match parse_command(buffer.as_slice()) {
+                    Ok((rest, command)) => {
+                        // TODO: Remove unnecessary allocation. (Replace
+                        //       with Vec::splice perhaps?)
+                        buffer = rest.to_owned();
+                        handle::<C, _>(command, &mut updates, &mut observer);
+                    }
+                    Err(Err::Incomplete(_)) => (),
+                    Err(e) => {
+                        error!("encountered invalid input: {}", err_str(&e));
+                        buffer.clear();
+                    }
+                }
+            }
+            Err(e) => {
+                if let Fd::Closed = *fd.lock().unwrap() {
+                    return observer;
+                }
+                error!("failed to read from source file: {}", e);
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+struct State<V> {
+    /// The raw handle of the file we are reading from.
+    fd: Arc<Mutex<Fd>>,
+    /// The thread reading from the file.
+    thread: JoinHandle<ObserverBox<Update<V>, String>>,
+}
+
+/// An object adapting a file to the `Observable` interface.
+#[derive(Debug)]
+pub struct File<C, V>
+where
+    C: DDlogConvert<Value = V>,
+    V: Debug + Send + 'static,
+{
+    /// The path to the file we want to adapt to.
+    path: PathBuf,
+    /// The state we maintain.
+    state: Option<State<V>>,
+    /// Unused phantom data.
+    _unused: PhantomData<C>,
+}
+
+impl<C, V> File<C, V>
+where
+    C: DDlogConvert<Value = V>,
+    V: Debug + Send + 'static,
+{
+    /// Create a new adapter streaming data from the file at the given
+    /// `path`.
+    pub fn new<P>(path: P) -> Result<Self, Error>
+    where
+        P: Into<PathBuf>,
+    {
+        Ok(Self {
+            path: path.into(),
+            state: None,
+            _unused: Default::default(),
+        })
+    }
+
+    fn start(
+        path: &Path,
+        observer: ObserverBox<Update<V>, String>,
+    ) -> Result<State<V>, ObserverBox<Update<V>, String>> {
+        let file = match FsFile::open(path) {
+            Ok(file) => file,
+            Err(e) => {
+                error!("failed to open file {}: {}", path.display(), e);
+                return Err(observer);
+            }
+        };
+        let fd = Arc::new(Mutex::new(Fd::Active(file.as_raw_fd())));
+        let state = State {
+            fd: fd.clone(),
+            thread: spawn(move || process::<C, _, _>(file, fd, observer)),
+        };
+
+        Ok(state)
+    }
+}
+
+impl<C, V> Drop for File<C, V>
+where
+    C: DDlogConvert<Value = V>,
+    V: Debug + Send + 'static,
+{
+    fn drop(&mut self) {
+        let _ = self.unsubscribe(&());
+    }
+}
+
+impl<C, V> Observable<Update<V>, String> for File<C, V>
+where
+    C: DDlogConvert<Value = V>,
+    V: Debug + Send + 'static,
+{
+    type Subscription = ();
+
+    fn subscribe(
+        &mut self,
+        observer: ObserverBox<Update<V>, String>,
+    ) -> Result<Self::Subscription, ObserverBox<Update<V>, String>> {
+        if self.state.is_some() {
+            Err(observer)
+        } else {
+            let state = Self::start(&self.path, observer)?;
+            let _ = self.state.replace(state);
+            Ok(())
+        }
+    }
+
+    fn unsubscribe(
+        &mut self,
+        _subscription: &Self::Subscription,
+    ) -> Option<ObserverBox<Update<V>, String>> {
+        if let Some(state) = self.state.take() {
+            if let Err(e) = state.fd.lock().unwrap().close() {
+                error!("failed to close adapted file: {}", e);
+                // We continue as there is not much we can do about
+                // the error. There shouldn't be any chance that we
+                // actually fail the close while the thread is still
+                // blocking on a read, but who knows.
+            }
+            match state.thread.join() {
+                Ok(observer) => Some(observer),
+                Err(e) => {
+                    error!("file observer thread panicked: {:?}", e);
+                    None
+                }
+            }
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::io::Write;
+    use std::sync::Mutex;
+    use std::thread::sleep;
+    use std::time::Duration;
+
+    use tempfile::NamedTempFile;
+
+    use differential_datalog::program::RelId;
+    use differential_datalog::record::UpdCmd;
+
+    use crate::await_expected;
+    use crate::MockObserver;
+    use crate::SharedObserver;
+
+    const TRANSACTION_DUMP: &'static [u8] = include_bytes!("file_test.dat");
+
+    #[derive(Debug)]
+    struct DummyConverter;
+
+    impl DDlogConvert for DummyConverter {
+        type Value = ();
+
+        fn relid2name(_rel_id: RelId) -> Option<&'static str> {
+            unimplemented!()
+        }
+
+        fn updcmd2upd(_upd_cmd: &UpdCmd) -> Result<Update<Self::Value>, String> {
+            // Exact details do not matter in this context, so just fake
+            // some data.
+            Ok(Update::Insert { relid: 0, v: () })
+        }
+    }
+
+    #[test]
+    fn non_existent_file() {
+        let mock = SharedObserver::new(Mutex::new(MockObserver::new()));
+        let mut adapter = File::<DummyConverter, _>::new("i-dont-actually-exist").unwrap();
+        let result = adapter.subscribe(Box::new(mock.clone()));
+
+        assert!(result.is_err(), result);
+    }
+
+    #[test]
+    fn adapt_observable_to_dump_file() {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(TRANSACTION_DUMP).unwrap();
+
+        let mock = SharedObserver::new(Mutex::new(MockObserver::new()));
+        let mut adapter = File::<DummyConverter, _>::new(file.path()).unwrap();
+        let _ = adapter.subscribe(Box::new(mock.clone())).unwrap();
+
+        await_expected(|| {
+            let (on_start, on_updates, on_commit) = {
+                let guard = mock.lock().unwrap();
+                (
+                    guard.called_on_start,
+                    guard.called_on_updates,
+                    guard.called_on_commit,
+                )
+            };
+            assert_eq!(on_start, 2);
+            assert_eq!(on_updates, 5);
+            assert_eq!(on_commit, 2);
+        });
+
+        // Add the same data into the file and verify that we get more
+        // updates.
+        file.write_all(TRANSACTION_DUMP).unwrap();
+
+        await_expected(|| {
+            let (on_start, on_updates, on_commit) = {
+                let guard = mock.lock().unwrap();
+                (
+                    guard.called_on_start,
+                    guard.called_on_updates,
+                    guard.called_on_commit,
+                )
+            };
+            assert_eq!(on_start, 4);
+            assert_eq!(on_updates, 10);
+            assert_eq!(on_commit, 4);
+        });
+
+        // Unsubscribe and verify that additional data does not result
+        // in more updates.
+        let _ = adapter.unsubscribe(&()).unwrap();
+
+        file.write_all(TRANSACTION_DUMP).unwrap();
+        sleep(Duration::from_millis(250));
+
+        assert_eq!(mock.lock().unwrap().called_on_start, 4);
+    }
+}

--- a/rust/template/distributed_datalog/src/sources/file_test.dat
+++ b/rust/template/distributed_datalog/src/sources/file_test.dat
@@ -1,0 +1,9 @@
+start;
+insert Word("test1"),
+insert Word("test2"),
+insert Word("test3");
+commit;
+start;
+insert Word("test4");
+insert Word("test5");
+commit;

--- a/rust/template/distributed_datalog/src/sources/mod.rs
+++ b/rust/template/distributed_datalog/src/sources/mod.rs
@@ -1,0 +1,5 @@
+//! Various sources for feeding data into a distributed computation.
+
+mod file;
+
+pub use file::File;

--- a/rust/template/src/lib.rs
+++ b/rust/template/src/lib.rs
@@ -47,6 +47,7 @@ use differential_datalog::decl_val_enum_into_record;
 use differential_datalog::int::*;
 use differential_datalog::program::*;
 use differential_datalog::record;
+use differential_datalog::record::UpdCmd;
 use differential_datalog::record::{FromRecord, IntoRecord, Mutator};
 use differential_datalog::uint::*;
 use differential_datalog::DDlogConvert;
@@ -55,6 +56,8 @@ use fnv::{FnvHashMap, FnvHashSet};
 use lazy_static::lazy_static;
 use libc::size_t;
 use num_traits::identities::One;
+
+use crate::api::updcmd2upd;
 
 pub mod api;
 pub mod ovsdb;
@@ -85,8 +88,14 @@ pub fn string_append(mut s1: String, s2: &String) -> String {
 pub struct DDlogConverter {}
 
 impl DDlogConvert for DDlogConverter {
+    type Value = Value;
+
     fn relid2name(relId: RelId) -> Option<&'static str> {
         relid2name(relId)
+    }
+
+    fn updcmd2upd(upd_cmd: &UpdCmd) -> Result<Update<Self::Value>, String> {
+        updcmd2upd(upd_cmd)
     }
 }
 

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -167,6 +167,8 @@ rustLibFiles specname =
         , (dir </> "distributed_datalog/src/observe/observer.rs"     , $(embedFile "rust/template/distributed_datalog/src/observe/observer.rs"))
         , (dir </> "distributed_datalog/src/observe/test.rs"         , $(embedFile "rust/template/distributed_datalog/src/observe/test.rs"))
         , (dir </> "distributed_datalog/src/server.rs"               , $(embedFile "rust/template/distributed_datalog/src/server.rs"))
+        , (dir </> "distributed_datalog/src/sources/file.rs"         , $(embedFile "rust/template/distributed_datalog/src/sources/file.rs"))
+        , (dir </> "distributed_datalog/src/sources/mod.rs"          , $(embedFile "rust/template/distributed_datalog/src/sources/mod.rs"))
         , (dir </> "distributed_datalog/src/tcp_channel/message.rs"  , $(embedFile "rust/template/distributed_datalog/src/tcp_channel/message.rs"))
         , (dir </> "distributed_datalog/src/tcp_channel/mod.rs"      , $(embedFile "rust/template/distributed_datalog/src/tcp_channel/mod.rs"))
         , (dir </> "distributed_datalog/src/tcp_channel/receiver.rs" , $(embedFile "rust/template/distributed_datalog/src/tcp_channel/receiver.rs"))


### PR DESCRIPTION
In order to really make use of any distributed computation we need a way
to feed data into it.
This change proposes such infrastructure in the form of an adapter from
a file to an observable. The expected file format is our usual CLI/dump
format. The adapter keeps "watching" the file and will process newly
written data.