### PR TITLE
Topic/buffered tcp sender

### DIFF
--- a/rust/template/distributed_datalog/Cargo.toml
+++ b/rust/template/distributed_datalog/Cargo.toml
@@ -15,6 +15,7 @@ maplit = "1.0"
 serde_json = "1.0"
 tempfile = "3.1"
 test-env-log = "0.1"
+waitfor = "0.1"
 
 [dependencies]
 bincode = "1.2"
@@ -24,7 +25,7 @@ nom = "4.0"
 serde = {version = "1.0", features = ["derive"]}
 uid = "0.1"
 uuid = {version = "0.8", default-features = false, features = ["serde", "v4"]}
-waitfor = "0.1"
+waitfor = {version = "0.1", optional = true}
 
 [features]
-test = []
+test = ["waitfor"]

--- a/rust/template/distributed_datalog/src/schema.rs
+++ b/rust/template/distributed_datalog/src/schema.rs
@@ -41,10 +41,7 @@ use std::collections::BTreeSet;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::fmt::Result as FmtResult;
-use std::io::Error;
 use std::net::SocketAddr;
-use std::net::ToSocketAddrs;
-use std::option::IntoIter;
 use std::path::PathBuf;
 
 use serde::Deserialize;
@@ -88,16 +85,6 @@ impl Ord for Addr {
 impl PartialOrd for Addr {
     fn partial_cmp(&self, other: &Addr) -> Option<Ordering> {
         Some(self.cmp(other))
-    }
-}
-
-impl ToSocketAddrs for Addr {
-    type Iter = IntoIter<SocketAddr>;
-
-    fn to_socket_addrs(&self) -> Result<Self::Iter, Error> {
-        match self {
-            Addr::Ip(addr) => addr.to_socket_addrs(),
-        }
     }
 }
 

--- a/rust/template/distributed_datalog/src/tcp_channel/message.rs
+++ b/rust/template/distributed_datalog/src/tcp_channel/message.rs
@@ -1,3 +1,4 @@
+use std::collections::LinkedList;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::fmt::Result;
@@ -7,10 +8,11 @@ use serde::Serialize;
 
 /// An enum used for representing (and serializing/deserializing)
 /// messages sent through the channel.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub enum Message<T> {
     Start,
     Updates(Vec<T>),
+    UpdateList(LinkedList<Vec<T>>),
     Commit,
     Complete,
 }
