### PR TITLE
Add some tracing information to our observables & observers

### DIFF
--- a/rust/template/distributed_datalog/Cargo.toml
+++ b/rust/template/distributed_datalog/Cargo.toml
@@ -22,6 +22,7 @@ libc = "0.2"
 log = "0.4"
 nom = "4.0"
 serde = {version = "1.0", features = ["derive"]}
+uid = "0.1"
 uuid = {version = "0.8", default-features = false, features = ["serde", "v4"]}
 waitfor = "0.1"
 


### PR DESCRIPTION
Getting an overview of what is happening in a particular setup can be
challenging, even for small configurations. In an attempt to provide a
first version of (arguably limited) introspection capabilities, this
change proposes the addition of some tracing information. We use the log
crate's trace macro (which just logs at a different log level as opposed
to, say, error, which we already use) to print chosen details of a
certain method being invoked. We also "tag" each observer/observable
with a dedicated ID, allowing for some limited correlation of events.
Such IDs are unique in any single process. In a truly distributed setup
IDs will be repeated (they just start at 1), but because output is
emitted on a different node uniqueness is still maintained (but may
require some post-processing).