### PR TITLE
Allow assignments in the RHS of an assignment.

### DIFF
--- a/src/Language/DifferentialDatalog/NS.hs
+++ b/src/Language/DifferentialDatalog/NS.hs
@@ -175,7 +175,7 @@ ctxMVars d ctx =
                                        in (plvars_not_iter, prvars_not_iter ++ [loopvar])
          CtxForBody _ _           -> error $ "NS.ctxMVars: invalid context " ++ show ctx
          CtxSetL _ _              -> (plvars, prvars)
-         CtxSetR _ _              -> ([], plvars ++ prvars)
+         CtxSetR _ _              -> (plvars, prvars)
          CtxBinOpL _ _            -> ([], plvars ++ prvars)
          CtxBinOpR _ _            -> ([], plvars ++ prvars)
          CtxUnOp _ _              -> ([], plvars ++ prvars)

--- a/test/datalog_tests/simple.ast.expected
+++ b/test/datalog_tests/simple.ast.expected
@@ -110,6 +110,9 @@ typedef Table2 = Table2{name: string, f2: bigint, f3: S}
 typedef Tnumber = bit<32>
 typedef ToAllocate = ToAllocate{name: string, ids: std.Vec<string>}
 typedef Tsymbol = intern.IString
+typedef Tt1 = Tt1{column1: signed<64>, column2: string, column3: bool}
+typedef Tt2 = Tt2{column1: signed<64>}
+typedef Ttmp0 = Ttmp0{col4: signed<64>}
 typedef Ttxt = intern.IString
 typedef UMinus_bigint = UMinus_bigint{description: string, n: bigint}
 typedef UMinus_s32 = UMinus_s32{description: string, n: signed<32>}
@@ -200,6 +203,19 @@ function a8 (): bit<32> =
     (((32'd125 | 32'd255) | 32'd511) | 32'd683)
 function a9 (): bit<32> =
     (((32'd125 | 32'd255) | 32'd511) | 32'd683)
+function agg1 (g1: std.Group<Tt1>): Ttmp0 =
+    (var first3 = true;
+     (var max5 = 64'sd0;
+      (for (i2 in g1) {
+           (var v0 = i2;
+            max5 = if first3 {
+                       v0.column1
+                   } else {
+                         (first3 = false;
+                          64'sd0)
+                     })
+       };
+       Ttmp0{.col4=max5})))
 extern function allocate.adjust_allocation (allocated: std.Map<'A,'N>, toallocate: std.Vec<'A>, min_val: 'N, max_val: 'N): std.Vec<('A, 'N)>
 extern function allocate.allocate (allocated: std.Set<'N>, toallocate: std.Vec<'B>, min_val: 'N, max_val: 'N): std.Vec<('B, 'N)>
 extern function allocate.allocate_opt (allocated: std.Set<'N>, toallocate: std.Vec<'B>, min_val: 'N, max_val: 'N): std.Vec<('B, std.Option<'N>)>

--- a/test/datalog_tests/simple.dl
+++ b/test/datalog_tests/simple.dl
@@ -1091,3 +1091,20 @@ LongJoin(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x
     Long(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19),
     Long(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19),
     Long(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19).
+
+typedef Tt1 = Tt1{column1:signed<64>, column2:string, column3:bool}
+typedef Tt2 = Tt2{column1:signed<64>}
+typedef Ttmp0 = Ttmp0{col4:signed<64>}
+function agg1(g1: Group<(Tt1)>):Ttmp0 =
+    var first3 = true;
+    (var max5 = 64'sd0);
+    (for (i2 in g1) {
+        var v0 = i2;
+        (max5 = if first3 {
+            v0.column1
+        } else {
+            first3 = false;
+            0
+        })
+    });
+    (Ttmp0{.col4 = max5})


### PR DESCRIPTION
This used to be illegal in the past:

```
var x: bit<32> = 0;
var y = {
    x = 1;
    true
}
```

There did not seem to be a good reason for this restriction other than
general hygiene, but since DDlog is expression-oriented, one advantage
of which is the ability to write complex expressions in the RHS of
assignment, we lift this restriction.

This resolves #496.