### PR TITLE
Fix failure of multi_transaction_tcp test

### DIFF
--- a/test/datalog_tests/server_api/tests/deltas.rs
+++ b/test/datalog_tests/server_api/tests/deltas.rs
@@ -247,7 +247,7 @@ fn multi_transaction_tcp() -> Result<(), String> {
         let _ = mux.add_observable(Box::new(recv1)).unwrap();
         let _ = mux.add_observable(Box::new(recv2)).unwrap();
 
-        Ok(Box::new(mux))
+        Ok(Box::new((mux, observable1, observable2)))
     }
 
     multi_transaction_test(do_test)


### PR DESCRIPTION
In pipeline run [379937922][ci-379937922] we have seen a failure of the
`multi_transaction_tcp test`. Local reproduction seems to indicate that
the `TcpSender` could not connect because it was closed:
> [ERROR distributed_datalog::tcp_channel::sender] TcpSender(20): failed to connect to 127.0.0.1:38669: Transport endpoint is not connected (os error 107)

This message maps to `ENOTCONN` which is an error code we emit if the
socket is closed early. A closure really should only happen if it gets
dropped. Looking at the test it appears that we are moving the `TcpSender`
object into the passed in `UpdatesObservable`, but the `UpdatesObservable`
will get dropped shortly after, dropping the `TcpSender` in the process.

To fix this problem, this change passes out the `UpdatesObservable`
objects to extend their lifetime.
Without the patch the issue can be reproduced within a few minutes. With
the patch I haven't had a single reproduction of this failure in several
hours.

[ci-379937922]: https://gitlab.com/ddlog/differential-datalog-ryzhyk/-/jobs/379937922