### PR TITLE
Topic/trait usage

### DIFF
--- a/rust/template/src/api.rs
+++ b/rust/template/src/api.rs
@@ -406,8 +406,8 @@ impl HDDlog {
 pub fn updcmd2upd(c: &record::UpdCmd) -> Result<Update<Value>, String> {
     match c {
         record::UpdCmd::Insert(rident, rec) => {
-            let relid: Relations =
-                relident2id(rident).ok_or_else(|| format!("Unknown relation {}", rident))?;
+            let relid =
+                Relations::try_from(rident).map_err(|_| format!("Unknown relation {}", rident))?;
             let val = relval_from_record(relid, rec)?;
             Ok(Update::Insert {
                 relid: relid as RelId,
@@ -415,8 +415,8 @@ pub fn updcmd2upd(c: &record::UpdCmd) -> Result<Update<Value>, String> {
             })
         }
         record::UpdCmd::Delete(rident, rec) => {
-            let relid: Relations =
-                relident2id(rident).ok_or_else(|| format!("Unknown relation {}", rident))?;
+            let relid =
+                Relations::try_from(rident).map_err(|()| format!("Unknown relation {}", rident))?;
             let val = relval_from_record(relid, rec)?;
             Ok(Update::DeleteValue {
                 relid: relid as RelId,
@@ -424,8 +424,8 @@ pub fn updcmd2upd(c: &record::UpdCmd) -> Result<Update<Value>, String> {
             })
         }
         record::UpdCmd::DeleteKey(rident, rec) => {
-            let relid: Relations =
-                relident2id(rident).ok_or_else(|| format!("Unknown relation {}", rident))?;
+            let relid =
+                Relations::try_from(rident).map_err(|()| format!("Unknown relation {}", rident))?;
             let key = relkey_from_record(relid, rec)?;
             Ok(Update::DeleteKey {
                 relid: relid as RelId,
@@ -433,8 +433,8 @@ pub fn updcmd2upd(c: &record::UpdCmd) -> Result<Update<Value>, String> {
             })
         }
         record::UpdCmd::Modify(rident, key, rec) => {
-            let relid: Relations =
-                relident2id(rident).ok_or_else(|| format!("Unknown relation {}", rident))?;
+            let relid =
+                Relations::try_from(rident).map_err(|()| format!("Unknown relation {}", rident))?;
             let key = relkey_from_record(relid, key)?;
             Ok(Update::Modify {
                 relid: relid as RelId,
@@ -442,13 +442,6 @@ pub fn updcmd2upd(c: &record::UpdCmd) -> Result<Update<Value>, String> {
                 m: Box::new(rec.clone()),
             })
         }
-    }
-}
-
-fn relident2id(r: &record::RelIdentifier) -> Option<Relations> {
-    match r {
-        record::RelIdentifier::RelName(rname) => Relations::try_from(rname.as_ref()).ok(),
-        record::RelIdentifier::RelId(id) => relid2rel(*id),
     }
 }
 

--- a/rust/template/src/api.rs
+++ b/rust/template/src/api.rs
@@ -59,7 +59,7 @@ impl HDDlog {
     }
 
     pub fn get_table_id(tname: &str) -> Result<Relations, String> {
-        relname2id(tname).ok_or_else(|| format!("unknown relation {}", tname))
+        Relations::try_from(tname).map_err(|()| format!("unknown relation {}", tname))
     }
 
     pub fn get_table_name(tid: RelId) -> Result<&'static str, String> {
@@ -447,7 +447,7 @@ pub fn updcmd2upd(c: &record::UpdCmd) -> Result<Update<Value>, String> {
 
 fn relident2id(r: &record::RelIdentifier) -> Option<Relations> {
     match r {
-        record::RelIdentifier::RelName(rname) => relname2id(rname),
+        record::RelIdentifier::RelName(rname) => Relations::try_from(rname.as_ref()).ok(),
         record::RelIdentifier::RelId(id) => relid2rel(*id),
     }
 }

--- a/rust/template/src/lib.rs
+++ b/rust/template/src/lib.rs
@@ -110,6 +110,17 @@ pub enum Relations {
     X = 0,
 }
 
+#[allow(clippy::trivially_copy_pass_by_ref)]
+impl Relations {
+    pub fn is_input(&self) -> bool {
+        panic!("Relations::is_input not implemented")
+    }
+
+    pub fn is_output(&self) -> bool {
+        panic!("Relations::is_output not implemented")
+    }
+}
+
 impl TryFrom<&str> for Relations {
     type Error = ();
 
@@ -148,14 +159,6 @@ impl Mutator<Value> for record::Record {
     fn mutate(&self, _x: &mut Value) -> Result<(), String> {
         panic!("Value::mutate not implemented")
     }
-}
-
-pub fn output_relname_to_id(_rname: &str) -> Option<Relations> {
-    panic!("output_relname_to_id not implemented")
-}
-
-pub fn input_relname_to_id(_rname: &str) -> Option<Relations> {
-    panic!("input_relname_to_id not implemented")
 }
 
 pub fn relid2rel(_rid: RelId) -> Option<Relations> {

--- a/rust/template/src/lib.rs
+++ b/rust/template/src/lib.rs
@@ -48,6 +48,7 @@ use differential_datalog::decl_val_enum_into_record;
 use differential_datalog::int::*;
 use differential_datalog::program::*;
 use differential_datalog::record;
+use differential_datalog::record::RelIdentifier;
 use differential_datalog::record::UpdCmd;
 use differential_datalog::record::{FromRecord, IntoRecord, Mutator};
 use differential_datalog::uint::*;
@@ -100,6 +101,17 @@ impl DDlogConvert for DDlogConverter {
     }
 }
 
+impl TryFrom<&RelIdentifier> for Relations {
+    type Error = ();
+
+    fn try_from(rel_id: &RelIdentifier) -> Result<Self, Self::Error> {
+        match rel_id {
+            RelIdentifier::RelName(rname) => Relations::try_from(rname.as_ref()),
+            RelIdentifier::RelId(id) => Relations::try_from(*id),
+        }
+    }
+}
+
 /*- !!!!!!!!!!!!!!!!!!!! -*/
 // Don't edit this line
 // Code below this point is needed to test-compile template
@@ -126,6 +138,14 @@ impl TryFrom<&str> for Relations {
 
     fn try_from(rname: &str) -> Result<Self, Self::Error> {
         panic!("Relations::try_from::<&str> not implemented")
+    }
+}
+
+impl TryFrom<RelId> for Relations {
+    type Error = ();
+
+    fn try_from(rid: RelId) -> Result<Self, Self::Error> {
+        panic!("Relations::try_from::<RelId> not implemented")
     }
 }
 
@@ -159,10 +179,6 @@ impl Mutator<Value> for record::Record {
     fn mutate(&self, _x: &mut Value) -> Result<(), String> {
         panic!("Value::mutate not implemented")
     }
-}
-
-pub fn relid2rel(_rid: RelId) -> Option<Relations> {
-    panic!("relid2rel not implemented")
 }
 
 pub fn relval_from_record(_rel: Relations, _rec: &record::Record) -> Result<Value, String> {

--- a/rust/template/src/lib.rs
+++ b/rust/template/src/lib.rs
@@ -13,6 +13,7 @@
 
 use std::borrow;
 use std::boxed;
+use std::convert::TryFrom;
 use std::ffi;
 use std::fmt;
 use std::fmt::Display;
@@ -109,6 +110,14 @@ pub enum Relations {
     X = 0,
 }
 
+impl TryFrom<&str> for Relations {
+    type Error = ();
+
+    fn try_from(rname: &str) -> Result<Self, Self::Error> {
+        panic!("Relations::try_from::<&str> not implemented")
+    }
+}
+
 #[derive(Eq, Ord, Clone, Hash, PartialEq, PartialOrd, Serialize, Deserialize, Debug)]
 pub enum Value {
     empty(),
@@ -139,10 +148,6 @@ impl Mutator<Value> for record::Record {
     fn mutate(&self, _x: &mut Value) -> Result<(), String> {
         panic!("Value::mutate not implemented")
     }
-}
-
-pub fn relname2id(_rname: &str) -> Option<Relations> {
-    panic!("relname2id not implemented")
 }
 
 pub fn output_relname_to_id(_rname: &str) -> Option<Relations> {

--- a/rust/template/src/main.rs
+++ b/rust/template/src/main.rs
@@ -4,6 +4,7 @@
 
 #![allow(dead_code, non_snake_case)]
 
+use std::convert::TryFrom;
 use std::io::stdout;
 use std::io::Write;
 use std::sync::Arc;
@@ -104,15 +105,15 @@ fn handle_cmd(
             Ok(())
         }
         Command::Dump(Some(rname)) => {
-            let relid = match output_relname_to_id(&rname) {
-                None => {
+            let relid = match Relations::try_from(rname.as_str()) {
+                Ok(rid) if rid.is_output() => rid as RelId,
+                _ => {
                     let err = format!("Unknown output relation {}", rname);
                     if interactive {
                         eprintln!("Error: {}", err);
                     }
                     return (Err(err), interactive);
                 }
-                Some(rid) => rid as RelId,
             };
             let _ = hddlog
                 .db
@@ -121,15 +122,15 @@ fn handle_cmd(
             Ok(())
         }
         Command::Clear(rname) => {
-            let relid = match input_relname_to_id(&rname) {
-                None => {
+            let relid = match Relations::try_from(rname.as_str()) {
+                Ok(rid) if rid.is_input() => rid as RelId,
+                _ => {
                     let err = format!("Unknown input relation {}", rname);
                     if interactive {
                         eprintln!("Error: {}", err);
                     }
                     return (Err(err), interactive);
                 }
-                Some(rid) => rid as RelId,
             };
             hddlog.clear_relation(relid)
         }

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -745,8 +745,8 @@ unddname x = if isPrefixOf "__" (name x) && elem short reservedNames
 mkValueFromRecord :: (?cfg::CompilerConfig) => DatalogProgram -> Doc
 mkValueFromRecord d@DatalogProgram{..} =
     mkRelname2Id d                                                                                  $$
-    mkOutputRelname2Id d                                                                            $$
-    mkInputRelname2Id d                                                                             $$
+    mkIsOutputRels d                                                                                $$
+    mkIsInputRels d                                                                                 $$
     mkRelId2Relations d                                                                             $$
     mkRelId2Name d                                                                                  $$
     mkRelId2NameC                                                                                   $$
@@ -798,31 +798,35 @@ mkRelname2Id d =
     mkrel :: Relation -> Doc
     mkrel rel = "\"" <> pp (name rel) <> "\" => Ok(Relations::" <> rname (name rel) <> "),"
 
-mkOutputRelname2Id :: DatalogProgram -> Doc
-mkOutputRelname2Id d =
-    "pub fn output_relname_to_id(rname: &str) -> Option<Relations> {" $$
-    "   match rname {"                                      $$
-    (nest' $ nest' $ vcat $ entries)                        $$
-    "       _  => None"                                     $$
-    "   }"                                                  $$
+mkIsOutputRels :: DatalogProgram -> Doc
+mkIsOutputRels d =
+    "impl Relations {" $$
+    "    pub fn is_output(&self) -> bool {"        $$
+    "        match self {"                         $$
+                 (nest' $ nest' $ vcat $ entries)  $$
+    "            _  => false"                      $$
+    "        }"                                    $$
+    "    }"                                        $$
     "}"
     where
     entries = map mkrel $ filter ((== RelOutput) .relRole) $ M.elems $ progRelations d
     mkrel :: Relation -> Doc
-    mkrel rel = "\"" <> pp (name rel) <> "\" => Some(Relations::" <> rname (name rel) <> "),"
+    mkrel rel = "Relations::" <> rname (name rel) <> " => true,"
 
-mkInputRelname2Id :: DatalogProgram -> Doc
-mkInputRelname2Id d =
-    "pub fn input_relname_to_id(rname: &str) -> Option<Relations> {" $$
-    "   match rname {"                                      $$
-    (nest' $ nest' $ vcat $ entries)                        $$
-    "       _  => None"                                     $$
-    "   }"                                                  $$
+mkIsInputRels :: DatalogProgram -> Doc
+mkIsInputRels d =
+    "impl Relations {" $$
+    "    pub fn is_input(&self) -> bool {"         $$
+    "        match self {"                         $$
+                 (nest' $ nest' $ vcat $ entries)  $$
+    "            _  => false"                      $$
+    "        }"                                    $$
+    "    }"                                        $$
     "}"
     where
     entries = map mkrel $ filter ((== RelInput) .relRole) $ M.elems $ progRelations d
     mkrel :: Relation -> Doc
-    mkrel rel = "\"" <> pp (name rel) <> "\" => Some(Relations::" <> rname (name rel) <> "),"
+    mkrel rel = "Relations::" <> rname (name rel) <> " => true,"
 
 -- Convert string to enum Relations
 mkRelId2Relations :: DatalogProgram -> Doc

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -781,19 +781,22 @@ mkValueFromRecord d@DatalogProgram{..} =
         "},"
         where t = typeNormalize d $ fromJust $ relKeyType d rel
 
--- Convert string to RelId
+-- Convert string to Relations
 mkRelname2Id :: DatalogProgram -> Doc
 mkRelname2Id d =
-    "pub fn relname2id(rname: &str) -> Option<Relations> {" $$
-    "   match rname {"                                      $$
-    (nest' $ nest' $ vcat $ entries)                        $$
-    "       _  => None"                                     $$
-    "   }"                                                  $$
+    "impl TryFrom<&str> for Relations {"                                  $$
+    "    type Error = ();"                                                $$
+    "    fn try_from(rname: &str) -> Result<Self, Self::Error> {"         $$
+    "         match rname {"                                              $$
+                  (nest' $ nest' $ vcat $ entries)                        $$
+    "             _  => Err(())"                                          $$
+    "         }"                                                          $$
+    "    }"                                                               $$
     "}"
     where
     entries = map mkrel $ M.elems $ progRelations d
     mkrel :: Relation -> Doc
-    mkrel rel = "\"" <> pp (name rel) <> "\" => Some(Relations::" <> rname (name rel) <> "),"
+    mkrel rel = "\"" <> pp (name rel) <> "\" => Ok(Relations::" <> rname (name rel) <> "),"
 
 mkOutputRelname2Id :: DatalogProgram -> Doc
 mkOutputRelname2Id d =

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -831,16 +831,19 @@ mkIsInputRels d =
 -- Convert string to enum Relations
 mkRelId2Relations :: DatalogProgram -> Doc
 mkRelId2Relations d =
-    "pub fn relid2rel(rid: RelId) -> Option<Relations> {"   $$
-    "   match rid {"                                        $$
-    (nest' $ nest' $ vcat $ entries)                        $$
-    "       _  => None"                                     $$
-    "   }"                                                  $$
+    "impl TryFrom<RelId> for Relations {"                                 $$
+    "    type Error = ();"                                                $$
+    "    fn try_from(rid: RelId) -> Result<Self, Self::Error> {"          $$
+    "         match rid {"                                                $$
+                  (nest' $ nest' $ vcat $ entries)                        $$
+    "             _  => Err(())"                                          $$
+    "         }"                                                          $$
+    "    }"                                                               $$
     "}"
     where
     entries = map mkrel $ M.elems $ progRelations d
     mkrel :: Relation -> Doc
-    mkrel rel = pp (relIdentifier d rel) <+> "=> Some(Relations::" <> rname (name rel) <> "),"
+    mkrel rel = pp (relIdentifier d rel) <+> "=> Ok(Relations::" <> rname (name rel) <> "),"
 
 mkRelId2Name :: DatalogProgram -> Doc
 mkRelId2Name d =


### PR DESCRIPTION
As discussed in person, this is a proposal for how we could decouple "generic" parts of the code from the generated code some more, while also cleaning up a bit.

In a nutshell, the proposal is to use Rust's `TryFrom` trait and implement it for `Relations` to provide certain functionality, as opposed to having explicit conversion functions.

Here is a list of functions we ultimately may want to convert. Checked off are the ones covered by this proposal:

- [x] `relname2id` => `TryFrom<&str> for Relations`
- [x] `output_relname_to_id` => `Relations::is_output`
- [x] `input_relname_to_id` => `Relations::is_input`
- [x] `relid2rel` => `TryFrom<RelId> for Relations`
- [ ] `relval_from_record` => ???
- [ ] `relkey_from_record` => ???
- [ ] `relid2name` => ???
- [ ] `relid2cname` => ???
