### PR TITLE
Simplify RelCfg::Input variant

### DIFF
--- a/rust/template/distributed_datalog/src/assign.rs
+++ b/rust/template/distributed_datalog/src/assign.rs
@@ -90,7 +90,7 @@ mod tests {
             uuids[0] => btreemap! {},
             uuids[1] => btreemap! {
                 1 => btreeset! {
-                    RelCfg::Input(btreeset! {0}),
+                    RelCfg::Input(0),
                 }
             },
         };

--- a/rust/template/distributed_datalog/src/instantiate.rs
+++ b/rust/template/distributed_datalog/src/instantiate.rs
@@ -68,12 +68,12 @@ fn deduce_outputs(
             .for_each(|(addr, node_cfg)| {
                 node_cfg.values().for_each(|rel_cfgs| {
                     rel_cfgs.iter().for_each(|rel_cfg| match rel_cfg {
-                        RelCfg::Input(inputs) => inputs.iter().for_each(|input| {
+                        RelCfg::Input(input) => {
                             if input == rel {
                                 let rels = outputs.entry(addr.clone()).or_default();
                                 let _ = rels.insert(*input);
                             }
-                        }),
+                        }
                         RelCfg::Source(_) | RelCfg::Sink(_) => (),
                     })
                 })
@@ -89,12 +89,10 @@ fn deduce_redirects(config: &NodeCfg) -> HashMap<RelId, RelId> {
     config.iter().fold(HashMap::new(), |redirects, (rel, cfg)| {
         cfg.iter().fold(redirects, |mut redirects, rel_cfg| {
             match rel_cfg {
-                RelCfg::Input(inputs) => {
+                RelCfg::Input(input) => {
                     // Each of the inputs needs to be redirected to the
                     // relation it feeds into.
-                    inputs.iter().for_each(|input| {
-                        let _ = redirects.insert(*input, *rel);
-                    })
+                    let _ = redirects.insert(*input, *rel);
                 }
                 RelCfg::Source(_) | RelCfg::Sink(_) => (),
             }
@@ -329,14 +327,15 @@ mod tests {
                 RelCfg::Sink(Sink::File(PathBuf::from("output_0_2.dump"))),
             },
             1 => btreeset! {
-                RelCfg::Input(btreeset!{2, 4}),
+                RelCfg::Input(2),
+                RelCfg::Input(4),
             },
             2 => btreeset! {
                 RelCfg::Sink(Sink::File(PathBuf::from("output_0_2.dump"))),
             },
             3 => btreeset! {
                 RelCfg::Sink(Sink::File(PathBuf::from("output_3.dump"))),
-                RelCfg::Input(btreeset!{0}),
+                RelCfg::Input(0),
             },
         };
 
@@ -367,7 +366,7 @@ mod tests {
         };
         let node1_cfg = btreemap! {
             1 => btreeset! {
-                RelCfg::Input(btreeset! {0}),
+                RelCfg::Input(0),
             },
         };
         let sys_cfg = btreemap! {
@@ -412,14 +411,10 @@ mod tests {
         };
         let node2_cfg = btreemap! {
             4 => btreeset!{
-                RelCfg::Input(btreeset!{
-                    1,
-                })
+                RelCfg::Input(1)
             },
             5 => btreeset!{
-                RelCfg::Input(btreeset!{
-                    3,
-                })
+                RelCfg::Input(3)
             },
             6 => btreeset!{
                 RelCfg::Sink(Sink::File("node2.dump".into())),

--- a/rust/template/distributed_datalog/src/lib.rs
+++ b/rust/template/distributed_datalog/src/lib.rs
@@ -77,7 +77,6 @@ pub use schema::Members;
 pub use schema::Node;
 pub use schema::NodeCfg;
 pub use schema::RelCfg;
-pub use schema::Relations;
 pub use schema::Sink;
 pub use schema::Source;
 pub use schema::SysCfg;

--- a/test/datalog_tests/server_api/tests/config.rs
+++ b/test/datalog_tests/server_api/tests/config.rs
@@ -75,14 +75,10 @@ fn instantiate_configuration_end_to_end() -> Result<(), String> {
     };
     let node3_cfg = btreemap! {
         server_api_3_P1Out as usize => btreeset!{
-            RelCfg::Input(btreeset!{
-                server_api_1_P1Out as usize,
-            })
+            RelCfg::Input(server_api_1_P1Out as usize)
         },
         server_api_3_P2Out as usize => btreeset!{
-            RelCfg::Input(btreeset!{
-                server_api_2_P2Out as usize,
-            })
+            RelCfg::Input(server_api_2_P2Out as usize)
         },
         server_api_3_P3Out as usize => btreeset!{
             RelCfg::Sink(Sink::File(path3.deref().into())),


### PR DESCRIPTION
The `RelCfg::Input` variant currently requires a set of input relations.
That is actually unnecessary, because a `NodeCfg` already contains a set
of `RelCfg` objects.
So let's simplify the logic by removing the inner set, flattening the resulting structure somewhat.