### PR TITLE
Pass group-by variables to aggregation functions.

### DIFF
--- a/lib/ovsdb.dl
+++ b/lib/ovsdb.dl
@@ -34,15 +34,15 @@ extern function map_extract_val_uuids(ids: Map<'K, uuid_or_string_t>): Map<'K, u
 // Like group2vec, but additionally filters out a sentinel value `Right{""}`.
 // A sentinel value is added to an empty set before `FlatMap` to ensure that `FlatMap`
 // generates at least one entry.  It must be filtered out in a subsequent `Aggregate`.
-extern function group2vec_remove_sentinel(g: Group<uuid_or_string_t>): Vec<uuid_or_string_t>
+extern function group2vec_remove_sentinel(g: Group<'K, uuid_or_string_t>): Vec<uuid_or_string_t>
 
 // Like group2set, but additionally filters out a sentinel value `Right{""}`.
 // A sentinel value is added to an empty set before `FlatMap` to ensure that `FlatMap`
 // generates at least one entry.  It must be filtered out in a subsequent `Aggregate`.
-extern function group2set_remove_sentinel(g: Group<uuid_or_string_t>): Set<uuid_or_string_t>
+extern function group2set_remove_sentinel(g: Group<'K, uuid_or_string_t>): Set<uuid_or_string_t>
 
 // Like group2map, but additionally filters out a sentinel value `Right{""}`.
 // A sentinel value is added to an empty map before `FlatMap` to ensure that `FlatMap`
 // generates at least one entry.  It must be filtered out in a subsequent `Aggregate`.
-extern function group2map_remove_sentinel(g: Group<('K, uuid_or_string_t)>): Map<'K, uuid_or_string_t>
+extern function group2map_remove_sentinel(g: Group<'K1, ('K2, uuid_or_string_t)>): Map<'K2, uuid_or_string_t>
 

--- a/lib/ovsdb.rs
+++ b/lib/ovsdb.rs
@@ -15,8 +15,8 @@ pub fn ovsdb_set_extract_uuids(ids: &std_Set<ovsdb_uuid_or_string_t>) -> std_Set
     std_Set::from_iter(ids.x.iter().map(|x| ovsdb_extract_uuid(x)))
 }
 
-pub fn ovsdb_group2vec_remove_sentinel(
-    g: &std_Group<ovsdb_uuid_or_string_t>,
+pub fn ovsdb_group2vec_remove_sentinel<K>(
+    g: &std_Group<K, ovsdb_uuid_or_string_t>,
 ) -> std_Vec<ovsdb_uuid_or_string_t> {
     let mut res = std_Vec::new();
     for ref v in g.iter() {
@@ -34,8 +34,8 @@ pub fn ovsdb_group2vec_remove_sentinel(
     res
 }
 
-pub fn ovsdb_group2set_remove_sentinel(
-    g: &std_Group<ovsdb_uuid_or_string_t>,
+pub fn ovsdb_group2set_remove_sentinel<K>(
+    g: &std_Group<K, ovsdb_uuid_or_string_t>,
 ) -> std_Set<ovsdb_uuid_or_string_t> {
     let mut res = std_Set::new();
     for ref v in g.iter() {
@@ -53,9 +53,9 @@ pub fn ovsdb_group2set_remove_sentinel(
     res
 }
 
-pub fn ovsdb_group2map_remove_sentinel<K: Ord + Clone>(
-    g: &std_Group<(K, ovsdb_uuid_or_string_t)>,
-) -> std_Map<K, ovsdb_uuid_or_string_t> {
+pub fn ovsdb_group2map_remove_sentinel<K1, K2: Ord + Clone>(
+    g: &std_Group<K1, (K2, ovsdb_uuid_or_string_t)>,
+) -> std_Map<K2, ovsdb_uuid_or_string_t> {
     let mut res = std_Map::new();
     for (ref k, ref v) in g.iter() {
         match v {

--- a/lib/souffle_lib.dl
+++ b/lib/souffle_lib.dl
@@ -25,4 +25,4 @@ function random(): Tnumber = 0
 function land(l: Tnumber, r: Tnumber): Tnumber = if (l != 0 and r != 0) 1 else 0
 function lor(l: Tnumber, r: Tnumber): Tnumber = if (l == 0 and r == 0) 0 else 1
 function lnot(l: Tnumber): Tnumber = if (l != 0) 0 else 1
-function group_count32(g: Group<'A>): Tnumber = castTo32(group_count(g))
+function group_count32(g: Group<'K, 'V>): Tnumber = castTo32(group_count(g))

--- a/lib/std.dl
+++ b/lib/std.dl
@@ -131,8 +131,13 @@ extern function hash128(x: 'X): bit<128>
 
 /* The `Group` type is used exclusively in aggregation operations.  It
  * represents a non-empty list of objects sorted in ascending order.
+ * `'K` is the type of group key, and `'V` is the type of value in the group.
  */
-extern type Group<'A>
+extern type Group<'K,'V>
+
+/* Extracts group key.
+ */
+extern function group_key(g: Group<'K, 'V>): 'K
 
 /*
  * Standard aggregates
@@ -140,23 +145,23 @@ extern type Group<'A>
 
 /* Returns the number of elements in the group, which is guaranteed
  * to be >0. */
-extern function group_count(g: Group<'A>): bit<64>
+extern function group_count(g: Group<'K, 'V>): bit<64>
 
 /* Returns the first element of the group.
  * It always exists, as aggregation cannot return an empty group. */
-extern function group_first(g: Group<'A>): 'A
+extern function group_first(g: Group<'K, 'V>): 'V
 
 /* Returns `n`th element of the group if the group is large enough
  * or `None` otherwise.
  */
-extern function group_nth(g: Group<'A>, n: bit<64>): Option<'A>
+extern function group_nth(g: Group<'K,'V>, n: bit<64>): Option<'V>
 
-extern function group2set(g: Group<'A>): Set<'A>
-extern function group2vec(g: Group<'A>): Vec<'A>
-extern function group2map(g: Group<('K,'V)>): Map<'K,'V>
-extern function group_sum(g: Group<'A>): 'A
+extern function group2set(g: Group<'K, 'V>): Set<'V>
+extern function group2vec(g: Group<'K, 'V>): Vec<'V>
+extern function group2map(g: Group<'K1, ('K2,'V)>): Map<'K2,'V>
+extern function group_sum(g: Group<'K, 'V>): 'V
 
-function group_unzip(g: Group<('X,'Y)>): (Vec<'X>, Vec<'Y>) = {
+function group_unzip(g: Group<'K, ('X,'Y)>): (Vec<'X>, Vec<'Y>) = {
     var xs: Vec<'X> = vec_empty();
     var ys: Vec<'Y> = vec_empty();
     for (v in g) {
@@ -167,15 +172,15 @@ function group_unzip(g: Group<('X,'Y)>): (Vec<'X>, Vec<'Y>) = {
     (xs,ys)
 }
 
-extern function group_set_unions(g: Group<Set<'A>>): Set<'A>
+extern function group_set_unions(g: Group<'K, Set<'A>>): Set<'A>
 
 /* Optimized version of group_set_unions that, when the group consits of
  * a single set, simply returns the reference to this set. */
-extern function group_setref_unions(g: Group<Ref<Set<'A>>>): Ref<Set<'A>>
+extern function group_setref_unions(g: Group<'K, Ref<Set<'A>>>): Ref<Set<'A>>
 
 /* Smallest and largest group elements. */
-extern function group_min(g: Group<'A>): 'A
-extern function group_max(g: Group<'A>): 'A
+extern function group_min(g: Group<'K, 'V>): 'V
+extern function group_max(g: Group<'K, 'V>): 'V
 
 /*
  * Vec

--- a/lib/tinyset.dl
+++ b/lib/tinyset.dl
@@ -18,9 +18,9 @@ extern function union(s1: Set64<'X>, s2: Set64<'X>): Set64<'X>
 extern function unions(sets: Vec<Set64<'X>>): Set64<'X>
 
 /* Aggregates */
-extern function group2set(g: Group<'A>): Set64<'A>
-extern function group_set_unions(g: Group<Set64<'A>>): Set64<'A>
+extern function group2set(g: Group<'K, 'V>): Set64<'V>
+extern function group_set_unions(g: Group<'K, Set64<'V>>): Set64<'V>
 
 /* Optimized version of group_set_unions that, when the group consits of
  * a single set, simply returns the reference to this set. */
-extern function group_setref_unions(g: Group<Ref<Set64<'A>>>): Ref<Set64<'A>>
+extern function group_setref_unions(g: Group<'K, Ref<Set64<'V>>>): Ref<Set64<'V>>

--- a/lib/tinyset.rs
+++ b/lib/tinyset.rs
@@ -323,7 +323,7 @@ pub fn tinyset_unions<X: u64set::Fits64 + Clone>(
     tinyset_Set64 { x: s }
 }
 
-pub fn tinyset_group2set<X: u64set::Fits64>(g: &std_Group<X>) -> tinyset_Set64<X> {
+pub fn tinyset_group2set<K, V: u64set::Fits64>(g: &std_Group<K, V>) -> tinyset_Set64<V> {
     let mut res = tinyset_Set64::new();
     for ref v in g.iter() {
         tinyset_insert(&mut res, v);
@@ -331,9 +331,9 @@ pub fn tinyset_group2set<X: u64set::Fits64>(g: &std_Group<X>) -> tinyset_Set64<X
     res
 }
 
-pub fn tinyset_group_set_unions<X: u64set::Fits64 + Clone>(
-    g: &std_Group<tinyset_Set64<X>>,
-) -> tinyset_Set64<X> {
+pub fn tinyset_group_set_unions<K, V: u64set::Fits64 + Clone>(
+    g: &std_Group<K, tinyset_Set64<V>>,
+) -> tinyset_Set64<V> {
     let mut res = u64set::Set64::new();
     for gr in g.iter() {
         for v in gr.unsorted_iter() {
@@ -345,9 +345,9 @@ pub fn tinyset_group_set_unions<X: u64set::Fits64 + Clone>(
     tinyset_Set64 { x: res }
 }
 
-pub fn tinyset_group_setref_unions<X: u64set::Fits64 + Ord + Clone>(
-    g: &std_Group<std_Ref<tinyset_Set64<X>>>,
-) -> std_Ref<tinyset_Set64<X>> {
+pub fn tinyset_group_setref_unions<K, V: u64set::Fits64 + Ord + Clone>(
+    g: &std_Group<K, std_Ref<tinyset_Set64<V>>>,
+) -> std_Ref<tinyset_Set64<V>> {
     if std_group_count(g) == 1 {
         std_group_first(g)
     } else {

--- a/rust/template/Cargo.toml
+++ b/rust/template/Cargo.toml
@@ -54,6 +54,9 @@ profile = ["cpuprofiler"]
 opt-level = 2
 debug = false
 rpath = false
+# false: Performs "thin local LTO" which performs "thin" LTO on the local crate
+# only across its codegen units. No LTO is performed if codegen units is 1 or
+# opt-level is 0.
 lto = false
 debug-assertions = false
 

--- a/rust/template/differential_datalog/program.rs
+++ b/rust/template/differential_datalog/program.rs
@@ -53,7 +53,6 @@ use differential_dataflow::trace::{BatchReader, Cursor, TraceReader};
 use differential_dataflow::AsCollection;
 use differential_dataflow::Collection;
 use differential_dataflow::Data;
-use timely;
 use timely::communication::initialize::Configuration;
 use timely::communication::Allocator;
 use timely::dataflow::operators::*;
@@ -1549,7 +1548,7 @@ impl Program {
             //print!("flush\n");
             r.flush();
         }
-        if let Some((_, session)) = sessions.iter_mut().nth(0) {
+        if let Some((_, session)) = sessions.iter_mut().next() {
             /* Do nothing if timestamp has not advanced since the last
              * transaction (i.e., no updates have arrived). */
             if frontier_ts.load(Ordering::SeqCst) < *session.time() {

--- a/rust/template/differential_datalog/record.rs
+++ b/rust/template/differential_datalog/record.rs
@@ -1,6 +1,5 @@
 //! An untyped representation of DDlog values and database update commands.
 
-use libc;
 use num::{BigInt, BigUint, ToPrimitive};
 use std::borrow::Cow;
 use std::collections::{btree_map, BTreeMap, BTreeSet};

--- a/rust/template/src/lib.rs
+++ b/rust/template/src/lib.rs
@@ -39,7 +39,6 @@ use timely::worker;
 use serde::Deserialize;
 use serde::Serialize;
 
-use abomonation;
 use differential_datalog::arcval;
 
 use differential_datalog::ddval::*;

--- a/sql/src/main/java/com/vmware/ddlog/ir/DDlogTVar.java
+++ b/sql/src/main/java/com/vmware/ddlog/ir/DDlogTVar.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2020 VMware Inc. All Rights Reserved.
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.vmware.ddlog.ir;
+
+import com.vmware.ddlog.util.Linq;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+public class DDlogTVar extends DDlogType {
+    private final String name;
+
+    public DDlogTVar(String name) {
+        super(false);
+        this.name = name;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public String toString() {
+        String result = "'" + this.name;
+        return this.wrapOption(result);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DDlogTVar that = (DDlogTVar) o;
+        return name.equals(that.name);
+    }
+
+    @Override
+    public DDlogType setMayBeNull(boolean mayBeNull) {
+        if (mayBeNull)
+            throw new RuntimeException("Nullable type variables not supported");
+        return this;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(name);
+        return result;
+    }
+}

--- a/sql/src/main/java/com/vmware/ddlog/translator/TranslationVisitor.java
+++ b/sql/src/main/java/com/vmware/ddlog/translator/TranslationVisitor.java
@@ -282,6 +282,7 @@ class TranslationVisitor extends AstVisitor<DDlogIRNode, TranslationContext> {
             tupleVars.add(new DDlogEVar(s.rowVariable, s.type));
         }
 
+        DDlogTVar key = new DDlogTVar("K");
         DDlogTTuple tuple = new DDlogTTuple(tupleFields.toArray(new DDlogType[0]));
         String iter = context.freshLocalName("i");  // loop iteration variable
         DDlogEVar iterVar = new DDlogEVar(iter, tuple);
@@ -300,7 +301,7 @@ class TranslationVisitor extends AstVisitor<DDlogIRNode, TranslationContext> {
         }
 
         String agg = context.freshGlobalName("agg");
-        DDlogTUser paramType = new DDlogTUser("Group", false, tuple);
+        DDlogTUser paramType = new DDlogTUser("Group", false, key, tuple);
         DDlogFuncArg param = new DDlogFuncArg(paramName, false, paramType);
         DDlogETuple callArg = new DDlogETuple(tupleVars.toArray(new DDlogExpression[0]));
         DDlogExpression init = new DDlogEBool(true);

--- a/sql/src/test/java/ddlog/QueriesTest.java
+++ b/sql/src/test/java/ddlog/QueriesTest.java
@@ -126,7 +126,7 @@ public class QueriesTest {
         String query = "create view v1 as SELECT MIN(column1) + MAX(column1) FROM t1";
         String program = this.header(false) +
                 "typedef Ttmp0 = Ttmp0{col4:signed<64>}\n" +
-                "function agg1(g1: Group<(Tt1)>):Ttmp0 =\n" +
+                "function agg1(g1: Group<'K, (Tt1)>):Ttmp0 =\n" +
                 "var first3 = true;\n" +
                 "(var min6 = 64'sd0);\n" +
                 "(var max8 = 64'sd0);\n" +
@@ -155,7 +155,7 @@ public class QueriesTest {
         String query = "create view v1 as SELECT MIN(column2) FROM t1";
         String program = this.header(false) +
                 "typedef Ttmp0 = Ttmp0{col4:string}\n" +
-                "function agg1(g1: Group<(Tt1)>):Ttmp0 =\n" +
+                "function agg1(g1: Group<'K, (Tt1)>):Ttmp0 =\n" +
                 "var first3 = true;\n" +
                 "(var min6 = \"\");\n" +
                 "(for (i2 in g1) {\n" +
@@ -179,7 +179,7 @@ public class QueriesTest {
         String query = "create view v1 as SELECT COUNT(column1), SUM(column1) FROM t1";
         String program = this.header(false) +
                 "typedef Ttmp0 = Ttmp0{col4:signed<64>, col7:signed<64>}\n" +
-                "function agg1(g1: Group<(Tt1)>):Ttmp0 =\n" +
+                "function agg1(g1: Group<'K, (Tt1)>):Ttmp0 =\n" +
                 "var first3 = true;\n" +
                 "(var count6 = 64'sd0);\n" +
                 "(var sum9 = 64'sd0);\n" +
@@ -208,7 +208,7 @@ public class QueriesTest {
         String query = "create view v1 as SELECT COUNT(*) FROM t1";
         String program = this.header(false) +
                 "typedef Ttmp0 = Ttmp0{col4:signed<64>}\n" +
-                "function agg1(g1: Group<(Tt1)>):Ttmp0 =\n" +
+                "function agg1(g1: Group<'K, (Tt1)>):Ttmp0 =\n" +
                 "var first3 = true;\n" +
                 "(var count5 = 64'sd0);\n" +
                 "(for (i2 in g1) {\n" +
@@ -232,7 +232,7 @@ public class QueriesTest {
         String program = this.header(false) +
                 "typedef Ttmp0 = Ttmp0{column1:signed<64>, column2:string, column3:bool, column10:signed<64>}\n" +
                 "typedef Ttmp1 = Ttmp1{col6:signed<64>}\n" +
-                "function agg2(g3: Group<(Tt1,Tt2)>):Ttmp1 =\n" +
+                "function agg2(g3: Group<'K, (Tt1,Tt2)>):Ttmp1 =\n" +
                 "var first5 = true;\n" +
                 "(var count8 = 64'sd0);\n" +
                 "(for (i4 in g3) {\n" +
@@ -257,7 +257,7 @@ public class QueriesTest {
         String query = "create view v1 as SELECT COUNT(column1) FROM t1";
         String program = this.header(false) +
                 "typedef Ttmp0 = Ttmp0{col4:signed<64>}\n" +
-                "function agg1(g1: Group<(Tt1)>):Ttmp0 =\n" +
+                "function agg1(g1: Group<'K, (Tt1)>):Ttmp0 =\n" +
                 "var first3 = true;\n" +
                 "(var count6 = 64'sd0);\n" +
                 "(for (i2 in g1) {\n" +
@@ -281,7 +281,7 @@ public class QueriesTest {
         String query = "create view v1 as SELECT COUNT(column1) FROM t1";
         String program = this.header(true) +
                 "typedef Ttmp0 = Ttmp0{col4:signed<64>}\n" +
-                "function agg1(g1: Group<(Tt1)>):Ttmp0 =\n" +
+                "function agg1(g1: Group<'K, (Tt1)>):Ttmp0 =\n" +
                 "var first3 = true;\n" +
                 "(var count6 = 64'sd0);\n" +
                 "(for (i2 in g1) {\n" +
@@ -305,7 +305,7 @@ public class QueriesTest {
         String query = "create view v1 as SELECT AVG(column1) FROM t1";
         String program = this.header(false) +
                 "typedef Ttmp0 = Ttmp0{col4:signed<64>}\n" +
-                "function agg1(g1: Group<(Tt1)>):Ttmp0 =\n" +
+                "function agg1(g1: Group<'K, (Tt1)>):Ttmp0 =\n" +
                 "var first3 = true;\n" +
                 "(var avg6 = (64'sd0, 64'sd0));\n" +
                 "(for (i2 in g1) {\n" +
@@ -329,7 +329,7 @@ public class QueriesTest {
         String query = "create view v1 as SELECT AVG(column1) FROM t1";
         String program = this.header(true) +
                 "typedef Ttmp0 = Ttmp0{col4:signed<64>}\n" +
-                "function agg1(g1: Group<(Tt1)>):Ttmp0 =\n" +
+                "function agg1(g1: Group<'K, (Tt1)>):Ttmp0 =\n" +
                 "var first3 = true;\n" +
                 "(var avg6 = (64'sd0, 64'sd0));\n" +
                 "(for (i2 in g1) {\n" +
@@ -353,7 +353,7 @@ public class QueriesTest {
         String query = "create view v1 as SELECT COUNT(*) FROM t1";
         String program = this.header(true) +
                 "typedef Ttmp0 = Ttmp0{col4:signed<64>}\n" +
-                "function agg1(g1: Group<(Tt1)>):Ttmp0 =\n" +
+                "function agg1(g1: Group<'K, (Tt1)>):Ttmp0 =\n" +
                 "var first3 = true;\n" +
                 "(var count5 = 64'sd0);\n" +
                 "(for (i2 in g1) {\n" +
@@ -572,7 +572,7 @@ public class QueriesTest {
         String query = "create view v1 as SELECT MAX(CASE WHEN column2 = 'foo' THEN column1 ELSE 0 END) FROM t1";
         String program = this.header(false) +
                 "typedef Ttmp0 = Ttmp0{col4:signed<64>}\n" +
-                "function agg1(g1: Group<(Tt1)>):Ttmp0 =\n" +
+                "function agg1(g1: Group<'K, (Tt1)>):Ttmp0 =\n" +
                 "var first3 = true;\n" +
                 "(var max6 = 64'sd0);\n" +
                 "(for (i2 in g1) {\n" +
@@ -622,7 +622,7 @@ public class QueriesTest {
         String query = "create view v1 as SELECT MAX(column1) FROM t1";
         String program = this.header(false) +
                 "typedef Ttmp0 = Ttmp0{col4:signed<64>}\n" +
-                "function agg1(g1: Group<(Tt1)>):Ttmp0 =\n" +
+                "function agg1(g1: Group<'K, (Tt1)>):Ttmp0 =\n" +
                 "var first3 = true;\n" +
                 "(var max6 = 64'sd0);\n" +
                 "(for (i2 in g1) {\n" +

--- a/src/Language/DifferentialDatalog/Type.hs
+++ b/src/Language/DifferentialDatalog/Type.hs
@@ -760,7 +760,7 @@ typeIterType d t =
     case typ' d t of
          TOpaque _ tname [t']  | elem tname sET_TYPES -> Just t'
          TOpaque _ tname [k,v] | tname == mAP_TYPE    -> Just $ tTuple [k,v]
-         TOpaque _ tname [t']  | tname == gROUP_TYPE  -> Just $ t'
+         TOpaque _ tname [_,v] | tname == gROUP_TYPE  -> Just v
          _                                            -> Nothing
 
 typeIsIterable :: (WithType a) =>  DatalogProgram -> a -> Bool

--- a/src/Language/DifferentialDatalog/Validate.hs
+++ b/src/Language/DifferentialDatalog/Validate.hs
@@ -343,16 +343,15 @@ ruleCheckAggregate d rl idx = do
     let RHSAggregate v vs fname e = ruleRHS rl !! idx
     let ctx = CtxRuleRAggregate rl idx
     exprValidate d [] ctx e
-    -- group-by variables are visible in this scope
+    -- Group-by variables are visible in this scope.
     mapM_ (checkVar (pos e) d ctx) vs
+    let group_by_types = map (typ . getVar d ctx) vs
     check (notElem v vs) (pos e) $ "Aggregate variable " ++ v ++ " already declared in this scope"
-    -- aggregation function exists and takes a group as its sole argument
+    -- Aggregation function exists and takes a group as its sole argument.
     f <- checkFunc (pos e) d fname
     check (length (funcArgs f) == 1) (pos e) $ "Aggregation function must take one argument, but " ++
                                                fname ++ " takes " ++ (show $ length $ funcArgs f) ++ " arguments"
-    -- figure out type of the aggregate
-    funcTypeArgSubsts d (pos e) f [tOpaque gROUP_TYPE [exprType d ctx e]]
-
+    funcTypeArgSubsts d (pos e) f [tOpaque gROUP_TYPE [tTuple group_by_types, exprType d ctx e]]
 
 -- | Validate relation transformer
 -- * input and output argument names must be unique

--- a/test/datalog_tests/api.ast.expected
+++ b/test/datalog_tests/api.ast.expected
@@ -3,7 +3,7 @@ typedef Rout = Rout{b: bool}
 typedef log.log_level_t = signed<32>
 typedef log.module_t = signed<32>
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
-extern type std.Group<'A>
+extern type std.Group<'K,'V>
 extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
@@ -24,18 +24,19 @@ typedef std.u8 = bit<8>
 extern function log.log (module: log.module_t, level: log.log_level_t, msg: string): bool
 extern function std.__builtin_2string (x: 'X): string
 extern function std.deref (x: std.Ref<'A>): 'A
-extern function std.group2map (g: std.Group<('K, 'V)>): std.Map<'K,'V>
-extern function std.group2set (g: std.Group<'A>): std.Set<'A>
-extern function std.group2vec (g: std.Group<'A>): std.Vec<'A>
-extern function std.group_count (g: std.Group<'A>): bit<64>
-extern function std.group_first (g: std.Group<'A>): 'A
-extern function std.group_max (g: std.Group<'A>): 'A
-extern function std.group_min (g: std.Group<'A>): 'A
-extern function std.group_nth (g: std.Group<'A>, n: bit<64>): std.Option<'A>
-extern function std.group_set_unions (g: std.Group<std.Set<'A>>): std.Set<'A>
-extern function std.group_setref_unions (g: std.Group<std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
-extern function std.group_sum (g: std.Group<'A>): 'A
-function std.group_unzip (g: std.Group<('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
+extern function std.group2map (g: std.Group<'K1,('K2, 'V)>): std.Map<'K2,'V>
+extern function std.group2set (g: std.Group<'K,'V>): std.Set<'V>
+extern function std.group2vec (g: std.Group<'K,'V>): std.Vec<'V>
+extern function std.group_count (g: std.Group<'K,'V>): bit<64>
+extern function std.group_first (g: std.Group<'K,'V>): 'V
+extern function std.group_key (g: std.Group<'K,'V>): 'K
+extern function std.group_max (g: std.Group<'K,'V>): 'V
+extern function std.group_min (g: std.Group<'K,'V>): 'V
+extern function std.group_nth (g: std.Group<'K,'V>, n: bit<64>): std.Option<'V>
+extern function std.group_set_unions (g: std.Group<'K,std.Set<'A>>): std.Set<'A>
+extern function std.group_setref_unions (g: std.Group<'K,std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
+extern function std.group_sum (g: std.Group<'K,'V>): 'V
+function std.group_unzip (g: std.Group<'K,('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
     ((var xs: std.Vec<'X>) = std.vec_empty();
      ((var ys: std.Vec<'Y>) = std.vec_empty();
       (for (v in g) {

--- a/test/datalog_tests/dcm1.ast.expected
+++ b/test/datalog_tests/dcm1.ast.expected
@@ -44,7 +44,7 @@ typedef intern.IString = intern.IObj<string>
 typedef log.log_level_t = signed<32>
 typedef log.module_t = signed<32>
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
-extern type std.Group<'A>
+extern type std.Group<'K,'V>
 extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
@@ -66,14 +66,14 @@ function cast_bit64_to_bigint (x: bit<64>): bigint =
     (x as bigint)
 function cast_bit64_to_signedbit64 (x: bit<64>): signed<64> =
     (x as signed<64>)
-function count_uniq (g: std.Group<signed<64>>): bit<64> =
+function count_uniq (g: std.Group<'K,signed<64>>): bit<64> =
     ((var set: std.Set<signed<64>>) = std.set_empty();
      (for (item in g) {
           std.set_insert(set, item)
       };
       ((var count: bit<64>) = std.set_size(set);
        count)))
-function group2expressions (g: std.Group<(signed<64>, intern.IString, intern.IString, intern.IString)>): std.Vec<(intern.IString, intern.IString, std.Set<intern.IString>)> =
+function group2expressions (g: std.Group<'K,(signed<64>, intern.IString, intern.IString, intern.IString)>): std.Vec<(intern.IString, intern.IString, std.Set<intern.IString>)> =
     ((var expressions: std.Map<signed<64>,(intern.IString, intern.IString, std.Set<intern.IString>)>) = std.map_empty();
      (for (e in g) {
           match (std.map_get(expressions, e.0)) {
@@ -126,18 +126,19 @@ function pod_matches_label_selector (expressions: std.Vec<(intern.IString, inter
       matches))
 extern function std.__builtin_2string (x: 'X): string
 extern function std.deref (x: std.Ref<'A>): 'A
-extern function std.group2map (g: std.Group<('K, 'V)>): std.Map<'K,'V>
-extern function std.group2set (g: std.Group<'A>): std.Set<'A>
-extern function std.group2vec (g: std.Group<'A>): std.Vec<'A>
-extern function std.group_count (g: std.Group<'A>): bit<64>
-extern function std.group_first (g: std.Group<'A>): 'A
-extern function std.group_max (g: std.Group<'A>): 'A
-extern function std.group_min (g: std.Group<'A>): 'A
-extern function std.group_nth (g: std.Group<'A>, n: bit<64>): std.Option<'A>
-extern function std.group_set_unions (g: std.Group<std.Set<'A>>): std.Set<'A>
-extern function std.group_setref_unions (g: std.Group<std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
-extern function std.group_sum (g: std.Group<'A>): 'A
-function std.group_unzip (g: std.Group<('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
+extern function std.group2map (g: std.Group<'K1,('K2, 'V)>): std.Map<'K2,'V>
+extern function std.group2set (g: std.Group<'K,'V>): std.Set<'V>
+extern function std.group2vec (g: std.Group<'K,'V>): std.Vec<'V>
+extern function std.group_count (g: std.Group<'K,'V>): bit<64>
+extern function std.group_first (g: std.Group<'K,'V>): 'V
+extern function std.group_key (g: std.Group<'K,'V>): 'K
+extern function std.group_max (g: std.Group<'K,'V>): 'V
+extern function std.group_min (g: std.Group<'K,'V>): 'V
+extern function std.group_nth (g: std.Group<'K,'V>, n: bit<64>): std.Option<'V>
+extern function std.group_set_unions (g: std.Group<'K,std.Set<'A>>): std.Set<'A>
+extern function std.group_setref_unions (g: std.Group<'K,std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
+extern function std.group_sum (g: std.Group<'K,'V>): 'V
+function std.group_unzip (g: std.Group<'K,('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
     ((var xs: std.Vec<'X>) = std.vec_empty();
      ((var ys: std.Vec<'Y>) = std.vec_empty();
       (for (v in g) {
@@ -237,7 +238,7 @@ extern function std.vec_push (v: mut std.Vec<'X>, x: 'X): ()
 extern function std.vec_push_imm (v: std.Vec<'X>, x: 'X): std.Vec<'X>
 extern function std.vec_singleton (x: 'X): std.Vec<'X>
 extern function std.vec_with_length (len: bit<64>, x: 'A): std.Vec<'A>
-function sum (g: std.Group<signed<64>>): signed<64> =
+function sum (g: std.Group<'K,signed<64>>): signed<64> =
     ((var sum: signed<64>) = 64'sd0;
      (for (resource in g) {
           sum = (resource + sum)

--- a/test/datalog_tests/dcm1.dl
+++ b/test/datalog_tests/dcm1.dl
@@ -129,7 +129,7 @@ relation NODETAINTSGROUP(node_name:IString, num_taints: bit<64>)
 /**assumption -- because underlying datastructures are sets, values will be unique**/
 output relation NODESTHATHAVETOLERATIONS(node_name:IString)
 
-function sum(g: Group<(signed<64>)>): (signed<64>) =
+function sum(g: Group<'K, (signed<64>)>): (signed<64>) =
 {
     var sum: signed<64> = 0;
     for (resource in g) {
@@ -138,7 +138,7 @@ function sum(g: Group<(signed<64>)>): (signed<64>) =
     sum
 }
 
-function count_uniq(g: Group<(signed<64>)>): (bit<64>) =
+function count_uniq(g: Group<'K, (signed<64>)>): (bit<64>) =
 {
     var set: Set<signed<64>> = set_empty();
     for (item in g) {
@@ -243,7 +243,7 @@ PodLabelSelector(pod_name, expressions) :-
 
 /* Convert a group of (match_expression, operator, key, value) tuples into a
  * vector of match expressions. */
-function group2expressions(g: Group<(signed<64>, IString, IString, IString)>): Vec<(IString, IString, Set<IString>)> =
+function group2expressions(g: Group<'K, (signed<64>, IString, IString, IString)>): Vec<(IString, IString, Set<IString>)> =
 {
     var expressions: Map<signed<64>, (IString, IString, Set<IString>)> = map_empty();
     for (e in g) {

--- a/test/datalog_tests/modules.ast.expected
+++ b/test/datalog_tests/modules.ast.expected
@@ -21,7 +21,7 @@ typedef redist.Span = redist.Span{entity: redist.entid_t, tns: std.Ref<tinyset.S
 typedef redist.entid_t = bit<32>
 typedef redist.tnid_t = bit<16>
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
-extern type std.Group<'A>
+extern type std.Group<'K,'V>
 extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
@@ -51,18 +51,19 @@ function redist.edge_parent (e: redist.BiEdge): redist.entid_t =
     e.parent
 extern function std.__builtin_2string (x: 'X): string
 extern function std.deref (x: std.Ref<'A>): 'A
-extern function std.group2map (g: std.Group<('K, 'V)>): std.Map<'K,'V>
-extern function std.group2set (g: std.Group<'A>): std.Set<'A>
-extern function std.group2vec (g: std.Group<'A>): std.Vec<'A>
-extern function std.group_count (g: std.Group<'A>): bit<64>
-extern function std.group_first (g: std.Group<'A>): 'A
-extern function std.group_max (g: std.Group<'A>): 'A
-extern function std.group_min (g: std.Group<'A>): 'A
-extern function std.group_nth (g: std.Group<'A>, n: bit<64>): std.Option<'A>
-extern function std.group_set_unions (g: std.Group<std.Set<'A>>): std.Set<'A>
-extern function std.group_setref_unions (g: std.Group<std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
-extern function std.group_sum (g: std.Group<'A>): 'A
-function std.group_unzip (g: std.Group<('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
+extern function std.group2map (g: std.Group<'K1,('K2, 'V)>): std.Map<'K2,'V>
+extern function std.group2set (g: std.Group<'K,'V>): std.Set<'V>
+extern function std.group2vec (g: std.Group<'K,'V>): std.Vec<'V>
+extern function std.group_count (g: std.Group<'K,'V>): bit<64>
+extern function std.group_first (g: std.Group<'K,'V>): 'V
+extern function std.group_key (g: std.Group<'K,'V>): 'K
+extern function std.group_max (g: std.Group<'K,'V>): 'V
+extern function std.group_min (g: std.Group<'K,'V>): 'V
+extern function std.group_nth (g: std.Group<'K,'V>, n: bit<64>): std.Option<'V>
+extern function std.group_set_unions (g: std.Group<'K,std.Set<'A>>): std.Set<'A>
+extern function std.group_setref_unions (g: std.Group<'K,std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
+extern function std.group_sum (g: std.Group<'K,'V>): 'V
+function std.group_unzip (g: std.Group<'K,('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
     ((var xs: std.Vec<'X>) = std.vec_empty();
      ((var ys: std.Vec<'Y>) = std.vec_empty();
       (for (v in g) {
@@ -164,9 +165,9 @@ extern function std.vec_singleton (x: 'X): std.Vec<'X>
 extern function std.vec_with_length (len: bit<64>, x: 'A): std.Vec<'A>
 extern function tinyset.contains (s: tinyset.Set64<'X>, v: 'X): bool
 extern function tinyset.empty (): tinyset.Set64<'X>
-extern function tinyset.group2set (g: std.Group<'A>): tinyset.Set64<'A>
-extern function tinyset.group_set_unions (g: std.Group<tinyset.Set64<'A>>): tinyset.Set64<'A>
-extern function tinyset.group_setref_unions (g: std.Group<std.Ref<tinyset.Set64<'A>>>): std.Ref<tinyset.Set64<'A>>
+extern function tinyset.group2set (g: std.Group<'K,'V>): tinyset.Set64<'V>
+extern function tinyset.group_set_unions (g: std.Group<'K,tinyset.Set64<'V>>): tinyset.Set64<'V>
+extern function tinyset.group_setref_unions (g: std.Group<'K,std.Ref<tinyset.Set64<'V>>>): std.Ref<tinyset.Set64<'V>>
 extern function tinyset.insert (s: mut tinyset.Set64<'X>, v: 'X): ()
 extern function tinyset.insert_imm (s: tinyset.Set64<'X>, v: 'X): tinyset.Set64<'X>
 extern function tinyset.is_empty (s: tinyset.Set64<'X>): bool

--- a/test/datalog_tests/ovn.ast.expected
+++ b/test/datalog_tests/ovn.ast.expected
@@ -71,7 +71,7 @@ typedef log.module_t = signed<32>
 typedef mac_addr_t = bit<48>
 typedef port_t = bit<16>
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
-extern type std.Group<'A>
+extern type std.Group<'K,'V>
 extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
@@ -102,18 +102,19 @@ extern function ipv6_string_mapped (addr: ip6_addr_t): string
 extern function log.log (module: log.module_t, level: log.log_level_t, msg: string): bool
 extern function std.__builtin_2string (x: 'X): string
 extern function std.deref (x: std.Ref<'A>): 'A
-extern function std.group2map (g: std.Group<('K, 'V)>): std.Map<'K,'V>
-extern function std.group2set (g: std.Group<'A>): std.Set<'A>
-extern function std.group2vec (g: std.Group<'A>): std.Vec<'A>
-extern function std.group_count (g: std.Group<'A>): bit<64>
-extern function std.group_first (g: std.Group<'A>): 'A
-extern function std.group_max (g: std.Group<'A>): 'A
-extern function std.group_min (g: std.Group<'A>): 'A
-extern function std.group_nth (g: std.Group<'A>, n: bit<64>): std.Option<'A>
-extern function std.group_set_unions (g: std.Group<std.Set<'A>>): std.Set<'A>
-extern function std.group_setref_unions (g: std.Group<std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
-extern function std.group_sum (g: std.Group<'A>): 'A
-function std.group_unzip (g: std.Group<('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
+extern function std.group2map (g: std.Group<'K1,('K2, 'V)>): std.Map<'K2,'V>
+extern function std.group2set (g: std.Group<'K,'V>): std.Set<'V>
+extern function std.group2vec (g: std.Group<'K,'V>): std.Vec<'V>
+extern function std.group_count (g: std.Group<'K,'V>): bit<64>
+extern function std.group_first (g: std.Group<'K,'V>): 'V
+extern function std.group_key (g: std.Group<'K,'V>): 'K
+extern function std.group_max (g: std.Group<'K,'V>): 'V
+extern function std.group_min (g: std.Group<'K,'V>): 'V
+extern function std.group_nth (g: std.Group<'K,'V>, n: bit<64>): std.Option<'V>
+extern function std.group_set_unions (g: std.Group<'K,std.Set<'A>>): std.Set<'A>
+extern function std.group_setref_unions (g: std.Group<'K,std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
+extern function std.group_sum (g: std.Group<'K,'V>): 'V
+function std.group_unzip (g: std.Group<'K,('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
     ((var xs: std.Vec<'X>) = std.vec_empty();
      ((var ys: std.Vec<'Y>) = std.vec_empty();
       (for (v in g) {

--- a/test/datalog_tests/ovn_ftl.ast.expected
+++ b/test/datalog_tests/ovn_ftl.ast.expected
@@ -9,7 +9,7 @@ typedef log.log_level_t = signed<32>
 typedef log.module_t = signed<32>
 typedef stage = LS_IN_ACL{} | LS_OUT_ACL{} | LR_IN_ADMISSION{} | LR_IN_IP_INPUT{} | LR_IN_UNSNAT{} | LR_OUT_SNAT{} | LR_IN_DNAT{} | LR_IN_ARP_RESOLVE{} | LR_IN_ARP_REQUEST{} | LR_IN_DEFRAG{} | LR_OUT_DELIVERY{} | LS_IN_LB{} | LS_OUT_LB{} | LS_IN_PRE_ACL{} | LS_OUT_PRE_ACL{} | LS_IN_PRE_LB{} | LS_OUT_PRE_LB{} | LS_IN_PRE_STATEFUL{} | LS_OUT_PRE_STATEFUL{} | LS_IN_STATEFUL{} | LS_OUT_STATEFUL{} | LS_IN_PORT_SEC_L2{} | LS_IN_PORT_SEC_IP{} | LS_IN_PORT_SEC_ND{} | LS_IN_ARP_RSP{} | LS_IN_DHCP_OPTIONS{} | LS_IN_DHCP_RESPONSE{} | LS_IN_L2_LKUP{} | LS_OUT_PORT_SEC_IP{} | LS_OUT_PORT_SEC_L2{}
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
-extern type std.Group<'A>
+extern type std.Group<'K,'V>
 extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
@@ -30,18 +30,19 @@ typedef std.u8 = bit<8>
 extern function log.log (module: log.module_t, level: log.log_level_t, msg: string): bool
 extern function std.__builtin_2string (x: 'X): string
 extern function std.deref (x: std.Ref<'A>): 'A
-extern function std.group2map (g: std.Group<('K, 'V)>): std.Map<'K,'V>
-extern function std.group2set (g: std.Group<'A>): std.Set<'A>
-extern function std.group2vec (g: std.Group<'A>): std.Vec<'A>
-extern function std.group_count (g: std.Group<'A>): bit<64>
-extern function std.group_first (g: std.Group<'A>): 'A
-extern function std.group_max (g: std.Group<'A>): 'A
-extern function std.group_min (g: std.Group<'A>): 'A
-extern function std.group_nth (g: std.Group<'A>, n: bit<64>): std.Option<'A>
-extern function std.group_set_unions (g: std.Group<std.Set<'A>>): std.Set<'A>
-extern function std.group_setref_unions (g: std.Group<std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
-extern function std.group_sum (g: std.Group<'A>): 'A
-function std.group_unzip (g: std.Group<('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
+extern function std.group2map (g: std.Group<'K1,('K2, 'V)>): std.Map<'K2,'V>
+extern function std.group2set (g: std.Group<'K,'V>): std.Set<'V>
+extern function std.group2vec (g: std.Group<'K,'V>): std.Vec<'V>
+extern function std.group_count (g: std.Group<'K,'V>): bit<64>
+extern function std.group_first (g: std.Group<'K,'V>): 'V
+extern function std.group_key (g: std.Group<'K,'V>): 'K
+extern function std.group_max (g: std.Group<'K,'V>): 'V
+extern function std.group_min (g: std.Group<'K,'V>): 'V
+extern function std.group_nth (g: std.Group<'K,'V>, n: bit<64>): std.Option<'V>
+extern function std.group_set_unions (g: std.Group<'K,std.Set<'A>>): std.Set<'A>
+extern function std.group_setref_unions (g: std.Group<'K,std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
+extern function std.group_sum (g: std.Group<'K,'V>): 'V
+function std.group_unzip (g: std.Group<'K,('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
     ((var xs: std.Vec<'X>) = std.vec_empty();
      ((var ys: std.Vec<'Y>) = std.vec_empty();
       (for (v in g) {

--- a/test/datalog_tests/path.ast.expected
+++ b/test/datalog_tests/path.ast.expected
@@ -4,7 +4,7 @@ typedef log.log_level_t = signed<32>
 typedef log.module_t = signed<32>
 typedef node = string
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
-extern type std.Group<'A>
+extern type std.Group<'K,'V>
 extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
@@ -25,18 +25,19 @@ typedef std.u8 = bit<8>
 extern function log.log (module: log.module_t, level: log.log_level_t, msg: string): bool
 extern function std.__builtin_2string (x: 'X): string
 extern function std.deref (x: std.Ref<'A>): 'A
-extern function std.group2map (g: std.Group<('K, 'V)>): std.Map<'K,'V>
-extern function std.group2set (g: std.Group<'A>): std.Set<'A>
-extern function std.group2vec (g: std.Group<'A>): std.Vec<'A>
-extern function std.group_count (g: std.Group<'A>): bit<64>
-extern function std.group_first (g: std.Group<'A>): 'A
-extern function std.group_max (g: std.Group<'A>): 'A
-extern function std.group_min (g: std.Group<'A>): 'A
-extern function std.group_nth (g: std.Group<'A>, n: bit<64>): std.Option<'A>
-extern function std.group_set_unions (g: std.Group<std.Set<'A>>): std.Set<'A>
-extern function std.group_setref_unions (g: std.Group<std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
-extern function std.group_sum (g: std.Group<'A>): 'A
-function std.group_unzip (g: std.Group<('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
+extern function std.group2map (g: std.Group<'K1,('K2, 'V)>): std.Map<'K2,'V>
+extern function std.group2set (g: std.Group<'K,'V>): std.Set<'V>
+extern function std.group2vec (g: std.Group<'K,'V>): std.Vec<'V>
+extern function std.group_count (g: std.Group<'K,'V>): bit<64>
+extern function std.group_first (g: std.Group<'K,'V>): 'V
+extern function std.group_key (g: std.Group<'K,'V>): 'K
+extern function std.group_max (g: std.Group<'K,'V>): 'V
+extern function std.group_min (g: std.Group<'K,'V>): 'V
+extern function std.group_nth (g: std.Group<'K,'V>, n: bit<64>): std.Option<'V>
+extern function std.group_set_unions (g: std.Group<'K,std.Set<'A>>): std.Set<'A>
+extern function std.group_setref_unions (g: std.Group<'K,std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
+extern function std.group_sum (g: std.Group<'K,'V>): 'V
+function std.group_unzip (g: std.Group<'K,('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
     ((var xs: std.Vec<'X>) = std.vec_empty();
      ((var ys: std.Vec<'Y>) = std.vec_empty();
       (for (v in g) {

--- a/test/datalog_tests/redist.ast.expected
+++ b/test/datalog_tests/redist.ast.expected
@@ -11,7 +11,7 @@ typedef entid_t = bit<32>
 typedef log.log_level_t = signed<32>
 typedef log.module_t = signed<32>
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
-extern type std.Group<'A>
+extern type std.Group<'K,'V>
 extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
@@ -38,18 +38,19 @@ function edge_parent (e: BiEdge): entid_t =
 extern function log.log (module: log.module_t, level: log.log_level_t, msg: string): bool
 extern function std.__builtin_2string (x: 'X): string
 extern function std.deref (x: std.Ref<'A>): 'A
-extern function std.group2map (g: std.Group<('K, 'V)>): std.Map<'K,'V>
-extern function std.group2set (g: std.Group<'A>): std.Set<'A>
-extern function std.group2vec (g: std.Group<'A>): std.Vec<'A>
-extern function std.group_count (g: std.Group<'A>): bit<64>
-extern function std.group_first (g: std.Group<'A>): 'A
-extern function std.group_max (g: std.Group<'A>): 'A
-extern function std.group_min (g: std.Group<'A>): 'A
-extern function std.group_nth (g: std.Group<'A>, n: bit<64>): std.Option<'A>
-extern function std.group_set_unions (g: std.Group<std.Set<'A>>): std.Set<'A>
-extern function std.group_setref_unions (g: std.Group<std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
-extern function std.group_sum (g: std.Group<'A>): 'A
-function std.group_unzip (g: std.Group<('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
+extern function std.group2map (g: std.Group<'K1,('K2, 'V)>): std.Map<'K2,'V>
+extern function std.group2set (g: std.Group<'K,'V>): std.Set<'V>
+extern function std.group2vec (g: std.Group<'K,'V>): std.Vec<'V>
+extern function std.group_count (g: std.Group<'K,'V>): bit<64>
+extern function std.group_first (g: std.Group<'K,'V>): 'V
+extern function std.group_key (g: std.Group<'K,'V>): 'K
+extern function std.group_max (g: std.Group<'K,'V>): 'V
+extern function std.group_min (g: std.Group<'K,'V>): 'V
+extern function std.group_nth (g: std.Group<'K,'V>, n: bit<64>): std.Option<'V>
+extern function std.group_set_unions (g: std.Group<'K,std.Set<'A>>): std.Set<'A>
+extern function std.group_setref_unions (g: std.Group<'K,std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
+extern function std.group_sum (g: std.Group<'K,'V>): 'V
+function std.group_unzip (g: std.Group<'K,('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
     ((var xs: std.Vec<'X>) = std.vec_empty();
      ((var ys: std.Vec<'Y>) = std.vec_empty();
       (for (v in g) {
@@ -151,9 +152,9 @@ extern function std.vec_singleton (x: 'X): std.Vec<'X>
 extern function std.vec_with_length (len: bit<64>, x: 'A): std.Vec<'A>
 extern function tinyset.contains (s: tinyset.Set64<'X>, v: 'X): bool
 extern function tinyset.empty (): tinyset.Set64<'X>
-extern function tinyset.group2set (g: std.Group<'A>): tinyset.Set64<'A>
-extern function tinyset.group_set_unions (g: std.Group<tinyset.Set64<'A>>): tinyset.Set64<'A>
-extern function tinyset.group_setref_unions (g: std.Group<std.Ref<tinyset.Set64<'A>>>): std.Ref<tinyset.Set64<'A>>
+extern function tinyset.group2set (g: std.Group<'K,'V>): tinyset.Set64<'V>
+extern function tinyset.group_set_unions (g: std.Group<'K,tinyset.Set64<'V>>): tinyset.Set64<'V>
+extern function tinyset.group_setref_unions (g: std.Group<'K,std.Ref<tinyset.Set64<'V>>>): std.Ref<tinyset.Set64<'V>>
 extern function tinyset.insert (s: mut tinyset.Set64<'X>, v: 'X): ()
 extern function tinyset.insert_imm (s: tinyset.Set64<'X>, v: 'X): tinyset.Set64<'X>
 extern function tinyset.is_empty (s: tinyset.Set64<'X>): bool

--- a/test/datalog_tests/redist_opt.ast.expected
+++ b/test/datalog_tests/redist_opt.ast.expected
@@ -25,7 +25,7 @@ typedef entid_t = bit<32>
 typedef log.log_level_t = signed<32>
 typedef log.module_t = signed<32>
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
-extern type std.Group<'A>
+extern type std.Group<'K,'V>
 extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
@@ -60,18 +60,19 @@ function edge_parent (e: (entid_t, entid_t)): entid_t =
 extern function log.log (module: log.module_t, level: log.log_level_t, msg: string): bool
 extern function std.__builtin_2string (x: 'X): string
 extern function std.deref (x: std.Ref<'A>): 'A
-extern function std.group2map (g: std.Group<('K, 'V)>): std.Map<'K,'V>
-extern function std.group2set (g: std.Group<'A>): std.Set<'A>
-extern function std.group2vec (g: std.Group<'A>): std.Vec<'A>
-extern function std.group_count (g: std.Group<'A>): bit<64>
-extern function std.group_first (g: std.Group<'A>): 'A
-extern function std.group_max (g: std.Group<'A>): 'A
-extern function std.group_min (g: std.Group<'A>): 'A
-extern function std.group_nth (g: std.Group<'A>, n: bit<64>): std.Option<'A>
-extern function std.group_set_unions (g: std.Group<std.Set<'A>>): std.Set<'A>
-extern function std.group_setref_unions (g: std.Group<std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
-extern function std.group_sum (g: std.Group<'A>): 'A
-function std.group_unzip (g: std.Group<('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
+extern function std.group2map (g: std.Group<'K1,('K2, 'V)>): std.Map<'K2,'V>
+extern function std.group2set (g: std.Group<'K,'V>): std.Set<'V>
+extern function std.group2vec (g: std.Group<'K,'V>): std.Vec<'V>
+extern function std.group_count (g: std.Group<'K,'V>): bit<64>
+extern function std.group_first (g: std.Group<'K,'V>): 'V
+extern function std.group_key (g: std.Group<'K,'V>): 'K
+extern function std.group_max (g: std.Group<'K,'V>): 'V
+extern function std.group_min (g: std.Group<'K,'V>): 'V
+extern function std.group_nth (g: std.Group<'K,'V>, n: bit<64>): std.Option<'V>
+extern function std.group_set_unions (g: std.Group<'K,std.Set<'A>>): std.Set<'A>
+extern function std.group_setref_unions (g: std.Group<'K,std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
+extern function std.group_sum (g: std.Group<'K,'V>): 'V
+function std.group_unzip (g: std.Group<'K,('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
     ((var xs: std.Vec<'X>) = std.vec_empty();
      ((var ys: std.Vec<'Y>) = std.vec_empty();
       (for (v in g) {
@@ -173,9 +174,9 @@ extern function std.vec_singleton (x: 'X): std.Vec<'X>
 extern function std.vec_with_length (len: bit<64>, x: 'A): std.Vec<'A>
 extern function tinyset.contains (s: tinyset.Set64<'X>, v: 'X): bool
 extern function tinyset.empty (): tinyset.Set64<'X>
-extern function tinyset.group2set (g: std.Group<'A>): tinyset.Set64<'A>
-extern function tinyset.group_set_unions (g: std.Group<tinyset.Set64<'A>>): tinyset.Set64<'A>
-extern function tinyset.group_setref_unions (g: std.Group<std.Ref<tinyset.Set64<'A>>>): std.Ref<tinyset.Set64<'A>>
+extern function tinyset.group2set (g: std.Group<'K,'V>): tinyset.Set64<'V>
+extern function tinyset.group_set_unions (g: std.Group<'K,tinyset.Set64<'V>>): tinyset.Set64<'V>
+extern function tinyset.group_setref_unions (g: std.Group<'K,std.Ref<tinyset.Set64<'V>>>): std.Ref<tinyset.Set64<'V>>
 extern function tinyset.insert (s: mut tinyset.Set64<'X>, v: 'X): ()
 extern function tinyset.insert_imm (s: tinyset.Set64<'X>, v: 'X): tinyset.Set64<'X>
 extern function tinyset.is_empty (s: tinyset.Set64<'X>): bool

--- a/test/datalog_tests/rules.fail.ast.expected
+++ b/test/datalog_tests/rules.fail.ast.expected
@@ -7,3 +7,7 @@ expecting letter or digit, "_", ".", "(" or "["
   ./test/datalog_tests/rules.fail.dl:7:1-9:1
 
 error: ./test/datalog_tests/rules.fail.dl:10:1-11:1: Relation R3 is mutually recursive with R2 and therefore cannot appear negated in this rule
+
+error: ./test/datalog_tests/rules.fail.dl:9:40-9:41: Cannot match expected type string and actual type (string, string) in call to function concat_ys (ys: std.Group<string,string>): string
+
+error: ./test/datalog_tests/rules.fail.dl:9:40-9:41: Cannot match expected type bigint and actual type string in call to function concat_ys (ys: std.Group<(string, bigint),string>): string

--- a/test/datalog_tests/rules.fail.dl
+++ b/test/datalog_tests/rules.fail.dl
@@ -24,4 +24,41 @@ relation R3(a3: string, b3: string)
 R2(x) :- R1(x), not R3(x, "foo").
 R3(x,"foo") :- R2(x).
 
+//---
 
+// Aggregate function does not take enough arguments.
+
+input relation AggregateMe3(x: string, y: string, z: string)
+output relation Concat(s: string)
+Concat(s) :-
+    AggregateMe3(x,y,z),
+    var s = Aggregate((x,z), concat_ys(y)).
+
+// Convert group into a string prefixed by group-by variable names
+function concat_ys(ys: Group<string, string>): string = {
+    var res = group_key(ys) ++ ":";
+    for (y in ys) {
+        res = res ++ y
+    };
+    res
+}
+
+//---
+
+// Aggregate function has wrong signature
+
+input relation AggregateMe3(x: string, y: string, z: string)
+output relation Concat(s: string)
+Concat(s) :-
+    AggregateMe3(x,y,z),
+    var s = Aggregate((x,z), concat_ys(y)).
+
+// Convert group into a string prefixed by group-by variable names
+function concat_ys(ys: Group<(string, bigint), string>): string = {
+    (var x, var z) = group_key(ys);
+    var res = x ++ ":";
+    for (y in ys) {
+        res = res ++ y
+    };
+    res
+}

--- a/test/datalog_tests/server_api.ast.expected
+++ b/test/datalog_tests/server_api.ast.expected
@@ -1,7 +1,7 @@
 typedef log.log_level_t = signed<32>
 typedef log.module_t = signed<32>
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
-extern type std.Group<'A>
+extern type std.Group<'K,'V>
 extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
@@ -22,18 +22,19 @@ typedef std.u8 = bit<8>
 extern function log.log (module: log.module_t, level: log.log_level_t, msg: string): bool
 extern function std.__builtin_2string (x: 'X): string
 extern function std.deref (x: std.Ref<'A>): 'A
-extern function std.group2map (g: std.Group<('K, 'V)>): std.Map<'K,'V>
-extern function std.group2set (g: std.Group<'A>): std.Set<'A>
-extern function std.group2vec (g: std.Group<'A>): std.Vec<'A>
-extern function std.group_count (g: std.Group<'A>): bit<64>
-extern function std.group_first (g: std.Group<'A>): 'A
-extern function std.group_max (g: std.Group<'A>): 'A
-extern function std.group_min (g: std.Group<'A>): 'A
-extern function std.group_nth (g: std.Group<'A>, n: bit<64>): std.Option<'A>
-extern function std.group_set_unions (g: std.Group<std.Set<'A>>): std.Set<'A>
-extern function std.group_setref_unions (g: std.Group<std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
-extern function std.group_sum (g: std.Group<'A>): 'A
-function std.group_unzip (g: std.Group<('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
+extern function std.group2map (g: std.Group<'K1,('K2, 'V)>): std.Map<'K2,'V>
+extern function std.group2set (g: std.Group<'K,'V>): std.Set<'V>
+extern function std.group2vec (g: std.Group<'K,'V>): std.Vec<'V>
+extern function std.group_count (g: std.Group<'K,'V>): bit<64>
+extern function std.group_first (g: std.Group<'K,'V>): 'V
+extern function std.group_key (g: std.Group<'K,'V>): 'K
+extern function std.group_max (g: std.Group<'K,'V>): 'V
+extern function std.group_min (g: std.Group<'K,'V>): 'V
+extern function std.group_nth (g: std.Group<'K,'V>, n: bit<64>): std.Option<'V>
+extern function std.group_set_unions (g: std.Group<'K,std.Set<'A>>): std.Set<'A>
+extern function std.group_setref_unions (g: std.Group<'K,std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
+extern function std.group_sum (g: std.Group<'K,'V>): 'V
+function std.group_unzip (g: std.Group<'K,('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
     ((var xs: std.Vec<'X>) = std.vec_empty();
      ((var ys: std.Vec<'Y>) = std.vec_empty();
       (for (v in g) {

--- a/test/datalog_tests/server_api_1.ast.expected
+++ b/test/datalog_tests/server_api_1.ast.expected
@@ -1,7 +1,7 @@
 typedef log.log_level_t = signed<32>
 typedef log.module_t = signed<32>
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
-extern type std.Group<'A>
+extern type std.Group<'K,'V>
 extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
@@ -22,18 +22,19 @@ typedef std.u8 = bit<8>
 extern function log.log (module: log.module_t, level: log.log_level_t, msg: string): bool
 extern function std.__builtin_2string (x: 'X): string
 extern function std.deref (x: std.Ref<'A>): 'A
-extern function std.group2map (g: std.Group<('K, 'V)>): std.Map<'K,'V>
-extern function std.group2set (g: std.Group<'A>): std.Set<'A>
-extern function std.group2vec (g: std.Group<'A>): std.Vec<'A>
-extern function std.group_count (g: std.Group<'A>): bit<64>
-extern function std.group_first (g: std.Group<'A>): 'A
-extern function std.group_max (g: std.Group<'A>): 'A
-extern function std.group_min (g: std.Group<'A>): 'A
-extern function std.group_nth (g: std.Group<'A>, n: bit<64>): std.Option<'A>
-extern function std.group_set_unions (g: std.Group<std.Set<'A>>): std.Set<'A>
-extern function std.group_setref_unions (g: std.Group<std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
-extern function std.group_sum (g: std.Group<'A>): 'A
-function std.group_unzip (g: std.Group<('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
+extern function std.group2map (g: std.Group<'K1,('K2, 'V)>): std.Map<'K2,'V>
+extern function std.group2set (g: std.Group<'K,'V>): std.Set<'V>
+extern function std.group2vec (g: std.Group<'K,'V>): std.Vec<'V>
+extern function std.group_count (g: std.Group<'K,'V>): bit<64>
+extern function std.group_first (g: std.Group<'K,'V>): 'V
+extern function std.group_key (g: std.Group<'K,'V>): 'K
+extern function std.group_max (g: std.Group<'K,'V>): 'V
+extern function std.group_min (g: std.Group<'K,'V>): 'V
+extern function std.group_nth (g: std.Group<'K,'V>, n: bit<64>): std.Option<'V>
+extern function std.group_set_unions (g: std.Group<'K,std.Set<'A>>): std.Set<'A>
+extern function std.group_setref_unions (g: std.Group<'K,std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
+extern function std.group_sum (g: std.Group<'K,'V>): 'V
+function std.group_unzip (g: std.Group<'K,('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
     ((var xs: std.Vec<'X>) = std.vec_empty();
      ((var ys: std.Vec<'Y>) = std.vec_empty();
       (for (v in g) {

--- a/test/datalog_tests/server_api_2.ast.expected
+++ b/test/datalog_tests/server_api_2.ast.expected
@@ -1,7 +1,7 @@
 typedef log.log_level_t = signed<32>
 typedef log.module_t = signed<32>
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
-extern type std.Group<'A>
+extern type std.Group<'K,'V>
 extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
@@ -22,18 +22,19 @@ typedef std.u8 = bit<8>
 extern function log.log (module: log.module_t, level: log.log_level_t, msg: string): bool
 extern function std.__builtin_2string (x: 'X): string
 extern function std.deref (x: std.Ref<'A>): 'A
-extern function std.group2map (g: std.Group<('K, 'V)>): std.Map<'K,'V>
-extern function std.group2set (g: std.Group<'A>): std.Set<'A>
-extern function std.group2vec (g: std.Group<'A>): std.Vec<'A>
-extern function std.group_count (g: std.Group<'A>): bit<64>
-extern function std.group_first (g: std.Group<'A>): 'A
-extern function std.group_max (g: std.Group<'A>): 'A
-extern function std.group_min (g: std.Group<'A>): 'A
-extern function std.group_nth (g: std.Group<'A>, n: bit<64>): std.Option<'A>
-extern function std.group_set_unions (g: std.Group<std.Set<'A>>): std.Set<'A>
-extern function std.group_setref_unions (g: std.Group<std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
-extern function std.group_sum (g: std.Group<'A>): 'A
-function std.group_unzip (g: std.Group<('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
+extern function std.group2map (g: std.Group<'K1,('K2, 'V)>): std.Map<'K2,'V>
+extern function std.group2set (g: std.Group<'K,'V>): std.Set<'V>
+extern function std.group2vec (g: std.Group<'K,'V>): std.Vec<'V>
+extern function std.group_count (g: std.Group<'K,'V>): bit<64>
+extern function std.group_first (g: std.Group<'K,'V>): 'V
+extern function std.group_key (g: std.Group<'K,'V>): 'K
+extern function std.group_max (g: std.Group<'K,'V>): 'V
+extern function std.group_min (g: std.Group<'K,'V>): 'V
+extern function std.group_nth (g: std.Group<'K,'V>, n: bit<64>): std.Option<'V>
+extern function std.group_set_unions (g: std.Group<'K,std.Set<'A>>): std.Set<'A>
+extern function std.group_setref_unions (g: std.Group<'K,std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
+extern function std.group_sum (g: std.Group<'K,'V>): 'V
+function std.group_unzip (g: std.Group<'K,('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
     ((var xs: std.Vec<'X>) = std.vec_empty();
      ((var ys: std.Vec<'Y>) = std.vec_empty();
       (for (v in g) {

--- a/test/datalog_tests/server_api_3.ast.expected
+++ b/test/datalog_tests/server_api_3.ast.expected
@@ -1,7 +1,7 @@
 typedef log.log_level_t = signed<32>
 typedef log.module_t = signed<32>
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
-extern type std.Group<'A>
+extern type std.Group<'K,'V>
 extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
@@ -22,18 +22,19 @@ typedef std.u8 = bit<8>
 extern function log.log (module: log.module_t, level: log.log_level_t, msg: string): bool
 extern function std.__builtin_2string (x: 'X): string
 extern function std.deref (x: std.Ref<'A>): 'A
-extern function std.group2map (g: std.Group<('K, 'V)>): std.Map<'K,'V>
-extern function std.group2set (g: std.Group<'A>): std.Set<'A>
-extern function std.group2vec (g: std.Group<'A>): std.Vec<'A>
-extern function std.group_count (g: std.Group<'A>): bit<64>
-extern function std.group_first (g: std.Group<'A>): 'A
-extern function std.group_max (g: std.Group<'A>): 'A
-extern function std.group_min (g: std.Group<'A>): 'A
-extern function std.group_nth (g: std.Group<'A>, n: bit<64>): std.Option<'A>
-extern function std.group_set_unions (g: std.Group<std.Set<'A>>): std.Set<'A>
-extern function std.group_setref_unions (g: std.Group<std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
-extern function std.group_sum (g: std.Group<'A>): 'A
-function std.group_unzip (g: std.Group<('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
+extern function std.group2map (g: std.Group<'K1,('K2, 'V)>): std.Map<'K2,'V>
+extern function std.group2set (g: std.Group<'K,'V>): std.Set<'V>
+extern function std.group2vec (g: std.Group<'K,'V>): std.Vec<'V>
+extern function std.group_count (g: std.Group<'K,'V>): bit<64>
+extern function std.group_first (g: std.Group<'K,'V>): 'V
+extern function std.group_key (g: std.Group<'K,'V>): 'K
+extern function std.group_max (g: std.Group<'K,'V>): 'V
+extern function std.group_min (g: std.Group<'K,'V>): 'V
+extern function std.group_nth (g: std.Group<'K,'V>, n: bit<64>): std.Option<'V>
+extern function std.group_set_unions (g: std.Group<'K,std.Set<'A>>): std.Set<'A>
+extern function std.group_setref_unions (g: std.Group<'K,std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
+extern function std.group_sum (g: std.Group<'K,'V>): 'V
+function std.group_unzip (g: std.Group<'K,('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
     ((var xs: std.Vec<'X>) = std.vec_empty();
      ((var ys: std.Vec<'Y>) = std.vec_empty();
       (for (v in g) {

--- a/test/datalog_tests/simple.ast.expected
+++ b/test/datalog_tests/simple.ast.expected
@@ -29,8 +29,10 @@ typedef Cast_u24 = Cast_u24{description: string, expected: bit<24>, actual: bit<
 typedef Cast_u256 = Cast_u256{description: string, expected: bit<256>, actual: bit<256>}
 typedef Cast_u32 = Cast_u32{description: string, actual: bit<32>, expected: bit<32>}
 typedef Compare = Compare{label: string, value: bool}
+typedef Concat = Concat{s: string}
 typedef ConcatString = ConcatString{s: string}
 typedef ControlFlow = ControlFlow{expr: string, value: string}
+typedef Counts1 = Counts1{x: string, occurrences: std.u64}
 typedef DMethod = DMethod{c1: Symbol, c2: Symbol}
 typedef DdlogBinding = DdlogBinding{tn: tnid_t, entity: entid_t}
 typedef DdlogDependency = DdlogDependency{parent: entid_t, child: entid_t}
@@ -100,6 +102,7 @@ typedef Strings = Strings{s: string}
 typedef Sum = Sum{x: string, sum: bit<32>}
 typedef Suspect = Suspect{name: string}
 typedef Symbol = intern.IString
+typedef Symmetric1 = Symmetric1{x: string, sym: bool}
 typedef T = T{x: bigint, y: string}
 typedef T1 = C11{f1: bigint, f2: (bigint, string)} | C12{f3: bit<32>, f4: (bool, bool, bool)}
 typedef T16 = t15
@@ -148,7 +151,7 @@ typedef souffle_types.Tnumber = signed<32>
 typedef souffle_types.Tsymbol = intern.IString
 typedef station = string
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
-extern type std.Group<'A>
+extern type std.Group<'K,'V>
 extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
@@ -217,7 +220,7 @@ function a8 (): bit<32> =
     (((32'd125 | 32'd255) | 32'd511) | 32'd683)
 function a9 (): bit<32> =
     (((32'd125 | 32'd255) | 32'd511) | 32'd683)
-function agg1 (g1: std.Group<Tt1>): Ttmp0 =
+function agg1 (g1: std.Group<'K,Tt1>): Ttmp0 =
     (var first3 = true;
      (var max5 = 64'sd0;
       (for (i2 in g1) {
@@ -261,6 +264,23 @@ function b1 (a: bool): bool =
 function c0 (a: bit<32>, b: bit<16>): bit<16> =
     (a;
      b)
+function concat_ys (ys: std.Group<(string, string),string>): string =
+    ((var x, var z) = std.group_key(ys);
+     (var res = (((x ++ "-") ++ z) ++ ":");
+      (for (y in ys) {
+           res = (res ++ y)
+       };
+       res)))
+function count_xs (ys: std.Group<string,string>): std.u64 =
+    ((var res: std.u64) = 64'd0;
+     (for (y in ys) {
+          if (y == std.group_key(ys)) {
+              res = (res + 64'd1)
+          } else {
+                ()
+            }
+      };
+      res))
 function double (x: bigint): bigint =
     (x << 32'd1)
 function double_evens (xs: std.Vec<bigint>): std.Vec<bigint> =
@@ -373,6 +393,15 @@ function filter_gt (xs: std.Vec<bigint>, threshold: bigint): std.Vec<bigint> =
            std.vec_push(res, x))
       };
       return res))
+function find_x_in_group (ys: std.Group<'A,'A>): bool =
+    (for (y in ys) {
+         if (y == std.group_key(ys)) {
+             return true
+         } else {
+               ()
+           }
+     };
+     false)
 function fnested (x: nested_t): string =
     (N{.field=C{.f1=var res, .f2=_}} = x;
      res)
@@ -440,7 +469,7 @@ function souffle_lib.cat (s: intern.IString, t: intern.IString): intern.IString 
     intern.string_intern((intern.istring_str(s) ++ intern.istring_str(t)))
 function souffle_lib.contains (s: intern.IString, i: intern.IString): bool =
     std.string_contains(intern.istring_str(i), intern.istring_str(s))
-function souffle_lib.group_count32 (g: std.Group<'A>): souffle_types.Tnumber =
+function souffle_lib.group_count32 (g: std.Group<'K,'V>): souffle_types.Tnumber =
     souffle_lib.castTo32(std.group_count(g))
 function souffle_lib.land (l: souffle_types.Tnumber, r: souffle_types.Tnumber): souffle_types.Tnumber =
     if ((l != 32'sd0) and (r != 32'sd0)) {
@@ -479,18 +508,19 @@ function souffle_lib.to_string (n: souffle_types.Tnumber): intern.IString =
     intern.string_intern(std.__builtin_2string(n))
 extern function std.__builtin_2string (x: 'X): string
 extern function std.deref (x: std.Ref<'A>): 'A
-extern function std.group2map (g: std.Group<('K, 'V)>): std.Map<'K,'V>
-extern function std.group2set (g: std.Group<'A>): std.Set<'A>
-extern function std.group2vec (g: std.Group<'A>): std.Vec<'A>
-extern function std.group_count (g: std.Group<'A>): bit<64>
-extern function std.group_first (g: std.Group<'A>): 'A
-extern function std.group_max (g: std.Group<'A>): 'A
-extern function std.group_min (g: std.Group<'A>): 'A
-extern function std.group_nth (g: std.Group<'A>, n: bit<64>): std.Option<'A>
-extern function std.group_set_unions (g: std.Group<std.Set<'A>>): std.Set<'A>
-extern function std.group_setref_unions (g: std.Group<std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
-extern function std.group_sum (g: std.Group<'A>): 'A
-function std.group_unzip (g: std.Group<('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
+extern function std.group2map (g: std.Group<'K1,('K2, 'V)>): std.Map<'K2,'V>
+extern function std.group2set (g: std.Group<'K,'V>): std.Set<'V>
+extern function std.group2vec (g: std.Group<'K,'V>): std.Vec<'V>
+extern function std.group_count (g: std.Group<'K,'V>): bit<64>
+extern function std.group_first (g: std.Group<'K,'V>): 'V
+extern function std.group_key (g: std.Group<'K,'V>): 'K
+extern function std.group_max (g: std.Group<'K,'V>): 'V
+extern function std.group_min (g: std.Group<'K,'V>): 'V
+extern function std.group_nth (g: std.Group<'K,'V>, n: bit<64>): std.Option<'V>
+extern function std.group_set_unions (g: std.Group<'K,std.Set<'A>>): std.Set<'A>
+extern function std.group_setref_unions (g: std.Group<'K,std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
+extern function std.group_sum (g: std.Group<'K,'V>): 'V
+function std.group_unzip (g: std.Group<'K,('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
     ((var xs: std.Vec<'X>) = std.vec_empty();
      ((var ys: std.Vec<'Y>) = std.vec_empty();
       (for (v in g) {
@@ -684,8 +714,10 @@ output relation Cast_u24 [Cast_u24]
 output relation Cast_u256 [Cast_u256]
 output relation Cast_u32 [Cast_u32]
 output relation Compare [Compare]
+output relation Concat [Concat]
 output relation ConcatString [ConcatString]
 output relation ControlFlow [ControlFlow]
+output relation Counts1 [Counts1]
 output relation DMethod [DMethod]
 input relation DdlogBinding [DdlogBinding]
 input relation DdlogDependency [DdlogDependency]
@@ -753,6 +785,7 @@ output relation StringOrd [StringOrd]
 input relation Strings [Strings]
 output relation Sum [Sum]
 input relation Suspect [Suspect]
+output relation Symmetric1 [Symmetric1]
 output relation T [T]
 input relation Table1 [Table1]
 output relation Table12 [Table12]
@@ -905,6 +938,8 @@ Strings(.s="word1 word2").
 Strings(.s="line1\nline2").
 Rel3(.x=x, .y=y, .z=z) :- Rel1(.x=x, .y=y), Rel2(.x=x, .z=z).
 Rel4(.x=x, .y=y, .b=b) :- Rel1(.x=x, .y=y), Rel2(.x=x, .z=Option1{.f1=_, .f2=IP4{.ip4=_}, .f3=(b, "buzz")}).
+Counts1(.x=x, .occurrences=count) :- AggregateMe1(.x=x, .y=y), var count = Aggregate((x), count_xs(y)).
+Symmetric1(.x=x, .sym=sym) :- AggregateMe1(.x=x, .y=y), var sym = Aggregate((x), find_x_in_group(y)).
 Aggregate1(.x=x, .cnt=cnt) :- AggregateMe1(.x=x, .y=y), var cnt = Aggregate((x), std.group_count(y)).
 AggregateCnt(.cnt=cnt) :- AggregateMe1(.x=x, .y=y), var cnt = Aggregate((), std.group_count(())).
 AggregateCnt2(.cnt=cnt) :- AggregateMe1(.x=x, .y=y), var cnt = Aggregate((), std.group_sum((64'd1: bit<64>))).
@@ -915,6 +950,8 @@ Aggregate4(.x=x, .map=map) :- AggregateMe1(.x=x, .y=y), var map = Aggregate((x),
 Disaggregate(.x=x, .y=y) :- AggregateMe1(.x=x, .y=y), var set = Aggregate((x), std.group2set(y)), var y = FlatMap(set).
 Sum(.x=x, .sum=sum) :- AggregateMeInts(.x=x, .y=y), var sum = Aggregate((x), std.group_sum(y)).
 AggregateByX(.x=x, .cnt=cnt) :- AggregateMe3(.x=x, .y=y, .z=z), AggregateMe1(.x=x, .y=y), var cnt = Aggregate((x), std.group_count(())).
+Concat(.s=s) :- AggregateMe3(.x=x, .y=y, .z=z), var s = Aggregate((x,
+                                                                   z), concat_ys(y)).
 WithKeyDbg(.key=k, .val=v) :- WithKey(.key=k, .val=v).
 Innocent(.name=name) :- Suspect(.name=name), not Gangster(.nickname=_, .name=name).
 ValidDestination(.addr=addr) :- Address(.addr=addr), IPAddr{.b3=var b3, .b2=var b2, .b1=_, .b0=_} = addr, not Blacklist(.addr=IPAddr{.b3=b3, .b2=b2, .b1=_, .b0=_}).

--- a/test/datalog_tests/simple.dat
+++ b/test/datalog_tests/simple.dat
@@ -55,6 +55,7 @@ start;
 insert AggregateMe1("a", "1"),
 insert AggregateMe1("a", "2"),
 insert AggregateMe1("a", "3"),
+insert AggregateMe1("a", "a"),
 insert AggregateMe1("b", "1"),
 insert AggregateMe1("b", "2"),
 insert AggregateMe1("b", "3");

--- a/test/datalog_tests/simple.dl
+++ b/test/datalog_tests/simple.dl
@@ -658,6 +658,38 @@ Rel4(x,y,b) :- Rel1(x,y),
 
 input relation AggregateMe1(x: string, y: string)
 
+output relation Counts1(x: string, occurrences: u64)
+
+Counts1(x, count) :-
+    AggregateMe1(x, y),
+    var count = Aggregate((x), count_xs(y)).
+
+// Count the number of occurrences of `x` in `ys`
+function count_xs(ys: Group<string, string>): u64 = {
+    var res: u64 = 0;
+    for (y in ys) {
+        if (y == group_key(ys)) {
+            res = res + 1
+        }
+    };
+    res
+}
+output relation Symmetric1(x: string, sym: bool)
+
+Symmetric1(x, sym) :-
+    AggregateMe1(x, y),
+    var sym = Aggregate((x), find_x_in_group(y)).
+
+// Check if `x` occurs in `ys`
+function find_x_in_group(ys: Group<'A, 'A>): bool = {
+    for (y in ys) {
+        if (y == group_key(ys)) {
+            return true
+        }
+    };
+    false
+}
+
 output relation Aggregate1(x: string, cnt: bit<64>)
 Aggregate1(x, cnt) :- AggregateMe1(x,y), var cnt = Aggregate((x), group_count(y)).
 
@@ -693,6 +725,21 @@ output relation AggregateByX(x: string, cnt: bit<64>)
 
 AggregateByX(x, cnt) :- AggregateMe3(x,y,z), AggregateMe1(x,y),
                         var cnt = Aggregate((x), group_count(())).
+
+output relation Concat(s: string)
+Concat(s) :-
+    AggregateMe3(x,y,z),
+    var s = Aggregate((x,z), concat_ys(y)).
+
+// Convert group into a string prefixed by group-by variable names
+function concat_ys(ys: Group<(string, string),string>): string = {
+    (var x, var z) = group_key(ys);
+    var res = x ++ "-" ++ z ++ ":";
+    for (y in ys) {
+        res = res ++ y
+    };
+    res
+}
 
 /* Primary key */
 input relation WithKey(key: bit<128>, val: string)
@@ -1114,7 +1161,7 @@ LongJoin(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x
 typedef Tt1 = Tt1{column1:signed<64>, column2:string, column3:bool}
 typedef Tt2 = Tt2{column1:signed<64>}
 typedef Ttmp0 = Ttmp0{col4:signed<64>}
-function agg1(g1: Group<(Tt1)>):Ttmp0 =
+function agg1(g1: Group<'K, (Tt1)>):Ttmp0 =
     var first3 = true;
     (var max5 = 64'sd0);
     (for (i2 in g1) {

--- a/test/datalog_tests/simple.dump.expected
+++ b/test/datalog_tests/simple.dump.expected
@@ -499,50 +499,60 @@ Rel3{.x = 0, .y = IP4{.ip4 = 100}, .z = Option1{.f1 = 0, .f2 = IP4{.ip4 = 300}, 
 Rel3:
 Rel3{0,IP4{100},Option1{0,IP4{300},(true, "foo")}}
 Aggregate1:
-Aggregate1{.x = "a", .cnt = 3}: +1
+Aggregate1{.x = "a", .cnt = 4}: +1
 Aggregate1{.x = "b", .cnt = 3}: +1
 Aggregate2:
-Aggregate2{.x = "a", .set = ["1", "2", "3"]}: +1
+Aggregate2{.x = "a", .set = ["1", "2", "3", "a"]}: +1
 Aggregate2{.x = "b", .set = ["1", "2", "3"]}: +1
 Aggregate3:
-Aggregate3{.x = "a", .vec = ["1", "2", "3"]}: +1
+Aggregate3{.x = "a", .vec = ["1", "2", "3", "a"]}: +1
 Aggregate3{.x = "b", .vec = ["1", "2", "3"]}: +1
 Aggregate4:
-Aggregate4{.x = "a", .map = [("a", "3")]}: +1
+Aggregate4{.x = "a", .map = [("a", "a")]}: +1
 Aggregate4{.x = "b", .map = [("b", "3")]}: +1
 AggregateByX:
 AggregateByX{.x = "a", .cnt = 3}: +1
 AggregateByX{.x = "b", .cnt = 3}: +1
 AggregateCnt:
-AggregateCnt{.cnt = 6}: +1
+AggregateCnt{.cnt = 7}: +1
 AggregateCnt2:
-AggregateCnt2{.cnt = 6}: +1
+AggregateCnt2{.cnt = 7}: +1
 AggregateCnt3:
-AggregateCnt3{.cnt = 4}: +1
+AggregateCnt3{.cnt = 5}: +1
+Concat:
+Concat{.s = "a-z:123"}: +1
+Concat{.s = "b-z:123"}: +1
+Counts1:
+Counts1{.x = "a", .occurrences = 1}: +1
+Counts1{.x = "b", .occurrences = 0}: +1
 Disaggregate:
 Disaggregate{.x = "a", .y = "1"}: +1
 Disaggregate{.x = "a", .y = "2"}: +1
 Disaggregate{.x = "a", .y = "3"}: +1
+Disaggregate{.x = "a", .y = "a"}: +1
 Disaggregate{.x = "b", .y = "1"}: +1
 Disaggregate{.x = "b", .y = "2"}: +1
 Disaggregate{.x = "b", .y = "3"}: +1
+Symmetric1:
+Symmetric1{.x = "a", .sym = true}: +1
+Symmetric1{.x = "b", .sym = false}: +1
 Aggregate1
-Aggregate1{"a",3}
+Aggregate1{"a",4}
 Aggregate1{"b",3}
 AggregateCnt
-AggregateCnt{6}
+AggregateCnt{7}
 AggregateCnt2
-AggregateCnt2{6}
+AggregateCnt2{7}
 AggregateCnt3
-AggregateCnt3{4}
+AggregateCnt3{5}
 Aggregate2
-Aggregate2{"a",["1","2","3"]}
+Aggregate2{"a",["1","2","3","a"]}
 Aggregate2{"b",["1","2","3"]}
 Aggregate3
-Aggregate3{"a",["1","2","3"]}
+Aggregate3{"a",["1","2","3","a"]}
 Aggregate3{"b",["1","2","3"]}
 Aggregate4
-Aggregate4{"a",[("a","3")]}
+Aggregate4{"a",[("a","a")]}
 Aggregate4{"b",[("b","3")]}
 AggregateByX
 AggregateByX{"a",3}
@@ -551,6 +561,7 @@ Disaggregate
 Disaggregate{"a","1"}
 Disaggregate{"a","2"}
 Disaggregate{"a","3"}
+Disaggregate{"a","a"}
 Disaggregate{"b","1"}
 Disaggregate{"b","2"}
 Disaggregate{"b","3"}

--- a/test/datalog_tests/span_string.ast.expected
+++ b/test/datalog_tests/span_string.ast.expected
@@ -11,7 +11,7 @@ typedef entid_t = uuid_t
 typedef log.log_level_t = signed<32>
 typedef log.module_t = signed<32>
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
-extern type std.Group<'A>
+extern type std.Group<'K,'V>
 extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
@@ -34,18 +34,19 @@ typedef uuid_t = string
 extern function log.log (module: log.module_t, level: log.log_level_t, msg: string): bool
 extern function std.__builtin_2string (x: 'X): string
 extern function std.deref (x: std.Ref<'A>): 'A
-extern function std.group2map (g: std.Group<('K, 'V)>): std.Map<'K,'V>
-extern function std.group2set (g: std.Group<'A>): std.Set<'A>
-extern function std.group2vec (g: std.Group<'A>): std.Vec<'A>
-extern function std.group_count (g: std.Group<'A>): bit<64>
-extern function std.group_first (g: std.Group<'A>): 'A
-extern function std.group_max (g: std.Group<'A>): 'A
-extern function std.group_min (g: std.Group<'A>): 'A
-extern function std.group_nth (g: std.Group<'A>, n: bit<64>): std.Option<'A>
-extern function std.group_set_unions (g: std.Group<std.Set<'A>>): std.Set<'A>
-extern function std.group_setref_unions (g: std.Group<std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
-extern function std.group_sum (g: std.Group<'A>): 'A
-function std.group_unzip (g: std.Group<('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
+extern function std.group2map (g: std.Group<'K1,('K2, 'V)>): std.Map<'K2,'V>
+extern function std.group2set (g: std.Group<'K,'V>): std.Set<'V>
+extern function std.group2vec (g: std.Group<'K,'V>): std.Vec<'V>
+extern function std.group_count (g: std.Group<'K,'V>): bit<64>
+extern function std.group_first (g: std.Group<'K,'V>): 'V
+extern function std.group_key (g: std.Group<'K,'V>): 'K
+extern function std.group_max (g: std.Group<'K,'V>): 'V
+extern function std.group_min (g: std.Group<'K,'V>): 'V
+extern function std.group_nth (g: std.Group<'K,'V>, n: bit<64>): std.Option<'V>
+extern function std.group_set_unions (g: std.Group<'K,std.Set<'A>>): std.Set<'A>
+extern function std.group_setref_unions (g: std.Group<'K,std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
+extern function std.group_sum (g: std.Group<'K,'V>): 'V
+function std.group_unzip (g: std.Group<'K,('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
     ((var xs: std.Vec<'X>) = std.vec_empty();
      ((var ys: std.Vec<'Y>) = std.vec_empty();
       (for (v in g) {

--- a/test/datalog_tests/span_uuid.ast.expected
+++ b/test/datalog_tests/span_uuid.ast.expected
@@ -11,7 +11,7 @@ typedef entid_t = uuid_t
 typedef log.log_level_t = signed<32>
 typedef log.module_t = signed<32>
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
-extern type std.Group<'A>
+extern type std.Group<'K,'V>
 extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
@@ -50,18 +50,19 @@ function mod_SPAN_UUID2 (): log.module_t =
     32'sd200
 extern function std.__builtin_2string (x: 'X): string
 extern function std.deref (x: std.Ref<'A>): 'A
-extern function std.group2map (g: std.Group<('K, 'V)>): std.Map<'K,'V>
-extern function std.group2set (g: std.Group<'A>): std.Set<'A>
-extern function std.group2vec (g: std.Group<'A>): std.Vec<'A>
-extern function std.group_count (g: std.Group<'A>): bit<64>
-extern function std.group_first (g: std.Group<'A>): 'A
-extern function std.group_max (g: std.Group<'A>): 'A
-extern function std.group_min (g: std.Group<'A>): 'A
-extern function std.group_nth (g: std.Group<'A>, n: bit<64>): std.Option<'A>
-extern function std.group_set_unions (g: std.Group<std.Set<'A>>): std.Set<'A>
-extern function std.group_setref_unions (g: std.Group<std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
-extern function std.group_sum (g: std.Group<'A>): 'A
-function std.group_unzip (g: std.Group<('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
+extern function std.group2map (g: std.Group<'K1,('K2, 'V)>): std.Map<'K2,'V>
+extern function std.group2set (g: std.Group<'K,'V>): std.Set<'V>
+extern function std.group2vec (g: std.Group<'K,'V>): std.Vec<'V>
+extern function std.group_count (g: std.Group<'K,'V>): bit<64>
+extern function std.group_first (g: std.Group<'K,'V>): 'V
+extern function std.group_key (g: std.Group<'K,'V>): 'K
+extern function std.group_max (g: std.Group<'K,'V>): 'V
+extern function std.group_min (g: std.Group<'K,'V>): 'V
+extern function std.group_nth (g: std.Group<'K,'V>, n: bit<64>): std.Option<'V>
+extern function std.group_set_unions (g: std.Group<'K,std.Set<'A>>): std.Set<'A>
+extern function std.group_setref_unions (g: std.Group<'K,std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
+extern function std.group_sum (g: std.Group<'K,'V>): 'V
+function std.group_unzip (g: std.Group<'K,('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
     ((var xs: std.Vec<'X>) = std.vec_empty();
      ((var ys: std.Vec<'Y>) = std.vec_empty();
       (for (v in g) {

--- a/test/datalog_tests/three.ast.expected
+++ b/test/datalog_tests/three.ast.expected
@@ -4,7 +4,7 @@ typedef O = O{x: bit<32>}
 typedef log.log_level_t = signed<32>
 typedef log.module_t = signed<32>
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
-extern type std.Group<'A>
+extern type std.Group<'K,'V>
 extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
@@ -25,18 +25,19 @@ typedef std.u8 = bit<8>
 extern function log.log (module: log.module_t, level: log.log_level_t, msg: string): bool
 extern function std.__builtin_2string (x: 'X): string
 extern function std.deref (x: std.Ref<'A>): 'A
-extern function std.group2map (g: std.Group<('K, 'V)>): std.Map<'K,'V>
-extern function std.group2set (g: std.Group<'A>): std.Set<'A>
-extern function std.group2vec (g: std.Group<'A>): std.Vec<'A>
-extern function std.group_count (g: std.Group<'A>): bit<64>
-extern function std.group_first (g: std.Group<'A>): 'A
-extern function std.group_max (g: std.Group<'A>): 'A
-extern function std.group_min (g: std.Group<'A>): 'A
-extern function std.group_nth (g: std.Group<'A>, n: bit<64>): std.Option<'A>
-extern function std.group_set_unions (g: std.Group<std.Set<'A>>): std.Set<'A>
-extern function std.group_setref_unions (g: std.Group<std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
-extern function std.group_sum (g: std.Group<'A>): 'A
-function std.group_unzip (g: std.Group<('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
+extern function std.group2map (g: std.Group<'K1,('K2, 'V)>): std.Map<'K2,'V>
+extern function std.group2set (g: std.Group<'K,'V>): std.Set<'V>
+extern function std.group2vec (g: std.Group<'K,'V>): std.Vec<'V>
+extern function std.group_count (g: std.Group<'K,'V>): bit<64>
+extern function std.group_first (g: std.Group<'K,'V>): 'V
+extern function std.group_key (g: std.Group<'K,'V>): 'K
+extern function std.group_max (g: std.Group<'K,'V>): 'V
+extern function std.group_min (g: std.Group<'K,'V>): 'V
+extern function std.group_nth (g: std.Group<'K,'V>, n: bit<64>): std.Option<'V>
+extern function std.group_set_unions (g: std.Group<'K,std.Set<'A>>): std.Set<'A>
+extern function std.group_setref_unions (g: std.Group<'K,std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
+extern function std.group_sum (g: std.Group<'K,'V>): 'V
+function std.group_unzip (g: std.Group<'K,('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
     ((var xs: std.Vec<'X>) = std.vec_empty();
      ((var ys: std.Vec<'Y>) = std.vec_empty();
       (for (v in g) {

--- a/test/datalog_tests/tutorial.ast.expected
+++ b/test/datalog_tests/tutorial.ast.expected
@@ -1,4 +1,5 @@
 typedef Address = Address{addr: ip_addr_t}
+typedef BestDeal = BestDeal{best: string}
 typedef BestPrice = BestPrice{item: string, price: bit<64>}
 typedef BestVendor = BestVendor{item: string, vendor: string, price: bit<64>}
 typedef Blacklisted = Blacklisted{ep: string}
@@ -65,7 +66,7 @@ typedef mac_addr_t = MACAddr{addr: bit<48>}
 typedef nethost_t = NHost{ip: ip_addr_t, mac: mac_addr_t}
 typedef stage = LS_IN_PRE_LB{} | LS_OUT_PRE_LB{}
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
-extern type std.Group<'A>
+extern type std.Group<'K,'V>
 extern type std.Map<'K,'V>
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
@@ -99,7 +100,7 @@ function addr_port (ip: ip_addr_t, proto: string, preferred_port: bit<16>): stri
      ((("" ++ ip_addr_t2string(ip)) ++ ":") ++ std.__builtin_2string(port)))
 function addr_to_tuple (addr: ip4_addr_t): (bit<8>, bit<8>, bit<8>, bit<8>) =
     (addr[31:24], addr[23:16], addr[15:8], addr[7:0])
-function best_vendor (g: std.Group<(string, bit<64>)>): (string, bit<64>) =
+function best_vendor (g: std.Group<'K,(string, bit<64>)>): (string, bit<64>) =
     (var min_vendor = "";
      ((var min_price: bit<64>) = 64'd18446744073709551615;
       (for (vendor_price in g) {
@@ -111,6 +112,18 @@ function best_vendor (g: std.Group<(string, bit<64>)>): (string, bit<64>) =
              }
        };
        (min_vendor, min_price))))
+function best_vendor_string (g: std.Group<string,(string, bit<64>)>): string =
+    (var min_vendor = "";
+     ((var min_price: bit<64>) = 64'd18446744073709551615;
+      (for (vendor_price in g) {
+           if (vendor_price.1 < min_price) {
+               (min_vendor = vendor_price.0;
+                min_price = vendor_price.1)
+           } else {
+                 ()
+             }
+       };
+       ((((("Best deal for " ++ std.group_key(g)) ++ ": ") ++ min_vendor) ++ ", $") ++ std.__builtin_2string(min_price)))))
 function evens (vec: std.Vec<bigint>): std.Vec<bigint> =
     ((var res: std.Vec<bigint>) = std.vec_empty();
      (for (x in vec) {
@@ -173,18 +186,19 @@ function split_ip_list (x: string): std.Vec<string> =
     split(x, " ")
 extern function std.__builtin_2string (x: 'X): string
 extern function std.deref (x: std.Ref<'A>): 'A
-extern function std.group2map (g: std.Group<('K, 'V)>): std.Map<'K,'V>
-extern function std.group2set (g: std.Group<'A>): std.Set<'A>
-extern function std.group2vec (g: std.Group<'A>): std.Vec<'A>
-extern function std.group_count (g: std.Group<'A>): bit<64>
-extern function std.group_first (g: std.Group<'A>): 'A
-extern function std.group_max (g: std.Group<'A>): 'A
-extern function std.group_min (g: std.Group<'A>): 'A
-extern function std.group_nth (g: std.Group<'A>, n: bit<64>): std.Option<'A>
-extern function std.group_set_unions (g: std.Group<std.Set<'A>>): std.Set<'A>
-extern function std.group_setref_unions (g: std.Group<std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
-extern function std.group_sum (g: std.Group<'A>): 'A
-function std.group_unzip (g: std.Group<('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
+extern function std.group2map (g: std.Group<'K1,('K2, 'V)>): std.Map<'K2,'V>
+extern function std.group2set (g: std.Group<'K,'V>): std.Set<'V>
+extern function std.group2vec (g: std.Group<'K,'V>): std.Vec<'V>
+extern function std.group_count (g: std.Group<'K,'V>): bit<64>
+extern function std.group_first (g: std.Group<'K,'V>): 'V
+extern function std.group_key (g: std.Group<'K,'V>): 'K
+extern function std.group_max (g: std.Group<'K,'V>): 'V
+extern function std.group_min (g: std.Group<'K,'V>): 'V
+extern function std.group_nth (g: std.Group<'K,'V>, n: bit<64>): std.Option<'V>
+extern function std.group_set_unions (g: std.Group<'K,std.Set<'A>>): std.Set<'A>
+extern function std.group_setref_unions (g: std.Group<'K,std.Ref<std.Set<'A>>>): std.Ref<std.Set<'A>>
+extern function std.group_sum (g: std.Group<'K,'V>): 'V
+function std.group_unzip (g: std.Group<'K,('X, 'Y)>): (std.Vec<'X>, std.Vec<'Y>) =
     ((var xs: std.Vec<'X>) = std.vec_empty();
      ((var ys: std.Vec<'Y>) = std.vec_empty();
       (for (v in g) {
@@ -294,6 +308,7 @@ function vsep (strs: std.Vec<string>): string =
       };
       res))
 output relation Address [Address]
+output relation BestDeal [BestDeal]
 output relation BestPrice [BestPrice]
 output relation BestVendor [BestVendor]
 input relation Blacklisted [Blacklisted]
@@ -363,6 +378,7 @@ Product(.x=x, .y=y, .prod=(x * y)) :- X(.x=x), X(.x=y).
 BestPrice(.item=item, .price=best_price) :- Price(.item=item, .vendor=_, .price=price), var best_price = Aggregate((item), std.group_min(price)).
 WorstPrice(.item=item, .price=best_price) :- Price(.item=item, .vendor=_, .price=price), var best_price = Aggregate((item), std.group_max(price)).
 BestVendor(.item=item, .vendor=best_vendor, .price=best_price) :- Price(.item=item, .vendor=vendor, .price=price), var best_vendor_price = Aggregate((item), best_vendor((vendor, price))), (var best_vendor, var best_price) = best_vendor_price.
+BestDeal(.best=best) :- Price(.item=item, .vendor=vendor, .price=price), var best = Aggregate((item), best_vendor_string((vendor, price))).
 TCPDstPort(.port=port) :- Packet(.pkt=EthPacket{.src=_, .dst=_, .payload=EthIP4{.ip4=IP4Pkt{.ttl=_, .src=_, .dst=_, .payload=IPTCP{.tcp=TCPPkt{.src=_, .dst=port, .flags=_}}}}}).
 TCPDstPort(.port=port) :- Packet(.pkt=EthPacket{.src=_, .dst=_, .payload=EthIP6{.ip6=IP6Pkt{.ttl=_, .src=_, .dst=_, .payload=IPTCP{.tcp=TCPPkt{.src=_, .dst=port, .flags=_}}}}}).
 UDPDstPort(.port=port) :- Packet(.pkt=pkt), var port = pkt_udp_port(pkt), (port != 16'd0).

--- a/test/datalog_tests/tutorial.dat
+++ b/test/datalog_tests/tutorial.dat
@@ -194,6 +194,9 @@ dump WorstPrice;
 echo BestVendor:;
 dump BestVendor;
 
+echo BestDeal:;
+dump BestDeal;
+
 start;
 
 insert Packet(EthPacket{

--- a/test/datalog_tests/tutorial.dl
+++ b/test/datalog_tests/tutorial.dl
@@ -260,7 +260,7 @@ WorstPrice(item, best_price) :-
 
 output relation BestVendor(item: string, vendor: string, price: bit<64>)
 
-function best_vendor(g: Group<(string, bit<64>)>): (string, bit<64>) =
+function best_vendor(g: Group<'K, (string, bit<64>)>): (string, bit<64>) =
 {
     var min_vendor = "";
     var min_price: bit<64> = 'hffffffffffffffff;
@@ -277,6 +277,24 @@ BestVendor(item, best_vendor, best_price) :-
     Price(item, vendor, price),
     var best_vendor_price = Aggregate((item), best_vendor((vendor, price))),
     (var best_vendor, var best_price) = best_vendor_price.
+
+function best_vendor_string(g: Group<string, (string, bit<64>)>): string =
+{
+    var min_vendor = "";
+    var min_price: bit<64> = 'hffffffffffffffff;
+    for (vendor_price in g) {
+        if (vendor_price.1 < min_price) {
+            min_vendor = vendor_price.0;
+            min_price = vendor_price.1
+        }
+    };
+    "Best deal for ${group_key(g)}: ${min_vendor}, $${min_price}"
+}
+
+output relation BestDeal(best: string)
+BestDeal(best) :-
+    Price(item, vendor, price),
+    var best = Aggregate((item), best_vendor_string((vendor, price))).
 
 /*
  * Example: tagged unions

--- a/test/datalog_tests/tutorial.dump.expected
+++ b/test/datalog_tests/tutorial.dump.expected
@@ -120,6 +120,9 @@ WorstPrice{"B",150}
 BestVendor:
 BestVendor{"A","Discount Corp",100}
 BestVendor{"B","Discount Corp",111}
+BestDeal:
+BestDeal{"Best deal for A: Discount Corp, $100"}
+BestDeal{"Best deal for B: Discount Corp, $111"}
 TCPDstPort:
 TCPDstPort{80}
 TCPDstPort{8080}


### PR DESCRIPTION
    Aggregation functions previously took the contents of the group as the
    only argument. In some cases, e.g., in the SQL converter, it is helpful
    to pass the group key as well.  We add this capability without changing
    existing syntax.  The only change is that the `Group` type is now
    parameterized with both key and value types.  A program can iterate over
    group values as before; in addition, the `group_key(Group<'K,'V>): 'K`
    function extracts the group key.
    
    Example:
    
    ```
    // Custom aggregation function that group of (vendor, price) tuples and
    // uses item name as key, and returns a string containing item name, along
    // with the lowest price and matching vendor for this item.
    function best_vendor_string(g: Group<string, (string, bit<64>)>): string =
    {
        var min_vendor = "";
        var min_price: bit<64> = 'hffffffffffffffff;
        for (vendor_price in g) {
            if (vendor_price.1 < min_price) {
                min_vendor = vendor_price.0;
                min_price = vendor_price.1
            }
        };
        "Best deal for ${group_key(g)}: ${min_vendor}, $${min_price}"
    }
    
    output relation BestDeal(best: string)
    BestDeal(best) :-
        Price(item, vendor, price),
        var best = Aggregate((item), best_vendor_string((vendor, price))).
    ```
