### PR TITLE
Validate.hs: Clarify error message.

### DIFF
--- a/src/Language/DifferentialDatalog/Validate.hs
+++ b/src/Language/DifferentialDatalog/Validate.hs
@@ -552,7 +552,7 @@ exprValidate1 _ _ _   EUnOp{}             = return ()
 
 exprValidate1 _ _ ctx (EPHolder p)        = do
     let msg = case ctx of
-                   CtxStruct EStruct{..} _ f -> "Missing field " ++ f ++ " in constructor " ++ exprConstructor
+                   CtxStruct EStruct{..} _ f -> "Missing field '" ++ f ++ "' in constructor " ++ exprConstructor
                    _               -> "_ is not allowed in this context"
     check (ctxPHolderAllowed ctx) p msg
 exprValidate1 d _ ctx (EBinding p v _)    = do

--- a/test/datalog_tests/function.fail.ast.expected
+++ b/test/datalog_tests/function.fail.ast.expected
@@ -1,6 +1,6 @@
 error: ./test/datalog_tests/function.fail.dl:3:5-3:10: Variable declaration is not allowed in this context
 
-error: ./test/datalog_tests/function.fail.dl:13:13-14:1: Missing field f2 in constructor C
+error: ./test/datalog_tests/function.fail.dl:13:13-14:1: Missing field 'f2' in constructor C
 
 error: ./test/datalog_tests/function.fail.dl:11:17-11:18: Variable v already defined in this scope
 


### PR DESCRIPTION
I spent 10 minutes trying to figure out what "Missing field name in
constructor" meant and it turned out that I was missing a field named
'name'.  A couple of quotation marks would have made it obvious.