### PR TITLE
Enable incremental Rust compilation.

### DIFF
--- a/rust/template/.cargo/config
+++ b/rust/template/.cargo/config
@@ -1,0 +1,3 @@
+[build]
+
+incremental = true

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -188,6 +188,7 @@ rustLibFiles specname =
         , (dir </> "ovsdb/Cargo.toml"                                , $(embedFile "rust/template/ovsdb/Cargo.toml"))
         , (dir </> "ovsdb/lib.rs"                                    , $(embedFile "rust/template/ovsdb/lib.rs"))
         , (dir </> "ovsdb/test.rs"                                   , $(embedFile "rust/template/ovsdb/test.rs"))
+        , (dir </> ".cargo/config"                                   , $(embedFile "rust/template/.cargo/config"))
         ]
     where dir = rustProjectDir specname
 


### PR DESCRIPTION
This commit turns on the `build.incremental` cargo option, which enables
incremental compilation in release mode.  As a result, small changes to
DDlog code often compile up to 40% faster in release mode.

Background:

Rust 1.24+ supports incremental compilation whereby the compiler caches
intermediate computations and reuses them across runs.  Incremental
compilation is enabled by default in non-release builds.  It is disabled
by default in release as it can have very small effect on performance (I
saw reports of 1-2% slowdown).

We hereby override this default behavior and enable incremental
compilation for all profiles, including release.

Results:

Based on limited amount of testing I've done, incremental compilation
makes a difference when changes to the DDlog program are small, e.g.,
a change to the OVN code that adds a new rule that does not introduce
new value types takes 3m 20s to recompile vs 5m with incremental
compilation disabled.

However, this is no silver bullet. For instance, adding a new unused
type declaration takes as long to re-compile with incremental enabled
as without it.

All this indicates that further improvements can be achieved by changing
the generated code structure to aid incremental compilation.  I will
investigate this and try to incorporate my findings in future commits.