### PR TITLE
Topic/file sink

### DIFF
--- a/rust/template/differential_datalog/lib.rs
+++ b/rust/template/differential_datalog/lib.rs
@@ -1,4 +1,9 @@
-#![allow(clippy::get_unwrap, clippy::type_complexity)]
+#![allow(
+    clippy::unknown_clippy_lints,
+    clippy::get_unwrap,
+    clippy::missing_safety_doc,
+    clippy::type_complexity
+)]
 
 mod callback;
 mod ddlog;

--- a/rust/template/differential_datalog/replay.rs
+++ b/rust/template/differential_datalog/replay.rs
@@ -62,14 +62,14 @@ where
 fn record_updates<'w, W, I, U, F, E>(
     writer: &'w mut W,
     updates: I,
-    record: F,
-    error: E,
+    mut record: F,
+    mut error: E,
 ) -> impl Iterator<Item = U> + 'w
 where
     W: Write,
     I: Iterator<Item = U> + 'w,
-    F: Fn(&mut W, &U) -> Result<()> + 'w,
-    E: Fn(Error) + 'w,
+    F: FnMut(&mut W, &U) -> Result<()> + 'w,
+    E: FnMut(Error) + 'w,
 {
     Peeking::new(updates).map(move |(upd, last)| {
         let _ = record(writer, &upd)
@@ -101,7 +101,7 @@ where
     V: Debug,
     W: Write,
     I: Iterator<Item = &'w UpdCmd> + 'w,
-    F: Fn(Error) + 'w,
+    F: FnMut(Error) + 'w,
 {
     record_updates(writer, upds, |w, u| w.record_upd_cmd::<C, _>(&u), error)
 }
@@ -121,7 +121,7 @@ where
     V: Display + Debug + 'w,
     W: Write,
     I: Iterator<Item = Update<V>> + 'w,
-    F: Fn(Error) + 'w,
+    F: FnMut(Error) + 'w,
 {
     record_updates(writer, upds, |w, u| w.record_val_upd::<C, _>(&u), error)
 }

--- a/rust/template/distributed_datalog/README.md
+++ b/rust/template/distributed_datalog/README.md
@@ -39,6 +39,9 @@ As it stands that means we have the following components:
 - a transaction multiplexer (`TxnMux`) that allows for serializing
   transactions as emitted by multiple `Observables` such that no two
   transactions interleave
+- [sources][sources] and [sinks][sinks] that produce and consume
+  updates, respectively, and can be fit into the system using the
+  `Observable` and `Observer` interfaces
 
 ### Examples & Tests
 **D3log** has unit as well as integration style tests using an actual
@@ -52,4 +55,6 @@ integration tests are located in the [`server_api`][server_api] program.
 [rust-template]: ..
 [server.rs]: src/server.rs
 [server_api]: ../../../test/datalog_tests/server_api
+[sinks]: src/sinks
+[sources]: src/sources
 [tcp_channel]: src/tcp_channel

--- a/rust/template/distributed_datalog/src/lib.rs
+++ b/rust/template/distributed_datalog/src/lib.rs
@@ -14,6 +14,9 @@ mod tcp_channel;
 mod test;
 mod txnmux;
 
+/// A module comprising sinks to forward data from a computation.
+pub mod sinks;
+
 /// A module comprising sources to feed data into a computation.
 pub mod sources;
 

--- a/rust/template/distributed_datalog/src/sinks/file.rs
+++ b/rust/template/distributed_datalog/src/sinks/file.rs
@@ -1,0 +1,151 @@
+use std::fmt::Debug;
+use std::fmt::Display;
+use std::fs::File as FsFile;
+use std::marker::PhantomData;
+
+use differential_datalog::program::Update;
+use differential_datalog::record_val_upds;
+use differential_datalog::DDlogConvert;
+use differential_datalog::RecordReplay;
+
+use crate::Observer;
+
+/// An object implementing the `Observer` interface and dumping
+/// transaction traces into a file.
+#[derive(Debug)]
+pub struct File<C> {
+    /// The file we dump our transaction traces into.
+    file: FsFile,
+    /// Unused phantom data.
+    _unused: PhantomData<C>,
+}
+
+impl<C> File<C> {
+    /// Create a new file based observer using the given file.
+    pub fn new(file: FsFile) -> Self {
+        Self {
+            file,
+            _unused: PhantomData,
+        }
+    }
+}
+
+impl<C, V> Observer<Update<V>, String> for File<C>
+where
+    C: Send + DDlogConvert<Value = V>,
+    V: Debug + Display + Send,
+{
+    fn on_start(&mut self) -> Result<(), String> {
+        self.file
+            .record_start()
+            .map_err(|e| format!("failed to record 'on_start' event: {}", e))
+    }
+
+    fn on_commit(&mut self) -> Result<(), String> {
+        self.file
+            .record_commit(false)
+            .map_err(|e| format!("failed to record 'on_commit' event: {}", e))
+    }
+
+    fn on_updates<'a>(
+        &mut self,
+        updates: Box<dyn Iterator<Item = Update<V>> + 'a>,
+    ) -> Result<(), String> {
+        let mut result = Ok(());
+        record_val_upds::<C, _, _, _, _>(&mut self.file, updates, |e| {
+            result = Err(e);
+        })
+        .for_each(|_| ());
+
+        result.map_err(|e| format!("failed to record 'on_updates' event(s): {}", e))
+    }
+
+    fn on_completed(&mut self) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::io::Read;
+
+    use tempfile::NamedTempFile;
+
+    use differential_datalog::program::RelId;
+    use differential_datalog::record::Record;
+    use differential_datalog::record::RelIdentifier;
+    use differential_datalog::record::UpdCmd;
+
+    #[derive(Debug)]
+    struct DummyConverter;
+
+    impl DDlogConvert for DummyConverter {
+        type Value = String;
+
+        fn relid2name(rel_id: RelId) -> Option<&'static str> {
+            match rel_id {
+                1 => Some("test_rel"),
+                _ => panic!("unexpected RelId {}", rel_id),
+            }
+        }
+
+        fn updcmd2upd(upd_cmd: &UpdCmd) -> Result<Update<Self::Value>, String> {
+            match upd_cmd {
+                UpdCmd::Insert(relident, record) => {
+                    let relid = match relident {
+                        RelIdentifier::RelId(relid) => *relid,
+                        _ => panic!(
+                            "encountered unexpected RelIdentifier variant: {:?}",
+                            relident
+                        ),
+                    };
+                    let v = match record {
+                        Record::String(string) => string.clone(),
+                        _ => panic!("encountered unexpected Record variant: {:?}", record),
+                    };
+                    Ok(Update::Insert { relid, v })
+                }
+                _ => panic!("unsupported UpdCmd: {:?}", upd_cmd),
+            }
+        }
+    }
+
+    #[test]
+    fn dump_events() {
+        let tempfile = NamedTempFile::new().unwrap();
+        let mut file = tempfile.reopen().unwrap();
+        let mut sink = File::<DummyConverter>::new(tempfile.into_file());
+        let observer = &mut sink as &mut dyn Observer<Update<String>, _>;
+
+        observer.on_start().unwrap();
+        observer.on_commit().unwrap();
+
+        let updates = vec![5, 4, 9, 1, 2, 3]
+            .into_iter()
+            .map(|val| Update::Insert {
+                relid: 1,
+                v: val.to_string(),
+            });
+
+        observer.on_start().unwrap();
+        observer.on_updates(Box::new(updates)).unwrap();
+        observer.on_commit().unwrap();
+
+        let mut content = String::new();
+        let _ = file.read_to_string(&mut content).unwrap();
+        let expected = r#"start;
+commit;
+start;
+insert test_rel[5],
+insert test_rel[4],
+insert test_rel[9],
+insert test_rel[1],
+insert test_rel[2],
+insert test_rel[3];
+commit;
+"#;
+        assert_eq!(content, expected);
+    }
+}

--- a/rust/template/distributed_datalog/src/sinks/mod.rs
+++ b/rust/template/distributed_datalog/src/sinks/mod.rs
@@ -1,0 +1,5 @@
+//! Various sinks for forwarding data from a distributed computation.
+
+mod file;
+
+pub use file::File;

--- a/rust/template/src/lib.rs
+++ b/rust/template/src/lib.rs
@@ -8,7 +8,9 @@
     dead_code,
     overflowing_literals,
     unreachable_patterns,
-    unused_variables
+    unused_variables,
+    clippy::unknown_clippy_lints,
+    clippy::missing_safety_doc
 )]
 
 use std::borrow;

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -168,6 +168,8 @@ rustLibFiles specname =
         , (dir </> "distributed_datalog/src/observe/observer.rs"     , $(embedFile "rust/template/distributed_datalog/src/observe/observer.rs"))
         , (dir </> "distributed_datalog/src/observe/test.rs"         , $(embedFile "rust/template/distributed_datalog/src/observe/test.rs"))
         , (dir </> "distributed_datalog/src/server.rs"               , $(embedFile "rust/template/distributed_datalog/src/server.rs"))
+        , (dir </> "distributed_datalog/src/sinks/file.rs"           , $(embedFile "rust/template/distributed_datalog/src/sinks/file.rs"))
+        , (dir </> "distributed_datalog/src/sinks/mod.rs"            , $(embedFile "rust/template/distributed_datalog/src/sinks/mod.rs"))
         , (dir </> "distributed_datalog/src/sources/file.rs"         , $(embedFile "rust/template/distributed_datalog/src/sources/file.rs"))
         , (dir </> "distributed_datalog/src/sources/mod.rs"          , $(embedFile "rust/template/distributed_datalog/src/sources/mod.rs"))
         , (dir </> "distributed_datalog/src/tcp_channel/message.rs"  , $(embedFile "rust/template/distributed_datalog/src/tcp_channel/message.rs"))


### PR DESCRIPTION
(depends on https://github.com/vmware/differential-datalog/pull/467)

A recent change introduced a file based source capable of reading our
"replay" format from a file and adapting it to the observer interface.
This change introduces a corresponding sink, which takes updates
received through the observer interface and dumps them into a file in
the form of our "replay" format.
