### PR TITLE
Introduce first "schema" definition

### DIFF
--- a/rust/template/differential_datalog/replay.rs
+++ b/rust/template/differential_datalog/replay.rs
@@ -134,6 +134,13 @@ pub trait RecordReplay: Write {
         writeln!(self, "start;")
     }
 
+    fn record_insert<V>(&mut self, name: &str, value: V) -> Result<()>
+    where
+        V: Display,
+    {
+        write!(self, "insert {}[{}]", name, value)
+    }
+
     /// Record an `UpdCmd`.
     fn record_upd_cmd<C, V>(&mut self, upd: &UpdCmd) -> Result<()>
     where
@@ -141,12 +148,9 @@ pub trait RecordReplay: Write {
         V: Debug,
     {
         match upd {
-            UpdCmd::Insert(rel, record) => write!(
-                self,
-                "insert {}[{}]",
-                relident2name::<C, _>(rel).unwrap_or(&"???"),
-                record,
-            ),
+            UpdCmd::Insert(rel, record) => {
+                self.record_insert(relident2name::<C, _>(rel).unwrap_or(&"???"), record)
+            }
             UpdCmd::Delete(rel, record) => write!(
                 self,
                 "delete {}[{}]",
@@ -176,12 +180,9 @@ pub trait RecordReplay: Write {
         V: Display + Debug,
     {
         match upd {
-            Update::Insert { relid, v } => write!(
-                self,
-                "insert {}[{}]",
-                C::relid2name(*relid).unwrap_or(&"???"),
-                v,
-            ),
+            Update::Insert { relid, v } => {
+                self.record_insert(C::relid2name(*relid).unwrap_or(&"???"), v)
+            }
             Update::DeleteValue { relid, v } => write!(
                 self,
                 "delete {}[{}]",

--- a/rust/template/distributed_datalog/Cargo.toml
+++ b/rust/template/distributed_datalog/Cargo.toml
@@ -11,6 +11,8 @@ path = "../differential_datalog"
 
 [dev-dependencies]
 env_logger = {version = "0.7", default_features = false, features = ["humantime"]}
+maplit = "1.0"
+serde_json = "1.0"
 tempfile = "3.1"
 test-env-log = "0.1"
 waitfor = "0.1"
@@ -22,6 +24,7 @@ log = "0.4"
 nom = "4.0"
 serde = {version = "1.0", features = ["derive"]}
 waitfor = {version = "0.1", optional = true}
+uuid = {version = "0.8", default-features = false, features = ["serde", "v4"]}
 
 [features]
 test = ["waitfor"]

--- a/rust/template/distributed_datalog/src/lib.rs
+++ b/rust/template/distributed_datalog/src/lib.rs
@@ -1,13 +1,53 @@
 #![allow(clippy::type_complexity)]
 #![warn(
+    bad_style,
+    dead_code,
+    future_incompatible,
+    illegal_floating_point_literal_pattern,
+    improper_ctypes,
+    intra_doc_link_resolution_failure,
+    late_bound_lifetime_arguments,
     missing_copy_implementations,
     missing_debug_implementations,
-    missing_docs
+    missing_docs,
+    no_mangle_generic_items,
+    non_shorthand_field_patterns,
+    nonstandard_style,
+    overflowing_literals,
+    path_statements,
+    patterns_in_fns_without_body,
+    plugin_as_library,
+    private_in_public,
+    proc_macro_derive_resolution_fallback,
+    renamed_and_removed_lints,
+    rust_2018_compatibility,
+    rust_2018_idioms,
+    safe_packed_borrows,
+    stable_features,
+    trivial_bounds,
+    trivial_numeric_casts,
+    type_alias_bounds,
+    tyvar_behind_raw_pointer,
+    unconditional_recursion,
+    unions_with_drop_fields,
+    unreachable_code,
+    unreachable_patterns,
+    unstable_features,
+    unstable_name_collisions,
+    unused,
+    unused_comparisons,
+    unused_import_braces,
+    unused_lifetimes,
+    unused_qualifications,
+    unused_results,
+    where_clauses_object_safety,
+    while_true
 )]
 
 //! Distributed computing for differential-datalog.
 
 mod observe;
+mod schema;
 mod server;
 mod tcp_channel;
 #[cfg(any(test, feature = "test"))]
@@ -27,6 +67,15 @@ pub use observe::ObserverBox;
 pub use observe::OptionalObserver;
 pub use observe::SharedObserver;
 pub use observe::UpdatesObservable;
+pub use schema::Member;
+pub use schema::Members;
+pub use schema::Node;
+pub use schema::NodeCfg;
+pub use schema::RelCfg;
+pub use schema::Relations;
+pub use schema::Sink;
+pub use schema::Source;
+pub use schema::SysCfg;
 pub use server::DDlogServer;
 pub use tcp_channel::TcpReceiver;
 pub use tcp_channel::TcpSender;

--- a/rust/template/distributed_datalog/src/observe/observable.rs
+++ b/rust/template/distributed_datalog/src/observe/observable.rs
@@ -126,7 +126,7 @@ where
         if guard.is_some() {
             Err(observer)
         } else {
-            guard.replace(observer);
+            let _ = guard.replace(observer);
             Ok(())
         }
     }

--- a/rust/template/distributed_datalog/src/schema.rs
+++ b/rust/template/distributed_datalog/src/schema.rs
@@ -1,0 +1,213 @@
+//! Schema definitions for d3log. Most of this data is to be stored in
+//! serialized form on some entity accessible from all nodes in the
+//! system.
+//!
+//! As a general note: we use BTree based maps & sets here over hashing
+//! based ones for two reasons:
+//! - they guarantee a stable order of elements which makes our
+//!   resulting computation predictable (node assignment based on data
+//!   in a hash map could yield different results on different nodes due
+//!   to randomness induced into the hashing part on purpose)
+//! - BTree based data structures can be nested nicely because `Ord` and
+//!   `PartialOrd` are defined for `BTreeMap` & `BTreeSet`, whereas hash
+//!   based ones need custom `Hash` definitions
+//!
+//! We have the following components:
+//! - Membership:
+//!   Nodes participating in the distributed computation are represented
+//!   by the `Member` struct.
+//! - Configuration:
+//!   From top to bottom we have a configuration describing the desired
+//!   state of the system, `SysCfg`. This state is essentially a
+//!   description of the required compute node configurations.
+//!   Each compute node configuration (`NodeCfg`) is comprised of a map
+//!   from relation IDs (the relations "belonging" to this node) to a
+//!   set of relation configurations, `RelCfg`. It's a set because a
+//!   relation can have multiple purposes. A relation configuration in
+//!   turn describes one property of the relation: it could have a set
+//!   of input relations and/or be fed directly from a source.
+
+use std::cmp::Ordering;
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::fmt::Display;
+use std::fmt::Formatter;
+use std::fmt::Result as FmtResult;
+use std::io::Error;
+use std::net::SocketAddr;
+use std::net::ToSocketAddrs;
+use std::option::IntoIter;
+use std::path::PathBuf;
+
+use serde::Deserialize;
+use serde::Serialize;
+
+use uuid::Uuid;
+
+use differential_datalog::program::RelId;
+
+/// An abstract representation of a node.
+///
+/// Nodes will eventually have to be assigned to members in order for a
+/// computation to happen.
+pub type Node = Uuid;
+
+/// An address of an actual member in the system.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub enum Addr {
+    /// A (ip-addr:port) pair describing how a member can be reached.
+    Ip(SocketAddr),
+}
+
+impl Display for Addr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Addr::Ip(addr) => addr.fmt(f),
+        }
+    }
+}
+
+impl Ord for Addr {
+    fn cmp(&self, other: &Addr) -> Ordering {
+        match self {
+            Addr::Ip(addr) => match other {
+                Addr::Ip(other_addr) => addr.to_string().cmp(&other_addr.to_string()),
+            },
+        }
+    }
+}
+
+impl PartialOrd for Addr {
+    fn partial_cmp(&self, other: &Addr) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl ToSocketAddrs for Addr {
+    type Iter = IntoIter<SocketAddr>;
+
+    fn to_socket_addrs(&self) -> Result<Self::Iter, Error> {
+        match self {
+            Addr::Ip(addr) => addr.to_socket_addrs(),
+        }
+    }
+}
+
+/// A struct representing an individual member participating in the
+/// distributed system.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+pub struct Member {
+    /// The address of the member.
+    addr: Addr,
+    // For now a member is nothing more but the address. In the future
+    // we may want to add additional information describing it that
+    // could help decide where to place a certain computation.
+}
+
+impl Member {
+    /// Create a new member represented by the given node.
+    pub fn new(addr: Addr) -> Self {
+        Self { addr }
+    }
+
+    /// Retrieve the member's node.
+    pub fn addr(&self) -> &Addr {
+        &self.addr
+    }
+}
+
+/// A type for representing a set of members.
+pub type Members = BTreeSet<Member>;
+
+/// A set of relations used in various contexts.
+pub type Relations = BTreeSet<RelId>;
+
+/// All the input sources we support.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+pub enum Source {
+    /// Input is coming from a file.
+    File(PathBuf),
+}
+
+/// All the output sinks we support.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+pub enum Sink {
+    /// Output is emitted into a file.
+    File(PathBuf),
+}
+
+/// A description of inputs and outputs of a relation.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+pub enum RelCfg {
+    /// A relation that is directly fed from a source.
+    Source(Source),
+    /// This relation is fed from the given set of relations.
+    Input(Relations),
+    /// A relation that outputs directly into a sink.
+    Sink(Sink),
+}
+
+/// Configuration of input/output relationships for a single node.
+pub type NodeCfg = BTreeMap<RelId, BTreeSet<RelCfg>>;
+
+/// The configuration of the system is comprised of input/output
+/// configurations for a certain set of nodes.
+///
+/// Each value in the map represents the configuration of a single node.
+/// In order to reason about nodes we assign a UUID to each.
+pub type SysCfg = BTreeMap<Uuid, NodeCfg>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use maplit::btreemap;
+    use maplit::btreeset;
+    use serde_json::to_string as to_json;
+
+    #[test]
+    fn compare_addrs() {
+        let addr0 = Addr::Ip("127.0.0.1:2000".parse().unwrap());
+        let addr1 = Addr::Ip("127.0.0.1:2001".parse().unwrap());
+
+        assert!(addr0 < addr1);
+    }
+
+    #[test]
+    fn serialize_relations() {
+        let relations = btreeset! {1, 2, 3};
+        let serialized = to_json(&relations).unwrap();
+        let expected = r#"[1,2,3]"#;
+
+        assert_eq!(serialized, expected);
+    }
+
+    #[test]
+    fn serialize_config() {
+        let uuid0 = Uuid::new_v4();
+        let uuid1 = Uuid::new_v4();
+        let (uuid0, uuid1) = if uuid0 <= uuid1 {
+            (uuid0, uuid1)
+        } else {
+            (uuid1, uuid0)
+        };
+
+        let config = btreemap! {
+            uuid0 => btreemap! {
+                2usize => btreeset!{ RelCfg::Source(Source::File(PathBuf::from("input.cmd"))) },
+            },
+            uuid1 => btreemap! {
+                3usize => btreeset!{ RelCfg::Input(btreeset! {2}) },
+            },
+        } as SysCfg;
+
+        let serialized = to_json(&config).unwrap();
+        let expected = r#"{""#.to_string()
+            + &uuid0.to_hyphenated_ref().to_string()
+            + r#"":{"2":[{"Source":{"File":"input.cmd"}}]},""#
+            + &uuid1.to_hyphenated_ref().to_string()
+            + r#"":{"3":[{"Input":[2]}]}}"#;
+
+        assert_eq!(serialized, expected);
+    }
+}

