### PR TITLE
.travis.yml: Bug in DIST_NAME logic.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,8 +93,8 @@ script:
 - if [ x${JAVA} = x1 ]; then stack install && cd java/test_flatbuf && ./run.sh; fi
 
 before_deploy:
-    - export DIST_NAME=ddlog-$TRAVIS_TAG-$(date +'%Y%m%d%H%M%S')-$OS_NAME
-    - ./build_distro.sh $TRAVIS_TAG
+    - export DIST_NAME=ddlog-$TRAVIS_TAG-$(date +'%Y%m%d%H%M%S')-$TRAVIS_OS_NAME
+    - ./build_distro.sh
 
 deploy:
   provider: releases

--- a/build_distro.sh
+++ b/build_distro.sh
@@ -5,24 +5,10 @@ set -xe
 echo Building DDlog distribution.
 echo IMPORTANT: this script must be run in a clean copy of the DDlog source tree.
 
-if [ `uname -s` = Darwin ]
-then OS_NAME=osx
-elif [ `uname -s` = Linux ]
-then OS_NAME=linux
-else
-    echo Unsupported OS `uname -s` 1>&2
-    exit 1
+if [ -z ${DIST_NAME} ]
+then
+    DIST_NAME=ddlog
 fi
-
-if [ $# -eq 0 ]
-  then
-      TAG=
-  else
-      TAG=$1-
-fi
-
-# add date and OS name to the tag
-export DIST_NAME=ddlog-$TAG$(date +'%Y%m%d%H%M%S')-$OS_NAME
 
 # Directory for distribution files.
 DIST_DIR=ddlog


### PR DESCRIPTION
The previous commit introduced a bug where the distribution archive
filename used by the Travis script did not match the one generated by
`build_distro.sh`.