### PR TITLE
Topic/rr

### DIFF
--- a/rust/template/Cargo.toml
+++ b/rust/template/Cargo.toml
@@ -27,9 +27,9 @@ path = "./ovsdb"
 
 [dependencies]
 abomonation = "0.7"
-cpuprofiler = {version = "0.0.3", optional = true}
+cpuprofiler = {version = "0.0", optional = true}
 differential-dataflow = "0.11.0"
-fnv="1.0.2"
+fnv = "1.0.2"
 lazy_static = "1.3"
 libc = "0.2"
 num-traits = "0.2"

--- a/rust/template/differential_datalog/lib.rs
+++ b/rust/template/differential_datalog/lib.rs
@@ -3,6 +3,7 @@
 mod callback;
 mod ddlog;
 mod profile;
+mod replay;
 #[cfg(test)]
 mod test;
 mod valmap;
@@ -22,4 +23,7 @@ mod test_record;
 pub use callback::Callback;
 pub use ddlog::DDlog;
 pub use ddlog::DDlogConvert;
+pub use replay::record_upd_cmds;
+pub use replay::record_val_upds;
+pub use replay::RecordReplay;
 pub use valmap::DeltaMap;

--- a/rust/template/differential_datalog/replay.rs
+++ b/rust/template/differential_datalog/replay.rs
@@ -1,0 +1,288 @@
+use std::fmt::Debug;
+use std::fmt::Display;
+use std::io::Error;
+use std::io::Result;
+use std::io::Write;
+use std::iter::Peekable;
+
+use crate::ddlog::DDlogConvert;
+use crate::program::RelId;
+use crate::program::Update;
+use crate::record::RelIdentifier;
+use crate::record::UpdCmd;
+
+/// A custom iterator that indicates in each yielded element whether it
+/// is the last one or not.
+struct Peeking<I>
+where
+    I: Iterator,
+{
+    iter: Peekable<I>,
+}
+
+impl<I> Peeking<I>
+where
+    I: Iterator,
+{
+    fn new(iter: I) -> Self {
+        Self {
+            iter: iter.peekable(),
+        }
+    }
+}
+
+impl<I> Iterator for Peeking<I>
+where
+    I: Iterator,
+{
+    /// The iterator yields tuples of items of the underlying iterator
+    /// together with an enum indicating whether this is the last
+    /// element.
+    type Item = (I::Item, bool);
+
+    fn next(&mut self) -> Option<(I::Item, bool)> {
+        let elem = self.iter.next()?;
+        let last = self.iter.peek().is_none();
+        Some((elem, last))
+    }
+}
+
+/// Convert a `RelIdentifier` into its symbolic name.
+fn relident2name<C, V>(rel_ident: &RelIdentifier) -> Option<&str>
+where
+    C: DDlogConvert<Value = V>,
+    V: Debug,
+{
+    match rel_ident {
+        RelIdentifier::RelName(rname) => Some(rname.as_ref()),
+        RelIdentifier::RelId(id) => C::relid2name(*id),
+    }
+}
+
+fn record_updates<'w, W, I, U, F, E>(
+    writer: &'w mut W,
+    updates: I,
+    record: F,
+    error: E,
+) -> impl Iterator<Item = U> + 'w
+where
+    W: Write,
+    I: Iterator<Item = U> + 'w,
+    F: Fn(&mut W, &U) -> Result<()> + 'w,
+    E: Fn(Error) + 'w,
+{
+    Peeking::new(updates).map(move |(upd, last)| {
+        let _ = record(writer, &upd)
+            .and_then(|_| {
+                if !last {
+                    writeln!(writer, ",")
+                } else {
+                    writeln!(writer, ";")
+                }
+            })
+            .map_err(|e| error(e));
+
+        upd
+    })
+}
+
+/// Record a list of `UpdCmd` objects into the given writable object.
+///
+/// `error` is a function that is invoked whenever writing out a record
+/// failed. Note that such errors do not cause the overall operation to
+/// fail.
+pub fn record_upd_cmds<'w, C, V, W, I, F>(
+    writer: &'w mut W,
+    upds: I,
+    error: F,
+) -> impl Iterator<Item = &'w UpdCmd> + 'w
+where
+    C: DDlogConvert<Value = V>,
+    V: Debug,
+    W: Write,
+    I: Iterator<Item = &'w UpdCmd> + 'w,
+    F: Fn(Error) + 'w,
+{
+    record_updates(writer, upds, |w, u| w.record_upd_cmd::<C, _>(&u), error)
+}
+
+/// Record a list of `Update` objects into the given writable object.
+///
+/// `error` is a function that is invoked whenever writing out a record
+/// failed. Note that such errors do not cause the overall operation to
+/// fail.
+pub fn record_val_upds<'w, C, W, I, F, V>(
+    writer: &'w mut W,
+    upds: I,
+    error: F,
+) -> impl Iterator<Item = Update<V>> + 'w
+where
+    C: DDlogConvert<Value = V>,
+    V: Display + Debug + 'w,
+    W: Write,
+    I: Iterator<Item = Update<V>> + 'w,
+    F: Fn(Error) + 'w,
+{
+    record_updates(writer, upds, |w, u| w.record_val_upd::<C, _>(&u), error)
+}
+
+/// A trait for recording various operations into something that can be written
+/// to, in order to be able to replay them at a later point in time.
+pub trait RecordReplay: Write {
+    /// Record a transaction start.
+    fn record_start(&mut self) -> Result<()> {
+        writeln!(self, "start;")
+    }
+
+    /// Record an `UpdCmd`.
+    fn record_upd_cmd<C, V>(&mut self, upd: &UpdCmd) -> Result<()>
+    where
+        C: DDlogConvert<Value = V>,
+        V: Debug,
+    {
+        match upd {
+            UpdCmd::Insert(rel, record) => write!(
+                self,
+                "insert {}[{}]",
+                relident2name::<C, _>(rel).unwrap_or(&"???"),
+                record,
+            ),
+            UpdCmd::Delete(rel, record) => write!(
+                self,
+                "delete {}[{}]",
+                relident2name::<C, _>(rel).unwrap_or(&"???"),
+                record,
+            ),
+            UpdCmd::DeleteKey(rel, record) => write!(
+                self,
+                "delete_key {} {}",
+                relident2name::<C, _>(rel).unwrap_or(&"???"),
+                record,
+            ),
+            UpdCmd::Modify(rel, key, mutator) => write!(
+                self,
+                "modify {} {} <- {}",
+                relident2name::<C, _>(rel).unwrap_or(&"???"),
+                key,
+                mutator,
+            ),
+        }
+    }
+
+    /// Record an `Update`.
+    fn record_val_upd<C, V>(&mut self, upd: &Update<V>) -> Result<()>
+    where
+        C: DDlogConvert<Value = V>,
+        V: Display + Debug,
+    {
+        match upd {
+            Update::Insert { relid, v } => write!(
+                self,
+                "insert {}[{}]",
+                C::relid2name(*relid).unwrap_or(&"???"),
+                v,
+            ),
+            Update::DeleteValue { relid, v } => write!(
+                self,
+                "delete {}[{}]",
+                C::relid2name(*relid).unwrap_or(&"???"),
+                v,
+            ),
+            Update::DeleteKey { relid, k } => write!(
+                self,
+                "delete_key {} {}",
+                C::relid2name(*relid).unwrap_or(&"???"),
+                k,
+            ),
+            Update::Modify { relid, k, m } => write!(
+                self,
+                "modify {} {} <- {}",
+                C::relid2name(*relid).unwrap_or(&"???"),
+                k,
+                m,
+            ),
+        }
+    }
+
+    /// Record a transaction commit.
+    fn record_commit(&mut self, record_changes: bool) -> Result<()> {
+        if record_changes {
+            writeln!(self, "commit dump_changes;")
+        } else {
+            writeln!(self, "commit;")
+        }
+    }
+
+    /// Record a transaction rollback.
+    fn record_rollback(&mut self) -> Result<()> {
+        writeln!(self, "rollback;")
+    }
+
+    /// Record a clear command.
+    fn record_clear<C, V>(&mut self, rid: RelId) -> Result<()>
+    where
+        C: DDlogConvert<Value = V>,
+        V: Debug,
+    {
+        writeln!(self, "clear {};", C::relid2name(rid).unwrap_or(&"???"))
+    }
+
+    /// Record a dump command.
+    fn record_dump<C, V>(&mut self, rid: RelId) -> Result<()>
+    where
+        C: DDlogConvert<Value = V>,
+        V: Debug,
+    {
+        writeln!(self, "dump {};", C::relid2name(rid).unwrap_or(&"???"))
+    }
+
+    /// Record CPU profiling.
+    fn record_cpu_profiling(&mut self, enable: bool) -> Result<()> {
+        writeln!(self, "profile cpu {};", if enable { "on" } else { "off" })
+    }
+
+    /// Record profiling.
+    fn record_profile(&mut self) -> Result<()> {
+        writeln!(self, "profile;")
+    }
+}
+
+impl<W> RecordReplay for W
+where
+    W: Write,
+{
+    // The default implementation is just fine.
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Test recording of "updates" using `record_updates`.
+    #[test]
+    fn multi_update_recording() {
+        fn test(updates: Vec<u64>, expected: &str) {
+            let mut buf = Vec::new();
+            let iter = updates.iter();
+            let error = |e| panic!("{}", e);
+
+            record_updates(&mut buf, iter, |w, r| write!(w, "update {}", r), error)
+                .for_each(|_| ());
+
+            assert_eq!(buf.as_slice(), expected.as_bytes());
+        }
+
+        test(Vec::new(), "");
+        test(vec![42], "update 42;\n");
+
+        let updates = vec![2, 9, 7, 4, 3, 10];
+        let expected = r#"update 2,
+update 9,
+update 7,
+update 4,
+update 3,
+update 10;
+"#;
+        test(updates, expected);
+    }
+}