--- a/rust/template/distributed_datalog/src/tcp_channel/message.rs
+++ b/rust/template/distributed_datalog/src/tcp_channel/message.rs
@@ -16,7 +16,7 @@ pub enum Message<T> {
 }
 
 impl<T> Display for Message<T> {
-    fn fmt(&self, formatter: &mut Formatter) -> Result {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> Result {
         let s = match self {
             Message::Start => "on_start",
             Message::Updates(_) => "on_updates",

--- a/rust/template/distributed_datalog/src/txnmux.rs
+++ b/rust/template/distributed_datalog/src/txnmux.rs
@@ -151,7 +151,7 @@ where
         if guard.is_some() {
             Err(observer)
         } else {
-            guard.replace(observer);
+            let _ = guard.replace(observer);
             Ok(())
         }
     }

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -167,6 +167,7 @@ rustLibFiles specname =
         , (dir </> "distributed_datalog/src/observe/observable.rs"   , $(embedFile "rust/template/distributed_datalog/src/observe/observable.rs"))
         , (dir </> "distributed_datalog/src/observe/observer.rs"     , $(embedFile "rust/template/distributed_datalog/src/observe/observer.rs"))
         , (dir </> "distributed_datalog/src/observe/test.rs"         , $(embedFile "rust/template/distributed_datalog/src/observe/test.rs"))
+        , (dir </> "distributed_datalog/src/schema.rs"               , $(embedFile "rust/template/distributed_datalog/src/schema.rs"))
         , (dir </> "distributed_datalog/src/server.rs"               , $(embedFile "rust/template/distributed_datalog/src/server.rs"))
         , (dir </> "distributed_datalog/src/sinks/file.rs"           , $(embedFile "rust/template/distributed_datalog/src/sinks/file.rs"))
         , (dir </> "distributed_datalog/src/sinks/mod.rs"            , $(embedFile "rust/template/distributed_datalog/src/sinks/mod.rs"))


### PR DESCRIPTION
This change introduces the first "schema" definition. It's basically a
bunch of Rust types that are also serializable in a sensible way and
that in conjunction are intended to be able to represent any system
configuration we would want to instantiate.
We have the following components:
- Membership:
  Nodes participating in the distributed computation are represented
  by the `Member` struct.
- Configuration:
  From top to bottom we have a configuration describing the desired
  state of the system, `SysCfg`. This state is essentially a
  description of the required compute node configurations.
  Each compute node configuration (`NodeCfg`) is comprised of a map
  from relation IDs (the relations "belonging" to this node) to a
  set of relation configurations, `RelCfg`. It's a set because a
  relation can have multiple purposes. A relation configuration in
  turn describes one property of the relation: it could have a set
  of input relations and/or be fed directly from a source.