### PR TITLE
Allow type annotations in patterns.

### DIFF
--- a/src/Language/DifferentialDatalog/Parse.hs
+++ b/src/Language/DifferentialDatalog/Parse.hs
@@ -487,7 +487,14 @@ evar = eVar <$> varIdent
 
 ematch = eMatch <$ reserved "match" <*> parens expr
                <*> (braces $ (commaSep1 $ (,) <$> pattern <* reservedOp "->" <*> expr))
-pattern = (withPos $
+
+{- Match pattern -}
+pattern = buildExpressionParser petable pterm
+      <?> "match pattern"
+
+petable = [[postf postType]]
+
+pterm = (withPos $
            eTuple   <$> (parens $ commaSep pattern)
        <|> eStruct  <$> consIdent <*> (option [] $ braces $ commaSep (namedpat <|> anonpat))
        <|> eVarDecl <$> varIdent
@@ -496,7 +503,7 @@ pattern = (withPos $
        <|> ebool
        <|> epattern_string
        <|> eint)
-      <?> "match pattern"
+      <?> "match term"
 
 anonpat = ("",) <$> pattern
 namedpat = (,) <$> (dot *> varIdent) <*> (reservedOp "=" *> pattern)
@@ -688,7 +695,7 @@ sbinary n fun = Infix $ (\l  r  -> E $ fun (fst $ pos l, snd $ pos r) l r) <$ re
 
 assign = Infix $ (\l r  -> E $ ESet (fst $ pos l, snd $ pos r) l r) <$ reservedOp "="
 
-{- F-expression (variable of field name) -}
+{- F-expression (variable or field name) -}
 fexpr =  buildExpressionParser fetable fterm
     <?> "column or field name"
 

--- a/test/datalog_tests/function.fail.ast.expected
+++ b/test/datalog_tests/function.fail.ast.expected
@@ -4,6 +4,13 @@ error: ./test/datalog_tests/function.fail.dl:13:13-14:1: Missing field f2 in con
 
 error: ./test/datalog_tests/function.fail.dl:11:17-11:18: Variable v already defined in this scope
 
+error: ./test/datalog_tests/function.fail.dl:11:17-11:24: Couldn't match expected type bit<32> with actual type bool (context: CtxTop
+CtxFunc            shadow
+CtxSeq2            ((var a: Alt) = C0{.x=1};  (var i: bit<32>) = match (a) {                         C0{.x=(var w: b...
+CtxSetR            (var i: bit<32>) = match (a) {                        C0{.x=(var w: bool)} -> w,                 ...
+CtxMatchPat        match (a) {     C0{.x=(var w: bool)} -> w,     C1{.x=var w} -> w } 0
+CtxStruct          C0{.x=(var w: bool)} x)
+
 error: ./test/datalog_tests/function.fail.dl:7:5-7:11: Variable v already defined in this scope
 
 error: ./test/datalog_tests/function.fail.dl:6:13-7:1: Access to guarded field "x"

--- a/test/datalog_tests/function.fail.dl
+++ b/test/datalog_tests/function.fail.dl
@@ -35,6 +35,21 @@ function shadow(v: string): () = {
 
 //---
 
+typedef Alt = C0{x: bit<32>}
+            | C1{x: bit<32>}
+
+// Invalid type annotation in pattern.
+function shadow(v: string): () = {
+    var a: Alt = C0{1};
+
+    var i: bit<32> = match (a) {
+        C0{.x = w: bool} -> w,
+        C1{w} -> w
+    }
+}
+
+//---
+
 // shadow local variable
 function shadow(): () = {
     var v: string = "bar";

--- a/test/datalog_tests/simple.ast.expected
+++ b/test/datalog_tests/simple.ast.expected
@@ -228,7 +228,7 @@ function f1 (x: T1, y: T2, q: T3): bool =
           C12{.f3=_, .f4=_} -> false
       };
       (match (y) {
-           C21{.f1=_, .f2=_} -> true,
+           (C21{.f1=(_: T1), .f2=_}: T2) -> true,
            C22{.f3=(_, C11{.f1=_, .f2=_})} -> true,
            _ -> false
        };
@@ -314,7 +314,7 @@ function patterns (): () =
                   C1{.x=_} -> false
               };
       (var i: bit<32>) = match (a) {
-                             C0{.x=var v} -> v,
+                             C0{.x=(var v: bit<32>)} -> v,
                              C1{.x=var v} -> v
                          }))
 extern function regex.regex_match (regex: string, str: string): bool
@@ -334,7 +334,7 @@ function shadow (): string =
     ((var b: std.Option<string>) = std.None{};
      (var a = std.Some{.x="foo"};
       match (a) {
-          std.Some{.x=var v} -> v,
+          std.Some{.x=(var v: string)} -> v,
           std.None{} -> ""
       }))
 function souffle_lib.castTo32 (i: bit<64>): souffle_types.Tnumber =

--- a/test/datalog_tests/simple.dl
+++ b/test/datalog_tests/simple.dl
@@ -159,7 +159,7 @@ function patterns(): () = {
     };
 
     var i: bit<32> = match (a) {
-        C0{.x = v} -> v,
+        C0{.x = var v: bit<32>} -> v,
         C1{v} -> v
     }
 }
@@ -168,7 +168,7 @@ function shadow(): string = {
     var b: Option<string> = None;
     var a = Some{"foo"};
     match (a) {
-        Some{v} -> v,
+        Some{v: string} -> v,
         None    -> ""
     }
 }
@@ -243,7 +243,7 @@ function f1(x: T1, y: T2, q: T3) : bool = {
     };
 
     match (y) {
-        C21{_,_}        -> true,
+        C21{_: T1,_}: T2-> true,
         C22{(_, C11{})} -> true,
         _               -> false
     };


### PR DESCRIPTION
These are now legal:

```
var i: bit<32> = match (a) {
    C0{.x = var v: bit<32>} -> v,
    C1{v} -> v
}
```

```
match (a) {
    Some{v: string} -> v,
    None    -> ""
}
```