@@ -20,6 +22,7 @@ impl<T> Display for Message<T> {
         let s = match self {
             Message::Start => "on_start",
             Message::Updates(_) => "on_updates",
+            Message::UpdateList(_) => "on_updates",
             Message::Commit => "on_commit",
             Message::Complete => "on_completed",
         };

--- a/rust/template/distributed_datalog/src/tcp_channel/mod.rs
+++ b/rust/template/distributed_datalog/src/tcp_channel/mod.rs
@@ -3,6 +3,7 @@
 mod message;
 mod receiver;
 mod sender;
+mod socket;
 
 pub use receiver::TcpReceiver;
 pub use sender::TcpSender;

--- a/rust/template/distributed_datalog/src/tcp_channel/mod.rs
+++ b/rust/template/distributed_datalog/src/tcp_channel/mod.rs
@@ -4,6 +4,7 @@ mod message;
 mod receiver;
 mod sender;
 mod socket;
+mod txnbuf;
 
 pub use receiver::TcpReceiver;
 pub use sender::TcpSender;

--- a/rust/template/distributed_datalog/src/tcp_channel/sender.rs
+++ b/rust/template/distributed_datalog/src/tcp_channel/sender.rs
@@ -1,112 +1,151 @@
-use std::io;
+use std::fmt::Debug;
 use std::io::BufWriter;
-use std::io::ErrorKind;
-use std::io::Write;
+use std::io::Error;
+use std::net::SocketAddr;
 use std::net::TcpStream;
-use std::net::ToSocketAddrs;
-use std::time::Duration;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::thread::spawn;
+use std::thread::JoinHandle;
 
-use bincode::serialize_into;
+use log::debug;
+use log::error;
 use log::trace;
 use serde::Serialize;
 use uid::Id;
-use waitfor::wait_for;
 
 use crate::observe::Observer;
-use crate::tcp_channel::message::Message;
+use crate::tcp_channel::socket::Cancelable;
+use crate::tcp_channel::socket::Socket;
+use crate::tcp_channel::txnbuf::TxnBuf;
 
 /// The sending end of a TCP channel with a specified address and a TCP
 /// connection.
 #[derive(Debug)]
-pub struct TcpSender {
+pub struct TcpSender<T>
+where
+    T: Debug,
+{
     /// The TCP sender's unique ID.
     id: usize,
-    /// The connected TCP stream used by this sender.
-    stream: BufWriter<TcpStream>,
+    /// The buffer we use for buffering transactions or pushing them out
+    /// over the wire.
+    buffer: Arc<Mutex<TxnBuf<BufWriter<TcpStream>, T>>>,
+    /// A cancellation handle we can use for canceling an ongoing
+    /// connect.
+    cancel: Cancelable,
+    /// The thread attempting to establish a connection to a receiver.
+    thread: Option<JoinHandle<Result<(), String>>>,
 }
 
-impl TcpSender {
+impl<T> TcpSender<T>
+where
+    T: Debug + Send + Serialize + 'static,
+{
     /// Create a new `TcpSender`, connecting to the given address.
-    pub fn connect<A>(addr: A) -> io::Result<Self>
-    where
-        A: ToSocketAddrs,
-    {
+    pub fn new(addr: SocketAddr) -> Result<Self, Error> {
         let id = Id::<()>::new().get();
-        trace!("TcpSender({})::connect", id);
+        trace!("TcpSender({})::new({})", id, addr);
+
+        let buffer = Arc::new(Mutex::new(TxnBuf::default()));
+        let socket = Socket::new()?;
+        let cancel = socket.to_cancelable();
+        let thread = Some(Self::connect(id, socket, addr, buffer.clone()));
 
         Ok(Self {
             id,
-            stream: BufWriter::new(TcpStream::connect(addr)?),
+            buffer,
+            cancel,
+            thread,
         })
     }
 
-    /// Try connecting to the given address and retry every `internal`
-    /// until `timeout` is reached if the connection was refused.
-    pub fn with_retry<A>(addr: A, timeout: Duration, interval: Duration) -> io::Result<Self>
-    where
-        A: ToSocketAddrs + Clone,
-    {
-        let id = Id::<()>::new().get();
-        trace!("TcpSender({})::with_retry", id);
+    /// Start a thread attempting to connect to the given address.
+    fn connect(
+        id: usize,
+        socket: Socket,
+        addr: SocketAddr,
+        buffer: Arc<Mutex<TxnBuf<BufWriter<TcpStream>, T>>>,
+    ) -> JoinHandle<Result<(), String>> {
+        spawn(move || {
+            let stream = socket
+                .connect(&addr)
+                .map_err(|e| format!("TcpSender({}): failed to connect to {}: {}", id, addr, e))?;
+            debug!("TcpSender({}): connected to {}", id, addr);
 
-        let result = wait_for(timeout, interval, || {
-            match TcpStream::connect(addr.clone()) {
-                Ok(c) => Ok(Some(c)),
-                Err(e) => {
-                    if e.kind() == ErrorKind::ConnectionRefused {
-                        Ok(None)
-                    } else {
-                        Err(e)
-                    }
-                }
+            let buffer = &mut buffer.lock().unwrap();
+            buffer
+                .set_mode_passthrough(BufWriter::new(stream))
+                .map_err(|e| {
+                    format!(
+                        "TcpSender({}): failed to flush cached transactions: {}",
+                        id, e
+                    )
+                })?;
+            Ok(())
+        })
+    }
+}
+
+impl<T> TcpSender<T>
+where
+    T: Debug,
+{
+    /// Block until a connection is established.
+    pub fn wait_connected(&mut self) -> Result<(), String> {
+        if let Some(t) = self.thread.take() {
+            match t.join() {
+                Ok(result) => result,
+                Err(e) => Err(format!(
+                    "TcpSender({}) thread has panicked: {:?}",
+                    self.id, e
+                )),
             }
-        });
-
-        match result {
-            Ok(None) => Err(io::Error::new(
-                ErrorKind::TimedOut,
-                "timed out (re)trying to connect",
-            )),
-            Ok(Some(c)) => Ok(Self {
-                id,
-                stream: BufWriter::new(c),
-            }),
-            Err(e) => Err(e),
+        } else {
+            Ok(())
         }
     }
 }
 
-impl<T> Observer<T, String> for TcpSender
+impl<T> Observer<T, String> for TcpSender<T>
 where
-    T: Serialize + Send,
+    T: Debug + Send + Serialize + 'static,
 {
-    /// Perform some action before data start coming in.
+    /// Perform some action before data starts coming in.
     fn on_start(&mut self) -> Result<(), String> {
         trace!("TcpSender({})::on_start", self.id);
-        serialize_into(&mut self.stream, &Message::<T>::Start).map_err(|e| e.to_string())
+        self.buffer.lock().unwrap().on_start()
     }
 
     /// Send a series of items over the TCP channel.
     fn on_updates<'a>(&mut self, updates: Box<dyn Iterator<Item = T> + 'a>) -> Result<(), String> {
         trace!("TcpSender({})::on_updates", self.id);
-
-        let message = Message::Updates(updates.collect());
-        serialize_into(&mut self.stream, &message).map_err(|e| e.to_string())
+        self.buffer.lock().unwrap().on_updates(updates)
     }
 
     /// Flush the TCP stream and signal the commit.
     fn on_commit(&mut self) -> Result<(), String> {
         trace!("TcpSender({})::on_commit", self.id);
-
-        serialize_into(&mut self.stream, &Message::<T>::Commit).map_err(|e| e.to_string())?;
-        self.stream.flush().map_err(|e| e.to_string())
+        self.buffer.lock().unwrap().on_commit()
     }
 
     fn on_completed(&mut self) -> Result<(), String> {
         trace!("TcpSender({})::on_completed", self.id);
+        self.buffer.lock().unwrap().on_completed()
+    }
+}
 
-        serialize_into(&mut self.stream, &Message::<T>::Complete).map_err(|e| e.to_string())?;
-        self.stream.flush().map_err(|e| e.to_string())
+impl<T> Drop for TcpSender<T>
+where
+    T: Debug,
+{
+    fn drop(&mut self) {
+        if let Err(e) = self.cancel.cancel() {
+            error!("failed to cancel connect: {}", e);
+        }
+        if let Err(e) = self.wait_connected() {
+            error!("{}", e);
+        }
     }
 }
 
@@ -116,6 +155,10 @@ mod tests {
 
     use test_env_log::test;
 
+    use crate::await_expected;
+    use crate::MockObserver;
+    use crate::Observable;
+    use crate::SharedObserver;
     use crate::TcpReceiver;
 
     /// Connect a `TcpSender` to a `TcpReceiver`.
@@ -123,7 +166,7 @@ mod tests {
     fn connect() {
         let recv = TcpReceiver::<()>::new("127.0.0.1:0").unwrap();
         {
-            let _send = TcpSender::connect(recv.addr()).unwrap();
+            let _send = TcpSender::<()>::new(*recv.addr());
         }
     }
 
@@ -133,7 +176,7 @@ mod tests {
     fn transmit_updates_no_consumer() {
         let recv = TcpReceiver::<String>::new("127.0.0.1:0").unwrap();
         {
-            let mut send = TcpSender::connect(recv.addr()).unwrap();
+            let mut send = TcpSender::new(*recv.addr()).unwrap();
 
             let send = &mut send as &mut dyn Observer<String, _>;
             send.on_start().unwrap();
@@ -141,5 +184,28 @@ mod tests {
                 .unwrap();
             send.on_commit().unwrap();
         }
+    }
+
+    #[test]
+    fn delayed_connect() {
+        let mut send = TcpSender::new("127.0.0.1:5006".parse().unwrap()).unwrap();
+        let mut recv = TcpReceiver::<u64>::new("127.0.0.1:5006").unwrap();
+        let observer = SharedObserver::new(Mutex::new(MockObserver::new()));
+        let _ = recv.subscribe(Box::new(observer.clone())).unwrap();
+
+        let send = &mut send as &mut dyn Observer<u64, _>;
+        send.on_start().unwrap();
+        send.on_updates(Box::new(vec![1, 2, 3].into_iter()))
+            .unwrap();
+        send.on_commit().unwrap();
+
+        await_expected(|| {
+            let on_updates = {
+                let mock = observer.lock().unwrap();
+                mock.called_on_updates
+            };
+
+            assert_eq!(on_updates, 3);
+        });
     }
 }

--- a/rust/template/distributed_datalog/src/tcp_channel/socket.rs
+++ b/rust/template/distributed_datalog/src/tcp_channel/socket.rs
@@ -1,0 +1,461 @@
+use std::convert::TryFrom;
+use std::convert::TryInto;
+use std::io::Error;
+use std::io::ErrorKind;
+use std::mem::forget;
+use std::net::SocketAddr;
+use std::net::TcpStream;
+use std::os::unix::io::AsRawFd;
+use std::os::unix::io::FromRawFd;
+use std::os::unix::io::IntoRawFd;
+use std::os::unix::io::RawFd;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use log::error;
+
+trait IsMinusOne {
+    fn is_minus_one(&self) -> bool;
+}
+
+macro_rules! impl_is_minus_one {
+    ($($t:ident)*) => ($(impl IsMinusOne for $t {
+        fn is_minus_one(&self) -> bool {
+            *self == -1
+        }
+    })*)
+}
+
+impl_is_minus_one! { i8 i16 i32 i64 isize }
+
+fn cvt<T: IsMinusOne>(t: T) -> Result<T, Error> {
+    if t.is_minus_one() {
+        Err(Error::last_os_error())
+    } else {
+        Ok(t)
+    }
+}
+
+fn into_inner(addr: &SocketAddr) -> (*const libc::sockaddr, libc::socklen_t) {
+    match addr {
+        SocketAddr::V4(ref a) => (
+            a as *const _ as *const _,
+            std::mem::size_of_val(a) as libc::socklen_t,
+        ),
+        SocketAddr::V6(ref a) => (
+            a as *const _ as *const _,
+            std::mem::size_of_val(a) as libc::socklen_t,
+        ),
+    }
+}
+
+fn set_nonblocking(fd: RawFd, nonblocking: bool) -> Result<(), Error> {
+    let mut nonblocking = nonblocking as libc::c_int;
+    cvt(unsafe { libc::ioctl(fd, libc::FIONBIO, &mut nonblocking) }).map(|_| ())
+}
+
+/// Attempt to connect the given socket file descriptor.
+///
+/// This function will not return until either
+/// 1) the socket was connected successfully
+/// OR
+/// 2) `closable` was closed asynchronously
+// This function is derived from the standard library's `connect_timeout`,
+// but without the timeout part, and instead added support for
+// asynchronous cancellation.
+fn connect(socket: &Fd, addr: &SocketAddr) -> Result<(), Error> {
+    'connect: loop {
+        let fd = socket.as_raw_fd();
+        set_nonblocking(fd, true)?;
+        let r = unsafe {
+            let (addrp, len) = into_inner(addr);
+            cvt(libc::connect(fd, addrp, len))
+        };
+        set_nonblocking(fd, false)?;
+
+        match r {
+            Ok(_) => return Ok(()),
+            Err(e) => {
+                let os_err = e.raw_os_error();
+                if os_err == Some(libc::ECONNREFUSED) {
+                    continue 'connect;
+                }
+                if os_err != Some(libc::EINPROGRESS) {
+                    return Err(e);
+                }
+            }
+        }
+
+        let mut pollfds = [libc::pollfd {
+            fd,
+            events: libc::POLLOUT,
+            revents: 0,
+        }];
+
+        // We use an infinite timeout. Users can cancel the operation,
+        // though.
+        let timeout = -1;
+        let count = pollfds.len().try_into().unwrap();
+
+        loop {
+            match unsafe { libc::poll(pollfds.as_mut_ptr(), count, timeout) } {
+                -1 => {
+                    let err = Error::last_os_error();
+                    if err.kind() != ErrorKind::Interrupted {
+                        return Err(err);
+                    }
+                }
+                0 => {
+                    // This case shouldn't really happen as it only applies
+                    // to timeouts. Ultimately it's just like any other
+                    // spurious wakeup and we continue.
+                }
+                _ => {
+                    if socket.is_shutdown() {
+                        return Err(Error::from_raw_os_error(libc::ENOTCONN));
+                    }
+                    // Linux returns POLLOUT|POLLERR|POLLHUP for refused
+                    // connections (!), so look for POLLHUP rather than read
+                    // readiness. If the connection got refused we start
+                    // over attempting to connect again.
+                    if pollfds[0].revents & libc::POLLHUP != 0 {
+                        continue 'connect;
+                    }
+                    return Ok(());
+                }
+            }
+        }
+    }
+}
+
+const FD_CLOSED: usize = 1 << (0usize.count_zeros() - 1);
+const FD_SHUTDOWN: usize = FD_CLOSED >> 1;
+
+#[derive(Debug)]
+struct Fd(AtomicUsize);
+
+impl Fd {
+    pub fn new<T>(fd: T) -> Self
+    where
+        // We deliberately use c_uint here which pushes the burden of
+        // checking for negative values to the client (while still
+        // having covering the full range of valid values).
+        T: Into<libc::c_uint>,
+    {
+        debug_assert_eq!(FD_CLOSED.count_ones(), 1);
+        debug_assert_eq!(FD_SHUTDOWN.count_ones(), 1);
+
+        let fd = usize::try_from(fd.into()).unwrap();
+        assert_eq!(fd & FD_SHUTDOWN, 0);
+        assert_eq!(fd & FD_CLOSED, 0);
+
+        // This type is based on the assumption that sizeof(c_uint) >=
+        // sizeof(usize), which really should hold all platforms we are
+        // interested in.
+        Fd(fd.into())
+    }
+
+    /// Transfer ownership of the underlying file descriptor into a new
+    /// object, if that hasn't been done already.
+    pub fn take(&self) -> Option<Fd> {
+        let fd = self.0.fetch_or(FD_CLOSED, Ordering::SeqCst);
+        // Note that we don't care about the shut down state of the
+        // object in this method, as shutting down the file descriptor
+        // does not invalidate it (yet, it transitions over to the new
+        // object).
+        if fd & FD_CLOSED != 0 {
+            None
+        } else {
+            Some(Fd(fd.into()))
+        }
+    }
+
+    /// Shut down the file descriptor.
+    ///
+    /// Note that no matter whether the shutdown actually succeeds or
+    /// not, the object won't ever allow another shutdown.
+    pub fn shutdown(&self) -> Result<(), Error> {
+        let fd = self.0.fetch_or(FD_SHUTDOWN, Ordering::SeqCst);
+        if fd & (FD_SHUTDOWN | FD_CLOSED) != 0 {
+            Ok(())
+        } else {
+            cvt(unsafe { libc::shutdown(fd.try_into().unwrap(), libc::SHUT_RDWR) }).map(|_| ())
+        }
+    }
+
+    /// Check whether the file descriptor has been shut down.
+    pub fn is_shutdown(&self) -> bool {
+        self.0.load(Ordering::SeqCst) & FD_SHUTDOWN != 0
+    }
+
+    /// Safely close the file descriptor.
+    ///
+    /// Note that no matter whether the close actually succeeds or not,
+    /// the object won't ever allow another close.
+    pub fn close(&self) -> Result<(), Error> {
+        if let Some(fd) = self.take() {
+            cvt(unsafe { libc::close(fd.into_raw_fd()) }).map(|_| ())?;
+        }
+        Ok(())
+    }
+
+    /// Check whether the file descriptor has been closed.
+    #[cfg(test)]
+    fn is_closed(&self) -> bool {
+        self.0.load(Ordering::SeqCst) & FD_CLOSED != 0
+    }
+}
+
+impl AsRawFd for Fd {
+    fn as_raw_fd(&self) -> RawFd {
+        let fd = self.0.load(Ordering::SeqCst) & !(FD_SHUTDOWN | FD_CLOSED);
+        // It's always safe to unwrap because we created the object from
+        // what is essentially a RawFd to begin with, it's just that we
+        // store it in something potentially larger.
+        fd.try_into().unwrap()
+    }
+}
+
+impl IntoRawFd for Fd {
+    fn into_raw_fd(self) -> RawFd {
+        let fd = self.as_raw_fd();
+        forget(self);
+        fd
+    }
+}
+
+impl Drop for Fd {
+    fn drop(&mut self) {
+        if let Err(e) = self.close() {
+            error!(
+                "failed to close file descriptor ({}): {}",
+                self.0.load(Ordering::SeqCst),
+                e
+            );
+        }
+    }
+}
+
+/// Create a socket file descriptor.
+fn socket() -> Result<Fd, Error> {
+    let fd =
+        cvt(unsafe { libc::socket(libc::AF_INET, libc::SOCK_STREAM | libc::SOCK_CLOEXEC, 0) })?;
+    Ok(Fd::new(fd as libc::c_uint))
+}
+
+/// An object representing a socket.
+#[derive(Debug)]
+pub struct Socket(Arc<Fd>);
+
+impl Socket {
+    /// Create a new `Socket` object.
+    pub fn new() -> Result<Self, Error> {
+        Ok(Self(Arc::new(socket()?)))
+    }
+
+    /// Connect the socket to the given address.
+    ///
+    /// This function will not return until a connection has been
+    /// established or the socket been closed.
+    pub fn connect(self, addr: &SocketAddr) -> Result<TcpStream, Error> {
+        if let Some(fd) = self.0.take() {
+            connect(&fd, addr).map(|_| unsafe { TcpStream::from_raw_fd(fd.into_raw_fd()) })
+        } else {
+            Err(Error::from_raw_os_error(libc::EBADF))
+        }
+    }
+
+    /// Retrieve a reference to a file descriptor that can be used to
+    /// asynchronously close the socket, unblocking any in-progress
+    /// connect(2) operations.
+    pub fn to_cancelable(&self) -> Cancelable {
+        Cancelable(self.0.clone())
+    }
+}
+
+#[derive(Debug)]
+pub struct Cancelable(Arc<Fd>);
+
+impl Cancelable {
+    /// Cancel the cancelable.
+    pub fn cancel(&self) -> Result<(), Error> {
+        match self.0.shutdown() {
+            // Don't signal an error if we just haven't connected yet.
+            Err(ref e) if e.raw_os_error() == Some(libc::ENOTCONN) => Ok(()),
+            r => r,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::io::Read;
+    use std::io::Write;
+    use std::net::TcpListener;
+    use std::thread::sleep;
+    use std::thread::spawn;
+    use std::time::Duration;
+
+    /// Test the closing on an `Fd`.
+    #[test]
+    fn close() {
+        let socket = Socket::new().unwrap();
+        let fd = socket.0;
+        let raw = fd.as_raw_fd();
+
+        assert!(!fd.is_closed());
+        assert!(fd.close().is_ok());
+        assert!(fd.is_closed());
+        assert_eq!(fd.as_raw_fd(), raw);
+
+        assert!(fd.close().is_ok());
+        assert!(fd.is_closed());
+        assert_eq!(fd.as_raw_fd(), raw);
+    }
+
+    /// Check the shutdown of an `Fd` and the invariants that go with
+    /// that.
+    #[test]
+    fn shutdown() {
+        // In order to properly test the shut down functionality we
+        // first have to connect the socket.
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let socket = Socket::new().unwrap();
+        let fd = socket.0.clone();
+        let _stream = socket.connect(&addr).unwrap();
+
+        assert!(!fd.is_shutdown());
+        assert!(fd.shutdown().is_ok());
+        assert!(fd.is_shutdown());
+
+        assert!(fd.shutdown().is_ok());
+        assert!(fd.is_shutdown());
+
+        assert!(fd.close().is_ok());
+        assert!(fd.is_shutdown());
+    }
+
+    /// Test that the `Fd::take` functionality works as expected.
+    #[test]
+    fn take() {
+        let socket = Socket::new().unwrap();
+        let fd = socket.0;
+        let copy = fd.take().unwrap();
+        assert!(!fd.is_shutdown());
+        assert!(fd.is_closed());
+        assert!(!copy.is_shutdown());
+        assert!(!copy.is_closed());
+
+        // Subsequent takes should fail.
+        assert!(fd.take().is_none());
+
+        // Closing of the new `Fd` should work as it did before.
+        assert!(copy.close().is_ok());
+    }
+
+    /// Test that we can establish a connection.
+    #[test]
+    fn connect() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let socket = Socket::new().unwrap();
+        let _ = socket.connect(&addr).unwrap();
+    }
+
+    /// Check that we can eventually connect when a service starts
+    /// listening on an address.
+    #[test]
+    fn connect_eventually() {
+        const MESSAGE: &[u8] = b"success\0";
+        const ADDR: &str = "127.0.0.1:5003";
+
+        fn test(delay_ns: u64) {
+            let thread = spawn(move || {
+                if delay_ns > 0 {
+                    sleep(Duration::from_nanos(delay_ns));
+                }
+
+                let listener = TcpListener::bind(ADDR).unwrap();
+                // Wait until we got an incoming connection and then exit
+                // the thread.
+                let (mut socket, _) = listener.accept().unwrap();
+                let mut data = Vec::new();
+                let _ = socket.read_to_end(&mut data).unwrap();
+                assert_eq!(data.as_slice(), MESSAGE);
+            });
+
+            {
+                let sock_addr = ADDR.parse().unwrap();
+                let socket = Socket::new().unwrap();
+                let mut stream = socket.connect(&sock_addr).unwrap();
+                let _ = stream.write_all(&MESSAGE).unwrap();
+            }
+
+            thread.join().unwrap();
+        }
+
+        for delay in (0..100_000).step_by(1_000) {
+            test(delay);
+        }
+    }
+
+    /// Test cancellation of an attempted connect when there is no
+    /// entity to connect to.
+    #[test]
+    fn cancel_no_accept() {
+        const ADDR: &str = "127.0.0.1:5004";
+
+        let sock_addr = ADDR.parse().unwrap();
+        let socket = Socket::new().unwrap();
+        let cancelable = socket.to_cancelable();
+
+        let thread = spawn(move || {
+            let err = socket.connect(&sock_addr).unwrap_err();
+            assert_eq!(err.raw_os_error(), Some(libc::ENOTCONN));
+        });
+
+        let _ = cancelable.cancel().unwrap();
+
+        thread.join().unwrap();
+    }
+
+    /// Test cancellation anywhere between attempting to connect and the
+    /// connection being accepted.
+    #[test]
+    fn cancel_with_bind() {
+        const ADDR: &str = "127.0.0.1:5005";
+
+        let sock_addr = ADDR.parse().unwrap();
+        let socket = Socket::new().unwrap();
+        let cancelable = socket.to_cancelable();
+
+        let thread1 = spawn(move || {
+            let _listener = TcpListener::bind(ADDR).unwrap();
+            // We probably don't want to actually accept the connection,
+            // because we don't know when the cancellation happens. If
+            // it happens before we connect, the accept would just block
+            // forever.
+            sleep(Duration::from_micros(100))
+        });
+
+        let thread2 = spawn(move || {
+            let _stream = socket.connect(&sock_addr);
+        });
+
+        // The operation may or may not succeed, depending on whether we
+        // actually connect or not.
+        let _result = cancelable.cancel();
+
+        // The main thing we care about is that the connect exits after
+        // cancelation, which is guaranteed to have happened after the
+        // join succeeded.
+        thread1.join().unwrap();
+        thread2.join().unwrap();
+    }
+}

--- a/rust/template/distributed_datalog/src/tcp_channel/txnbuf.rs
+++ b/rust/template/distributed_datalog/src/tcp_channel/txnbuf.rs
@@ -1,0 +1,249 @@
+//! A module providing functionality for buffering of transactions. Such
+//! buffering comes in handy in scenarios where the future receiver of a
+//! transaction is not yet available to process it.
+
+use std::collections::LinkedList;
+use std::fmt::Debug;
+use std::io::Write;
+use std::mem::replace;
+
+use bincode::serialize_into;
+use serde::Serialize;
+
+use crate::observe::Observer;
+use crate::tcp_channel::message::Message;
+
+/// A type representing the updates of a transaction.
+type Transaction<T> = LinkedList<Vec<T>>;
+
+/// A buffer for transactions.
+#[derive(Debug)]
+pub enum TxnBuf<W, T>
+where
+    W: Debug,
+    T: Debug,
+{
+    /// A list of buffered transactions.
+    Updates {
+        /// We merge all "completed" transactions (i.e., those for which
+        /// we have seen a commit) into a single one.
+        complete: Transaction<T>,
+        /// The transaction currently in progress.
+        ongoing: Option<Transaction<T>>,
+        /// We have received an `on_completed` event.
+        on_completed: bool,
+    },
+    /// A writer is present and we no longer need to buffer
+    /// transactions.
+    Writer(W),
+}
+
+impl<W, T> TxnBuf<W, T>
+where
+    W: Debug + Send + Write,
+    T: Debug + Send + Serialize,
+{
+    /// Convert the `TxnBuf` into the `Writer` variant.
+    ///
+    /// An error return indicates a failure to flush all buffered
+    /// transactions. The objects is in an undefined state afterwards.
+    pub fn set_mode_passthrough(&mut self, mut writer: W) -> Result<(), String> {
+        match self {
+            TxnBuf::Updates {
+                complete,
+                ongoing,
+                on_completed,
+            } => {
+                Self::handle_txn(&mut writer, replace(complete, LinkedList::new()))?;
+                Self::handle_partial_txn(&mut writer, ongoing.take())?;
+                if *on_completed {
+                    Self::handle_msg(&mut writer, &Message::<T>::Complete)?;
+                }
+                writer.flush().map_err(|e| e.to_string())?;
+                *self = TxnBuf::Writer(writer);
+                Ok(())
+            }
+            TxnBuf::Writer(..) => panic!("TxnBuf is already a Writer variant"),
+        }
+    }
+
+    /// Send a full transaction.
+    fn handle_txn(writer: &mut W, txn: Transaction<T>) -> Result<(), String> {
+        if !txn.is_empty() {
+            Self::handle_msg(writer, &Message::<T>::Start)?;
+            Self::handle_msg(writer, &Message::UpdateList(txn))?;
+            Self::handle_msg(writer, &Message::<T>::Commit)?;
+        }
+        Ok(())
+    }
+
+    /// Send a partial transaction.
+    fn handle_partial_txn(writer: &mut W, txn: Option<Transaction<T>>) -> Result<(), String> {
+        if let Some(updates) = txn {
+            // If there is a partial transaction that means that we
+            // received a transaction start and potentially updates, but
+            // no commit yet.
+            Self::handle_msg(writer, &Message::<T>::Start)?;
+            if !updates.is_empty() {
+                Self::handle_msg(writer, &Message::UpdateList(updates))?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Send a single message.
+    fn handle_msg(writer: &mut W, msg: &Message<T>) -> Result<(), String> {
+        serialize_into(writer, msg).map_err(|e| e.to_string())
+    }
+}
+
+impl<W, T> Default for TxnBuf<W, T>
+where
+    W: Debug,
+    T: Debug,
+{
+    fn default() -> Self {
+        TxnBuf::Updates {
+            complete: LinkedList::default(),
+            ongoing: None,
+            on_completed: false,
+        }
+    }
+}
+
+impl<W, T> Observer<T, String> for TxnBuf<W, T>
+where
+    W: Debug + Send + Write,
+    T: Debug + Send + Serialize,
+{
+    /// Perform some action before data starts coming in.
+    fn on_start(&mut self) -> Result<(), String> {
+        match self {
+            TxnBuf::Updates { ongoing, .. } => {
+                if ongoing.is_none() {
+                    *ongoing = Some(LinkedList::new());
+                } else {
+                    panic!("received multiple on_start events")
+                }
+            }
+            TxnBuf::Writer(writer) => Self::handle_msg(writer, &Message::<T>::Start)?,
+        }
+        Ok(())
+    }
+
+    /// Send a series of items over the TCP channel.
+    fn on_updates<'a>(&mut self, updates: Box<dyn Iterator<Item = T> + 'a>) -> Result<(), String> {
+        match self {
+            TxnBuf::Updates { ongoing, .. } => {
+                if let Some(transaction) = ongoing {
+                    transaction.push_back(updates.collect())
+                } else {
+                    panic!("on_updates was not preceded by an on_start event")
+                }
+            }
+            TxnBuf::Writer(writer) => {
+                Self::handle_msg(writer, &Message::Updates(updates.collect()))?
+            }
+        }
+        Ok(())
+    }
+
+    /// Flush the TCP stream and signal the commit.
+    fn on_commit(&mut self) -> Result<(), String> {
+        match self {
+            TxnBuf::Updates {
+                complete, ongoing, ..
+            } => {
+                if let Some(transaction) = ongoing {
+                    complete.append(transaction);
+                    *ongoing = None
+                } else {
+                    panic!("on_commit was not preceded by an on_start event")
+                }
+            }
+            TxnBuf::Writer(writer) => {
+                Self::handle_msg(writer, &Message::<T>::Commit)?;
+                writer.flush().map_err(|e| e.to_string())?
+            }
+        }
+        Ok(())
+    }
+
+    fn on_completed(&mut self) -> Result<(), String> {
+        match self {
+            TxnBuf::Updates { on_completed, .. } => *on_completed = true,
+            TxnBuf::Writer(writer) => {
+                Self::handle_msg(writer, &Message::<T>::Complete)?;
+                writer.flush().map_err(|e| e.to_string())?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use bincode::deserialize_from;
+
+    /// Test caching of transactions in a `TxnBuf`.
+    #[test]
+    fn transaction_caching() {
+        fn test<F>(expected: Vec<Message<u64>>, f: F)
+        where
+            F: FnOnce(&mut TxnBuf<Vec<u8>, u64>) -> Result<(), String>,
+        {
+            let mut buffer = TxnBuf::default();
+            f(&mut buffer).unwrap();
+            buffer.set_mode_passthrough(Vec::new()).unwrap();
+
+            match buffer {
+                TxnBuf::Writer(buf) => {
+                    let mut slice = buf.as_slice();
+                    for expected in expected {
+                        let msg = deserialize_from::<_, Message<u64>>(&mut slice).unwrap();
+                        assert_eq!(msg, expected);
+                    }
+
+                    // Make sure we did not have any additional messages
+                    // in the reader.
+                    let result = deserialize_from::<_, Message<u64>>(&mut slice);
+                    assert!(result.is_err(), result)
+                }
+                TxnBuf::Updates { .. } => unreachable!(),
+            }
+        }
+
+        test(vec![Message::Start], |buffer| buffer.on_start());
+
+        test(vec![], |buffer| {
+            buffer.on_start()?;
+            buffer.on_commit()?;
+            Ok(())
+        });
+
+        let updates = vec![vec![1, 2], vec![3], vec![4, 5, 6]]
+            .into_iter()
+            .collect();
+        let expected = vec![
+            Message::Start,
+            Message::UpdateList(updates),
+            Message::Commit,
+            Message::Start,
+        ];
+        test(expected, |buffer| {
+            buffer.on_start()?;
+            buffer.on_updates(Box::new(vec![1, 2].into_iter()))?;
+            buffer.on_updates(Box::new(vec![3].into_iter()))?;
+            buffer.on_commit()?;
+
+            buffer.on_start()?;
+            buffer.on_updates(Box::new(vec![4, 5, 6].into_iter()))?;
+            buffer.on_commit()?;
+
+            buffer.on_start()?;
+            Ok(())
+        });
+    }
+}

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -180,6 +180,7 @@ rustLibFiles specname =
         , (dir </> "distributed_datalog/src/tcp_channel/receiver.rs" , $(embedFile "rust/template/distributed_datalog/src/tcp_channel/receiver.rs"))
         , (dir </> "distributed_datalog/src/tcp_channel/sender.rs"   , $(embedFile "rust/template/distributed_datalog/src/tcp_channel/sender.rs"))
         , (dir </> "distributed_datalog/src/tcp_channel/socket.rs"   , $(embedFile "rust/template/distributed_datalog/src/tcp_channel/socket.rs"))
+        , (dir </> "distributed_datalog/src/tcp_channel/txnbuf.rs"   , $(embedFile "rust/template/distributed_datalog/src/tcp_channel/txnbuf.rs"))
         , (dir </> "distributed_datalog/src/test.rs"                 , $(embedFile "rust/template/distributed_datalog/src/test.rs"))
         , (dir </> "distributed_datalog/src/txnmux.rs"               , $(embedFile "rust/template/distributed_datalog/src/txnmux.rs"))
         , (dir </> "ovsdb/Cargo.toml"                                , $(embedFile "rust/template/ovsdb/Cargo.toml"))

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -179,6 +179,7 @@ rustLibFiles specname =
         , (dir </> "distributed_datalog/src/tcp_channel/mod.rs"      , $(embedFile "rust/template/distributed_datalog/src/tcp_channel/mod.rs"))
         , (dir </> "distributed_datalog/src/tcp_channel/receiver.rs" , $(embedFile "rust/template/distributed_datalog/src/tcp_channel/receiver.rs"))
         , (dir </> "distributed_datalog/src/tcp_channel/sender.rs"   , $(embedFile "rust/template/distributed_datalog/src/tcp_channel/sender.rs"))
+        , (dir </> "distributed_datalog/src/tcp_channel/socket.rs"   , $(embedFile "rust/template/distributed_datalog/src/tcp_channel/socket.rs"))
         , (dir </> "distributed_datalog/src/test.rs"                 , $(embedFile "rust/template/distributed_datalog/src/test.rs"))
         , (dir </> "distributed_datalog/src/txnmux.rs"               , $(embedFile "rust/template/distributed_datalog/src/txnmux.rs"))
         , (dir </> "ovsdb/Cargo.toml"                                , $(embedFile "rust/template/ovsdb/Cargo.toml"))

--- a/test/datalog_tests/server_api/tests/config.rs
+++ b/test/datalog_tests/server_api/tests/config.rs
@@ -102,17 +102,9 @@ fn instantiate_configuration_end_to_end() -> Result<(), String> {
     };
 
     let assignment = simple_assign(sys_cfg.keys(), members.iter()).unwrap();
-
-    // TODO: Because of TCP senders synchronously connecting to TCP
-    //       receivers we instantiate the nodes in "reverse", meaning
-    //       with the ones feeding the others first. That's only
-    //       possible while we don't have any loops in the
-    //       configuration. In the future we may want to make
-    //       `TcpSender` more clever and allowing it to buffer updates,
-    //       or something along those lines.
-    let _realization3 = instantiate::<HDDlog>(sys_cfg.clone(), &node3, &assignment).unwrap();
-    let _realization2 = instantiate::<HDDlog>(sys_cfg.clone(), &node2, &assignment).unwrap();
     let _realization1 = instantiate::<HDDlog>(sys_cfg.clone(), &node1, &assignment).unwrap();
+    let _realization2 = instantiate::<HDDlog>(sys_cfg.clone(), &node2, &assignment).unwrap();
+    let _realization3 = instantiate::<HDDlog>(sys_cfg.clone(), &node3, &assignment).unwrap();
 
     await_expected(move || {
         let mut string = String::new();

--- a/test/datalog_tests/server_api/tests/deltas.rs
+++ b/test/datalog_tests/server_api/tests/deltas.rs
@@ -104,7 +104,7 @@ fn single_delta_tcp() -> Result<(), String> {
         observer: SharedObserver<DDlogServer>,
     ) -> Result<Box<dyn Any>, String> {
         let mut recv = TcpReceiver::new("127.0.0.1:0").unwrap();
-        let send = TcpSender::connect(*recv.addr()).unwrap();
+        let send = TcpSender::new(*recv.addr()).unwrap();
 
         let _ = recv.subscribe(Box::new(observer)).unwrap();
         let _ = observable.subscribe(Box::new(send)).unwrap();
@@ -236,10 +236,10 @@ fn multi_transaction_tcp() -> Result<(), String> {
         let _ = mux.subscribe(Box::new(observer)).unwrap();
 
         let recv1 = TcpReceiver::new("127.0.0.1:0").unwrap();
-        let send1 = TcpSender::connect(*recv1.addr()).unwrap();
+        let send1 = TcpSender::new(*recv1.addr()).unwrap();
 
         let recv2 = TcpReceiver::new("127.0.0.1:0").unwrap();
-        let send2 = TcpSender::connect(*recv2.addr()).unwrap();
+        let send2 = TcpSender::new(*recv2.addr()).unwrap();
 
         let _ = observable1.subscribe(Box::new(send1)).unwrap();
         let _ = observable2.subscribe(Box::new(send2)).unwrap();

--- a/test/datalog_tests/server_api/tests/events.rs
+++ b/test/datalog_tests/server_api/tests/events.rs
@@ -293,7 +293,7 @@ fn setup_tcp() -> (DDlogServer, UpdatesObservable, MockObserver, Box<dyn Any>) {
     let mut stream = server.add_stream(hashset! {server_api_1_P1Out as usize});
 
     let mut recv = TcpReceiver::<Update<Value>>::new("127.0.0.1:0").unwrap();
-    let send = TcpSender::connect(*recv.addr()).unwrap();
+    let send = TcpSender::new(*recv.addr()).unwrap();
 
     let _ = stream.subscribe(Box::new(send)).unwrap();
     let _ = recv.subscribe(Box::new(observer.clone())).unwrap();


### PR DESCRIPTION
Make `TcpSender` buffer transactions until it connected

The code for instantiating a system or node configuration attempts to
create a `TcpSender` to feed output relations to a different node.
Currently the `TcpSender` creation is attempting to synchronously connect
to the desired address, which can be a long blocking operation. But even
if it returns quickly (e.g., in cases where the connection is refused
immediately), we retry for a certain duration -- again blocking the
caller.
Such blocking is undesired in any of these code paths, as it can easily
cause deadlocks (or at least a state where nobody can make progress
until a timeout is reached).
