### PR TITLE
Eliminate unnecessary start & commit events

### DIFF
--- a/rust/template/distributed_datalog/src/server.rs
+++ b/rust/template/distributed_datalog/src/server.rs
@@ -90,12 +90,7 @@ where
     /// Start a transaction when deltas start coming in.
     fn on_start(&mut self) -> Result<(), String> {
         if let Some(ref mut prog) = self.prog {
-            prog.transaction_start()?;
-
-            for outlet in &mut self.outlets {
-                outlet.observer.on_start()?
-            }
-            Ok(())
+            prog.transaction_start()
         } else {
             Ok(())
         }
@@ -135,9 +130,10 @@ where
                         .peekable();
 
                     if upds.peek().is_some() {
+                        observer.on_start()?;
                         observer.on_updates(Box::new(upds))?;
+                        observer.on_commit()?;
                     }
-                    observer.on_commit()?;
                 }
             }
             Ok(())

--- a/test/datalog_tests/server_api/tests/config.rs
+++ b/test/datalog_tests/server_api/tests/config.rs
@@ -36,8 +36,6 @@ use server_api_ddlog::Relations::server_api_3_P3Out;
 fn instantiate_configuration_end_to_end() -> Result<(), String> {
     const SERVER_API_1_P1IN: &'static [u8] = include_bytes!("server_api_1_p1in.dat");
     const SERVER_API_2_P2IN: &'static [u8] = include_bytes!("server_api_2_p2in.dat");
-    // TODO: Right now the dump contains an empty start; commit; pair.
-    //       Investigate why it is emitted and eliminate the source.
     const SERVER_API_3_P3OUT: &'static str = include_str!("server_api_3_p3out.dump.expected");
 
     let mut file1 = NamedTempFile::new().unwrap();

--- a/test/datalog_tests/server_api/tests/events.rs
+++ b/test/datalog_tests/server_api/tests/events.rs
@@ -51,9 +51,9 @@ fn start_commit_on_no_updates(
             )
         };
 
-        assert_eq!(on_start, 1);
+        assert_eq!(on_start, 0);
         assert_eq!(on_updates, 0);
-        assert_eq!(on_commit, 1);
+        assert_eq!(on_commit, 0);
     });
 
     server.shutdown()?;
@@ -123,12 +123,28 @@ fn unsubscribe(
     observer: MockObserver,
 ) -> Result<(), String> {
     server.on_start()?;
+    server.on_updates(Box::new(
+        [UpdCmd::Insert(
+            RelIdentifier::RelId(server_api_1_P1In as usize),
+            Record::String("test1".to_string()),
+        )]
+        .into_iter()
+        .map(|cmd| updcmd2upd(cmd).unwrap()),
+    ))?;
     server.on_commit()?;
 
     assert!(observable.unsubscribe(&()).is_some());
     assert!(observable.unsubscribe(&()).is_none());
 
     server.on_start()?;
+    server.on_updates(Box::new(
+        [UpdCmd::Insert(
+            RelIdentifier::RelId(server_api_1_P1In as usize),
+            Record::String("test2".to_string()),
+        )]
+        .into_iter()
+        .map(|cmd| updcmd2upd(cmd).unwrap()),
+    ))?;
     server.on_commit()?;
 
     await_expected(|| {

--- a/test/datalog_tests/server_api/tests/server_api_3_p3out.dump.expected
+++ b/test/datalog_tests/server_api/tests/server_api_3_p3out.dump.expected
@@ -1,5 +1,3 @@
 start;
-commit;
-start;
 insert server_api_3.P3Out["server_api_1:1server_api_2:1"];
 commit;


### PR DESCRIPTION
With the end-to-end test we noticed that an unnecessary start-commit
pair of events is emitted into the replay file. The reason is to be
found in the `DDlogServer`, which invokes `on_start` and `on_commit` on
observers even if no data is actually emitted. We probably don't need
such useless chatter, so rework this logic to only emit those events if
actual deltas are calculated.