--- a/rust/template/src/api.rs
+++ b/rust/template/src/api.rs
@@ -1,9 +1,11 @@
 use differential_datalog::program::*;
 use differential_datalog::record;
 use differential_datalog::record::IntoRecord;
+use differential_datalog::record_val_upds;
 use differential_datalog::Callback;
 use differential_datalog::DDlog;
 use differential_datalog::DeltaMap;
+use differential_datalog::RecordReplay;
 
 use libc::size_t;
 use std::ffi;
@@ -156,7 +158,7 @@ impl DDlog for HDDlog {
         self.prog.lock().unwrap().transaction_start()
     }
 
-    fn transaction_commit_dump_changes(&self) -> Result<DeltaMap<Value>, String> {
+    fn transaction_commit_dump_changes(&self) -> Result<DeltaMap<Self::Value>, String> {
         self.record_transaction_commit(true);
         *self.deltadb.lock().unwrap() = Some(DeltaMap::new());
 
@@ -191,7 +193,7 @@ impl DDlog for HDDlog {
     }
 
     fn transaction_rollback(&self) -> Result<(), String> {
-        let _ = self.record_transaction_rollback();
+        self.record_transaction_rollback();
         self.prog.lock().unwrap().transaction_rollback()
     }
 
@@ -233,37 +235,19 @@ impl DDlog for HDDlog {
     #[cfg(feature = "flatbuf")]
     fn apply_updates_from_flatbuf(&self, buf: &[u8]) -> Result<(), String> {
         let cmditer = flatbuf::updates_from_flatbuf(buf)?;
-        let upds: Result<Vec<Update<Value>>, String> =
+        let upds: Result<Vec<Update<Self::Value>>, String> =
             cmditer.map(|cmd| Update::from_flatbuf(cmd)).collect();
         self.apply_valupdates(upds?.into_iter())
     }
 
     fn apply_valupdates<I>(&self, upds: I) -> Result<(), String>
     where
-        I: Iterator<Item = Update<Value>>,
+        I: Iterator<Item = Update<Self::Value>>,
     {
         if let Some(ref f) = self.replay_file {
             let mut file = f.lock().unwrap();
-            /* Count the number of elements in `upds`. */
-            let mut n = 0;
-
-            let res = self
-                .prog
-                .lock()
-                .unwrap()
-                .apply_updates(upds.enumerate().map(|(i, upd)| {
-                    n += 1;
-                    if i > 0 {
-                        let _ = writeln!(file, ",");
-                    };
-                    record_valupdate(&mut *file, &upd);
-                    upd
-                }));
-            /* Print semicolon if `upds` were not empty. */
-            if n > 0 {
-                let _ = writeln!(file, ";");
-            }
-            res
+            let upds = record_val_upds::<Self::Convert, _, _, _, _>(&mut *file, upds, |_| ());
+            self.prog.lock().unwrap().apply_updates(upds)
         } else {
             self.prog.lock().unwrap().apply_updates(upds)
         }
@@ -350,162 +334,71 @@ impl HDDlog {
 
     fn record_transaction_start(&self) {
         if let Some(ref f) = self.replay_file {
-            if writeln!(f.lock().unwrap(), "start;").is_err() {
+            let _ = f.lock().unwrap().record_start().map_err(|_| {
                 self.eprintln("failed to record invocation in replay file");
-            }
+            });
         }
     }
 
     fn record_transaction_commit(&self, record_changes: bool) {
         if let Some(ref f) = self.replay_file {
-            let res = if record_changes {
-                writeln!(f.lock().unwrap(), "commit dump_changes;")
-            } else {
-                writeln!(f.lock().unwrap(), "commit;")
-            };
-            if res.is_err() {
+            let _ = f
+                .lock()
+                .unwrap()
+                .record_commit(record_changes)
+                .map_err(|_| {
+                    self.eprintln("failed to record invocation in replay file");
+                });
+        }
+    }
+
+    fn record_transaction_rollback(&self) {
+        if let Some(ref f) = self.replay_file {
+            let _ = f.lock().unwrap().record_rollback().map_err(|_| {
                 self.eprintln("failed to record invocation in replay file");
-            }
+            });
         }
     }
 
-    fn record_transaction_rollback(&self) -> Result<(), String> {
+    fn record_clear_relation(&self, rid: RelId) {
         if let Some(ref f) = self.replay_file {
-            if writeln!(f.lock().unwrap(), "rollback;").is_err() {
-                Err("failed to record invocation in replay file".to_string())
-            } else {
-                Ok(())
-            }
-        } else {
-            Ok(())
+            let _ = f
+                .lock()
+                .unwrap()
+                .record_clear::<DDlogConverter, _>(rid)
+                .map_err(|e| {
+                    self.eprintln("failed to record invocation in replay file");
+                });
         }
     }
 
-    fn record_clear_relation(&self, table: usize) {
+    fn record_dump_table(&self, rid: RelId) {
         if let Some(ref f) = self.replay_file {
-            if writeln!(
-                f.lock().unwrap(),
-                "clear {};",
-                relid2name(table).unwrap_or(&"???")
-            )
-            .is_err()
-            {
-                self.eprintln("failed to record invocation in replay file");
-            }
-        }
-    }
-
-    fn record_dump_table(&self, table: usize) {
-        if let Some(ref f) = self.replay_file {
-            if writeln!(
-                f.lock().unwrap(),
-                "dump {};",
-                relid2name(table).unwrap_or(&"???")
-            )
-            .is_err()
-            {
-                self.eprintln("ddlog_dump_table(): failed to record invocation in replay file");
-            }
+            let _ = f
+                .lock()
+                .unwrap()
+                .record_dump::<DDlogConverter, _>(rid)
+                .map_err(|e| {
+                    self.eprintln("ddlog_dump_table(): failed to record invocation in replay file");
+                });
         }
     }
 
     fn record_enable_cpu_profiling(&self, enable: bool) {
         if let Some(ref f) = self.replay_file {
-            if writeln!(
-                f.lock().unwrap(),
-                "profile cpu {};",
-                if enable { "on" } else { "off" }
-            )
-            .is_err()
-            {
+            let _ = f.lock().unwrap().record_cpu_profiling(enable).map_err(|_| {
                 self.eprintln(
                     "ddlog_cpu_profiling_enable(): failed to record invocation in replay file",
-                );
-            }
+                )
+            });
         }
     }
 
     fn record_profile(&self) {
         if let Some(ref f) = self.replay_file {
-            if writeln!(f.lock().unwrap(), "profile;").is_err() {
-                self.eprintln("failed to record invocation in replay file");
-            }
-        }
-    }
-}
-
-pub fn record_update(file: &mut fs::File, upd: &record::UpdCmd) {
-    match upd {
-        record::UpdCmd::Insert(rel, record) => {
-            let _ = write!(
-                file,
-                "insert {}[{}]",
-                relident2name(rel).unwrap_or(&"???"),
-                record
-            );
-        }
-        record::UpdCmd::Delete(rel, record) => {
-            let _ = write!(
-                file,
-                "delete {}[{}]",
-                relident2name(rel).unwrap_or(&"???"),
-                record
-            );
-        }
-        record::UpdCmd::DeleteKey(rel, record) => {
-            let _ = write!(
-                file,
-                "delete_key {} {}",
-                relident2name(rel).unwrap_or(&"???"),
-                record
-            );
-        }
-        record::UpdCmd::Modify(rel, key, mutator) => {
-            let _ = write!(
-                file,
-                "modify {} {} <- {}",
-                relident2name(rel).unwrap_or(&"???"),
-                key,
-                mutator
-            );
-        }
-    }
-}
-
-pub fn record_valupdate(file: &mut fs::File, upd: &Update<Value>) {
-    match upd {
-        Update::Insert { relid, v } => {
-            let _ = write!(
-                file,
-                "insert {}[{}]",
-                relid2name(*relid).unwrap_or(&"???"),
-                v
-            );
-        }
-        Update::DeleteValue { relid, v } => {
-            let _ = write!(
-                file,
-                "delete {}[{}]",
-                relid2name(*relid).unwrap_or(&"???"),
-                v
-            );
-        }
-        Update::DeleteKey { relid, k } => {
-            let _ = write!(
-                file,
-                "delete_key {} {}",
-                relid2name(*relid).unwrap_or(&"???"),
-                k
-            );
-        }
-        Update::Modify { relid, k, m } => {
-            let _ = write!(
-                file,
-                "modify {} {} <- {}",
-                relid2name(*relid).unwrap_or(&"???"),
-                k,
-                m
-            );
+            let _ = f.lock().unwrap().record_profile().map_err(|_| {
+                self.eprintln("record_profile: failed to record invocation in replay file");
+            });
         }
     }
 }
@@ -556,13 +449,6 @@ fn relident2id(r: &record::RelIdentifier) -> Option<Relations> {
     match r {
         record::RelIdentifier::RelName(rname) => relname2id(rname),
         record::RelIdentifier::RelId(id) => relid2rel(*id),
-    }
-}
-
-fn relident2name(r: &record::RelIdentifier) -> Option<&str> {
-    match r {
-        record::RelIdentifier::RelName(rname) => Some(rname.as_ref()),
-        record::RelIdentifier::RelId(id) => relid2name(*id),
     }
 }
 

--- a/rust/template/src/lib.rs
+++ b/rust/template/src/lib.rs
@@ -153,10 +153,6 @@ pub fn input_relname_to_id(_rname: &str) -> Option<Relations> {
     panic!("input_relname_to_id not implemented")
 }
 
-pub fn record_update(_file: &mut fs::File, _upd: &record::UpdCmd) {
-    panic!("record_update not implemented")
-}
-
 pub fn relid2rel(_rid: RelId) -> Option<Relations> {
     panic!("relid2rel not implemented")
 }

--- a/rust/template/src/ovsdb.rs
+++ b/rust/template/src/ovsdb.rs
@@ -1,15 +1,20 @@
 //! OVSDB JSON interface to RunningProgram
 
-use super::api::{record_update, updcmd2upd, HDDlog};
-use super::{relname2id, Value};
-use ddlog_ovsdb_adapter::*;
-use differential_datalog::program::*;
-use differential_datalog::record::{IntoRecord, UpdCmd};
-use differential_datalog::DeltaMap;
 use std::ffi::{CStr, CString};
 use std::io::Write;
 use std::os::raw::{c_char, c_int};
 use std::sync;
+
+use ddlog_ovsdb_adapter::*;
+use differential_datalog::program::*;
+use differential_datalog::record::{IntoRecord, UpdCmd};
+use differential_datalog::record_upd_cmds;
+use differential_datalog::DeltaMap;
+use differential_datalog::RecordReplay;
+
+use crate::api::{updcmd2upd, HDDlog};
+use crate::DDlogConverter;
+use crate::{relname2id, Value};
 
 /// Parse OVSDB JSON <table-updates> value into DDlog commands; apply commands to a DDlog program.
 ///
@@ -69,16 +74,11 @@ fn apply_updates(
 fn record_updatecmds(prog: &sync::Arc<HDDlog>, upds: &[UpdCmd]) {
     if let Some(ref f) = prog.replay_file {
         let mut file = f.lock().unwrap();
-        let n = upds.len();
-        for (i, upd) in upds.iter().enumerate() {
-            let sep = if i == n - 1 { ";" } else { "," };
-            record_update(&mut *file, upd);
-            if writeln!(&mut *file, "{}", sep).is_err() {
-                prog.eprintln(
-                    "ddlog_transaction_start(): failed to record invocation in replay file",
-                );
-            }
-        }
+        let iter = upds.iter();
+        record_upd_cmds::<DDlogConverter, _, _, _, _>(&mut *file, iter, |_| {
+            prog.eprintln("ddlog_apply_ovsdb_updates(): failed to record invocation in replay file")
+        })
+        .for_each(|_| ());
     }
 }
 

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -152,6 +152,7 @@ rustLibFiles specname =
         , (dir </> "differential_datalog/profile.rs"                 , $(embedFile "rust/template/differential_datalog/profile.rs"))
         , (dir </> "differential_datalog/program.rs"                 , $(embedFile "rust/template/differential_datalog/program.rs"))
         , (dir </> "differential_datalog/record.rs"                  , $(embedFile "rust/template/differential_datalog/record.rs"))
+        , (dir </> "differential_datalog/replay.rs"                  , $(embedFile "rust/template/differential_datalog/replay.rs"))
         , (dir </> "differential_datalog/test.rs"                    , $(embedFile "rust/template/differential_datalog/test.rs"))
         , (dir </> "differential_datalog/test_record.rs"             , $(embedFile "rust/template/differential_datalog/test_record.rs"))
         , (dir </> "differential_datalog/uint.rs"                    , $(embedFile "rust/template/differential_datalog/uint.rs"))


### PR DESCRIPTION
Factor out record replay functionality into separate trait

With an upcoming change we would like to introduce a sink that can
produce a dump that is recognized by our CLI. In order to do so it
would be nice to reuse some of the existing logic for persisting
transactions.
Unfortunately, this functionality is not well isolated and fairly spread
out through various functions/methods. In order to unify all of this
logic in one place, this change proposes the introduction of another
trait, RecordReplay, that provides functions for recording various
operations (such as transaction start, transaction commit, etc.).