### PR TITLE
build_java.sh: skip `stack install` outside of DDlog repo.

### DIFF
--- a/java/build_java.sh
+++ b/java/build_java.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 # Shell script which generates a Java program from a DDlog program and compiles it
 
-stack install
+# Only run `stack install` if we are inside the DDlog source tree;
+# otherwise expect `ddlog` to already be in `$PATH`
+if test -f "../../stack.yaml"; then
+    stack install
+fi
+
 if command clang -v 2>/dev/null; then
     export CC=clang
 else


### PR DESCRIPTION
`build_java.sh` runs `stack install` to make sure that it uses an
up-to-date version of the compiler.  However this does not work outiside
of the DDlog source tree, e.g., when testing a binary release of DDlog.

The fix is to check that the `stack.yaml` file exists and skip the
`stack install` step if it doesn't.