### PR TITLE
DDlog v0.11.0

### DIFF
--- a/rust/template/Cargo.toml
+++ b/rust/template/Cargo.toml
@@ -28,8 +28,7 @@ path = "./ovsdb"
 [dependencies]
 abomonation = "0.7"
 cpuprofiler = {version = "0.0.3", optional = true}
-#differential-dataflow = "0.9"
-differential-dataflow = { git = "https://github.com/ryzhyk/differential-dataflow", branch="0.10.4" }
+differential-dataflow = "0.11.0"
 fnv="1.0.2"
 lazy_static = "1.3"
 libc = "0.2"
@@ -37,9 +36,7 @@ num-traits = "0.2"
 rustop = "1.0.2"
 serde = {version = "1.0", features = ["derive"]}
 time = "0.1"
-#timely = "0.9"
-#timely = { git = "https://github.com/TimelyDataflow/timely-dataflow" }
-timely = { git = "https://github.com/ryzhyk/timely-dataflow" }
+timely = "0.11"
 twox-hash = "1.1"
 
 # FlatBuffers dependency enabled by the `flatbuf` feature.

--- a/rust/template/differential_datalog/Cargo.toml
+++ b/rust/template/differential_datalog/Cargo.toml
@@ -3,25 +3,17 @@ name = "differential_datalog"
 version = "0.1.0"
 edition = "2018"
 
-[dependencies.graph_map]
-git = "https://github.com/frankmcsherry/graph-map.git"
-
 [dev-dependencies]
 byteorder = "0.4.2"
 getopts = "0.2.14"
 itertools = "^0.6"
-rand = "0.3.13"
 serde_derive = "1.0"
 
 [dependencies]
-#differential-dataflow = "0.9"
-differential-dataflow = { git = "https://github.com/ryzhyk/differential-dataflow", branch="0.10.4" }
-#differential-dataflow = { git = "https://github.com/ryzhyk/differential-dataflow"}
+differential-dataflow = "0.11.0"
 abomonation = "0.7"
 fnv = "1.0.2"
-#timely = "0.9"
-#timely = { git = "https://github.com/TimelyDataflow/timely-dataflow" }
-timely = { git = "https://github.com/ryzhyk/timely-dataflow" }
+timely = "0.11"
 libc = "0.2"
 num = { version = "0.2", features = ["serde"] }
 sequence_trie = "0.3"

--- a/src/Language/DifferentialDatalog/Version.hs
+++ b/src/Language/DifferentialDatalog/Version.hs
@@ -32,7 +32,7 @@ import GitHash
 
 -- Keep this in sync with the binary release version on github
 dDLOG_VERSION :: String
-dDLOG_VERSION = "v0.10.5"
+dDLOG_VERSION = "v0.11.0"
 
 gitHash :: String
 gitHash = giHash $$tGitInfoCwd


### PR DESCRIPTION
- Switch to DD release 0.11.0
- Cleanup some unused dependencies in `Cargo.toml`
- Bump version to 0.11.0