### PR TITLE
Topic/fd misc

### DIFF
--- a/rust/template/distributed_datalog/src/tcp_channel/mod.rs
+++ b/rust/template/distributed_datalog/src/tcp_channel/mod.rs
@@ -8,3 +8,4 @@ mod txnbuf;
 
 pub use receiver::TcpReceiver;
 pub use sender::TcpSender;
+pub use socket::Fd;

--- a/rust/template/distributed_datalog/src/tcp_channel/receiver.rs
+++ b/rust/template/distributed_datalog/src/tcp_channel/receiver.rs
@@ -31,6 +31,7 @@ use crate::observe::ObserverBox;
 use crate::observe::SharedObserver;
 use crate::tcp_channel::message::Message;
 use crate::tcp_channel::socket::Fd;
+use crate::tcp_channel::socket::ShutdownExt;
 use crate::txnmux::TxnMux;
 
 /// A struct representing both an `Observer` and an `Observable` that

--- a/rust/template/distributed_datalog/src/tcp_channel/txnbuf.rs
+++ b/rust/template/distributed_datalog/src/tcp_channel/txnbuf.rs
@@ -231,12 +231,14 @@ mod tests {
             Message::UpdateList(updates),
             Message::Commit,
             Message::Start,
+            Message::Complete,
         ];
         test(expected, |buffer| {
             buffer.on_start()?;
             buffer.on_updates(Box::new(vec![1, 2].into_iter()))?;
             buffer.on_updates(Box::new(vec![3].into_iter()))?;
             buffer.on_commit()?;
+            buffer.on_completed()?;
 
             buffer.on_start()?;
             buffer.on_updates(Box::new(vec![4, 5, 6].into_iter()))?;


### PR DESCRIPTION
This pull request converges all modules in a single `Fd` struct. Previously we had more or less ad-hoc versions in the file source and the `TcpReceiver`, adding unnecessary complexity. Also, the "new" `Fd` struct (the one added most recently) no longer requires us to use `Mutex`es (which triples memory requirements and requires explicit locking).

It also takes care of fixing two bugs, one being the source of a hang in the `socket::cancel_no_accept` test and the other a double file descriptor close, causing sporadic failures in unrelated tests.