### PR TITLE
Require explicit specification of output relations

### DIFF
--- a/rust/template/distributed_datalog/src/assign.rs
+++ b/rust/template/distributed_datalog/src/assign.rs
@@ -87,7 +87,11 @@ mod tests {
         let node1 = Addr::Ip("127.0.0.1:2".parse().unwrap());
 
         let config = btreemap! {
-            uuids[0] => btreemap! {},
+            uuids[0] => btreemap! {
+                1 => btreeset! {
+                    RelCfg::Output(uuids[1], 1),
+                }
+            },
             uuids[1] => btreemap! {
                 1 => btreeset! {
                     RelCfg::Input(0),

--- a/rust/template/distributed_datalog/src/schema.rs
+++ b/rust/template/distributed_datalog/src/schema.rs
@@ -148,6 +148,8 @@ pub enum RelCfg {
     Source(Source),
     /// This relation is fed from the given relation.
     Input(RelId),
+    /// This relation feeds the given input relation on the given node.
+    Output(Node, RelId),
     /// A relation that outputs directly into a sink.
     Sink(Sink),
 }

--- a/test/datalog_tests/server_api/tests/config.rs
+++ b/test/datalog_tests/server_api/tests/config.rs
@@ -65,13 +65,17 @@ fn instantiate_configuration_end_to_end() -> Result<(), String> {
         server_api_1_P1In as usize => btreeset!{
             RelCfg::Source(Source::File(path1.deref().into())),
         },
-        server_api_1_P1Out as usize => btreeset!{},
+        server_api_1_P1Out as usize => btreeset!{
+            RelCfg::Output(uuids[2], server_api_3_P1Out as usize),
+        },
     };
     let node2_cfg = btreemap! {
         server_api_2_P2In as usize => btreeset!{
             RelCfg::Source(Source::File(path2.deref().into())),
         },
-        server_api_2_P2Out as usize => btreeset!{}
+        server_api_2_P2Out as usize => btreeset!{
+            RelCfg::Output(uuids[2], server_api_3_P2Out as usize),
+        },
     };
     let node3_cfg = btreemap! {
         server_api_3_P1Out as usize => btreeset!{


### PR DESCRIPTION
So far we have followed an approach where we did not explicitly specify
output relations in the system and node configurations. Instead, those
were deduced by looking at the input relations of other nodes'
relations.
While reasonably nice and concise, there are a few problems with this
approach:
- it seems inconsistent that we specify sources, inputs, and sinks (also
  a form of output), but not outputs themselves
- calculating output relations requires knowledge of the complete system
  configuration
- the output deduction was a rather complex piece of code

This change introduces a new variant, `Output`, to the `RelCfg` enum that
indicates that a relation is an output relation and should feed into a given
node.
The downside with this approach is that we now can have an invalid
configuration, where inputs are specified but no corresponding outputs,
for example. The believe is that we can and should generate the
configuration in one way or another, which would alleviate this problem
in many cases.