### PR TITLE
Antrea

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -209,6 +209,15 @@ test-ovn-northd:
         - git clone https://github.com/ddlog-dev/ovn-test-data.git
         - ./test-ovn.sh
 
+# Test antrea
+test-antrea:
+    extends: .install-ddlog
+    tags:
+        - ddlog-ci-1
+    script:
+        - cd test/antrea
+        - ../datalog_tests/run-test.sh networkpolicy_controller.dl release
+
 # Test the SQL-to-DDlog compiler.
 test-sql:
     extends: .install-ddlog

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Build Status](https://travis-ci.com/vmware/differential-datalog.svg?branch=master)](https://travis-ci.com/vmware/differential-datalog)
 [![pipeline status](https://gitlab.com/ddlog/differential-datalog/badges/master/pipeline.svg)](https://gitlab.com/ddlog/differential-datalog/commits/master)
-[![rustc](https://img.shields.io/badge/rustc-1.36+-blue.svg)](https://blog.rust-lang.org/2019/07/04/Rust-1.36.0.html)
+[![rustc](https://img.shields.io/badge/rustc-1.39+-blue.svg)](https://blog.rust-lang.org/2019/11/07/Rust-1.39.0.html)
 
 # Differential Datalog (DDlog)
 
@@ -89,7 +89,7 @@ To download `stack` (if you don't already have it) use:
 wget -qO- https://get.haskellstack.org/ | sh
 ```
 
-You will also need to install the Rust toolchain v1.36 or later:
+You will also need to install the Rust toolchain v1.39 or later:
 
 ```
 curl https://sh.rustup.rs -sSf | sh

--- a/lib/std.dl
+++ b/lib/std.dl
@@ -46,11 +46,45 @@ function is_some(x: Option<'A>): bool = {
     }
 }
 
+function option_unwrap_or(x: Option<'A>, def: 'A): 'A = {
+    match (x) {
+        Some{v} -> v,
+        None -> def
+    }
+}
+
 /*
  * Either
  */
 typedef Either<'A,'B> = Left{l: 'A}
                       | Right{r: 'B}
+
+/*
+ * Result
+ */
+typedef Result<'V,'E> = Ok{res: 'V}
+                      | Err{err: 'E}
+
+function is_ok(res: Result<'V,'E>): bool = {
+    match (res) {
+        Ok{} -> true,
+        Err{} -> false
+    }
+}
+
+function is_err(res: Result<'V,'E>): bool = {
+    match (res) {
+        Ok{} -> false,
+        Err{} -> true
+    }
+}
+
+function result_unwrap_or(res: Result<'V,'E>, def: 'V): 'V = {
+    match (res) {
+        Ok{v} -> v,
+        Err{} -> def
+    }
+} 
 
 /*
  * Range
@@ -137,9 +171,11 @@ extern function group_max(g: Group<'A>): 'A
 extern type Vec<'A>
 
 extern function vec_empty(): Vec<'A>
+extern function vec_with_length(len: bit<64>, x: 'A): Vec<'A>
 extern function vec_len(v: Vec<'X>): bit<64>
 extern function vec_singleton(x: 'X): Vec<'X>
 extern function vec_push(v: mut Vec<'X>, x: 'X): ()
+extern function vec_append(v: mut Vec<'X>, other: Vec<'X>): ()
 extern function vec_push_imm(v: Vec<'X>, x: 'X): Vec<'X>
 extern function vec_contains(v: Vec<'X>, x: 'X): bool
 extern function vec_is_empty(v: Vec<'X>): bool

--- a/lib/std.rs
+++ b/lib/std.rs
@@ -174,6 +174,9 @@ impl<T: Clone> std_Vec<T> {
     pub fn extend_from_slice(&mut self, other: &[T]) {
         self.x.extend_from_slice(other);
     }
+    pub fn resize(&mut self, new_len: usize, value: T) {
+        self.x.resize(new_len, value);
+    }
 }
 
 impl<T: FromRecord> FromRecord for std_Vec<T> {
@@ -284,8 +287,18 @@ pub fn std_vec_empty<X: Ord + Clone>() -> std_Vec<X> {
     std_Vec::new()
 }
 
+pub fn std_vec_with_length<X: Ord + Clone>(len: &u64, x: &X) -> std_Vec<X> {
+    let mut res = std_Vec::with_capacity(*len as usize);
+    res.resize(*len as usize, x.clone());
+    res
+}
+
 pub fn std_vec_singleton<X: Ord + Clone>(x: &X) -> std_Vec<X> {
     std_Vec { x: vec![x.clone()] }
+}
+
+pub fn std_vec_append<X: Ord + Clone>(v: &mut std_Vec<X>, other: &std_Vec<X>) {
+    v.extend_from_slice(other.x.as_slice());
 }
 
 pub fn std_vec_push<X: Ord + Clone>(v: &mut std_Vec<X>, x: &X) {

--- a/rust/template/differential_datalog/record.rs
+++ b/rust/template/differential_datalog/record.rs
@@ -1185,7 +1185,7 @@ macro_rules! decl_arr_from_record {
             fn into_record(self) -> Record {
                 Record::Array(
                     CollectionKind::Vector,
-                    self.into_iter()
+                    self.iter()
                         .map(|x: &T| (*x).clone().into_record())
                         .collect(),
                 )

--- a/rust/template/distributed_datalog/src/lib.rs
+++ b/rust/template/distributed_datalog/src/lib.rs
@@ -16,7 +16,6 @@
     overflowing_literals,
     path_statements,
     patterns_in_fns_without_body,
-    plugin_as_library,
     private_in_public,
     proc_macro_derive_resolution_fallback,
     renamed_and_removed_lints,

--- a/src/Language/DifferentialDatalog/ECtx.hs
+++ b/src/Language/DifferentialDatalog/ECtx.hs
@@ -46,7 +46,10 @@ module Language.DifferentialDatalog.ECtx(
      ctxInRuleRHSPattern,
      ctxIsIndex,
      ctxInIndex,
-     ctxIsFunc)
+     ctxIsFunc,
+     ctxInFunc,
+     ctxIsForLoopBody,
+     ctxInForLoopBody)
 where
 
 import Data.Maybe
@@ -143,3 +146,17 @@ ctxInRuleRHSPattern _                     = False
 ctxIsFunc :: ECtx -> Bool
 ctxIsFunc CtxFunc{} = True
 ctxIsFunc _         = False
+
+-- | Returns the function that the context belongs to or 'Nothing'
+-- if 'ctx' is outside the body of a function.
+ctxInFunc :: ECtx -> Maybe Function
+ctxInFunc (CtxFunc f) = Just f
+ctxInFunc CtxTop      = Nothing
+ctxInFunc ctx         = ctxInFunc (ctxParent ctx)
+
+ctxIsForLoopBody :: ECtx -> Bool
+ctxIsForLoopBody CtxForBody{} = True
+ctxIsForLoopBody _            = False
+
+ctxInForLoopBody :: ECtx -> Bool
+ctxInForLoopBody ctx = any ctxIsForLoopBody $ ctxAncestors ctx

--- a/src/Language/DifferentialDatalog/Module.hs
+++ b/src/Language/DifferentialDatalog/Module.hs
@@ -29,6 +29,9 @@ Description: DDlog's module system implemented as syntactic sugar over core synt
 {-# LANGUAGE RecordWildCards, FlexibleContexts, TupleSections, LambdaCase, OverloadedStrings #-}
 
 module Language.DifferentialDatalog.Module(
+    nameScope,
+    nameLocal,
+    scoped,
     parseDatalogProgram) where
 
 import Prelude hiding((<>), mod, readFile, writeFile)

--- a/src/Language/DifferentialDatalog/NS.hs
+++ b/src/Language/DifferentialDatalog/NS.hs
@@ -176,6 +176,7 @@ ctxMVars d ctx =
          CtxForBody _ _           -> error $ "NS.ctxMVars: invalid context " ++ show ctx
          CtxSetL _ _              -> (plvars, prvars)
          CtxSetR _ _              -> (plvars, prvars)
+         CtxReturn _ _            -> (plvars, prvars)
          CtxBinOpL _ _            -> ([], plvars ++ prvars)
          CtxBinOpR _ _            -> ([], plvars ++ prvars)
          CtxUnOp _ _              -> ([], plvars ++ prvars)

--- a/src/Language/DifferentialDatalog/NS.hs
+++ b/src/Language/DifferentialDatalog/NS.hs
@@ -168,11 +168,11 @@ ctxMVars d ctx =
          CtxITEElse _ _           -> (plvars, prvars)
          CtxForIter _ _           -> (plvars, prvars)
          CtxForBody e@EFor{..} pctx -> let loopvar = (exprLoopVar, typeIterType d =<< exprTypeMaybe d (CtxForIter e pctx) exprIter)
-                                           -- variables that occur in the iterator expression are not
-                                           -- accessible inside the loop
+                                           -- variables that occur in the iterator expression cannot
+                                           -- be modified inside the loop
                                            plvars_not_iter = filter (\(v,_) -> notElem v $ exprVars exprIter) plvars
-                                           prvars_not_iter = filter (\(v,_) -> notElem v $ exprVars exprIter) prvars
-                                       in (plvars_not_iter, prvars_not_iter ++ [loopvar])
+                                           plvars_iter = filter (\(v,_) -> elem v $ exprVars exprIter) plvars
+                                       in (plvars_not_iter, prvars ++ plvars_iter ++ [loopvar])
          CtxForBody _ _           -> error $ "NS.ctxMVars: invalid context " ++ show ctx
          CtxSetL _ _              -> (plvars, prvars)
          CtxSetR _ _              -> (plvars, prvars)

--- a/src/Language/DifferentialDatalog/Parse.hs
+++ b/src/Language/DifferentialDatalog/Parse.hs
@@ -71,6 +71,8 @@ reservedNames = ["as",
                  "and",
                  "bit",
                  "bool",
+                 "break",
+                 "continue",
                  "default",
                  "extern",
                  "else",
@@ -87,6 +89,7 @@ reservedNames = ["as",
                  "not",
                  "or",
                  "relation",
+                 "return",
                  "signed",
                  "skip",
                  "string",
@@ -473,6 +476,13 @@ term' = withPos $
      <|> eite
      <|> efor
      <|> evardcl
+     <|> econtinue
+     <|> ebreak
+     <|> ereturn
+
+econtinue = eContinue <$ reserved "continue"
+ebreak    = eBreak <$ reserved "break"
+ereturn   = eReturn <$ reserved "return" <*> option (eTuple []) expr
 
 eapply = eApply <$ isapply <*> funcIdent <*> (parens $ commaSep expr)
     where isapply = try $ lookAhead $ do

--- a/src/Language/DifferentialDatalog/Type.hs
+++ b/src/Language/DifferentialDatalog/Type.hs
@@ -312,6 +312,9 @@ exprNodeType' _ ctx (EITE p _ Nothing e)  = mtype2me p ctx e
 exprNodeType' _ _   (EITE _ _ (Just t) _) = return t
 exprNodeType' _ _   (EFor _ _ _ _)        = return $ tTuple []
 exprNodeType' _ _   (ESet _ _ _)          = return $ tTuple []
+exprNodeType' d ctx (EContinue _)         = return $ maybe (tTuple []) id (ctxExpectType d ctx)
+exprNodeType' d ctx (EBreak _)            = return $ maybe (tTuple []) id (ctxExpectType d ctx)
+exprNodeType' d ctx (EReturn _ _)         = return $ maybe (tTuple []) id (ctxExpectType d ctx)
 
 exprNodeType' d _   (EBinOp _ op (Just e1) (Just e2)) =
     case op of
@@ -559,6 +562,9 @@ ctxExpectType _ (CtxForBody _ _)                     = Just $ tTuple []
 ctxExpectType d (CtxSetL e@(ESet _ _ rhs) ctx)       = exprTypeMaybe d (CtxSetR e ctx) rhs
 ctxExpectType d (CtxSetR (ESet _ lhs _) ctx)         = -- avoid infinite recursion by evaluating lhs standalone
                                                        exprTypeMaybe d (CtxSeq1 (ESeq nopos lhs (error "ctxExpectType: should be unreachable")) ctx) lhs
+ctxExpectType _ (CtxReturn _ ctx)                    = case ctxInFunc ctx of
+                                                            Just f  -> Just $ funcType f
+                                                            Nothing -> Nothing
 ctxExpectType d (CtxBinOpL e ctx)                    =
     case exprBOp e of
          Eq     -> trhs

--- a/src/Language/DifferentialDatalog/Type.hs
+++ b/src/Language/DifferentialDatalog/Type.hs
@@ -46,6 +46,7 @@ module Language.DifferentialDatalog.Type(
     typeConsTree,
     consTreeAbduct,
     typeMapM,
+    typeMap,
     funcTypeArgSubsts,
     funcGroupArgTypes,
     sET_TYPES,
@@ -60,6 +61,7 @@ module Language.DifferentialDatalog.Type(
 import Data.Maybe
 import Data.List
 import Control.Monad.Except
+import Control.Monad.Identity
 import qualified Data.Map as M
 --import Debug.Trace
 
@@ -749,6 +751,9 @@ typeMapM fun t@TVar{}      = fun t
 typeMapM fun t@TOpaque{..} = do
     args <- mapM (typeMapM fun) typeArgs
     fun $ t { typeArgs = args }
+
+typeMap :: (Type -> Type) -> Type -> Type
+typeMap f t = runIdentity $ typeMapM (return . f) t
 
 typeIterType :: DatalogProgram -> Type -> Maybe Type
 typeIterType d t =

--- a/src/Language/DifferentialDatalog/Validate.hs
+++ b/src/Language/DifferentialDatalog/Validate.hs
@@ -544,6 +544,9 @@ exprValidate1 _ _ _   ESeq{}              = return ()
 exprValidate1 _ _ _   EITE{}              = return ()
 exprValidate1 d _ ctx EFor{..}            = checkNoVar exprPos d ctx exprLoopVar
 exprValidate1 d _ ctx (ESet _ l _)        = checkLExpr d ctx l
+exprValidate1 _ _ ctx (EContinue p)       = check (ctxInForLoopBody ctx) p "\"continue\" outside of a loop"
+exprValidate1 _ _ ctx (EBreak p)          = check (ctxInForLoopBody ctx) p "\"break\" outside of a loop"
+exprValidate1 _ _ ctx (EReturn p _)       = check (isJust $ ctxInFunc ctx) p "\"return\" outside of a function body"
 exprValidate1 _ _ _   EBinOp{}            = return ()
 exprValidate1 _ _ _   EUnOp{}             = return ()
 

--- a/src/Language/DifferentialDatalog/Validate.hs
+++ b/src/Language/DifferentialDatalog/Validate.hs
@@ -47,6 +47,7 @@ import Language.DifferentialDatalog.Expr
 import Language.DifferentialDatalog.DatalogProgram
 import {-# SOURCE #-} Language.DifferentialDatalog.Rule
 import Language.DifferentialDatalog.Relation
+import Language.DifferentialDatalog.Module
 
 bUILTIN_2STRING_FUNC :: String
 bUILTIN_2STRING_FUNC = "std.__builtin_2string"
@@ -724,7 +725,9 @@ exprInjectStringConversions d ctx e@(EBinOp p Concat l r) | (te == tString) && (
     return $ E $ EBinOp p Concat l r'
     where te = exprType'' d ctx $ E e
           tr = exprType'' d (CtxBinOpR e ctx) r
-          mk2string_func cs = ((toLower $ head cs) : tail cs) ++ tOSTRING_FUNC_SUFFIX
+          mk2string_func cs = scoped scope $ ((toLower $ head local) : tail local) ++ tOSTRING_FUNC_SUFFIX
+              where scope = nameScope cs
+                    local = nameLocal cs
 
 exprInjectStringConversions _ _   e = return $ E e
 

--- a/test/antrea/k8spolicy.dl
+++ b/test/antrea/k8spolicy.dl
@@ -1,0 +1,347 @@
+/*
+ * Inputs consumed by Antrea controller from Kuberneters: pods, namespaces,
+ * network policies.
+ */
+
+// TODO(leonid): this module should probably be broken up into several to match Go module hierachy.
+
+import intern
+
+typedef UID = UID{uid: string}
+
+// PodSpec is a description of a pod.
+typedef PodSpec = PodSpec {
+    // NodeName is a request to schedule this pod onto a specific node. If it is non-empty,
+    // the scheduler simply schedules this pod onto that node, assuming that it fits resource
+    // requirements.
+    nodeName: string
+}
+
+// PodStatus represents information about the status of a pod. Status may trail the actual
+// state of a system, especially if the node that hosts the pod cannot contact the control
+// plane.
+typedef PodStatus = PodStatus {
+    // IP address allocated to the pod. Routable at least within the cluster.
+    // Empty if not yet allocated.
+    podIP: string
+}
+
+// Pod is a collection of containers that can run on a host. This resource is created
+// by clients and scheduled onto hosts. */
+// TODO(leonid): primary key
+input relation Pod (
+    // Name must be unique within a namespace.
+    name: Option<string>,
+    // Namespace defines the space within each name must be unique.
+    namespace: Option<string>,
+    // UID is the unique in time and space value for this object.
+    uid: UID,
+    // Map of string keys and values that can be used to organize and categorize
+    // (scope and select) objects. May match selectors of replication controllers
+    // and services.
+    // More info: http://kubernetes.io/docs/user-guide/labels
+    // +optional
+    labels: Map<string, string>,
+    // Specification of the desired behavior of the pod.
+    spec: PodSpec,
+    // Most recently observed status of the pod.
+    status: PodStatus
+)
+
+// Namespace provides a scope for Names.
+// Use of multiple namespaces is optional.
+input relation Namespace (
+    // Name must be unique within a namespace.
+    name: string,
+    // UID is the unique in time and space value for this object.
+    uid: UID,
+    // Map of string keys and values that can be used to organize and categorize
+    // (scope and select) objects. May match selectors of replication controllers
+    // and services.
+    // More info: http://kubernetes.io/docs/user-guide/labels
+    // +optional
+    labels: Map<string, string>
+)
+
+// A label selector is a label query over a set of resources. The result of matchLabels and
+// matchExpressions are ANDed. An empty label selector matches all objects. A null
+// label selector matches no objects.
+typedef LabelSelector = LabelSelector {
+    // matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+    // map is equivalent to an element of matchExpressions, whose key field is "key", the
+    // operator is "In", and the values array contains only "value". The requirements are ANDed.
+    // +optional
+    matchLabels: Map<string,string>,
+    // matchExpressions is a list of label selector requirements. The requirements are ANDed.
+    // +optional
+    matchExpressions: Vec<LabelSelectorRequirement>
+}
+
+/* The native Antrea implementation converts LabelSelector to a generic selector
+ * struct before . */
+// Matches returns true if the Requirement matches the input Labels.
+// There is a match in the following cases:
+// (1) The operator is Exists and Labels has the Requirement's key.
+// (2) The operator is In, Labels has the Requirement's key and Labels'
+//     value for that key is in Requirement's value set.
+// (3) The operator is NotIn, Labels has the Requirement's key and
+//     Labels' value for that key is not in Requirement's value set.
+// (4) The operator is DoesNotExist or NotIn and Labels does not have the
+//     Requirement's key.
+function labelSelectorMatches(selector: Option<Ref<LabelSelector>>, labels: Map<string, string>): bool =
+{
+    match (selector) {
+        None -> false,
+        Some{s} -> {
+            var sel = deref(s);
+            if (map_is_empty(sel.matchLabels) and vec_is_empty(sel.matchExpressions)) {
+                true
+            } else {
+                for (lab in sel.matchLabels) {
+                    if (map_get(labels, lab.0) != Some{lab.1}) { return false }
+                };
+                for (e in sel.matchExpressions) {
+                    var matches = match (e.operator) {
+                        LabelSelectorOpIn -> {
+                            match (map_get(labels, e.reqkey)) {
+                                None -> false,
+                                Some{val} -> vec_contains(e.values, val)
+                            }
+                        },
+                        LabelSelectorOpNotIn -> {
+                            match (map_get(labels, e.reqkey)) {
+                                None -> true,
+                                Some{val} -> not vec_contains(e.values, val)
+                            }
+                        },
+                        LabelSelectorOpExists -> map_contains_key(labels, e.reqkey),
+                        LabelSelectorOpDoesNotExist -> not map_contains_key(labels, e.reqkey)
+                    };
+                    if (not matches) { return false }
+                };
+                true
+            }
+        }
+    }
+}
+
+// A label selector operator is the set of operators that can be used in a selector requirement.
+typedef LabelSelectorOperator = LabelSelectorOpIn
+                              | LabelSelectorOpNotIn
+                              | LabelSelectorOpExists
+                              | LabelSelectorOpDoesNotExist
+
+// DDlog looks for a function with this name when converting
+// LabelSelectorOperator to string.
+function labelSelectorOperator2string(op: LabelSelectorOperator): string =
+{
+    match (op) {
+        LabelSelectorOpIn           -> "In",
+        LabelSelectorOpNotIn        -> "NotIn",
+        LabelSelectorOpExists       -> "Exists",
+        LabelSelectorOpDoesNotExist -> "DoesNotExist"
+    }
+}
+
+// A label selector requirement is a selector that contains values, a key, and an operator that
+// relates the key and values.
+typedef LabelSelectorRequirement = LabelSelectorRequirement {
+    // key is the label key that the selector applies to.
+    // +patchMergeKey=key
+    // +patchStrategy=merge
+    reqkey: string,
+    // operator represents a key's relationship to a set of values.
+    // Valid operators are In, NotIn, Exists and DoesNotExist.
+    operator: LabelSelectorOperator,
+    // values is an array of string values. If the operator is In or NotIn,
+    // the values array must be non-empty. If the operator is Exists or DoesNotExist,
+    // the values array must be empty. This array is replaced during a strategic
+    // merge patch.
+    // +optional
+    values: Vec<string>
+}
+
+typedef PolicyType = PolicyTypeIngress
+                   | PolicyTypeEgress
+
+// NetworkPolicySpec provides the specification of a NetworkPolicy
+typedef NetworkPolicySpec = NetworkPolicySpec {
+    // Selects the pods to which this NetworkPolicy object applies. The array of
+    // ingress rules is applied to any pods selected by this field. Multiple network
+    // policies can select the same set of pods. In this case, the ingress rules for
+    // each are combined additively. This field is NOT optional and follows standard
+    // label selector semantics. An empty podSelector matches all pods in this
+    // namespace.
+    podSelector: Ref<LabelSelector>,
+
+    // List of ingress rules to be applied to the selected pods. Traffic is allowed to
+    // a pod if there are no NetworkPolicies selecting the pod
+    // (and cluster policy otherwise allows the traffic), OR if the traffic source is
+    // the pod's local node, OR if the traffic matches at least one ingress rule
+    // across all of the NetworkPolicy objects whose podSelector matches the pod. If
+    // this field is empty then this NetworkPolicy does not allow any traffic (and serves
+    // solely to ensure that the pods it selects are isolated by default)
+    // +optional
+    ingress: Vec<NetworkPolicyIngressRule>,
+
+    // List of egress rules to be applied to the selected pods. Outgoing traffic is
+    // allowed if there are no NetworkPolicies selecting the pod (and cluster policy
+    // otherwise allows the traffic), OR if the traffic matches at least one egress rule
+    // across all of the NetworkPolicy objects whose podSelector matches the pod. If
+    // this field is empty then this NetworkPolicy limits all outgoing traffic (and serves
+    // solely to ensure that the pods it selects are isolated by default).
+    // This field is beta-level in 1.8
+    // +optional
+    egress: Vec<NetworkPolicyEgressRule>,
+
+    // List of rule types that the NetworkPolicy relates to.
+    // Valid options are "Ingress", "Egress", or "Ingress,Egress".
+    // If this field is not specified, it will default based on the existence of Ingress or Egress rules;
+    // policies that contain an Egress section are assumed to affect Egress, and all policies
+    // (whether or not they contain an Ingress section) are assumed to affect Ingress.
+    // If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ].
+    // Likewise, if you want to write a policy that specifies that no egress is allowed,
+    // you must specify a policyTypes value that include "Egress" (since such a policy would not include
+    // an Egress section and would otherwise default to just [ "Ingress" ]).
+    // This field is beta-level in 1.8
+    // +optional
+    policyTypes: Vec<PolicyType>
+}
+
+// NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods
+// matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+typedef NetworkPolicyIngressRule = NetworkPolicyIngressRule {
+    // List of ports which should be made accessible on the pods selected for this
+    // rule. Each item in this list is combined using a logical OR. If this field is
+    // empty or missing, this rule matches all ports (traffic not restricted by port).
+    // If this field is present and contains at least one item, then this rule allows
+    // traffic only if the traffic matches at least one port in the list.
+    // +optional
+    ports: Vec<NetworkPolicyPort>,
+
+    // List of sources which should be able to access the pods selected for this rule.
+    // Items in this list are combined using a logical OR operation. If this field is
+    // empty or missing, this rule matches all sources (traffic not restricted by
+    // source). If this field is present and contains at least on item, this rule
+    // allows traffic only if the traffic matches at least one item in the from list.
+    // +optional
+    from: Vec<NetworkPolicyPeer>
+}
+
+// NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+// matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+// This type is beta-level in 1.8
+typedef NetworkPolicyEgressRule = NetworkPolicyEgressRule {
+    // List of destination ports for outgoing traffic.
+    // Each item in this list is combined using a logical OR. If this field is
+    // empty or missing, this rule matches all ports (traffic not restricted by port).
+    // If this field is present and contains at least one item, then this rule allows
+    // traffic only if the traffic matches at least one port in the list.
+    // +optional
+    ports: Vec<NetworkPolicyPort>,
+    // List of destinations for outgoing traffic of pods selected for this rule.
+    // Items in this list are combined using a logical OR operation. If this field is
+    // empty or missing, this rule matches all destinations (traffic not restricted by
+    // destination). If this field is present and contains at least one item, this rule
+    // allows traffic only if the traffic matches at least one item in the to list.
+    // +optional
+    to: Vec<NetworkPolicyPeer>
+}
+
+// NetworkPolicy describes what network traffic is allowed for a set of Pods
+input relation NetworkPolicy (
+    // Name must be unique within a namespace.
+    name: string,
+    // Namespace defines the space within each name must be unique.
+    namespace: string,
+    // UID is the unique in time and space value for this object.
+    uid: UID,
+    // Specification of the desired behavior for this NetworkPolicy.
+    spec: NetworkPolicySpec
+)
+
+
+typedef Protocol = IString
+
+typedef IntOrString = Either<signed<32>, string>
+
+function intOrStringIntValue(x: IntOrString): signed<32> =
+{
+    match (x) {
+        Left{i} -> i,
+        Right{s} -> {
+            match (parse_dec_i64(s)) {
+                None -> 0,
+                Some{i} -> i as signed<32>
+            }
+        }
+    }
+}
+
+// NetworkPolicyPort describes a port to allow traffic on
+typedef NetworkPolicyPort = NetworkPolicyPort {
+    // The protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this
+    // field defaults to TCP.
+    // +optional
+    protocol: Option<Protocol>,
+
+    // The port on the given protocol. This can either be a numerical or named port on
+    // a pod. If this field is not provided, this matches all port names and numbers.
+    // +optional
+    port: Option<IntOrString>
+}
+
+// IPBlock describes a particular CIDR (Ex. "192.168.1.1/24") that is allowed to the pods
+// matched by a NetworkPolicySpec's podSelector. The except entry describes CIDRs that should
+// not be included within this rule.
+typedef IPBlock = IPBlock {
+    // CIDR is a string representing the IP Block
+    // Valid examples are "192.168.1.1/24"
+    cidr: string,
+    // Except is a slice of CIDRs that should not be included within an IP Block
+    // Valid examples are "192.168.1.1/24"
+    // Except values will be rejected if they are outside the CIDR range
+    // +optional
+    except: Vec<string>
+}
+
+function iPBlock2string(x: IPBlock): string =
+{
+    "IPBlock{${x.cidr},${string_join(x.except,\",\")}}"
+}
+
+
+// NetworkPolicyPeer describes a peer to allow traffic from. Only certain combinations of
+// fields are allowed
+typedef NetworkPolicyPeer = NetworkPolicyPeer {
+    // This is a label selector which selects Pods. This field follows standard label
+    // selector semantics; if present but empty, it selects all pods.
+    //
+    // If NamespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+    // the Pods matching PodSelector in the Namespaces selected by NamespaceSelector.
+    // Otherwise it selects the Pods matching PodSelector in the policy's own Namespace.
+    // +optional
+    podSelector: Option<Ref<LabelSelector>>,
+
+    // Selects Namespaces using cluster-scoped labels. This field follows standard label
+    // selector semantics; if present but empty, it selects all namespaces.
+    //
+    // If PodSelector is also set, then the NetworkPolicyPeer as a whole selects
+    // the Pods matching PodSelector in the Namespaces selected by NamespaceSelector.
+    // Otherwise it selects all Pods in the Namespaces selected by NamespaceSelector.
+    // +optional
+    namespaceSelector: Option<Ref<LabelSelector>>,
+
+    // IPBlock defines policy on a particular IPBlock. If this field is set then
+    // neither of the other fields can be.
+    // +optional
+    ipBlock: Option<IPBlock>
+}
+
+// PodReference represents a Pod Reference.
+typedef PodReference = PodReference {
+    // The name of this pod.
+    name: string,
+    // The namespace of this pod.
+    namespace: string
+}

--- a/test/antrea/networkpolicy_controller.dl
+++ b/test/antrea/networkpolicy_controller.dl
@@ -1,0 +1,351 @@
+/*
+ * DDlog implementation of Antrea controller logic (see networkpolicy_controller.go).
+ */
+
+import intern
+import k8spolicy as k8s
+import types
+
+// TODO(leonid)
+function log_error(e: string): () = ()
+
+/* In DDlog, we split the AppliedToGroup struct into three relations:
+ * AppliedToGroup: stores group name, id, and GroupSelector
+ * AppliedToGroupPodsByNode: stores the node-to-pods mapping.
+ * AppliedToGroupSpan: group span (nodes where the group must be sent).
+ */
+
+output relation AppliedToGroup (
+    // UID is generated from the hash value of GroupSelector.NormalizedName.
+    uid: k8s.UID,
+    // Name of this group, currently it's same as UID.
+    name: string,
+    // Selector describes how the group selects pods.
+    selector: GroupSelector
+)
+
+// PodsByNode is a mapping from nodeName to a set of Pods on the Node.
+output relation AppliedToGroupPodsByNode(appliedToGroup: k8s.UID, podsByNode: Map<string, Set<k8s.UID>>)
+
+// AppliedToGroupSpan: set of node names that this AddressGroup should be sent to.
+output relation AppliedToGroupSpan(appliedToGroup: k8s.UID, span: Set<k8s.UID>)
+
+/* In DDlog, we split the AddressGroup struct into three relations:
+ * AddressGroup: stores group name, id, and GroupSelector
+ * AddressGroupAddress: stores addresses of nodes that match the group selector.
+ * AddressGroupSpan: group span (nodes where the group must be sent).
+ */
+
+// AddressGroup describes a set of addresses used as source or destination of Network Policy rules.
+output relation AddressGroup (
+    // UID is generated from the hash value of GroupSelector.NormalizedName.
+    uid: k8s.UID,
+    // Name of this group, currently it's same as UID.
+    name: string,
+    // Selector describes how the group selects pods to get their addresses.
+    selector: GroupSelector
+)
+
+// Addresses is a set of IP addresses selected by this group.
+output relation AddressGroupAddress(addresGroup: k8s.UID, address: string)
+
+// AddressGroupSpan: set of node names that this AddressGroup should be sent to.
+output relation AddressGroupSpan(addressGroup: k8s.UID, span: Set<k8s.UID>)
+
+// NetworkPolicy describes what network traffic is allowed for a set of Pods.
+output relation NetworkPolicy (
+    // UID of the original K8s Network Policy.
+    uid: k8s.UID,
+    // Name of the original K8s Network Policy.
+    name: string,
+    // Namespace of the original K8s Network Policy.
+    namespace: string,
+    // Rules is a list of rules to be applied to the selected Pods.
+    rules: Vec<NetworkPolicyRule>,
+    // AppliedToGroups is a list of names of AppliedToGroups to which this policy applies.
+    appliedToGroups: Vec<string>
+)
+
+// NetworkPolicySpan: set of node names that this NetworkPolicy should be sent to.
+output relation NetworkPolicySpan(policy: k8s.UID, span: Set<k8s.UID>)
+
+// createAppliedToGroup creates an AppliedToGroup object.
+function createAppliedToGroup(np: k8s.NetworkPolicy): AppliedToGroup =
+{
+    var groupSelector = toGroupSelector(np.namespace, Some{np.spec.podSelector}, None);
+    var appliedToGroupUID = getNormalizedUID(groupSelector.normalizedName);
+    // Construct a new AppliedToGroup.
+    AppliedToGroup {
+        .name       = appliedToGroupUID,
+        .uid        = k8s.UID{appliedToGroupUID},
+        .selector   = groupSelector
+    }
+}
+
+function toAntreaPeer(peers: Vec<k8s.NetworkPolicyPeer>, np: k8s.NetworkPolicy): (NetworkPolicyPeer, Vec<AddressGroup>) =
+{
+    // Empty NetworkPolicyPeer is supposed to match all addresses.
+    // See https://kubernetes.io/docs/concepts/services-networking/network-policies/#default-allow-all-ingress-traffic.
+    // It's treated as an IPBlock "0.0.0.0/0".
+    if (vec_is_empty(peers)) {
+        (matchAllPeer(), vec_empty())
+    } else {
+        var ipBlocks: Vec<IPBlock> = vec_empty();
+        var addressGroupNames: Vec<string> = vec_empty();
+        var addressGroups: Vec<AddressGroup> = vec_empty();
+
+        for (peer in peers) {
+            // A networking.NetworkPolicyPeer will either have an IPBlock or a
+            // podSelector and/or namespaceSelector set.
+            match (peer.ipBlock) {
+                Some{peerIPBlock} -> {
+                    match (toAntreaIPBlock(peerIPBlock)) {
+                        Err{err} -> {
+                            log_error("Failure processing NetworkPolicy ${np.namespace}/${np.name} IPBlock ${peerIPBlock}: ${err}")
+                        },
+                        Ok{ipBlock} -> {
+                            vec_push(ipBlocks, ipBlock)
+                        }
+                    }
+                },
+                None -> {
+                    var addressGroup = createAddressGroup(peer, np);
+                    vec_push(addressGroups, addressGroup);
+                    vec_push(addressGroupNames, addressGroup.name)
+                }
+            }
+        };
+        var nppeer = NetworkPolicyPeer {
+            .addressGroups  = addressGroupNames,
+            .ipBlocks       = ipBlocks
+        };
+        (nppeer, addressGroups)
+    }
+}
+
+// toAntreaProtocol converts a v1.Protocol object to an Antrea Protocol object.
+function toAntreaProtocol(npProtocol: Option<k8s.Protocol>): Protocol =
+{
+    // If Protocol is unset, it must default to TCP protocol.
+    match (npProtocol) {
+        None -> protocolTCP(),
+        Some{proto} -> proto
+    }
+}
+
+// toAntreaServices converts a networkingv1.NetworkPolicyPort object to an
+// Antrea Service object.
+function toAntreaServices(npPorts: Vec<k8s.NetworkPolicyPort>): Vec<Service> =
+{
+    var antreaServices: Vec<Service> = vec_empty();
+    for (npPort in npPorts) {
+        var antreaService = Service {
+            .protocol   = toAntreaProtocol(npPort.protocol),
+            .port       = match (npPort.port) {
+                None    -> None: Option<signed<32>>,
+                // TODO(abhiraut): Retrieve ports for named ports.
+                Some{p} -> Some{ k8s.intOrStringIntValue(p) }
+            }
+        };
+        vec_push(antreaServices, antreaService)
+    };
+    antreaServices
+}
+
+// toAntreaIPBlock converts a networkingv1.IPBlock to an Antrea IPBlock.
+function toAntreaIPBlock(ipBlock: k8s.IPBlock): Result<IPBlock,string> =
+{
+    // Convert the allowed IPBlock to networkpolicy.IPNet.
+    match (cidrStrToIPNet(ipBlock.cidr)) {
+        Err{err} -> Err{err},
+        Ok{ipNet} -> {
+            var exceptNets: Vec<IPNet> = vec_empty();
+            for (exc in ipBlock.except) {
+                // Convert the except IPBlock to networkpolicy.IPNet.
+                match (cidrStrToIPNet(exc)) {
+                    Err{e} -> {
+                        return Err{e}
+                    },
+                    Ok{exceptNet} -> {
+                        vec_push(exceptNets, exceptNet)
+                    }
+                }
+            };
+            Ok { IPBlock { .cidr   = ipNet, .except = exceptNets } }
+        }
+    }
+}
+
+// createAddressGroup creates an AddressGroup object corresponding to a
+// NetworkPolicyPeer object in NetworkPolicyRule. This function simply
+// creates the object without actually populating the PodAddresses as the
+// affected Pods are calculated during sync process.
+function createAddressGroup(peer: k8s.NetworkPolicyPeer, np: k8s.NetworkPolicy): AddressGroup =
+{
+    var groupSelector = toGroupSelector(np.namespace, peer.podSelector, peer.namespaceSelector);
+    var normalizedUID = getNormalizedUID(groupSelector.normalizedName);
+
+    // Create an AddressGroup object per Peer object.
+    AddressGroup{
+        .uid        = k8s.UID{normalizedUID},
+        .name       = normalizedUID,
+        .selector   = groupSelector
+    }
+}
+
+// processNetworkPolicy creates an internal NetworkPolicy instance corresponding
+// to the networkingv1.NetworkPolicy object. This method does not commit the
+// internal NetworkPolicy in store, instead returns an instance to the caller
+// wherein, it will be either stored as a new Object in case of ADD event or
+// modified and store the updated instance, in case of an UPDATE event.
+function processNetworkPolicy(np: k8s.NetworkPolicy): (NetworkPolicy, AppliedToGroup, Vec<AddressGroup>) =
+{
+    var appliedToGroup = createAppliedToGroup(np);
+    var rules: Vec<NetworkPolicyRule> = vec_empty();
+    var addressGroups: Vec<AddressGroup> = vec_empty();
+    var ingressRuleExists = false;
+    var egressRuleExists  = false;
+
+    // Compute NetworkPolicyRule for Ingress Rule.
+    for (ingressRule in np.spec.ingress) {
+        ingressRuleExists = true;
+        (var from, var agroups) = toAntreaPeer(ingressRule.from, np);
+        vec_append(addressGroups, agroups);
+        vec_push(rules, NetworkPolicyRule{
+            .direction = DirectionIn,
+            .from      = from,
+            .to        = networkPolicyPeerEmpty(),
+            .services  = toAntreaServices(ingressRule.ports)
+        })
+    };
+    // Compute NetworkPolicyRule for Egress Rule.
+    for (egressRule in np.spec.egress) {
+        egressRuleExists = true;
+        (var to, var agroups) = toAntreaPeer(egressRule.to, np);
+        vec_append(addressGroups, agroups);
+        vec_push(rules, NetworkPolicyRule {
+            .direction = DirectionOut,
+            .from      = networkPolicyPeerEmpty(),
+            .to        = to,
+            .services  = toAntreaServices(egressRule.ports)
+        })
+    };
+
+    // Traffic in a direction must be isolated if Spec.PolicyTypes specify it explicitly.
+    var ingressIsolated = false;
+    var egressIsolated = false;
+    for (policyType in np.spec.policyTypes) {
+        match (policyType) {
+            k8s.PolicyTypeIngress -> ingressIsolated = true,
+            k8s.PolicyTypeEgress  -> egressIsolated = true
+        }
+    };
+
+    // If ingress isolation is specified explicitly and there's no ingress rule, append a deny-all ingress rule.
+    // See https://kubernetes.io/docs/concepts/services-networking/network-policies/#default-deny-all-ingress-traffic
+    if (ingressIsolated and (not ingressRuleExists)) {
+        vec_push(rules, denyAllIngressRule())
+    };
+    // If egress isolation is specified explicitly and there's no egress rule, append a deny-all egress rule.
+    // See https://kubernetes.io/docs/concepts/services-networking/network-policies/#default-deny-all-egress-traffic
+    if (egressIsolated and (not egressRuleExists)) {
+        vec_push(rules, denyAllEgressRule())
+    };
+
+    var policy = NetworkPolicy {
+        .name               = np.name,
+        .namespace          = np.namespace,
+        .uid                = np.uid,
+        .appliedToGroups    = vec_singleton(appliedToGroup.name),
+        .rules              = rules
+    };
+
+    (policy, appliedToGroup, addressGroups)
+}
+
+// Intermediate relation that stores policy and all associated address groups.
+// This relation does not get indexed and therefore should not take any memory.
+relation NetworkPolicyExt(
+    policy: NetworkPolicy,
+    addressGroups: Vec<AddressGroup>
+)
+
+NetworkPolicyExt(internalPolicy, addrGroups),
+AppliedToGroup[appliedTo] :-
+    k8s.NetworkPolicy[policy],
+    (var internalPolicy, var appliedTo, var addrGroups) = processNetworkPolicy(policy).
+
+NetworkPolicy[policy] :- NetworkPolicyExt(policy, _).
+
+AddressGroup[group] :-
+    NetworkPolicyExt(_, groups),
+    var group = FlatMap(groups).
+
+AddressGroupAddress(addressGroup.uid, pod.status.podIP) :-
+    // Namespace presence indicates Pods must be selected from the same Namespace.
+    addressGroup in AddressGroup(.selector = GroupSelector{.nsSelector = NSSelectorNS{ns}}),
+    pod in k8s.Pod(.namespace = Some{ns}),
+    pod.status.podIP != "",
+    k8s.labelSelectorMatches(addressGroup.selector.podSelector, pod.labels).
+
+AddressGroupAddress(addressGroup.uid, pod.status.podIP) :-
+    // Pods must be selected from Namespaces matching nsSelector.
+    addressGroup in AddressGroup(.selector = GroupSelector{.nsSelector = NSSelectorLS{namespaceSelector}, .podSelector = podSelector}),
+    namespace in k8s.Namespace(),
+    k8s.labelSelectorMatches(Some{namespaceSelector}, namespace.labels),
+    pod in k8s.Pod(.namespace = Some{namespace.name}),
+    pod.status.podIP != "",
+    is_none(podSelector) or k8s.labelSelectorMatches(podSelector, pod.labels).
+
+// NetworkPolicyAddressGroup: stores all address groups that a network policy references;
+// used to compute AddressGroupSpan.
+relation NetworkPolicyAddressGroup(np: k8s.UID, addressGroup: string)
+
+NetworkPolicyAddressGroup(np, addressGroup) :-
+    NetworkPolicy(.uid = np, .rules = rules),
+    var addressGroups = {
+        var addressGroups: Vec<string> = vec_empty();
+        for (rule in rules) {
+            vec_append(addressGroups, rule.from.addressGroups);
+            vec_append(addressGroups, rule.to.addressGroups)
+        };
+        addressGroups
+    },
+    var addressGroup = FlatMap(addressGroups).
+
+AddressGroupSpan(k8s.UID{addressGroup}, span) :-
+    AddressGroup(.uid = k8s.UID{addressGroup}),
+    // Get all internal NetworkPolicy objects that refers this AddressGroup.
+    NetworkPolicyAddressGroup(np, addressGroup),
+    NetworkPolicySpan(np, npSpan),
+    var span = Aggregate((addressGroup), group_set_unions(npSpan)).
+
+// AppliedToGroupPod: pods that belong to a group along with nodes
+// where the pod is scheduled;
+// used to compute AppliedToGroupPodsByNode and AppliedToGroupSpan.
+relation AppliedToGroupPod(appliedToGroup: k8s.UID, pod: k8s.UID, nodeName: string)
+
+AppliedToGroupPod(appliedToGroup, pod.uid, pod.spec.nodeName) :-
+    // TODO(leonid): Is it correct that we only consider selectors with namespace name set?
+    AppliedToGroup(.uid = appliedToGroup,
+                   .selector = GroupSelector{.nsSelector = NSSelectorNS{namespace}, .podSelector = podSelector}),
+    // Retrieve all Pods matching the podSelector.
+    pod in k8s.Pod(.namespace = Some{namespace}),
+    // No need to process Pod when it's not scheduled.
+    pod.spec.nodeName != "",
+    k8s.labelSelectorMatches(podSelector, pod.labels).
+
+AppliedToGroupPodsByNode(appliedToGroup, podsByNode) :-
+    AppliedToGroupPod(appliedToGroup, pod, nodeName),
+    var podsOnNode = Aggregate((appliedToGroup, nodeName), group2set(pod)),
+    var podsByNode = Aggregate((appliedToGroup), group2map((nodeName, podsOnNode))).
+
+AppliedToGroupSpan(appliedToGroup, span) :-
+    AppliedToGroupPod(appliedToGroup, pod, _),
+    var span = Aggregate((appliedToGroup), group2set(pod)).
+
+NetworkPolicySpan(policy, span) :-
+    NetworkPolicy(.uid = policy, .appliedToGroups = appliedToGroups),
+    var appliedToGroup = FlatMap(appliedToGroups),
+    AppliedToGroupSpan(k8s.UID{appliedToGroup}, groupSpan),
+    var span = Aggregate((policy), group_set_unions(groupSpan)).

--- a/test/antrea/types.dl
+++ b/test/antrea/types.dl
@@ -1,0 +1,272 @@
+/*
+ * Types used in internal Antrea NetworkPolicy definition.
+ */
+
+import intern
+import k8spolicy as k8s
+
+// getNormalizedUID generates a unique UUID based on a given string.
+// For example, it can be used to generate keys using normalized selectors
+// unique within the Namespace by adding the constant UID.
+function getNormalizedUID(name: string): string = {
+    var uuid = hash128(name);
+    // TODO: implement proper UUID formatter.
+    "${uuid}"
+}
+
+// normalizeExpr converts an expression to the form "key1 OP [value1...]".
+function normalizeExpr(ekey: string, operator: k8s.LabelSelectorOperator, values: Vec<string>): string =
+{
+    if vec_is_empty(values) {
+        "${ekey} ${operator}"
+    } else {
+        "${ekey} ${operator} [${string_join(values, \",\")}]"
+    }
+}
+
+// selectorToString creates a string corresponding to a labelSelector in the form of
+// "key1 IN [value1,...] And key2 NotIn [value2,...] And ...".
+function selectorToString(selector: Ref<k8s.LabelSelector>): string =
+{
+    var sel = deref(selector);
+    var selSlice: Set<string> = set_empty();
+    // Append labels in matchLabels as "key In [value]".
+    for (kv in sel.matchLabels) {
+        set_insert(selSlice, normalizeExpr(kv.0, k8s.LabelSelectorOpIn, vec_singleton(kv.1)))
+    };
+    for (expr in sel.matchExpressions) {
+        match (expr.operator) {
+            k8s.LabelSelectorOpIn -> {
+                set_insert(selSlice, normalizeExpr(expr.reqkey, k8s.LabelSelectorOpIn, expr.values))
+            },
+            k8s.LabelSelectorOpNotIn -> {
+                set_insert(selSlice, normalizeExpr(expr.reqkey, k8s.LabelSelectorOpNotIn, expr.values))
+            },
+            k8s.LabelSelectorOpExists -> {
+                set_insert(selSlice, normalizeExpr(expr.reqkey, k8s.LabelSelectorOpExists, vec_empty()))
+            },
+            k8s.LabelSelectorOpDoesNotExist -> {
+                set_insert(selSlice, normalizeExpr(expr.reqkey, k8s.LabelSelectorOpDoesNotExist, vec_empty()))
+            }
+        }
+    };
+    string_join(set2vec(selSlice), " And ")
+}
+
+// A namespace selector is either a namespace name (or "")
+// or a namespace label selector.
+typedef NSSelector = NSSelectorNS{ns: string}
+                   | NSSelectorLS{selector: Ref<k8s.LabelSelector>}
+
+// GroupSelector describes how to select pods.
+typedef GroupSelector = GroupSelector {
+    // The normalized name is calculated from Namespace, PodSelector, and NamespaceSelector.
+    // If multiple policies have same selectors, they should share this group by comparing NormalizedName.
+    // It's also used to generate Name and UUID of group.
+    normalizedName: string,
+    // Only pods from these namespaces will be matched.
+    nsSelector: NSSelector,
+    // This is a label selector which selects pods. If Namespace is also set, it selects the pods in the namespace.
+    // If NamespaceSelector is also set, it selects the pods in the namespaces selected by NamespaceSelector.
+    podSelector: Option<Ref<k8s.LabelSelector>>
+}
+
+// generateNormalizedName generates a string, based on the selectors, in
+// the following format: "namespace=NamespaceName And podSelector=normalizedPodSelector".
+// Note: Namespace and nsSelector may or may not be set depending on the
+// selector. However, they cannot be set simultaneously.
+function generateNormalizedName(nsSelector: NSSelector, podSelector: Option<Ref<k8s.LabelSelector>>): string =
+{
+    var normalizedName: Set<string> = set_empty();
+    match (nsSelector) {
+        NSSelectorLS{ls} -> {
+            set_insert(normalizedName, "namespaceSelector=${selectorToString(ls)}")
+        },
+        NSSelectorNS{ns} -> {
+            if (ns != "") {
+                set_insert(normalizedName, "namespace=${ns}")
+            }
+        }
+    };
+    match (podSelector) {
+        Some{ls} -> set_insert(normalizedName, "podSelector=${selectorToString(ls)}"),
+        _ -> ()
+    };
+    string_join(set2vec(normalizedName), " And ")
+}
+
+// toGroupSelector converts the podSelector and namespaceSelector
+// and NetworkPolicy Namespace to a networkpolicy.GroupSelector object.
+function toGroupSelector(namespace: string,
+                         podSelector: Option<Ref<k8s.LabelSelector>>,
+                         nsLabelSelector: Option<Ref<k8s.LabelSelector>>): GroupSelector =
+{
+    var nsSelector = match (nsLabelSelector) {
+        // No namespaceSelector indicates that the pods must be selected within
+        // the NetworkPolicy's Namespace.
+        None            -> NSSelectorNS{namespace},
+        Some{selector}  -> NSSelectorLS{selector}
+    };
+    GroupSelector {
+        .normalizedName = generateNormalizedName(nsSelector, podSelector),
+        .podSelector    = podSelector,
+        .nsSelector     = nsSelector
+    }
+}
+
+// PodSet is a set of Pod references.
+typedef PodSet = Set<k8s.PodReference>
+
+typedef Direction = DirectionIn
+                  | DirectionOut
+
+// NetworkPolicyPeer describes a peer of NetworkPolicyRules.
+// It could be a list of names of AddressGroups and/or a list of IPBlock.
+typedef NetworkPolicyPeer = NetworkPolicyPeer {
+    // A list of names of AddressGroups.
+    addressGroups: Vec<string>,
+    // A list of IPBlock.
+    ipBlocks: Vec<IPBlock>
+}
+
+function networkPolicyPeerEmpty(): NetworkPolicyPeer =
+{
+    NetworkPolicyPeer {
+        .addressGroups = vec_empty(),
+        .ipBlocks = vec_empty()
+    }
+}
+
+// matchAllPeer is a NetworkPolicyPeer matching all source/destination IP addresses.
+function matchAllPeer(): NetworkPolicyPeer =
+{
+    NetworkPolicyPeer {
+        .addressGroups = vec_empty(),
+        .ipBlocks      = vec_singleton(IPBlock{
+            .cidr = IPNet {
+                .ip             = ipv4zero(),
+                .prefixLength   = 32'sd0
+            },
+            .except = vec_empty(): Vec<IPNet>
+        })
+    }
+}
+
+typedef IPAddress = IPAddress{addr: Vec<bit<8>>}
+
+function ipv4zero(): IPAddress = {
+    ipv4(0, 0, 0, 0)
+}
+
+function ipv4(a: bit<8>, b: bit<8>, c: bit<8>, d: bit<8>): IPAddress =
+{
+    var bytes: Vec<bit<8>> = vec_with_length(12, 8'd0);
+    vec_push(bytes, a);
+    vec_push(bytes, b);
+    vec_push(bytes, c);
+    vec_push(bytes, d);
+    IPAddress{bytes}
+}
+
+// IPNet describes an IP network.
+typedef IPNet = IPNet {
+    ip:             IPAddress,
+    prefixLength:   signed<32>
+}
+
+// TODO(leonid)
+function parseIP(s: string): Vec<bit<8>> = {
+    vec_empty()
+}
+
+// IPStrToIPAddress converts an IP string to networkpolicy.IPAddress.
+// nil will returned if the IP string is not valid.
+function ipStrToIPAddress(ip: string): IPAddress =
+{
+    IPAddress{parseIP(ip)}
+}
+
+// CIDRStrToIPNet converts a CIDR (eg. 10.0.0.0/16) to a *networkpolicy.IPNet.
+function cidrStrToIPNet(cidr: string): Result<IPNet,string> =
+{
+    // Split the cidr to retrieve the IP and prefix.
+    var s = string_split(cidr, "/");
+    if (vec_len(s) != (2:bit<64>)) {
+        Err{"invalid format for IPBlock CIDR: ${cidr}"}
+    } else {
+        // Convert prefix length to int32
+        match (parse_dec_i64(option_unwrap_or(vec_nth(s,1),""))) {
+            None -> Err{"invalid prefix length: ${option_unwrap_or(vec_nth(s,1),\"\")}"},
+            Some{prefixLen64} -> {
+                Ok {
+                    IPNet {
+                        .ip             = ipStrToIPAddress(option_unwrap_or(vec_nth(s,0),"")),
+                        .prefixLength   = prefixLen64 as signed<32>
+                    }
+                }
+            }
+        }
+    }
+}
+
+// IPBlock describes a particular CIDR (Ex. "192.168.1.1/24"). The except entry describes CIDRs that should
+// not be included within this rule.
+typedef IPBlock = IPBlock {
+    // CIDR is an IPNet represents the IP Block.
+    cidr: IPNet,
+    // Except is a slice of IPNets that should not be included within an IP Block.
+    // Except values will be rejected if they are outside the CIDR range.
+    // +optional
+    except: Vec<IPNet>
+}
+
+typedef Protocol = IString
+
+function protocolTCP(): Protocol = string_intern("TCP")
+function protocolUDP(): Protocol = string_intern("UDP")
+function protocolSCTP(): Protocol = string_intern("SCTP")
+
+// Service describes a port to allow traffic on.
+typedef Service = Service {
+    // The protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this
+    // field defaults to TCP.
+    // +optional
+    protocol: Protocol,
+    // The port on the given protocol. If not specified, this matches all port numbers.
+    // +optional
+    port: Option<signed<32>>
+}
+
+// NetworkPolicyRule describes a particular set of traffic that is allowed.
+typedef NetworkPolicyRule = NetworkPolicyRule {
+    // The direction of this rule.
+    // If it's set to In, From must be set and To must not be set.
+    // If it's set to Out, To must be set and From must not be set.
+    direction: Direction,
+    // From represents sources which should be able to access the pods selected by the policy.
+    from: NetworkPolicyPeer,
+    // To represents destinations which should be able to be accessed by the pods selected by the policy.
+    to: NetworkPolicyPeer,
+    // Services is a list of services which should be matched.
+    services: Vec<Service>
+}
+
+// denyAllIngressRule is a NetworkPolicyRule which denies all ingress traffic.
+function denyAllIngressRule(): NetworkPolicyRule = {
+    NetworkPolicyRule {
+        .direction  = DirectionIn,
+        .from       = networkPolicyPeerEmpty(),
+        .to         = networkPolicyPeerEmpty(),
+        .services   = vec_empty()
+    }
+}
+
+// denyAllEgressRule is a NetworkPolicyRule which denies all egress traffic.
+function denyAllEgressRule(): NetworkPolicyRule = {
+    NetworkPolicyRule {
+        .direction  = DirectionOut,
+        .from       = networkPolicyPeerEmpty(),
+        .to         = networkPolicyPeerEmpty(),
+        .services   = vec_empty()
+    }
+}

--- a/test/datalog_tests/api.ast.expected
+++ b/test/datalog_tests/api.ast.expected
@@ -8,6 +8,7 @@ extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
 extern type std.Ref<'A>
+typedef std.Result<'V,'E> = std.Ok{res: 'V} | std.Err{err: 'E}
 extern type std.Set<'A>
 extern type std.Vec<'A>
 extern function log.log (module: log.module_t, level: log.log_level_t, msg: string): bool
@@ -38,10 +39,20 @@ extern function std.hash64 (x: 'X): bit<64>
 extern function std.hex (x: 'X): string
 extern function std.htonl (x: bit<32>): bit<32>
 extern function std.htons (x: bit<16>): bit<16>
+function std.is_err (res: std.Result<'V,'E>): bool =
+    match (res) {
+        std.Ok{.res=_} -> false,
+        std.Err{.err=_} -> true
+    }
 function std.is_none (x: std.Option<'A>): bool =
     match (x) {
         std.None{} -> true,
         _ -> false
+    }
+function std.is_ok (res: std.Result<'V,'E>): bool =
+    match (res) {
+        std.Ok{.res=_} -> true,
+        std.Err{.err=_} -> false
     }
 function std.is_some (x: std.Option<'A>): bool =
     match (x) {
@@ -71,11 +82,21 @@ function std.min (x: 'A, y: 'A): 'A =
       }
 extern function std.ntohl (x: bit<32>): bit<32>
 extern function std.ntohs (x: bit<16>): bit<16>
+function std.option_unwrap_or (x: std.Option<'A>, def: 'A): 'A =
+    match (x) {
+        std.Some{.x=var v} -> v,
+        std.None{} -> def
+    }
 extern function std.parse_dec_i64 (s: string): std.Option<signed<64>>
 extern function std.parse_dec_u64 (s: string): std.Option<bit<64>>
 extern function std.pow32 (base: 'A, exp: bit<32>): 'A
 extern function std.range (from: 'A, to: 'A, step: 'A): std.Vec<'A>
 extern function std.ref_new (x: 'A): std.Ref<'A>
+function std.result_unwrap_or (res: std.Result<'V,'E>, def: 'V): 'V =
+    match (res) {
+        std.Ok{.res=var v} -> v,
+        std.Err{.err=_} -> def
+    }
 extern function std.set2vec (s: std.Set<'A>): std.Vec<'A>
 extern function std.set_contains (s: std.Set<'X>, v: 'X): bool
 extern function std.set_empty (): std.Set<'X>
@@ -94,6 +115,7 @@ extern function std.string_len (s: string): bit<64>
 extern function std.string_split (s: string, sep: string): std.Vec<string>
 extern function std.string_substr (s: string, start: bit<64>, end: bit<64>): string
 extern function std.vec2set (s: std.Vec<'A>): std.Set<'A>
+extern function std.vec_append (v: mut std.Vec<'X>, other: std.Vec<'X>): ()
 extern function std.vec_contains (v: std.Vec<'X>, x: 'X): bool
 extern function std.vec_empty (): std.Vec<'A>
 extern function std.vec_is_empty (v: std.Vec<'X>): bool
@@ -102,6 +124,7 @@ extern function std.vec_nth (v: std.Vec<'X>, n: bit<64>): std.Option<'X>
 extern function std.vec_push (v: mut std.Vec<'X>, x: 'X): ()
 extern function std.vec_push_imm (v: std.Vec<'X>, x: 'X): std.Vec<'X>
 extern function std.vec_singleton (x: 'X): std.Vec<'X>
+extern function std.vec_with_length (len: bit<64>, x: 'A): std.Vec<'A>
 input relation Rin [Rin]
 output relation Rout [Rout]
 Rout(.b=b) :- Rin(.b=b).

--- a/test/datalog_tests/dcm1.ast.expected
+++ b/test/datalog_tests/dcm1.ast.expected
@@ -49,6 +49,7 @@ extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
 extern type std.Ref<'A>
+typedef std.Result<'V,'E> = std.Ok{res: 'V} | std.Err{err: 'E}
 extern type std.Set<'A>
 extern type std.Vec<'A>
 function cast_bit64_to_bigint (x: bit<64>): bigint =
@@ -140,10 +141,20 @@ extern function std.hash64 (x: 'X): bit<64>
 extern function std.hex (x: 'X): string
 extern function std.htonl (x: bit<32>): bit<32>
 extern function std.htons (x: bit<16>): bit<16>
+function std.is_err (res: std.Result<'V,'E>): bool =
+    match (res) {
+        std.Ok{.res=_} -> false,
+        std.Err{.err=_} -> true
+    }
 function std.is_none (x: std.Option<'A>): bool =
     match (x) {
         std.None{} -> true,
         _ -> false
+    }
+function std.is_ok (res: std.Result<'V,'E>): bool =
+    match (res) {
+        std.Ok{.res=_} -> true,
+        std.Err{.err=_} -> false
     }
 function std.is_some (x: std.Option<'A>): bool =
     match (x) {
@@ -173,11 +184,21 @@ function std.min (x: 'A, y: 'A): 'A =
       }
 extern function std.ntohl (x: bit<32>): bit<32>
 extern function std.ntohs (x: bit<16>): bit<16>
+function std.option_unwrap_or (x: std.Option<'A>, def: 'A): 'A =
+    match (x) {
+        std.Some{.x=var v} -> v,
+        std.None{} -> def
+    }
 extern function std.parse_dec_i64 (s: string): std.Option<signed<64>>
 extern function std.parse_dec_u64 (s: string): std.Option<bit<64>>
 extern function std.pow32 (base: 'A, exp: bit<32>): 'A
 extern function std.range (from: 'A, to: 'A, step: 'A): std.Vec<'A>
 extern function std.ref_new (x: 'A): std.Ref<'A>
+function std.result_unwrap_or (res: std.Result<'V,'E>, def: 'V): 'V =
+    match (res) {
+        std.Ok{.res=var v} -> v,
+        std.Err{.err=_} -> def
+    }
 extern function std.set2vec (s: std.Set<'A>): std.Vec<'A>
 extern function std.set_contains (s: std.Set<'X>, v: 'X): bool
 extern function std.set_empty (): std.Set<'X>
@@ -196,6 +217,7 @@ extern function std.string_len (s: string): bit<64>
 extern function std.string_split (s: string, sep: string): std.Vec<string>
 extern function std.string_substr (s: string, start: bit<64>, end: bit<64>): string
 extern function std.vec2set (s: std.Vec<'A>): std.Set<'A>
+extern function std.vec_append (v: mut std.Vec<'X>, other: std.Vec<'X>): ()
 extern function std.vec_contains (v: std.Vec<'X>, x: 'X): bool
 extern function std.vec_empty (): std.Vec<'A>
 extern function std.vec_is_empty (v: std.Vec<'X>): bool
@@ -204,6 +226,7 @@ extern function std.vec_nth (v: std.Vec<'X>, n: bit<64>): std.Option<'X>
 extern function std.vec_push (v: mut std.Vec<'X>, x: 'X): ()
 extern function std.vec_push_imm (v: std.Vec<'X>, x: 'X): std.Vec<'X>
 extern function std.vec_singleton (x: 'X): std.Vec<'X>
+extern function std.vec_with_length (len: bit<64>, x: 'A): std.Vec<'A>
 function sum (g: std.Group<signed<64>>): signed<64> =
     ((var sum: signed<64>) = 64'sd0;
      (for (resource in g) {

--- a/test/datalog_tests/function.fail.ast.expected
+++ b/test/datalog_tests/function.fail.ast.expected
@@ -35,4 +35,16 @@ error: ./test/datalog_tests/function.fail.dl:3:37-5:1: Cannot type-cast expressi
 
 error: ./test/datalog_tests/function.fail.dl:3:35-5:1: Cannot type-cast expression to bool.  Only bit<>, signed<>, and bigint types can be cast to.
 
-error: ./test/datalog_tests/function.fail.dl:3:34-4:1: Cannot type-cast expression of type string.  The type-cast operator is only supported for bit<> and signed<> types.
+error: ./test/datalog_tests/function.fail.dl:3:34-5:1: Cannot type-cast expression of type string.  The type-cast operator is only supported for bit<> and signed<> types.
+
+error: ./test/datalog_tests/function.fail.dl:6:5-7:1: "continue" outside of a loop
+
+error: ./test/datalog_tests/function.fail.dl:8:9-8:18: Expression continue is not an l-value
+
+error: ./test/datalog_tests/function.fail.dl:6:12-7:1: Couldn't match expected type () with actual type bool (context: CtxTop
+CtxFunc            control_flow
+CtxReturn          return false)
+
+Failed to parse input file: "./test/datalog_tests/function.fail.dl" (line 8, column 1):
+unexpected end of input
+expecting "," or "."

--- a/test/datalog_tests/function.fail.dl
+++ b/test/datalog_tests/function.fail.dl
@@ -127,3 +127,38 @@ function cast(x: bit<16>): bool = x as bool
 //---
 
 function cast(x: string): bool = x as bool
+
+//---
+
+// continue outside of loop
+
+function control_flow(): () = {
+    continue
+}
+
+//---
+
+// continue in LHS of assignment.
+
+function control_flow(): () = {
+    var v: Vec<bool> = vec_empty();
+    for (x in v) {
+        continue = true
+    }
+}
+
+//---
+
+// return incorrect type.
+
+function control_flow(): () = {
+    return false
+}
+
+//---
+
+// return outside ofa function
+
+relation NotFunction(x: bool)
+
+NotFunction(true) :- NotFunction(return false)

--- a/test/datalog_tests/modules.ast.expected
+++ b/test/datalog_tests/modules.ast.expected
@@ -26,6 +26,7 @@ extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
 extern type std.Ref<'A>
+typedef std.Result<'V,'E> = std.Ok{res: 'V} | std.Err{err: 'E}
 extern type std.Set<'A>
 extern type std.Vec<'A>
 extern type tinyset.Set64<'X>
@@ -65,10 +66,20 @@ extern function std.hash64 (x: 'X): bit<64>
 extern function std.hex (x: 'X): string
 extern function std.htonl (x: bit<32>): bit<32>
 extern function std.htons (x: bit<16>): bit<16>
+function std.is_err (res: std.Result<'V,'E>): bool =
+    match (res) {
+        std.Ok{.res=_} -> false,
+        std.Err{.err=_} -> true
+    }
 function std.is_none (x: std.Option<'A>): bool =
     match (x) {
         std.None{} -> true,
         _ -> false
+    }
+function std.is_ok (res: std.Result<'V,'E>): bool =
+    match (res) {
+        std.Ok{.res=_} -> true,
+        std.Err{.err=_} -> false
     }
 function std.is_some (x: std.Option<'A>): bool =
     match (x) {
@@ -98,11 +109,21 @@ function std.min (x: 'A, y: 'A): 'A =
       }
 extern function std.ntohl (x: bit<32>): bit<32>
 extern function std.ntohs (x: bit<16>): bit<16>
+function std.option_unwrap_or (x: std.Option<'A>, def: 'A): 'A =
+    match (x) {
+        std.Some{.x=var v} -> v,
+        std.None{} -> def
+    }
 extern function std.parse_dec_i64 (s: string): std.Option<signed<64>>
 extern function std.parse_dec_u64 (s: string): std.Option<bit<64>>
 extern function std.pow32 (base: 'A, exp: bit<32>): 'A
 extern function std.range (from: 'A, to: 'A, step: 'A): std.Vec<'A>
 extern function std.ref_new (x: 'A): std.Ref<'A>
+function std.result_unwrap_or (res: std.Result<'V,'E>, def: 'V): 'V =
+    match (res) {
+        std.Ok{.res=var v} -> v,
+        std.Err{.err=_} -> def
+    }
 extern function std.set2vec (s: std.Set<'A>): std.Vec<'A>
 extern function std.set_contains (s: std.Set<'X>, v: 'X): bool
 extern function std.set_empty (): std.Set<'X>
@@ -121,6 +142,7 @@ extern function std.string_len (s: string): bit<64>
 extern function std.string_split (s: string, sep: string): std.Vec<string>
 extern function std.string_substr (s: string, start: bit<64>, end: bit<64>): string
 extern function std.vec2set (s: std.Vec<'A>): std.Set<'A>
+extern function std.vec_append (v: mut std.Vec<'X>, other: std.Vec<'X>): ()
 extern function std.vec_contains (v: std.Vec<'X>, x: 'X): bool
 extern function std.vec_empty (): std.Vec<'A>
 extern function std.vec_is_empty (v: std.Vec<'X>): bool
@@ -129,6 +151,7 @@ extern function std.vec_nth (v: std.Vec<'X>, n: bit<64>): std.Option<'X>
 extern function std.vec_push (v: mut std.Vec<'X>, x: 'X): ()
 extern function std.vec_push_imm (v: std.Vec<'X>, x: 'X): std.Vec<'X>
 extern function std.vec_singleton (x: 'X): std.Vec<'X>
+extern function std.vec_with_length (len: bit<64>, x: 'A): std.Vec<'A>
 extern function tinyset.contains (s: tinyset.Set64<'X>, v: 'X): bool
 extern function tinyset.empty (): tinyset.Set64<'X>
 extern function tinyset.group2set (g: std.Group<'A>): tinyset.Set64<'A>

--- a/test/datalog_tests/ovn.ast.expected
+++ b/test/datalog_tests/ovn.ast.expected
@@ -76,6 +76,7 @@ extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
 extern type std.Ref<'A>
+typedef std.Result<'V,'E> = std.Ok{res: 'V} | std.Err{err: 'E}
 extern type std.Set<'A>
 extern type std.Vec<'A>
 typedef uuid = bit<128>
@@ -116,10 +117,20 @@ extern function std.hash64 (x: 'X): bit<64>
 extern function std.hex (x: 'X): string
 extern function std.htonl (x: bit<32>): bit<32>
 extern function std.htons (x: bit<16>): bit<16>
+function std.is_err (res: std.Result<'V,'E>): bool =
+    match (res) {
+        std.Ok{.res=_} -> false,
+        std.Err{.err=_} -> true
+    }
 function std.is_none (x: std.Option<'A>): bool =
     match (x) {
         std.None{} -> true,
         _ -> false
+    }
+function std.is_ok (res: std.Result<'V,'E>): bool =
+    match (res) {
+        std.Ok{.res=_} -> true,
+        std.Err{.err=_} -> false
     }
 function std.is_some (x: std.Option<'A>): bool =
     match (x) {
@@ -149,11 +160,21 @@ function std.min (x: 'A, y: 'A): 'A =
       }
 extern function std.ntohl (x: bit<32>): bit<32>
 extern function std.ntohs (x: bit<16>): bit<16>
+function std.option_unwrap_or (x: std.Option<'A>, def: 'A): 'A =
+    match (x) {
+        std.Some{.x=var v} -> v,
+        std.None{} -> def
+    }
 extern function std.parse_dec_i64 (s: string): std.Option<signed<64>>
 extern function std.parse_dec_u64 (s: string): std.Option<bit<64>>
 extern function std.pow32 (base: 'A, exp: bit<32>): 'A
 extern function std.range (from: 'A, to: 'A, step: 'A): std.Vec<'A>
 extern function std.ref_new (x: 'A): std.Ref<'A>
+function std.result_unwrap_or (res: std.Result<'V,'E>, def: 'V): 'V =
+    match (res) {
+        std.Ok{.res=var v} -> v,
+        std.Err{.err=_} -> def
+    }
 extern function std.set2vec (s: std.Set<'A>): std.Vec<'A>
 extern function std.set_contains (s: std.Set<'X>, v: 'X): bool
 extern function std.set_empty (): std.Set<'X>
@@ -172,6 +193,7 @@ extern function std.string_len (s: string): bit<64>
 extern function std.string_split (s: string, sep: string): std.Vec<string>
 extern function std.string_substr (s: string, start: bit<64>, end: bit<64>): string
 extern function std.vec2set (s: std.Vec<'A>): std.Set<'A>
+extern function std.vec_append (v: mut std.Vec<'X>, other: std.Vec<'X>): ()
 extern function std.vec_contains (v: std.Vec<'X>, x: 'X): bool
 extern function std.vec_empty (): std.Vec<'A>
 extern function std.vec_is_empty (v: std.Vec<'X>): bool
@@ -180,6 +202,7 @@ extern function std.vec_nth (v: std.Vec<'X>, n: bit<64>): std.Option<'X>
 extern function std.vec_push (v: mut std.Vec<'X>, x: 'X): ()
 extern function std.vec_push_imm (v: std.Vec<'X>, x: 'X): std.Vec<'X>
 extern function std.vec_singleton (x: 'X): std.Vec<'X>
+extern function std.vec_with_length (len: bit<64>, x: 'A): std.Vec<'A>
 input relation ACL [ACL]
 input relation ACL_external_ids [ACL_external_ids]
 input relation Address_Set [Address_Set]

--- a/test/datalog_tests/ovn_ftl.ast.expected
+++ b/test/datalog_tests/ovn_ftl.ast.expected
@@ -14,6 +14,7 @@ extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
 extern type std.Ref<'A>
+typedef std.Result<'V,'E> = std.Ok{res: 'V} | std.Err{err: 'E}
 extern type std.Set<'A>
 extern type std.Vec<'A>
 extern function log.log (module: log.module_t, level: log.log_level_t, msg: string): bool
@@ -44,10 +45,20 @@ extern function std.hash64 (x: 'X): bit<64>
 extern function std.hex (x: 'X): string
 extern function std.htonl (x: bit<32>): bit<32>
 extern function std.htons (x: bit<16>): bit<16>
+function std.is_err (res: std.Result<'V,'E>): bool =
+    match (res) {
+        std.Ok{.res=_} -> false,
+        std.Err{.err=_} -> true
+    }
 function std.is_none (x: std.Option<'A>): bool =
     match (x) {
         std.None{} -> true,
         _ -> false
+    }
+function std.is_ok (res: std.Result<'V,'E>): bool =
+    match (res) {
+        std.Ok{.res=_} -> true,
+        std.Err{.err=_} -> false
     }
 function std.is_some (x: std.Option<'A>): bool =
     match (x) {
@@ -77,11 +88,21 @@ function std.min (x: 'A, y: 'A): 'A =
       }
 extern function std.ntohl (x: bit<32>): bit<32>
 extern function std.ntohs (x: bit<16>): bit<16>
+function std.option_unwrap_or (x: std.Option<'A>, def: 'A): 'A =
+    match (x) {
+        std.Some{.x=var v} -> v,
+        std.None{} -> def
+    }
 extern function std.parse_dec_i64 (s: string): std.Option<signed<64>>
 extern function std.parse_dec_u64 (s: string): std.Option<bit<64>>
 extern function std.pow32 (base: 'A, exp: bit<32>): 'A
 extern function std.range (from: 'A, to: 'A, step: 'A): std.Vec<'A>
 extern function std.ref_new (x: 'A): std.Ref<'A>
+function std.result_unwrap_or (res: std.Result<'V,'E>, def: 'V): 'V =
+    match (res) {
+        std.Ok{.res=var v} -> v,
+        std.Err{.err=_} -> def
+    }
 extern function std.set2vec (s: std.Set<'A>): std.Vec<'A>
 extern function std.set_contains (s: std.Set<'X>, v: 'X): bool
 extern function std.set_empty (): std.Set<'X>
@@ -100,6 +121,7 @@ extern function std.string_len (s: string): bit<64>
 extern function std.string_split (s: string, sep: string): std.Vec<string>
 extern function std.string_substr (s: string, start: bit<64>, end: bit<64>): string
 extern function std.vec2set (s: std.Vec<'A>): std.Set<'A>
+extern function std.vec_append (v: mut std.Vec<'X>, other: std.Vec<'X>): ()
 extern function std.vec_contains (v: std.Vec<'X>, x: 'X): bool
 extern function std.vec_empty (): std.Vec<'A>
 extern function std.vec_is_empty (v: std.Vec<'X>): bool
@@ -108,6 +130,7 @@ extern function std.vec_nth (v: std.Vec<'X>, n: bit<64>): std.Option<'X>
 extern function std.vec_push (v: mut std.Vec<'X>, x: 'X): ()
 extern function std.vec_push_imm (v: std.Vec<'X>, x: 'X): std.Vec<'X>
 extern function std.vec_singleton (x: 'X): std.Vec<'X>
+extern function std.vec_with_length (len: bit<64>, x: 'A): std.Vec<'A>
 output relation Flow [Flow]
 input relation Load_Balancer [Load_Balancer]
 input relation Logical_Router [Logical_Router]

--- a/test/datalog_tests/path.ast.expected
+++ b/test/datalog_tests/path.ast.expected
@@ -9,6 +9,7 @@ extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
 extern type std.Ref<'A>
+typedef std.Result<'V,'E> = std.Ok{res: 'V} | std.Err{err: 'E}
 extern type std.Set<'A>
 extern type std.Vec<'A>
 extern function log.log (module: log.module_t, level: log.log_level_t, msg: string): bool
@@ -39,10 +40,20 @@ extern function std.hash64 (x: 'X): bit<64>
 extern function std.hex (x: 'X): string
 extern function std.htonl (x: bit<32>): bit<32>
 extern function std.htons (x: bit<16>): bit<16>
+function std.is_err (res: std.Result<'V,'E>): bool =
+    match (res) {
+        std.Ok{.res=_} -> false,
+        std.Err{.err=_} -> true
+    }
 function std.is_none (x: std.Option<'A>): bool =
     match (x) {
         std.None{} -> true,
         _ -> false
+    }
+function std.is_ok (res: std.Result<'V,'E>): bool =
+    match (res) {
+        std.Ok{.res=_} -> true,
+        std.Err{.err=_} -> false
     }
 function std.is_some (x: std.Option<'A>): bool =
     match (x) {
@@ -72,11 +83,21 @@ function std.min (x: 'A, y: 'A): 'A =
       }
 extern function std.ntohl (x: bit<32>): bit<32>
 extern function std.ntohs (x: bit<16>): bit<16>
+function std.option_unwrap_or (x: std.Option<'A>, def: 'A): 'A =
+    match (x) {
+        std.Some{.x=var v} -> v,
+        std.None{} -> def
+    }
 extern function std.parse_dec_i64 (s: string): std.Option<signed<64>>
 extern function std.parse_dec_u64 (s: string): std.Option<bit<64>>
 extern function std.pow32 (base: 'A, exp: bit<32>): 'A
 extern function std.range (from: 'A, to: 'A, step: 'A): std.Vec<'A>
 extern function std.ref_new (x: 'A): std.Ref<'A>
+function std.result_unwrap_or (res: std.Result<'V,'E>, def: 'V): 'V =
+    match (res) {
+        std.Ok{.res=var v} -> v,
+        std.Err{.err=_} -> def
+    }
 extern function std.set2vec (s: std.Set<'A>): std.Vec<'A>
 extern function std.set_contains (s: std.Set<'X>, v: 'X): bool
 extern function std.set_empty (): std.Set<'X>
@@ -95,6 +116,7 @@ extern function std.string_len (s: string): bit<64>
 extern function std.string_split (s: string, sep: string): std.Vec<string>
 extern function std.string_substr (s: string, start: bit<64>, end: bit<64>): string
 extern function std.vec2set (s: std.Vec<'A>): std.Set<'A>
+extern function std.vec_append (v: mut std.Vec<'X>, other: std.Vec<'X>): ()
 extern function std.vec_contains (v: std.Vec<'X>, x: 'X): bool
 extern function std.vec_empty (): std.Vec<'A>
 extern function std.vec_is_empty (v: std.Vec<'X>): bool
@@ -103,6 +125,7 @@ extern function std.vec_nth (v: std.Vec<'X>, n: bit<64>): std.Option<'X>
 extern function std.vec_push (v: mut std.Vec<'X>, x: 'X): ()
 extern function std.vec_push_imm (v: std.Vec<'X>, x: 'X): std.Vec<'X>
 extern function std.vec_singleton (x: 'X): std.Vec<'X>
+extern function std.vec_with_length (len: bit<64>, x: 'A): std.Vec<'A>
 input relation Edge [Edge]
 output relation Path [Path]
 Path(.s1=x, .s2=y) :- Edge(.s=x, .t=y).

--- a/test/datalog_tests/redist.ast.expected
+++ b/test/datalog_tests/redist.ast.expected
@@ -16,6 +16,7 @@ extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
 extern type std.Ref<'A>
+typedef std.Result<'V,'E> = std.Ok{res: 'V} | std.Err{err: 'E}
 extern type std.Set<'A>
 extern type std.Vec<'A>
 extern type tinyset.Set64<'X>
@@ -52,10 +53,20 @@ extern function std.hash64 (x: 'X): bit<64>
 extern function std.hex (x: 'X): string
 extern function std.htonl (x: bit<32>): bit<32>
 extern function std.htons (x: bit<16>): bit<16>
+function std.is_err (res: std.Result<'V,'E>): bool =
+    match (res) {
+        std.Ok{.res=_} -> false,
+        std.Err{.err=_} -> true
+    }
 function std.is_none (x: std.Option<'A>): bool =
     match (x) {
         std.None{} -> true,
         _ -> false
+    }
+function std.is_ok (res: std.Result<'V,'E>): bool =
+    match (res) {
+        std.Ok{.res=_} -> true,
+        std.Err{.err=_} -> false
     }
 function std.is_some (x: std.Option<'A>): bool =
     match (x) {
@@ -85,11 +96,21 @@ function std.min (x: 'A, y: 'A): 'A =
       }
 extern function std.ntohl (x: bit<32>): bit<32>
 extern function std.ntohs (x: bit<16>): bit<16>
+function std.option_unwrap_or (x: std.Option<'A>, def: 'A): 'A =
+    match (x) {
+        std.Some{.x=var v} -> v,
+        std.None{} -> def
+    }
 extern function std.parse_dec_i64 (s: string): std.Option<signed<64>>
 extern function std.parse_dec_u64 (s: string): std.Option<bit<64>>
 extern function std.pow32 (base: 'A, exp: bit<32>): 'A
 extern function std.range (from: 'A, to: 'A, step: 'A): std.Vec<'A>
 extern function std.ref_new (x: 'A): std.Ref<'A>
+function std.result_unwrap_or (res: std.Result<'V,'E>, def: 'V): 'V =
+    match (res) {
+        std.Ok{.res=var v} -> v,
+        std.Err{.err=_} -> def
+    }
 extern function std.set2vec (s: std.Set<'A>): std.Vec<'A>
 extern function std.set_contains (s: std.Set<'X>, v: 'X): bool
 extern function std.set_empty (): std.Set<'X>
@@ -108,6 +129,7 @@ extern function std.string_len (s: string): bit<64>
 extern function std.string_split (s: string, sep: string): std.Vec<string>
 extern function std.string_substr (s: string, start: bit<64>, end: bit<64>): string
 extern function std.vec2set (s: std.Vec<'A>): std.Set<'A>
+extern function std.vec_append (v: mut std.Vec<'X>, other: std.Vec<'X>): ()
 extern function std.vec_contains (v: std.Vec<'X>, x: 'X): bool
 extern function std.vec_empty (): std.Vec<'A>
 extern function std.vec_is_empty (v: std.Vec<'X>): bool
@@ -116,6 +138,7 @@ extern function std.vec_nth (v: std.Vec<'X>, n: bit<64>): std.Option<'X>
 extern function std.vec_push (v: mut std.Vec<'X>, x: 'X): ()
 extern function std.vec_push_imm (v: std.Vec<'X>, x: 'X): std.Vec<'X>
 extern function std.vec_singleton (x: 'X): std.Vec<'X>
+extern function std.vec_with_length (len: bit<64>, x: 'A): std.Vec<'A>
 extern function tinyset.contains (s: tinyset.Set64<'X>, v: 'X): bool
 extern function tinyset.empty (): tinyset.Set64<'X>
 extern function tinyset.group2set (g: std.Group<'A>): tinyset.Set64<'A>

--- a/test/datalog_tests/redist_opt.ast.expected
+++ b/test/datalog_tests/redist_opt.ast.expected
@@ -30,6 +30,7 @@ extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
 extern type std.Ref<'A>
+typedef std.Result<'V,'E> = std.Ok{res: 'V} | std.Err{err: 'E}
 extern type std.Set<'A>
 extern type std.Vec<'A>
 extern type tinyset.Set64<'X>
@@ -74,10 +75,20 @@ extern function std.hash64 (x: 'X): bit<64>
 extern function std.hex (x: 'X): string
 extern function std.htonl (x: bit<32>): bit<32>
 extern function std.htons (x: bit<16>): bit<16>
+function std.is_err (res: std.Result<'V,'E>): bool =
+    match (res) {
+        std.Ok{.res=_} -> false,
+        std.Err{.err=_} -> true
+    }
 function std.is_none (x: std.Option<'A>): bool =
     match (x) {
         std.None{} -> true,
         _ -> false
+    }
+function std.is_ok (res: std.Result<'V,'E>): bool =
+    match (res) {
+        std.Ok{.res=_} -> true,
+        std.Err{.err=_} -> false
     }
 function std.is_some (x: std.Option<'A>): bool =
     match (x) {
@@ -107,11 +118,21 @@ function std.min (x: 'A, y: 'A): 'A =
       }
 extern function std.ntohl (x: bit<32>): bit<32>
 extern function std.ntohs (x: bit<16>): bit<16>
+function std.option_unwrap_or (x: std.Option<'A>, def: 'A): 'A =
+    match (x) {
+        std.Some{.x=var v} -> v,
+        std.None{} -> def
+    }
 extern function std.parse_dec_i64 (s: string): std.Option<signed<64>>
 extern function std.parse_dec_u64 (s: string): std.Option<bit<64>>
 extern function std.pow32 (base: 'A, exp: bit<32>): 'A
 extern function std.range (from: 'A, to: 'A, step: 'A): std.Vec<'A>
 extern function std.ref_new (x: 'A): std.Ref<'A>
+function std.result_unwrap_or (res: std.Result<'V,'E>, def: 'V): 'V =
+    match (res) {
+        std.Ok{.res=var v} -> v,
+        std.Err{.err=_} -> def
+    }
 extern function std.set2vec (s: std.Set<'A>): std.Vec<'A>
 extern function std.set_contains (s: std.Set<'X>, v: 'X): bool
 extern function std.set_empty (): std.Set<'X>
@@ -130,6 +151,7 @@ extern function std.string_len (s: string): bit<64>
 extern function std.string_split (s: string, sep: string): std.Vec<string>
 extern function std.string_substr (s: string, start: bit<64>, end: bit<64>): string
 extern function std.vec2set (s: std.Vec<'A>): std.Set<'A>
+extern function std.vec_append (v: mut std.Vec<'X>, other: std.Vec<'X>): ()
 extern function std.vec_contains (v: std.Vec<'X>, x: 'X): bool
 extern function std.vec_empty (): std.Vec<'A>
 extern function std.vec_is_empty (v: std.Vec<'X>): bool
@@ -138,6 +160,7 @@ extern function std.vec_nth (v: std.Vec<'X>, n: bit<64>): std.Option<'X>
 extern function std.vec_push (v: mut std.Vec<'X>, x: 'X): ()
 extern function std.vec_push_imm (v: std.Vec<'X>, x: 'X): std.Vec<'X>
 extern function std.vec_singleton (x: 'X): std.Vec<'X>
+extern function std.vec_with_length (len: bit<64>, x: 'A): std.Vec<'A>
 extern function tinyset.contains (s: tinyset.Set64<'X>, v: 'X): bool
 extern function tinyset.empty (): tinyset.Set64<'X>
 extern function tinyset.group2set (g: std.Group<'A>): tinyset.Set64<'A>

--- a/test/datalog_tests/server_api.ast.expected
+++ b/test/datalog_tests/server_api.ast.expected
@@ -6,6 +6,7 @@ extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
 extern type std.Ref<'A>
+typedef std.Result<'V,'E> = std.Ok{res: 'V} | std.Err{err: 'E}
 extern type std.Set<'A>
 extern type std.Vec<'A>
 extern function log.log (module: log.module_t, level: log.log_level_t, msg: string): bool
@@ -36,10 +37,20 @@ extern function std.hash64 (x: 'X): bit<64>
 extern function std.hex (x: 'X): string
 extern function std.htonl (x: bit<32>): bit<32>
 extern function std.htons (x: bit<16>): bit<16>
+function std.is_err (res: std.Result<'V,'E>): bool =
+    match (res) {
+        std.Ok{.res=_} -> false,
+        std.Err{.err=_} -> true
+    }
 function std.is_none (x: std.Option<'A>): bool =
     match (x) {
         std.None{} -> true,
         _ -> false
+    }
+function std.is_ok (res: std.Result<'V,'E>): bool =
+    match (res) {
+        std.Ok{.res=_} -> true,
+        std.Err{.err=_} -> false
     }
 function std.is_some (x: std.Option<'A>): bool =
     match (x) {
@@ -69,11 +80,21 @@ function std.min (x: 'A, y: 'A): 'A =
       }
 extern function std.ntohl (x: bit<32>): bit<32>
 extern function std.ntohs (x: bit<16>): bit<16>
+function std.option_unwrap_or (x: std.Option<'A>, def: 'A): 'A =
+    match (x) {
+        std.Some{.x=var v} -> v,
+        std.None{} -> def
+    }
 extern function std.parse_dec_i64 (s: string): std.Option<signed<64>>
 extern function std.parse_dec_u64 (s: string): std.Option<bit<64>>
 extern function std.pow32 (base: 'A, exp: bit<32>): 'A
 extern function std.range (from: 'A, to: 'A, step: 'A): std.Vec<'A>
 extern function std.ref_new (x: 'A): std.Ref<'A>
+function std.result_unwrap_or (res: std.Result<'V,'E>, def: 'V): 'V =
+    match (res) {
+        std.Ok{.res=var v} -> v,
+        std.Err{.err=_} -> def
+    }
 extern function std.set2vec (s: std.Set<'A>): std.Vec<'A>
 extern function std.set_contains (s: std.Set<'X>, v: 'X): bool
 extern function std.set_empty (): std.Set<'X>
@@ -92,6 +113,7 @@ extern function std.string_len (s: string): bit<64>
 extern function std.string_split (s: string, sep: string): std.Vec<string>
 extern function std.string_substr (s: string, start: bit<64>, end: bit<64>): string
 extern function std.vec2set (s: std.Vec<'A>): std.Set<'A>
+extern function std.vec_append (v: mut std.Vec<'X>, other: std.Vec<'X>): ()
 extern function std.vec_contains (v: std.Vec<'X>, x: 'X): bool
 extern function std.vec_empty (): std.Vec<'A>
 extern function std.vec_is_empty (v: std.Vec<'X>): bool
@@ -100,6 +122,7 @@ extern function std.vec_nth (v: std.Vec<'X>, n: bit<64>): std.Option<'X>
 extern function std.vec_push (v: mut std.Vec<'X>, x: 'X): ()
 extern function std.vec_push_imm (v: std.Vec<'X>, x: 'X): std.Vec<'X>
 extern function std.vec_singleton (x: 'X): std.Vec<'X>
+extern function std.vec_with_length (len: bit<64>, x: 'A): std.Vec<'A>
 input relation server_api_1.P1In [string]
 output relation server_api_1.P1Out [string]
 input relation server_api_2.P2In [string]

--- a/test/datalog_tests/server_api_1.ast.expected
+++ b/test/datalog_tests/server_api_1.ast.expected
@@ -6,6 +6,7 @@ extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
 extern type std.Ref<'A>
+typedef std.Result<'V,'E> = std.Ok{res: 'V} | std.Err{err: 'E}
 extern type std.Set<'A>
 extern type std.Vec<'A>
 extern function log.log (module: log.module_t, level: log.log_level_t, msg: string): bool
@@ -36,10 +37,20 @@ extern function std.hash64 (x: 'X): bit<64>
 extern function std.hex (x: 'X): string
 extern function std.htonl (x: bit<32>): bit<32>
 extern function std.htons (x: bit<16>): bit<16>
+function std.is_err (res: std.Result<'V,'E>): bool =
+    match (res) {
+        std.Ok{.res=_} -> false,
+        std.Err{.err=_} -> true
+    }
 function std.is_none (x: std.Option<'A>): bool =
     match (x) {
         std.None{} -> true,
         _ -> false
+    }
+function std.is_ok (res: std.Result<'V,'E>): bool =
+    match (res) {
+        std.Ok{.res=_} -> true,
+        std.Err{.err=_} -> false
     }
 function std.is_some (x: std.Option<'A>): bool =
     match (x) {
@@ -69,11 +80,21 @@ function std.min (x: 'A, y: 'A): 'A =
       }
 extern function std.ntohl (x: bit<32>): bit<32>
 extern function std.ntohs (x: bit<16>): bit<16>
+function std.option_unwrap_or (x: std.Option<'A>, def: 'A): 'A =
+    match (x) {
+        std.Some{.x=var v} -> v,
+        std.None{} -> def
+    }
 extern function std.parse_dec_i64 (s: string): std.Option<signed<64>>
 extern function std.parse_dec_u64 (s: string): std.Option<bit<64>>
 extern function std.pow32 (base: 'A, exp: bit<32>): 'A
 extern function std.range (from: 'A, to: 'A, step: 'A): std.Vec<'A>
 extern function std.ref_new (x: 'A): std.Ref<'A>
+function std.result_unwrap_or (res: std.Result<'V,'E>, def: 'V): 'V =
+    match (res) {
+        std.Ok{.res=var v} -> v,
+        std.Err{.err=_} -> def
+    }
 extern function std.set2vec (s: std.Set<'A>): std.Vec<'A>
 extern function std.set_contains (s: std.Set<'X>, v: 'X): bool
 extern function std.set_empty (): std.Set<'X>
@@ -92,6 +113,7 @@ extern function std.string_len (s: string): bit<64>
 extern function std.string_split (s: string, sep: string): std.Vec<string>
 extern function std.string_substr (s: string, start: bit<64>, end: bit<64>): string
 extern function std.vec2set (s: std.Vec<'A>): std.Set<'A>
+extern function std.vec_append (v: mut std.Vec<'X>, other: std.Vec<'X>): ()
 extern function std.vec_contains (v: std.Vec<'X>, x: 'X): bool
 extern function std.vec_empty (): std.Vec<'A>
 extern function std.vec_is_empty (v: std.Vec<'X>): bool
@@ -100,6 +122,7 @@ extern function std.vec_nth (v: std.Vec<'X>, n: bit<64>): std.Option<'X>
 extern function std.vec_push (v: mut std.Vec<'X>, x: 'X): ()
 extern function std.vec_push_imm (v: std.Vec<'X>, x: 'X): std.Vec<'X>
 extern function std.vec_singleton (x: 'X): std.Vec<'X>
+extern function std.vec_with_length (len: bit<64>, x: 'A): std.Vec<'A>
 input relation P1In [string]
 output relation P1Out [string]
 P1Out[s] :- P1In[s].

--- a/test/datalog_tests/server_api_2.ast.expected
+++ b/test/datalog_tests/server_api_2.ast.expected
@@ -6,6 +6,7 @@ extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
 extern type std.Ref<'A>
+typedef std.Result<'V,'E> = std.Ok{res: 'V} | std.Err{err: 'E}
 extern type std.Set<'A>
 extern type std.Vec<'A>
 extern function log.log (module: log.module_t, level: log.log_level_t, msg: string): bool
@@ -36,10 +37,20 @@ extern function std.hash64 (x: 'X): bit<64>
 extern function std.hex (x: 'X): string
 extern function std.htonl (x: bit<32>): bit<32>
 extern function std.htons (x: bit<16>): bit<16>
+function std.is_err (res: std.Result<'V,'E>): bool =
+    match (res) {
+        std.Ok{.res=_} -> false,
+        std.Err{.err=_} -> true
+    }
 function std.is_none (x: std.Option<'A>): bool =
     match (x) {
         std.None{} -> true,
         _ -> false
+    }
+function std.is_ok (res: std.Result<'V,'E>): bool =
+    match (res) {
+        std.Ok{.res=_} -> true,
+        std.Err{.err=_} -> false
     }
 function std.is_some (x: std.Option<'A>): bool =
     match (x) {
@@ -69,11 +80,21 @@ function std.min (x: 'A, y: 'A): 'A =
       }
 extern function std.ntohl (x: bit<32>): bit<32>
 extern function std.ntohs (x: bit<16>): bit<16>
+function std.option_unwrap_or (x: std.Option<'A>, def: 'A): 'A =
+    match (x) {
+        std.Some{.x=var v} -> v,
+        std.None{} -> def
+    }
 extern function std.parse_dec_i64 (s: string): std.Option<signed<64>>
 extern function std.parse_dec_u64 (s: string): std.Option<bit<64>>
 extern function std.pow32 (base: 'A, exp: bit<32>): 'A
 extern function std.range (from: 'A, to: 'A, step: 'A): std.Vec<'A>
 extern function std.ref_new (x: 'A): std.Ref<'A>
+function std.result_unwrap_or (res: std.Result<'V,'E>, def: 'V): 'V =
+    match (res) {
+        std.Ok{.res=var v} -> v,
+        std.Err{.err=_} -> def
+    }
 extern function std.set2vec (s: std.Set<'A>): std.Vec<'A>
 extern function std.set_contains (s: std.Set<'X>, v: 'X): bool
 extern function std.set_empty (): std.Set<'X>
@@ -92,6 +113,7 @@ extern function std.string_len (s: string): bit<64>
 extern function std.string_split (s: string, sep: string): std.Vec<string>
 extern function std.string_substr (s: string, start: bit<64>, end: bit<64>): string
 extern function std.vec2set (s: std.Vec<'A>): std.Set<'A>
+extern function std.vec_append (v: mut std.Vec<'X>, other: std.Vec<'X>): ()
 extern function std.vec_contains (v: std.Vec<'X>, x: 'X): bool
 extern function std.vec_empty (): std.Vec<'A>
 extern function std.vec_is_empty (v: std.Vec<'X>): bool
@@ -100,6 +122,7 @@ extern function std.vec_nth (v: std.Vec<'X>, n: bit<64>): std.Option<'X>
 extern function std.vec_push (v: mut std.Vec<'X>, x: 'X): ()
 extern function std.vec_push_imm (v: std.Vec<'X>, x: 'X): std.Vec<'X>
 extern function std.vec_singleton (x: 'X): std.Vec<'X>
+extern function std.vec_with_length (len: bit<64>, x: 'A): std.Vec<'A>
 input relation P2In [string]
 output relation P2Out [string]
 P2Out[s] :- P2In[s].

--- a/test/datalog_tests/server_api_3.ast.expected
+++ b/test/datalog_tests/server_api_3.ast.expected
@@ -6,6 +6,7 @@ extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
 extern type std.Ref<'A>
+typedef std.Result<'V,'E> = std.Ok{res: 'V} | std.Err{err: 'E}
 extern type std.Set<'A>
 extern type std.Vec<'A>
 extern function log.log (module: log.module_t, level: log.log_level_t, msg: string): bool
@@ -36,10 +37,20 @@ extern function std.hash64 (x: 'X): bit<64>
 extern function std.hex (x: 'X): string
 extern function std.htonl (x: bit<32>): bit<32>
 extern function std.htons (x: bit<16>): bit<16>
+function std.is_err (res: std.Result<'V,'E>): bool =
+    match (res) {
+        std.Ok{.res=_} -> false,
+        std.Err{.err=_} -> true
+    }
 function std.is_none (x: std.Option<'A>): bool =
     match (x) {
         std.None{} -> true,
         _ -> false
+    }
+function std.is_ok (res: std.Result<'V,'E>): bool =
+    match (res) {
+        std.Ok{.res=_} -> true,
+        std.Err{.err=_} -> false
     }
 function std.is_some (x: std.Option<'A>): bool =
     match (x) {
@@ -69,11 +80,21 @@ function std.min (x: 'A, y: 'A): 'A =
       }
 extern function std.ntohl (x: bit<32>): bit<32>
 extern function std.ntohs (x: bit<16>): bit<16>
+function std.option_unwrap_or (x: std.Option<'A>, def: 'A): 'A =
+    match (x) {
+        std.Some{.x=var v} -> v,
+        std.None{} -> def
+    }
 extern function std.parse_dec_i64 (s: string): std.Option<signed<64>>
 extern function std.parse_dec_u64 (s: string): std.Option<bit<64>>
 extern function std.pow32 (base: 'A, exp: bit<32>): 'A
 extern function std.range (from: 'A, to: 'A, step: 'A): std.Vec<'A>
 extern function std.ref_new (x: 'A): std.Ref<'A>
+function std.result_unwrap_or (res: std.Result<'V,'E>, def: 'V): 'V =
+    match (res) {
+        std.Ok{.res=var v} -> v,
+        std.Err{.err=_} -> def
+    }
 extern function std.set2vec (s: std.Set<'A>): std.Vec<'A>
 extern function std.set_contains (s: std.Set<'X>, v: 'X): bool
 extern function std.set_empty (): std.Set<'X>
@@ -92,6 +113,7 @@ extern function std.string_len (s: string): bit<64>
 extern function std.string_split (s: string, sep: string): std.Vec<string>
 extern function std.string_substr (s: string, start: bit<64>, end: bit<64>): string
 extern function std.vec2set (s: std.Vec<'A>): std.Set<'A>
+extern function std.vec_append (v: mut std.Vec<'X>, other: std.Vec<'X>): ()
 extern function std.vec_contains (v: std.Vec<'X>, x: 'X): bool
 extern function std.vec_empty (): std.Vec<'A>
 extern function std.vec_is_empty (v: std.Vec<'X>): bool
@@ -100,6 +122,7 @@ extern function std.vec_nth (v: std.Vec<'X>, n: bit<64>): std.Option<'X>
 extern function std.vec_push (v: mut std.Vec<'X>, x: 'X): ()
 extern function std.vec_push_imm (v: std.Vec<'X>, x: 'X): std.Vec<'X>
 extern function std.vec_singleton (x: 'X): std.Vec<'X>
+extern function std.vec_with_length (len: bit<64>, x: 'A): std.Vec<'A>
 input relation P1Out [string]
 input relation P2Out [string]
 output relation P3Out [string]

--- a/test/datalog_tests/simple.ast.expected
+++ b/test/datalog_tests/simple.ast.expected
@@ -30,6 +30,7 @@ typedef Cast_u256 = Cast_u256{description: string, expected: bit<256>, actual: b
 typedef Cast_u32 = Cast_u32{description: string, actual: bit<32>, expected: bit<32>}
 typedef Compare = Compare{label: string, value: bool}
 typedef ConcatString = ConcatString{s: string}
+typedef ControlFlow = ControlFlow{expr: string, value: string}
 typedef DMethod = DMethod{c1: Symbol, c2: Symbol}
 typedef DdlogBinding = DdlogBinding{tn: tnid_t, entity: entid_t}
 typedef DdlogDependency = DdlogDependency{parent: entid_t, child: entid_t}
@@ -219,10 +220,30 @@ function agg1 (g1: std.Group<Tt1>): Ttmp0 =
                      })
        };
        Ttmp0{.col4=max5})))
+function all (xs: std.Vec<bool>): bool =
+    (for (x in xs) {
+         if (not x) {
+             return false
+         } else {
+               ()
+           }
+     };
+     return true)
 extern function allocate.adjust_allocation (allocated: std.Map<'A,'N>, toallocate: std.Vec<'A>, min_val: 'N, max_val: 'N): std.Vec<('A, 'N)>
 extern function allocate.allocate (allocated: std.Set<'N>, toallocate: std.Vec<'B>, min_val: 'N, max_val: 'N): std.Vec<('B, 'N)>
 extern function allocate.allocate_opt (allocated: std.Set<'N>, toallocate: std.Vec<'B>, min_val: 'N, max_val: 'N): std.Vec<('B, std.Option<'N>)>
 extern function allocate.allocate_with_hint (allocated: std.Set<'N>, toallocate: std.Vec<('B, std.Option<'N>)>, min_val: 'N, max_val: 'N): std.Vec<('B, 'N)>
+function any (xs: std.Vec<bool>): bool =
+    (var res = false;
+     (for (x in xs) {
+          if x {
+              (res = true;
+               break)
+          } else {
+                ()
+            }
+      };
+      return res))
 function b0 (): bool =
     (true and false)
 function b1 (a: bool): bool =
@@ -610,6 +631,7 @@ output relation Cast_u256 [Cast_u256]
 output relation Cast_u32 [Cast_u32]
 output relation Compare [Compare]
 output relation ConcatString [ConcatString]
+output relation ControlFlow [ControlFlow]
 output relation DMethod [DMethod]
 input relation DdlogBinding [DdlogBinding]
 input relation DdlogDependency [DdlogDependency]

--- a/test/datalog_tests/simple.ast.expected
+++ b/test/datalog_tests/simple.ast.expected
@@ -19,6 +19,7 @@ typedef Alt = C0{x: bit<32>} | C1{x: bit<32>}
 typedef Answer = Answer{x: station}
 typedef Arithm = Arithm{n: bit<32>}
 typedef BMethod = BMethod{b1: Symbol, b2: Symbol}
+typedef BigintVectors = BigintVectors{expr: string, vec: std.Vec<bigint>}
 typedef Blacklist = Blacklist{addr: ip_addr_t}
 typedef C = C{f1: string, f2: string}
 typedef CMethod = CMethod{c1: Symbol, c2: Symbol}
@@ -151,6 +152,7 @@ extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
 extern type std.Ref<'A>
+typedef std.Result<'V,'E> = std.Ok{res: 'V} | std.Err{err: 'E}
 extern type std.Set<'A>
 extern type std.Vec<'A>
 typedef string_syn = string
@@ -295,6 +297,17 @@ function f1 (x: T1, y: T2, q: T3): bool =
                   "bar" -> true,
                   _ -> false
               }))))))))))
+function filter_gt (xs: std.Vec<bigint>, threshold: bigint): std.Vec<bigint> =
+    ((var res: std.Vec<bigint>) = std.vec_empty();
+     (for (x in xs) {
+          ((if (x <= threshold) {
+                continue
+            } else {
+                  ()
+              }: ());
+           std.vec_push(res, x))
+      };
+      return res))
 function fnested (x: nested_t): string =
     (N{.field=C{.f1=var res, .f2=_}} = x;
      res)
@@ -426,10 +439,20 @@ extern function std.hash64 (x: 'X): bit<64>
 extern function std.hex (x: 'X): string
 extern function std.htonl (x: bit<32>): bit<32>
 extern function std.htons (x: bit<16>): bit<16>
+function std.is_err (res: std.Result<'V,'E>): bool =
+    match (res) {
+        std.Ok{.res=_} -> false,
+        std.Err{.err=_} -> true
+    }
 function std.is_none (x: std.Option<'A>): bool =
     match (x) {
         std.None{} -> true,
         _ -> false
+    }
+function std.is_ok (res: std.Result<'V,'E>): bool =
+    match (res) {
+        std.Ok{.res=_} -> true,
+        std.Err{.err=_} -> false
     }
 function std.is_some (x: std.Option<'A>): bool =
     match (x) {
@@ -459,11 +482,21 @@ function std.min (x: 'A, y: 'A): 'A =
       }
 extern function std.ntohl (x: bit<32>): bit<32>
 extern function std.ntohs (x: bit<16>): bit<16>
+function std.option_unwrap_or (x: std.Option<'A>, def: 'A): 'A =
+    match (x) {
+        std.Some{.x=var v} -> v,
+        std.None{} -> def
+    }
 extern function std.parse_dec_i64 (s: string): std.Option<signed<64>>
 extern function std.parse_dec_u64 (s: string): std.Option<bit<64>>
 extern function std.pow32 (base: 'A, exp: bit<32>): 'A
 extern function std.range (from: 'A, to: 'A, step: 'A): std.Vec<'A>
 extern function std.ref_new (x: 'A): std.Ref<'A>
+function std.result_unwrap_or (res: std.Result<'V,'E>, def: 'V): 'V =
+    match (res) {
+        std.Ok{.res=var v} -> v,
+        std.Err{.err=_} -> def
+    }
 extern function std.set2vec (s: std.Set<'A>): std.Vec<'A>
 extern function std.set_contains (s: std.Set<'X>, v: 'X): bool
 extern function std.set_empty (): std.Set<'X>
@@ -482,6 +515,7 @@ extern function std.string_len (s: string): bit<64>
 extern function std.string_split (s: string, sep: string): std.Vec<string>
 extern function std.string_substr (s: string, start: bit<64>, end: bit<64>): string
 extern function std.vec2set (s: std.Vec<'A>): std.Set<'A>
+extern function std.vec_append (v: mut std.Vec<'X>, other: std.Vec<'X>): ()
 extern function std.vec_contains (v: std.Vec<'X>, x: 'X): bool
 extern function std.vec_empty (): std.Vec<'A>
 extern function std.vec_is_empty (v: std.Vec<'X>): bool
@@ -490,6 +524,7 @@ extern function std.vec_nth (v: std.Vec<'X>, n: bit<64>): std.Option<'X>
 extern function std.vec_push (v: mut std.Vec<'X>, x: 'X): ()
 extern function std.vec_push_imm (v: std.Vec<'X>, x: 'X): std.Vec<'X>
 extern function std.vec_singleton (x: 'X): std.Vec<'X>
+extern function std.vec_with_length (len: bit<64>, x: 'A): std.Vec<'A>
 function strings (): () =
     (var str1 = ("foo" ++ "bar");
      (var str2 = ((("foobar" ++ "buzz") ++ "\nraw string ") ++ "quoted string");
@@ -565,6 +600,7 @@ output relation Allocation [Allocation]
 output relation Answer [Answer]
 output relation Arithm [Arithm]
 input relation BMethod [BMethod]
+output relation BigintVectors [BigintVectors]
 input relation Blacklist [Blacklist]
 output relation CMethod [CMethod]
 output relation Cast_bigint [Cast_bigint]
@@ -928,4 +964,9 @@ R14(.t=(1, (true, ("", 32'd1)))).
 R14(.t=(0, (true, ("", 32'd1)))).
 J(.b=b) :- R13(.t=a), R14(.t=c), (a.3 == c.1.1.1), var b = a.1.
 LongJoin(.x0=x0, .x1=x1, .x2=x2, .x3=x3, .x4=x4, .x5=x5, .x6=x6, .x7=x7, .x8=x8, .x9=x9, .x10=x10, .x11=x11, .x12=x12, .x13=x13, .x14=x14, .x15=x15, .x16=x16, .x17=x17, .x18=x18, .x19=x19) :- Long(.x0=x0, .x1=x1, .x2=x2, .x3=x3, .x4=x4, .x5=x5, .x6=x6, .x7=x7, .x8=x8, .x9=x9, .x10=x10, .x11=x11, .x12=x12, .x13=x13, .x14=x14, .x15=x15, .x16=x16, .x17=x17, .x18=x18, .x19=x19), Long(.x0=x0, .x1=x1, .x2=x2, .x3=x3, .x4=x4, .x5=x5, .x6=x6, .x7=x7, .x8=x8, .x9=x9, .x10=x10, .x11=x11, .x12=x12, .x13=x13, .x14=x14, .x15=x15, .x16=x16, .x17=x17, .x18=x18, .x19=x19), Long(.x0=x0, .x1=x1, .x2=x2, .x3=x3, .x4=x4, .x5=x5, .x6=x6, .x7=x7, .x8=x8, .x9=x9, .x10=x10, .x11=x11, .x12=x12, .x13=x13, .x14=x14, .x15=x15, .x16=x16, .x17=x17, .x18=x18, .x19=x19).
+ControlFlow(.expr="all(true, true, false)", .value=("" ++ std.__builtin_2string(all(std.vec_push_imm(std.vec_push_imm(std.vec_push_imm((std.vec_empty(): std.Vec<bool>), true), true), false))))).
+ControlFlow(.expr="all(true, true, true)", .value=("" ++ std.__builtin_2string(all(std.vec_push_imm(std.vec_push_imm(std.vec_push_imm((std.vec_empty(): std.Vec<bool>), true), true), true))))).
+ControlFlow(.expr="any(false, true, false)", .value=("" ++ std.__builtin_2string(any(std.vec_push_imm(std.vec_push_imm(std.vec_push_imm((std.vec_empty(): std.Vec<bool>), false), true), false))))).
+ControlFlow(.expr="any(false, false, false)", .value=("" ++ std.__builtin_2string(any(std.vec_push_imm(std.vec_push_imm(std.vec_push_imm((std.vec_empty(): std.Vec<bool>), false), false), false))))).
+BigintVectors(.expr="filter_gt((10, 20, 30), 15)", .vec=filter_gt(std.vec_push_imm(std.vec_push_imm(std.vec_push_imm((std.vec_empty(): std.Vec<bigint>), 10), 20), 30), 15)).
 apply graph.SCC(Edge, edge_from, edge_to) -> (SCCLabel)

--- a/test/datalog_tests/simple.dl
+++ b/test/datalog_tests/simple.dl
@@ -1127,3 +1127,54 @@ function agg1(g1: Group<(Tt1)>):Ttmp0 =
         })
     });
     (Ttmp0{.col4 = max5})
+
+
+/* tests for `break`, `continue`, and `return` statements. */
+
+function all(xs: Vec<bool>): bool =
+{
+    for (x in xs) {
+        if (not x) return false
+    };
+    return true
+}
+
+function any(xs: Vec<bool>): bool =
+{
+    var res = false;
+    for (x in xs) {
+        if (x) {
+            res = true;
+            break
+        }
+    };
+    return res
+}
+
+output relation ControlFlow(expr: string, value: string)
+
+ControlFlow("all(true, true, false)",
+    "${all(vec_push_imm(vec_push_imm(vec_push_imm(vec_empty(): Vec<bool>, true), true), false))}").
+
+ControlFlow("all(true, true, true)",
+    "${all(vec_push_imm(vec_push_imm(vec_push_imm(vec_empty(): Vec<bool>, true), true), true))}").
+
+ControlFlow("any(false, true, false)",
+    "${any(vec_push_imm(vec_push_imm(vec_push_imm(vec_empty(): Vec<bool>, false), true), false))}").
+
+ControlFlow("any(false, false, false)",
+    "${any(vec_push_imm(vec_push_imm(vec_push_imm(vec_empty(): Vec<bool>, false), false), false))}").
+
+function filter_gt(xs: Vec<bigint>, threshold: bigint): Vec<bigint> =
+{
+    var res: Vec<bigint> = vec_empty();
+    for (x in xs) {
+        if (x <= threshold) continue: ();
+        vec_push(res, x)
+    };
+    return res
+}
+
+output relation BigintVectors(expr: string, vec: Vec<bigint>)
+BigintVectors("filter_gt((10, 20, 30), 15)",
+    filter_gt(vec_push_imm(vec_push_imm(vec_push_imm(vec_empty(): Vec<bigint>, 10), 20), 30), 15)).

--- a/test/datalog_tests/simple.dump.expected
+++ b/test/datalog_tests/simple.dump.expected
@@ -64,6 +64,9 @@ Arithm{12}
 Arithm{13}
 Arithm{14}
 
+BigintVectors:
+BigintVectors{"filter_gt((10, 20, 30), 15)",[20,30]}
+
 Cast_bigint:
 Cast_bigint{"(32'sd0 - 32'sd10) as bigint",-10,-10}
 Cast_bigint{"128'd100 as bigint",100,100}
@@ -136,6 +139,12 @@ Compare{"C{\"a\", \"b\"} > C{\"b\", \"e\"}",false}
 Compare{"None < Some{1}",true}
 Compare{"Some{0} < Some{1}",true}
 Compare{"true >= false",true}
+
+ControlFlow:
+ControlFlow{"all(true, true, false)","false"}
+ControlFlow{"all(true, true, true)","true"}
+ControlFlow{"any(false, false, false)","false"}
+ControlFlow{"any(false, true, false)","true"}
 
 J:
 J{true}
@@ -266,6 +275,9 @@ Arithm{12}
 Arithm{13}
 Arithm{14}
 
+BigintVectors:
+BigintVectors{"filter_gt((10, 20, 30), 15)",[20,30]}
+
 Cast_bigint:
 Cast_bigint{"(32'sd0 - 32'sd10) as bigint",-10,-10}
 Cast_bigint{"128'd100 as bigint",100,100}
@@ -338,6 +350,12 @@ Compare{"C{\"a\", \"b\"} > C{\"b\", \"e\"}",false}
 Compare{"None < Some{1}",true}
 Compare{"Some{0} < Some{1}",true}
 Compare{"true >= false",true}
+
+ControlFlow:
+ControlFlow{"all(true, true, false)","false"}
+ControlFlow{"all(true, true, true)","true"}
+ControlFlow{"any(false, false, false)","false"}
+ControlFlow{"any(false, true, false)","true"}
 
 J:
 J{true}

--- a/test/datalog_tests/span_string.ast.expected
+++ b/test/datalog_tests/span_string.ast.expected
@@ -16,6 +16,7 @@ extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
 extern type std.Ref<'A>
+typedef std.Result<'V,'E> = std.Ok{res: 'V} | std.Err{err: 'E}
 extern type std.Set<'A>
 extern type std.Vec<'A>
 typedef tnid_t = uuid_t
@@ -48,10 +49,20 @@ extern function std.hash64 (x: 'X): bit<64>
 extern function std.hex (x: 'X): string
 extern function std.htonl (x: bit<32>): bit<32>
 extern function std.htons (x: bit<16>): bit<16>
+function std.is_err (res: std.Result<'V,'E>): bool =
+    match (res) {
+        std.Ok{.res=_} -> false,
+        std.Err{.err=_} -> true
+    }
 function std.is_none (x: std.Option<'A>): bool =
     match (x) {
         std.None{} -> true,
         _ -> false
+    }
+function std.is_ok (res: std.Result<'V,'E>): bool =
+    match (res) {
+        std.Ok{.res=_} -> true,
+        std.Err{.err=_} -> false
     }
 function std.is_some (x: std.Option<'A>): bool =
     match (x) {
@@ -81,11 +92,21 @@ function std.min (x: 'A, y: 'A): 'A =
       }
 extern function std.ntohl (x: bit<32>): bit<32>
 extern function std.ntohs (x: bit<16>): bit<16>
+function std.option_unwrap_or (x: std.Option<'A>, def: 'A): 'A =
+    match (x) {
+        std.Some{.x=var v} -> v,
+        std.None{} -> def
+    }
 extern function std.parse_dec_i64 (s: string): std.Option<signed<64>>
 extern function std.parse_dec_u64 (s: string): std.Option<bit<64>>
 extern function std.pow32 (base: 'A, exp: bit<32>): 'A
 extern function std.range (from: 'A, to: 'A, step: 'A): std.Vec<'A>
 extern function std.ref_new (x: 'A): std.Ref<'A>
+function std.result_unwrap_or (res: std.Result<'V,'E>, def: 'V): 'V =
+    match (res) {
+        std.Ok{.res=var v} -> v,
+        std.Err{.err=_} -> def
+    }
 extern function std.set2vec (s: std.Set<'A>): std.Vec<'A>
 extern function std.set_contains (s: std.Set<'X>, v: 'X): bool
 extern function std.set_empty (): std.Set<'X>
@@ -104,6 +125,7 @@ extern function std.string_len (s: string): bit<64>
 extern function std.string_split (s: string, sep: string): std.Vec<string>
 extern function std.string_substr (s: string, start: bit<64>, end: bit<64>): string
 extern function std.vec2set (s: std.Vec<'A>): std.Set<'A>
+extern function std.vec_append (v: mut std.Vec<'X>, other: std.Vec<'X>): ()
 extern function std.vec_contains (v: std.Vec<'X>, x: 'X): bool
 extern function std.vec_empty (): std.Vec<'A>
 extern function std.vec_is_empty (v: std.Vec<'X>): bool
@@ -112,6 +134,7 @@ extern function std.vec_nth (v: std.Vec<'X>, n: bit<64>): std.Option<'X>
 extern function std.vec_push (v: mut std.Vec<'X>, x: 'X): ()
 extern function std.vec_push_imm (v: std.Vec<'X>, x: 'X): std.Vec<'X>
 extern function std.vec_singleton (x: 'X): std.Vec<'X>
+extern function std.vec_with_length (len: bit<64>, x: 'A): std.Vec<'A>
 input relation Binding [Binding]
 input relation Container [Container]
 output relation ContainerSpan [ContainerSpan]

--- a/test/datalog_tests/span_uuid.ast.expected
+++ b/test/datalog_tests/span_uuid.ast.expected
@@ -16,6 +16,7 @@ extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
 extern type std.Ref<'A>
+typedef std.Result<'V,'E> = std.Ok{res: 'V} | std.Err{err: 'E}
 extern type std.Set<'A>
 extern type std.Vec<'A>
 typedef tnid_t = uuid_t
@@ -64,10 +65,20 @@ extern function std.hash64 (x: 'X): bit<64>
 extern function std.hex (x: 'X): string
 extern function std.htonl (x: bit<32>): bit<32>
 extern function std.htons (x: bit<16>): bit<16>
+function std.is_err (res: std.Result<'V,'E>): bool =
+    match (res) {
+        std.Ok{.res=_} -> false,
+        std.Err{.err=_} -> true
+    }
 function std.is_none (x: std.Option<'A>): bool =
     match (x) {
         std.None{} -> true,
         _ -> false
+    }
+function std.is_ok (res: std.Result<'V,'E>): bool =
+    match (res) {
+        std.Ok{.res=_} -> true,
+        std.Err{.err=_} -> false
     }
 function std.is_some (x: std.Option<'A>): bool =
     match (x) {
@@ -97,11 +108,21 @@ function std.min (x: 'A, y: 'A): 'A =
       }
 extern function std.ntohl (x: bit<32>): bit<32>
 extern function std.ntohs (x: bit<16>): bit<16>
+function std.option_unwrap_or (x: std.Option<'A>, def: 'A): 'A =
+    match (x) {
+        std.Some{.x=var v} -> v,
+        std.None{} -> def
+    }
 extern function std.parse_dec_i64 (s: string): std.Option<signed<64>>
 extern function std.parse_dec_u64 (s: string): std.Option<bit<64>>
 extern function std.pow32 (base: 'A, exp: bit<32>): 'A
 extern function std.range (from: 'A, to: 'A, step: 'A): std.Vec<'A>
 extern function std.ref_new (x: 'A): std.Ref<'A>
+function std.result_unwrap_or (res: std.Result<'V,'E>, def: 'V): 'V =
+    match (res) {
+        std.Ok{.res=var v} -> v,
+        std.Err{.err=_} -> def
+    }
 extern function std.set2vec (s: std.Set<'A>): std.Vec<'A>
 extern function std.set_contains (s: std.Set<'X>, v: 'X): bool
 extern function std.set_empty (): std.Set<'X>
@@ -120,6 +141,7 @@ extern function std.string_len (s: string): bit<64>
 extern function std.string_split (s: string, sep: string): std.Vec<string>
 extern function std.string_substr (s: string, start: bit<64>, end: bit<64>): string
 extern function std.vec2set (s: std.Vec<'A>): std.Set<'A>
+extern function std.vec_append (v: mut std.Vec<'X>, other: std.Vec<'X>): ()
 extern function std.vec_contains (v: std.Vec<'X>, x: 'X): bool
 extern function std.vec_empty (): std.Vec<'A>
 extern function std.vec_is_empty (v: std.Vec<'X>): bool
@@ -128,6 +150,7 @@ extern function std.vec_nth (v: std.Vec<'X>, n: bit<64>): std.Option<'X>
 extern function std.vec_push (v: mut std.Vec<'X>, x: 'X): ()
 extern function std.vec_push_imm (v: std.Vec<'X>, x: 'X): std.Vec<'X>
 extern function std.vec_singleton (x: 'X): std.Vec<'X>
+extern function std.vec_with_length (len: bit<64>, x: 'A): std.Vec<'A>
 input relation Binding [Binding]
 input relation Container [Container]
 output relation ContainerSpan [ContainerSpan]

--- a/test/datalog_tests/three.ast.expected
+++ b/test/datalog_tests/three.ast.expected
@@ -9,6 +9,7 @@ extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
 extern type std.Ref<'A>
+typedef std.Result<'V,'E> = std.Ok{res: 'V} | std.Err{err: 'E}
 extern type std.Set<'A>
 extern type std.Vec<'A>
 extern function log.log (module: log.module_t, level: log.log_level_t, msg: string): bool
@@ -39,10 +40,20 @@ extern function std.hash64 (x: 'X): bit<64>
 extern function std.hex (x: 'X): string
 extern function std.htonl (x: bit<32>): bit<32>
 extern function std.htons (x: bit<16>): bit<16>
+function std.is_err (res: std.Result<'V,'E>): bool =
+    match (res) {
+        std.Ok{.res=_} -> false,
+        std.Err{.err=_} -> true
+    }
 function std.is_none (x: std.Option<'A>): bool =
     match (x) {
         std.None{} -> true,
         _ -> false
+    }
+function std.is_ok (res: std.Result<'V,'E>): bool =
+    match (res) {
+        std.Ok{.res=_} -> true,
+        std.Err{.err=_} -> false
     }
 function std.is_some (x: std.Option<'A>): bool =
     match (x) {
@@ -72,11 +83,21 @@ function std.min (x: 'A, y: 'A): 'A =
       }
 extern function std.ntohl (x: bit<32>): bit<32>
 extern function std.ntohs (x: bit<16>): bit<16>
+function std.option_unwrap_or (x: std.Option<'A>, def: 'A): 'A =
+    match (x) {
+        std.Some{.x=var v} -> v,
+        std.None{} -> def
+    }
 extern function std.parse_dec_i64 (s: string): std.Option<signed<64>>
 extern function std.parse_dec_u64 (s: string): std.Option<bit<64>>
 extern function std.pow32 (base: 'A, exp: bit<32>): 'A
 extern function std.range (from: 'A, to: 'A, step: 'A): std.Vec<'A>
 extern function std.ref_new (x: 'A): std.Ref<'A>
+function std.result_unwrap_or (res: std.Result<'V,'E>, def: 'V): 'V =
+    match (res) {
+        std.Ok{.res=var v} -> v,
+        std.Err{.err=_} -> def
+    }
 extern function std.set2vec (s: std.Set<'A>): std.Vec<'A>
 extern function std.set_contains (s: std.Set<'X>, v: 'X): bool
 extern function std.set_empty (): std.Set<'X>
@@ -95,6 +116,7 @@ extern function std.string_len (s: string): bit<64>
 extern function std.string_split (s: string, sep: string): std.Vec<string>
 extern function std.string_substr (s: string, start: bit<64>, end: bit<64>): string
 extern function std.vec2set (s: std.Vec<'A>): std.Set<'A>
+extern function std.vec_append (v: mut std.Vec<'X>, other: std.Vec<'X>): ()
 extern function std.vec_contains (v: std.Vec<'X>, x: 'X): bool
 extern function std.vec_empty (): std.Vec<'A>
 extern function std.vec_is_empty (v: std.Vec<'X>): bool
@@ -103,6 +125,7 @@ extern function std.vec_nth (v: std.Vec<'X>, n: bit<64>): std.Option<'X>
 extern function std.vec_push (v: mut std.Vec<'X>, x: 'X): ()
 extern function std.vec_push_imm (v: std.Vec<'X>, x: 'X): std.Vec<'X>
 extern function std.vec_singleton (x: 'X): std.Vec<'X>
+extern function std.vec_with_length (len: bit<64>, x: 'A): std.Vec<'A>
 input relation I [I]
 relation M [M]
 output relation O [O]

--- a/test/datalog_tests/tutorial.ast.expected
+++ b/test/datalog_tests/tutorial.ast.expected
@@ -66,6 +66,7 @@ extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
 extern type std.Ref<'A>
+typedef std.Result<'V,'E> = std.Ok{res: 'V} | std.Err{err: 'E}
 extern type std.Set<'A>
 extern type std.Vec<'A>
 typedef student_id = bit<64>
@@ -161,10 +162,20 @@ extern function std.hash64 (x: 'X): bit<64>
 extern function std.hex (x: 'X): string
 extern function std.htonl (x: bit<32>): bit<32>
 extern function std.htons (x: bit<16>): bit<16>
+function std.is_err (res: std.Result<'V,'E>): bool =
+    match (res) {
+        std.Ok{.res=_} -> false,
+        std.Err{.err=_} -> true
+    }
 function std.is_none (x: std.Option<'A>): bool =
     match (x) {
         std.None{} -> true,
         _ -> false
+    }
+function std.is_ok (res: std.Result<'V,'E>): bool =
+    match (res) {
+        std.Ok{.res=_} -> true,
+        std.Err{.err=_} -> false
     }
 function std.is_some (x: std.Option<'A>): bool =
     match (x) {
@@ -194,11 +205,21 @@ function std.min (x: 'A, y: 'A): 'A =
       }
 extern function std.ntohl (x: bit<32>): bit<32>
 extern function std.ntohs (x: bit<16>): bit<16>
+function std.option_unwrap_or (x: std.Option<'A>, def: 'A): 'A =
+    match (x) {
+        std.Some{.x=var v} -> v,
+        std.None{} -> def
+    }
 extern function std.parse_dec_i64 (s: string): std.Option<signed<64>>
 extern function std.parse_dec_u64 (s: string): std.Option<bit<64>>
 extern function std.pow32 (base: 'A, exp: bit<32>): 'A
 extern function std.range (from: 'A, to: 'A, step: 'A): std.Vec<'A>
 extern function std.ref_new (x: 'A): std.Ref<'A>
+function std.result_unwrap_or (res: std.Result<'V,'E>, def: 'V): 'V =
+    match (res) {
+        std.Ok{.res=var v} -> v,
+        std.Err{.err=_} -> def
+    }
 extern function std.set2vec (s: std.Set<'A>): std.Vec<'A>
 extern function std.set_contains (s: std.Set<'X>, v: 'X): bool
 extern function std.set_empty (): std.Set<'X>
@@ -217,6 +238,7 @@ extern function std.string_len (s: string): bit<64>
 extern function std.string_split (s: string, sep: string): std.Vec<string>
 extern function std.string_substr (s: string, start: bit<64>, end: bit<64>): string
 extern function std.vec2set (s: std.Vec<'A>): std.Set<'A>
+extern function std.vec_append (v: mut std.Vec<'X>, other: std.Vec<'X>): ()
 extern function std.vec_contains (v: std.Vec<'X>, x: 'X): bool
 extern function std.vec_empty (): std.Vec<'A>
 extern function std.vec_is_empty (v: std.Vec<'X>): bool
@@ -225,6 +247,7 @@ extern function std.vec_nth (v: std.Vec<'X>, n: bit<64>): std.Option<'X>
 extern function std.vec_push (v: mut std.Vec<'X>, x: 'X): ()
 extern function std.vec_push_imm (v: std.Vec<'X>, x: 'X): std.Vec<'X>
 extern function std.vec_singleton (x: 'X): std.Vec<'X>
+extern function std.vec_with_length (len: bit<64>, x: 'A): std.Vec<'A>
 extern function string_slice_unsafe (x: string, from: bit<64>, to: bit<64>): string
 function tcp6_packet (ethsrc: bit<48>, ethdst: bit<48>, ipsrc: ip6_addr_t, ipdst: ip6_addr_t, srcport: bit<16>, dstport: bit<16>): eth_pkt_t =
     EthPacket{.src=ethsrc, .dst=ethdst, .payload=EthIP6{.ip6=IP6Pkt{.ttl=8'd10, .src=ipsrc, .dst=ipdst, .payload=IPTCP{.tcp=TCPPkt{.src=srcport, .dst=dstport, .flags=9'd0}}}}}

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -33,7 +33,7 @@ ENV PATH=/root/.local/bin:/root/.cargo/bin:$PATH
 ENV CLASSPATH=$CLASSPATH:/flatbuffers/java
 
 # Install Rust
-RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.36.0 -y
+RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.39.0 -y
 RUN rustup component add rustfmt
 RUN rustup component add clippy
 

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -43,8 +43,7 @@ RUN cd differential-datalog && stack --no-terminal --install-ghc test --only-dep
 RUN rm -rf differential-datalog
 
 # Python packages needed by souffle scripts
-RUN pip install     \
-    parglare
+RUN pip install parglare==0.10.0
 
 ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 ENV JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"

--- a/tools/vim/syntax/dl.vim
+++ b/tools/vim/syntax/dl.vim
@@ -22,7 +22,7 @@ syn match  dlDelimiter	       "[\[\]!?@#\~&|\^=<>%+-,;\:\.@]"
 syn region dlRawString start='\[|' end="|]"
 
 "Regular keywords
-syn keyword dlStatement        mut and extern function apply transformer not or input index on output relation match var let switch FlatMap Aggregate import as primary key
+syn keyword dlStatement        mut break continue return and extern function apply transformer not or input index on output relation match var let switch FlatMap Aggregate import as primary key
 
 syn keyword dlTodo             contained TODO FIXME XXX
 


### PR DESCRIPTION
Initial implementation of Antrea controller logic in DDlog:
https://github.com/vmware-tanzu/antrea/blob/master/pkg/controller/networkpolicy/networkpolicy_controller.go

There are several todos in the code, and we only test that the code
compiles, not that it does anything useful.

This PR also introduces three new constructs: `continue`, `break`, and `return`. (#70)