### PR TITLE
Add support for instantiating a configuration

### DIFF
--- a/rust/template/differential_datalog/ddlog.rs
+++ b/rust/template/differential_datalog/ddlog.rs
@@ -23,7 +23,7 @@ pub trait DDlogConvert: Debug {
 /// A trait capturing program instantiation and handling of
 /// transactions.
 pub trait DDlog: Debug {
-    type Convert: DDlogConvert;
+    type Convert: DDlogConvert<Value = Self::Value>;
     type Value: Val;
 
     /// Run the program.

--- a/rust/template/distributed_datalog/Cargo.toml
+++ b/rust/template/distributed_datalog/Cargo.toml
@@ -15,7 +15,6 @@ maplit = "1.0"
 serde_json = "1.0"
 tempfile = "3.1"
 test-env-log = "0.1"
-waitfor = "0.1"
 
 [dependencies]
 bincode = "1.2"
@@ -23,8 +22,8 @@ libc = "0.2"
 log = "0.4"
 nom = "4.0"
 serde = {version = "1.0", features = ["derive"]}
-waitfor = {version = "0.1", optional = true}
 uuid = {version = "0.8", default-features = false, features = ["serde", "v4"]}
+waitfor = "0.1"
 
 [features]
-test = ["waitfor"]
+test = []

--- a/rust/template/distributed_datalog/src/assign.rs
+++ b/rust/template/distributed_datalog/src/assign.rs
@@ -1,0 +1,109 @@
+use std::collections::BTreeMap;
+
+use crate::instantiate::Assignment;
+use crate::schema::Member;
+use crate::schema::Node;
+
+/// Assign nodes to actual members in the system.
+///
+/// Right now the assignment is the simplest possible where we just take
+/// members in "some" order and assign them to nodes until we have
+/// covered all.
+// TODO: We very likely want to have some more brains in here (such as
+//       a consistent hashing algorithm) or we will incur potentially
+//       excessive reconfigurations in the system whenever a node is
+//       added or removed.
+pub fn simple_assign<'n, 'm, N, M>(nodes: N, mut members: M) -> Option<Assignment>
+where
+    N: Iterator<Item = &'n Node> + ExactSizeIterator,
+    M: Iterator<Item = &'m Member> + ExactSizeIterator,
+{
+    // If the configuration prescribes more nodes than we have members
+    // in the system we can't find an assignment.
+    // TODO: In theory we could map two or more nodes to a single
+    //       member.
+    if members.len() < nodes.len() {
+        return None;
+    }
+
+    let assignment = BTreeMap::new();
+
+    Some(nodes.fold(assignment, |mut assignment, uuid| {
+        match members.next() {
+            Some(member) => {
+                let node = *member.addr();
+                let _result = assignment.insert(*uuid, node);
+                debug_assert_eq!(_result, None);
+            }
+            None => unreachable!(),
+        }
+        assignment
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::path::PathBuf;
+
+    use maplit::btreemap;
+    use maplit::btreeset;
+
+    use uuid::Uuid;
+
+    use crate::schema::Addr;
+    use crate::schema::Member;
+    use crate::schema::RelCfg;
+    use crate::schema::Source;
+
+    #[test]
+    fn assign_insufficient_members() {
+        let uuid0 = Uuid::new_v4();
+        let uuid1 = Uuid::new_v4();
+        let node0 = Addr::Ip("127.0.0.1:1".parse().unwrap());
+
+        let config = btreemap! {
+            uuid0 => btreemap! { 0 => btreeset! {} },
+            uuid1 => btreemap! {
+                1 => btreeset! {
+                    RelCfg::Source(Source::File(PathBuf::from("input.cmd")))
+                }
+            },
+        };
+        let members = btreeset! {
+            Member::new(node0),
+        };
+
+        let assignment = simple_assign(config.keys(), members.iter());
+        assert_eq!(assignment, None);
+    }
+
+    #[test]
+    fn assign_members() {
+        let mut uuids = vec![Uuid::new_v4(), Uuid::new_v4()];
+        uuids.sort();
+        let node0 = Addr::Ip("127.0.0.1:1".parse().unwrap());
+        let node1 = Addr::Ip("127.0.0.1:2".parse().unwrap());
+
+        let config = btreemap! {
+            uuids[0] => btreemap! {},
+            uuids[1] => btreemap! {
+                1 => btreeset! {
+                    RelCfg::Input(btreeset! {0}),
+                }
+            },
+        };
+        let members = btreeset! {
+            Member::new(node0.clone()),
+            Member::new(node1.clone()),
+        };
+
+        let assignment = simple_assign(config.keys(), members.iter()).unwrap();
+        let expected = btreemap! {
+            uuids[0] => node0,
+            uuids[1] => node1,
+        };
+        assert_eq!(assignment, expected);
+    }
+}

--- a/rust/template/distributed_datalog/src/instantiate.rs
+++ b/rust/template/distributed_datalog/src/instantiate.rs
@@ -1,0 +1,457 @@
+//! A module for instantiating a desired configuration for a distributed
+//! computation. This functionality is meant to be executed by all nodes
+//! participating in the distributed computation and will take care of
+//! configuring the "local" compute node accordingly, by creating a
+//! `DDlogServer` instance, a `TcpReceiver`, a `TxnMux`, and file sinks
+//! and sources if desired.
+
+use std::collections::BTreeMap;
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::fmt::Debug;
+use std::fs::File;
+use std::path::Path;
+use std::time::Duration;
+
+use differential_datalog::program::RelId;
+use differential_datalog::program::Update;
+use differential_datalog::program::Val;
+use differential_datalog::record::Record;
+use differential_datalog::DDlog;
+
+use crate::observe::Observable;
+use crate::schema::Addr;
+use crate::schema::Node;
+use crate::schema::NodeCfg;
+use crate::schema::RelCfg;
+use crate::schema::Sink;
+use crate::schema::Source;
+use crate::schema::SysCfg;
+use crate::sinks::File as FileSink;
+use crate::sources::File as FileSource;
+use crate::tcp_channel::TcpReceiver;
+use crate::tcp_channel::TcpSender;
+use crate::txnmux::TxnMux;
+use crate::DDlogServer;
+
+/// A mapping from member address to relation IDs used for describing
+/// output relationships.
+pub type Outputs = BTreeMap<Addr, HashSet<RelId>>;
+/// A mapping from abstract nodes to actual members in the system.
+pub type Assignment = BTreeMap<Node, Addr>;
+
+/// Deduce the output streaming relations we require.
+///
+/// In a nutshell, this function deduces a mapping from all relations on
+/// a node to other nodes that have relations that have this relation as
+/// input. Unfortunately doing so is rather costly, as we ultimately
+/// have to visit pretty much all relations in the assignment and check
+/// them.
+fn deduce_outputs(
+    addr: &Addr,
+    node_cfg: &NodeCfg,
+    sys_cfg: &SysCfg,
+    assignment: &Assignment,
+) -> Outputs {
+    node_cfg.keys().fold(Outputs::new(), |mut outputs, rel| {
+        sys_cfg
+            .iter()
+            .filter_map(|(uuid, node_cfg)| {
+                assignment.get(uuid).and_then(|other_addr| {
+                    if other_addr != addr {
+                        Some((other_addr, node_cfg))
+                    } else {
+                        None
+                    }
+                })
+            })
+            .for_each(|(addr, node_cfg)| {
+                node_cfg.values().for_each(|rel_cfgs| {
+                    rel_cfgs.iter().for_each(|rel_cfg| match rel_cfg {
+                        RelCfg::Input(inputs) => inputs.iter().for_each(|input| {
+                            if input == rel {
+                                let rels = outputs.entry(addr.clone()).or_default();
+                                let _ = rels.insert(*input);
+                            }
+                        }),
+                        RelCfg::Source(_) | RelCfg::Sink(_) => (),
+                    })
+                })
+            });
+
+        outputs
+    })
+}
+
+/// Deduce the required redirections for a given input/output
+/// configuration.
+fn deduce_redirects(config: &NodeCfg) -> HashMap<RelId, RelId> {
+    config.iter().fold(HashMap::new(), |redirects, (rel, cfg)| {
+        cfg.iter().fold(redirects, |mut redirects, rel_cfg| {
+            match rel_cfg {
+                RelCfg::Input(inputs) => {
+                    // Each of the inputs needs to be redirected to the
+                    // relation it feeds into.
+                    inputs.iter().for_each(|input| {
+                        let _ = redirects.insert(*input, *rel);
+                    })
+                }
+                RelCfg::Source(_) | RelCfg::Sink(_) => (),
+            }
+            redirects
+        })
+    })
+}
+
+/// Create a `DDlogServer` as per the given node configuration.
+fn create_server<P>(node_cfg: &NodeCfg) -> Result<DDlogServer<P>, String>
+where
+    P: Send + DDlog,
+{
+    let redirects = deduce_redirects(node_cfg);
+    // TODO: Should the number of workers be made configurable?
+    let program = P::run(2, false, |_, _: &Record, _| {})?;
+
+    Ok(DDlogServer::new(program, redirects))
+}
+
+/// Create a transaction multiplexer wrapping the given server.
+fn create_txn_mux<P>(server: DDlogServer<P>) -> Result<TxnMux<Update<P::Value>, String>, String>
+where
+    P: Send + DDlog + 'static,
+{
+    let mut txnmux = TxnMux::new();
+    txnmux
+        .subscribe(Box::new(server))
+        .map_err(|_| "failed to subscribe DDlogServer to TxnMux")?;
+
+    Ok(txnmux)
+}
+
+/// Add as many `TcpSender` objects as required given the provided node
+/// configuration.
+fn add_tcp_senders<P>(server: &mut DDlogServer<P>, outputs: Outputs) -> Result<(), String>
+where
+    P: DDlog,
+{
+    // Create streams for the deduced output relations.
+    outputs.into_iter().try_for_each(|(addr, rel_ids)| {
+        let timeout = Duration::from_secs(30);
+        let interval = Duration::from_millis(500);
+        let sender = TcpSender::with_retry(&addr, timeout, interval)
+            .map_err(|e| format!("failed to connect to node {}: {}", addr, e))?;
+
+        let mut stream = server.add_stream(rel_ids);
+        // TODO: What should we really do if we can't subscribe?
+        stream
+            .subscribe(Box::new(sender))
+            .map_err(|_| "failed to subscribe TCP sender".to_string())?;
+        Ok(())
+    })
+}
+
+/// Add a `TcpReceiver` feeding the given server if one is needed given
+/// the provided node configuration.
+fn add_tcp_receiver<V>(txnmux: &mut TxnMux<Update<V>, String>, addr: &Addr) -> Result<(), String>
+where
+    V: Val,
+{
+    let receiver =
+        TcpReceiver::new(addr).map_err(|e| format!("failed to create TcpReceiver: {}", e))?;
+    txnmux
+        .add_observable(Box::new(receiver))
+        .map_err(|_| "failed to register TcpReceiver with TxnMux".to_string())?;
+    Ok(())
+}
+
+/// Deduce a mapping from file sink to a list of relation IDs for the
+/// given node configuration.
+fn deduce_sinks_or_sources(node_cfg: &NodeCfg, sinks: bool) -> BTreeMap<&Path, HashSet<RelId>> {
+    node_cfg
+        .iter()
+        .fold(BTreeMap::new(), |map, (relid, rel_cfgs)| {
+            rel_cfgs.iter().fold(map, |mut map, rel_cfg| {
+                match rel_cfg {
+                    RelCfg::Sink(sink) if sinks => match sink {
+                        Sink::File(path) => {
+                            let _ = map.entry(path).or_default().insert(*relid);
+                        }
+                    },
+                    RelCfg::Source(source) if !sinks => match source {
+                        Source::File(path) => {
+                            let _ = map.entry(path).or_default().insert(*relid);
+                        }
+                    },
+                    _ => (),
+                };
+                map
+            })
+        })
+}
+
+/// Add file sinks to the given server object, as per the node
+/// configuration.
+fn add_file_sinks<P>(server: &mut DDlogServer<P>, node_cfg: &NodeCfg) -> Result<(), String>
+where
+    P: Send + DDlog + 'static,
+    P::Convert: Send,
+{
+    deduce_sinks_or_sources(node_cfg, true)
+        .iter()
+        .try_for_each(|(path, rel_ids)| {
+            let file = File::create(path)
+                .map_err(|e| format!("failed to create file {}: {}", path.display(), e))?;
+            let sink = FileSink::<P::Convert>::new(file);
+
+            let mut stream = server.add_stream(rel_ids.clone());
+            stream.subscribe(Box::new(sink)).map_err(|_| {
+                format!(
+                    "failed to subscribe file sink {} to DDlogServer",
+                    path.display()
+                )
+            })?;
+            Ok(())
+        })
+}
+
+fn add_file_sources<P>(
+    txnmux: &mut TxnMux<Update<P::Value>, String>,
+    node_cfg: &NodeCfg,
+) -> Result<(), String>
+where
+    P: DDlog + 'static,
+    P::Convert: Send,
+{
+    deduce_sinks_or_sources(node_cfg, false)
+        .iter()
+        .try_for_each(|(path, _rel_ids)| {
+            let source = FileSource::<P::Convert, _>::new(path);
+            txnmux
+                .add_observable(Box::new(source))
+                .map_err(|_| format!("failed to add file source {} to TxnMux", path.display()))?;
+            Ok(())
+        })
+}
+
+/// Realize the given configuration locally.
+// TODO: Right now this function assumes a pristine state (i.e., nothing
+//       had been created previously), however we really would want to
+//       transition from a previously created state (which happens to be
+//       "empty" initially) to the given one.
+fn realize<P>(
+    addr: &Addr,
+    node_cfg: &NodeCfg,
+    outputs: Outputs,
+) -> Result<Realization<P::Value>, String>
+where
+    P: Send + DDlog + 'static,
+    P::Convert: Send,
+{
+    let mut server = create_server::<P>(&node_cfg)?;
+    add_tcp_senders(&mut server, outputs)?;
+    add_file_sinks(&mut server, node_cfg)?;
+
+    let mut txnmux = create_txn_mux(server)?;
+    add_tcp_receiver(&mut txnmux, addr)?;
+    add_file_sources::<P>(&mut txnmux, node_cfg)?;
+
+    Ok(Realization { txnmux })
+}
+
+/// An object representing a realized configuration.
+///
+/// Right now all clients can do with object of this type is dropping
+/// them to tear everything down.
+#[derive(Debug)]
+pub struct Realization<V>
+where
+    V: Debug + Send,
+{
+    /// The transaction multiplexer everything is registered to.
+    txnmux: TxnMux<Update<V>, String>,
+}
+
+/// Instantiate a configuration on a particular node under the given
+/// assignment.
+pub fn instantiate<P>(
+    sys_cfg: SysCfg,
+    addr: &Addr,
+    assignment: &Assignment,
+) -> Result<Vec<Realization<P::Value>>, String>
+where
+    P: Send + DDlog + 'static,
+    P::Convert: Send,
+{
+    assignment
+        .iter()
+        .filter_map(|(uuid, assigned_addr)| {
+            if assigned_addr == addr {
+                sys_cfg.get(uuid)
+            } else {
+                None
+            }
+        })
+        .try_fold(Vec::new(), |mut accumulator, node_cfg| {
+            // The supplied configuration by design does not
+            // include information about output streaming
+            // relations, because these can be inferred by
+            // looking at the input relations of other nodes.
+            // Start by doing exactly that such that we have
+            // enough information to fully configure a node
+            // locally.
+            let outputs = deduce_outputs(&addr, node_cfg, &sys_cfg, assignment);
+            realize::<P>(addr, node_cfg, outputs).map(|realization| {
+                accumulator.push(realization);
+                accumulator
+            })
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::path::PathBuf;
+
+    use maplit::btreemap;
+    use maplit::btreeset;
+    use maplit::hashset;
+
+    use uuid::Uuid;
+
+    use crate::schema::Source;
+
+    #[test]
+    fn file_sink_deduction() {
+        let node_cfg = btreemap! {
+            0 => btreeset! {
+                RelCfg::Source(Source::File(PathBuf::from("input.dat"))),
+                RelCfg::Sink(Sink::File(PathBuf::from("output_0_2.dump"))),
+            },
+            1 => btreeset! {
+                RelCfg::Input(btreeset!{2, 4}),
+            },
+            2 => btreeset! {
+                RelCfg::Sink(Sink::File(PathBuf::from("output_0_2.dump"))),
+            },
+            3 => btreeset! {
+                RelCfg::Sink(Sink::File(PathBuf::from("output_3.dump"))),
+                RelCfg::Input(btreeset!{0}),
+            },
+        };
+
+        let sinks = deduce_sinks_or_sources(&node_cfg, true);
+        assert_eq!(sinks.len(), 2);
+
+        let rel_ids = sinks.get(Path::new("output_0_2.dump")).unwrap();
+        assert_eq!(rel_ids.len(), 2);
+        assert!(rel_ids.contains(&0));
+        assert!(rel_ids.contains(&2));
+
+        let rel_ids = sinks.get(Path::new("output_3.dump")).unwrap();
+        assert_eq!(rel_ids.len(), 1);
+        assert!(rel_ids.contains(&3));
+    }
+
+    #[test]
+    fn output_deduction_two_nodes() {
+        let uuid0 = Uuid::new_v4();
+        let uuid1 = Uuid::new_v4();
+        let node0 = Addr::Ip("127.0.0.1:1".parse().unwrap());
+        let node1 = Addr::Ip("127.0.0.1:2".parse().unwrap());
+
+        let node0_cfg = btreemap! {
+            0 => btreeset! {
+                RelCfg::Source(Source::File(PathBuf::from("input.cmd"))),
+            },
+        };
+        let node1_cfg = btreemap! {
+            1 => btreeset! {
+                RelCfg::Input(btreeset! {0}),
+            },
+        };
+        let sys_cfg = btreemap! {
+            uuid0 => node0_cfg.clone(),
+            uuid1 => node1_cfg.clone(),
+        };
+        let assignment = btreemap! {
+            uuid0 => node0.clone(),
+            uuid1 => node1.clone(),
+        };
+
+        let outputs = deduce_outputs(&node0, &node0_cfg, &sys_cfg, &assignment);
+        let expected = btreemap! {
+            node1.clone() => hashset! { 0 },
+        };
+        assert_eq!(outputs, expected);
+
+        let outputs = deduce_outputs(&node1, &node1_cfg, &sys_cfg, &assignment);
+        assert_eq!(outputs, Outputs::new());
+    }
+
+    #[test]
+    fn output_deduction_three_nodes() {
+        let uuid0 = Uuid::new_v4();
+        let uuid1 = Uuid::new_v4();
+        let uuid2 = Uuid::new_v4();
+        let node0 = Addr::Ip("127.0.0.1:1".parse().unwrap());
+        let node1 = Addr::Ip("127.0.0.1:2".parse().unwrap());
+        let node2 = Addr::Ip("127.0.0.1:3".parse().unwrap());
+
+        let node0_cfg = btreemap! {
+            0 => btreeset!{
+                RelCfg::Source(Source::File("input0.dat".into())),
+            },
+            1 => btreeset!{},
+        };
+        let node1_cfg = btreemap! {
+            2 => btreeset!{
+                RelCfg::Source(Source::File("input2.dat".into())),
+            },
+            3 => btreeset!{}
+        };
+        let node2_cfg = btreemap! {
+            4 => btreeset!{
+                RelCfg::Input(btreeset!{
+                    1,
+                })
+            },
+            5 => btreeset!{
+                RelCfg::Input(btreeset!{
+                    3,
+                })
+            },
+            6 => btreeset!{
+                RelCfg::Sink(Sink::File("node2.dump".into())),
+            },
+        };
+
+        let sys_cfg = btreemap! {
+            uuid0 => node0_cfg.clone(),
+            uuid1 => node1_cfg.clone(),
+            uuid2 => node2_cfg.clone(),
+        };
+
+        let assignment = btreemap! {
+            uuid0 => node0.clone(),
+            uuid1 => node1.clone(),
+            uuid2 => node2.clone(),
+        };
+
+        let outputs = deduce_outputs(&node0, &node0_cfg, &sys_cfg, &assignment);
+        let expected = btreemap! {
+            node2.clone() => hashset! { 1 },
+        };
+        assert_eq!(outputs, expected);
+
+        let outputs = deduce_outputs(&node1, &node1_cfg, &sys_cfg, &assignment);
+        let expected = btreemap! {
+            node2.clone() => hashset! { 3 },
+        };
+        assert_eq!(outputs, expected);
+
+        let outputs = deduce_outputs(&node2, &node2_cfg, &sys_cfg, &assignment);
+        let expected = btreemap! {};
+        assert_eq!(outputs, expected);
+    }
+}

--- a/rust/template/distributed_datalog/src/lib.rs
+++ b/rust/template/distributed_datalog/src/lib.rs
@@ -46,6 +46,9 @@
 
 //! Distributed computing for differential-datalog.
 
+#[cfg(any(test, feature = "test"))]
+mod assign;
+mod instantiate;
 mod observe;
 mod schema;
 mod server;
@@ -60,6 +63,7 @@ pub mod sinks;
 /// A module comprising sources to feed data into a computation.
 pub mod sources;
 
+pub use instantiate::instantiate;
 pub use observe::Observable;
 pub use observe::ObservableBox;
 pub use observe::Observer;
@@ -67,6 +71,7 @@ pub use observe::ObserverBox;
 pub use observe::OptionalObserver;
 pub use observe::SharedObserver;
 pub use observe::UpdatesObservable;
+pub use schema::Addr;
 pub use schema::Member;
 pub use schema::Members;
 pub use schema::Node;
@@ -82,7 +87,4 @@ pub use tcp_channel::TcpSender;
 pub use txnmux::TxnMux;
 
 #[cfg(any(test, feature = "test"))]
-pub use observe::MockObserver;
-
-#[cfg(any(test, feature = "test"))]
-pub use test::await_expected;
+pub use {assign::simple_assign, observe::MockObserver, test::await_expected};

--- a/rust/template/distributed_datalog/src/schema.rs
+++ b/rust/template/distributed_datalog/src/schema.rs
@@ -120,6 +120,13 @@ impl Member {
 pub type Members = BTreeSet<Member>;
 
 /// A set of relations used in various contexts.
+///
+/// # Important:
+///
+/// We currently assume globally unique relation IDs, which also means
+/// we require the exact same program to be present on all nodes in the
+/// system. This is a simplifying assumption made for the time being.
+/// Ideally, a relation ID really would be a `(Node, RelId)` tuple.
 pub type Relations = BTreeSet<RelId>;
 
 /// All the input sources we support.
@@ -155,7 +162,7 @@ pub type NodeCfg = BTreeMap<RelId, BTreeSet<RelCfg>>;
 ///
 /// Each value in the map represents the configuration of a single node.
 /// In order to reason about nodes we assign a UUID to each.
-pub type SysCfg = BTreeMap<Uuid, NodeCfg>;
+pub type SysCfg = BTreeMap<Node, NodeCfg>;
 
 #[cfg(test)]
 mod tests {
@@ -167,8 +174,8 @@ mod tests {
 
     #[test]
     fn compare_addrs() {
-        let addr0 = Addr::Ip("127.0.0.1:2000".parse().unwrap());
-        let addr1 = Addr::Ip("127.0.0.1:2001".parse().unwrap());
+        let addr0 = Addr::Ip("127.0.0.1:1".parse().unwrap());
+        let addr1 = Addr::Ip("127.0.0.1:2".parse().unwrap());
 
         assert!(addr0 < addr1);
     }

--- a/rust/template/distributed_datalog/src/sources/file.rs
+++ b/rust/template/distributed_datalog/src/sources/file.rs
@@ -176,15 +176,15 @@ where
 {
     /// Create a new adapter streaming data from the file at the given
     /// `path`.
-    pub fn new<P>(path: P) -> Result<Self, Error>
+    pub fn new<P>(path: P) -> Self
     where
         P: Into<PathBuf>,
     {
-        Ok(Self {
+        Self {
             path: path.into(),
             state: None,
             _unused: Default::default(),
-        })
+        }
     }
 
     fn start(
@@ -303,7 +303,7 @@ mod tests {
     #[test]
     fn non_existent_file() {
         let mock = SharedObserver::new(Mutex::new(MockObserver::new()));
-        let mut adapter = File::<DummyConverter, _>::new("i-dont-actually-exist").unwrap();
+        let mut adapter = File::<DummyConverter, _>::new("i-dont-actually-exist");
         let result = adapter.subscribe(Box::new(mock.clone()));
 
         assert!(result.is_err(), result);
@@ -315,7 +315,7 @@ mod tests {
         file.write_all(TRANSACTION_DUMP).unwrap();
 
         let mock = SharedObserver::new(Mutex::new(MockObserver::new()));
-        let mut adapter = File::<DummyConverter, _>::new(file.path()).unwrap();
+        let mut adapter = File::<DummyConverter, _>::new(file.path());
         let _ = adapter.subscribe(Box::new(mock.clone())).unwrap();
 
         await_expected(|| {

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -162,6 +162,8 @@ rustLibFiles specname =
         , (dir </> "cmd_parser/lib.rs"                               , $(embedFile "rust/template/cmd_parser/lib.rs"))
         , (dir </> "cmd_parser/parse.rs"                             , $(embedFile "rust/template/cmd_parser/parse.rs"))
         , (dir </> "distributed_datalog/Cargo.toml"                  , $(embedFile "rust/template/distributed_datalog/Cargo.toml"))
+        , (dir </> "distributed_datalog/src/assign.rs"               , $(embedFile "rust/template/distributed_datalog/src/assign.rs"))
+        , (dir </> "distributed_datalog/src/instantiate.rs"          , $(embedFile "rust/template/distributed_datalog/src/instantiate.rs"))
         , (dir </> "distributed_datalog/src/lib.rs"                  , $(embedFile "rust/template/distributed_datalog/src/lib.rs"))
         , (dir </> "distributed_datalog/src/observe/mod.rs"          , $(embedFile "rust/template/distributed_datalog/src/observe/mod.rs"))
         , (dir </> "distributed_datalog/src/observe/observable.rs"   , $(embedFile "rust/template/distributed_datalog/src/observe/observable.rs"))

--- a/test/datalog_tests/server_api/Cargo.toml
+++ b/test/datalog_tests/server_api/Cargo.toml
@@ -8,6 +8,8 @@ differential_datalog = {path = "../server_api_ddlog/differential_datalog"}
 distributed_datalog = {path = "../server_api_ddlog/distributed_datalog", features=["test"]}
 maplit = "1.0"
 server_api = {path = "../server_api_ddlog"}
+tempfile = "3.1"
+uuid = {version = "0.8", default-features = false, features = ["v4"]}
 
 [dev-dependencies]
 env_logger = {version = "0.6", default_features = false, features = ["humantime"]}

--- a/test/datalog_tests/server_api/tests/config.rs
+++ b/test/datalog_tests/server_api/tests/config.rs
@@ -1,0 +1,128 @@
+use std::io::Read;
+use std::io::Seek;
+use std::io::SeekFrom;
+use std::io::Write;
+use std::ops::Deref;
+
+use maplit::btreemap;
+use maplit::btreeset;
+
+use tempfile::NamedTempFile;
+use test_env_log::test;
+
+use uuid::Uuid;
+
+use distributed_datalog::await_expected;
+use distributed_datalog::instantiate;
+use distributed_datalog::simple_assign;
+use distributed_datalog::Addr;
+use distributed_datalog::Member;
+use distributed_datalog::RelCfg;
+use distributed_datalog::Sink;
+use distributed_datalog::Source;
+
+use server_api_ddlog::api::HDDlog;
+use server_api_ddlog::Relations::server_api_1_P1In;
+use server_api_ddlog::Relations::server_api_1_P1Out;
+use server_api_ddlog::Relations::server_api_2_P2In;
+use server_api_ddlog::Relations::server_api_2_P2Out;
+use server_api_ddlog::Relations::server_api_3_P1Out;
+use server_api_ddlog::Relations::server_api_3_P2Out;
+use server_api_ddlog::Relations::server_api_3_P3Out;
+
+/// Test delta retrieval in the face of two concurrent transactions over
+/// a TCP channel.
+#[test]
+fn instantiate_configuration_end_to_end() -> Result<(), String> {
+    const SERVER_API_1_P1IN: &'static [u8] = include_bytes!("server_api_1_p1in.dat");
+    const SERVER_API_2_P2IN: &'static [u8] = include_bytes!("server_api_2_p2in.dat");
+    // TODO: Right now the dump contains an empty start; commit; pair.
+    //       Investigate why it is emitted and eliminate the source.
+    const SERVER_API_3_P3OUT: &'static str = include_str!("server_api_3_p3out.dump.expected");
+
+    let mut file1 = NamedTempFile::new().unwrap();
+    file1.write_all(SERVER_API_1_P1IN).unwrap();
+    let path1 = file1.into_temp_path();
+
+    let mut file2 = NamedTempFile::new().unwrap();
+    file2.write_all(SERVER_API_2_P2IN).unwrap();
+    let path2 = file2.into_temp_path();
+
+    let (mut file3, path3) = NamedTempFile::new().unwrap().into_parts();
+
+    // We require UUIDs in ascending order to be able to create a stable
+    // assignment.
+    let mut uuids = vec![Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4()];
+    uuids.sort();
+
+    // TODO: We run risk of port collisions here. The range is chosen to
+    //       be unlikely to be used by the system for ephemeral ports,
+    //       but that is not enough in the long term. We likely need
+    //       some form of registry.
+    let node1 = Addr::Ip("127.0.0.1:5000".parse().unwrap());
+    let node2 = Addr::Ip("127.0.0.1:5001".parse().unwrap());
+    let node3 = Addr::Ip("127.0.0.1:5002".parse().unwrap());
+
+    let node1_cfg = btreemap! {
+        server_api_1_P1In as usize => btreeset!{
+            RelCfg::Source(Source::File(path1.deref().into())),
+        },
+        server_api_1_P1Out as usize => btreeset!{},
+    };
+    let node2_cfg = btreemap! {
+        server_api_2_P2In as usize => btreeset!{
+            RelCfg::Source(Source::File(path2.deref().into())),
+        },
+        server_api_2_P2Out as usize => btreeset!{}
+    };
+    let node3_cfg = btreemap! {
+        server_api_3_P1Out as usize => btreeset!{
+            RelCfg::Input(btreeset!{
+                server_api_1_P1Out as usize,
+            })
+        },
+        server_api_3_P2Out as usize => btreeset!{
+            RelCfg::Input(btreeset!{
+                server_api_2_P2Out as usize,
+            })
+        },
+        server_api_3_P3Out as usize => btreeset!{
+            RelCfg::Sink(Sink::File(path3.deref().into())),
+        },
+    };
+
+    let sys_cfg = btreemap! {
+        uuids[0] => node1_cfg,
+        uuids[1] => node2_cfg,
+        uuids[2] => node3_cfg,
+    };
+
+    let members = btreeset! {
+        Member::new(node1.clone()),
+        Member::new(node2.clone()),
+        Member::new(node3.clone()),
+    };
+
+    let assignment = simple_assign(sys_cfg.keys(), members.iter()).unwrap();
+
+    // TODO: Because of TCP senders synchronously connecting to TCP
+    //       receivers we instantiate the nodes in "reverse", meaning
+    //       with the ones feeding the others first. That's only
+    //       possible while we don't have any loops in the
+    //       configuration. In the future we may want to make
+    //       `TcpSender` more clever and allowing it to buffer updates,
+    //       or something along those lines.
+    let _realization3 = instantiate::<HDDlog>(sys_cfg.clone(), &node3, &assignment).unwrap();
+    let _realization2 = instantiate::<HDDlog>(sys_cfg.clone(), &node2, &assignment).unwrap();
+    let _realization1 = instantiate::<HDDlog>(sys_cfg.clone(), &node1, &assignment).unwrap();
+
+    await_expected(move || {
+        let mut string = String::new();
+        let _ = file3.seek(SeekFrom::Start(0)).unwrap();
+        let _ = file3.read_to_string(&mut string).unwrap();
+
+        assert_eq!(string, SERVER_API_3_P3OUT);
+    });
+
+    Ok(())
+}

--- a/test/datalog_tests/server_api/tests/server_api_1_p1in.dat
+++ b/test/datalog_tests/server_api/tests/server_api_1_p1in.dat
@@ -1,0 +1,3 @@
+start;
+insert server_api_1.P1In["server_api_1:1"];
+commit;

--- a/test/datalog_tests/server_api/tests/server_api_2_p2in.dat
+++ b/test/datalog_tests/server_api/tests/server_api_2_p2in.dat
@@ -1,0 +1,3 @@
+start;
+insert server_api_2.P2In["server_api_2:1"];
+commit;

--- a/test/datalog_tests/server_api/tests/server_api_3_p3out.dump.expected
+++ b/test/datalog_tests/server_api/tests/server_api_3_p3out.dump.expected
@@ -1,0 +1,5 @@
+start;
+commit;
+start;
+insert server_api_3.P3Out["server_api_1:1server_api_2:1"];
+commit;


### PR DESCRIPTION
This change adds support for instantiating a system configuration
defined as per the schema. That means, given a system configuration and
an assignment from nodes to members, we can create everything needed to
bring up a particular node locally.