### PR TITLE
k8policy.dl: Remove reduntand `Option<>` wrappers.

### DIFF
--- a/test/antrea/k8spolicy.dl
+++ b/test/antrea/k8spolicy.dl
@@ -31,9 +31,9 @@ typedef PodStatus = PodStatus {
 // TODO(leonid): primary key
 input relation Pod (
     // Name must be unique within a namespace.
-    name: Option<string>,
+    name: string,
     // Namespace defines the space within each name must be unique.
-    namespace: Option<string>,
+    namespace: string,
     // UID is the unique in time and space value for this object.
     uid: UID,
     // Map of string keys and values that can be used to organize and categorize
@@ -259,7 +259,6 @@ input relation NetworkPolicy (
     // Specification of the desired behavior for this NetworkPolicy.
     spec: NetworkPolicySpec
 )
-
 
 typedef Protocol = IString
 

--- a/test/antrea/networkpolicy_controller.dat
+++ b/test/antrea/networkpolicy_controller.dat
@@ -13,8 +13,8 @@ insert k8spolicy.Namespace(
     .labels = []),
 
 insert k8spolicy.Pod(
-    .name = std.Some{"ns1.pod1"},
-    .namespace = std.Some{"ns1"},
+    .name = "ns1.pod1",
+    .namespace = "ns1",
     .uid = k8spolicy.UID{"adb006eb-07fd-4a4b-9b09-d899267aeadc"},
     .labels = [],
     .spec = k8spolicy.PodSpec{.nodeName = "node1"},
@@ -22,8 +22,8 @@ insert k8spolicy.Pod(
 ),
 
 insert k8spolicy.Pod(
-    .name = std.Some{"ns1.pod2"},
-    .namespace = std.Some{"ns1"},
+    .name = "ns1.pod2",
+    .namespace = "ns1",
     .uid = k8spolicy.UID{"17024561-7949-4f63-a248-bc29075f04b2"},
     .labels = [],
     .spec = k8spolicy.PodSpec{.nodeName = "node2"},
@@ -31,8 +31,8 @@ insert k8spolicy.Pod(
 ),
 
 insert k8spolicy.Pod(
-    .name = std.Some{"ns2.pod1"},
-    .namespace = std.Some{"ns2"},
+    .name = "ns2.pod1",
+    .namespace = "ns2",
     .uid = k8spolicy.UID{"2fc100dd-a981-47e2-8a62-e9b2dff3a5d3"},
     .labels = [],
     .spec = k8spolicy.PodSpec{.nodeName = "node1"},
@@ -40,8 +40,8 @@ insert k8spolicy.Pod(
 ),
 
 insert k8spolicy.Pod(
-    .name = std.Some{"ns2.pod2"},
-    .namespace = std.Some{"ns2"},
+    .name = "ns2.pod2",
+    .namespace = "ns2",
     .uid = k8spolicy.UID{"ad847460-cb25-43e7-a44c-d2ff7bdb65ac"},
     .labels = [],
     .spec = k8spolicy.PodSpec{.nodeName = "node2"},
@@ -49,8 +49,8 @@ insert k8spolicy.Pod(
 ),
 
 insert k8spolicy.Pod(
-    .name = std.Some{"<top>.pod1"},
-    .namespace = std.None,
+    .name = "<top>.pod1",
+    .namespace = "",
     .uid = k8spolicy.UID{"a5f3a901-040d-407c-a842-918e250f79de"},
     .labels = [],
     .spec = k8spolicy.PodSpec{.nodeName = "node1"},
@@ -58,8 +58,8 @@ insert k8spolicy.Pod(
 ),
 
 insert k8spolicy.Pod(
-    .name = std.Some{"<top>.pod2"},
-    .namespace = std.None,
+    .name = "<top>.pod2",
+    .namespace = "",
     .uid = k8spolicy.UID{"23d84e05-e0b6-446d-a919-440d1b74ebfc"},
     .labels = [],
     .spec = k8spolicy.PodSpec{.nodeName = "node2"},

--- a/test/antrea/networkpolicy_controller.dl
+++ b/test/antrea/networkpolicy_controller.dl
@@ -284,7 +284,7 @@ AddressGroup[group] :-
 AddressGroupAddress(addressGroup.uid, pod.status.podIP) :-
     // Namespace presence indicates Pods must be selected from the same Namespace.
     addressGroup in AddressGroup(.selector = GroupSelector{.nsSelector = NSSelectorNS{ns}}),
-    pod in k8s.Pod(.namespace = Some{ns}),
+    pod in k8s.Pod(.namespace = ns),
     pod.status.podIP != "",
     k8s.labelSelectorMatches(addressGroup.selector.podSelector, pod.labels).
 
@@ -293,7 +293,7 @@ AddressGroupAddress(addressGroup.uid, pod.status.podIP) :-
     addressGroup in AddressGroup(.selector = GroupSelector{.nsSelector = NSSelectorLS{namespaceSelector}, .podSelector = podSelector}),
     namespace in k8s.Namespace(),
     k8s.labelSelectorMatches(Some{namespaceSelector}, namespace.labels),
-    pod in k8s.Pod(.namespace = Some{namespace.name}),
+    pod in k8s.Pod(.namespace = namespace.name),
     pod.status.podIP != "",
     is_none(podSelector) or k8s.labelSelectorMatches(podSelector, pod.labels).
 
@@ -330,7 +330,7 @@ AppliedToGroupPod(appliedToGroup, pod.uid, pod.spec.nodeName) :-
     AppliedToGroup(.uid = appliedToGroup,
                    .selector = GroupSelector{.nsSelector = NSSelectorNS{namespace}, .podSelector = podSelector}),
     // Retrieve all Pods matching the podSelector.
-    pod in k8s.Pod(.namespace = Some{namespace}),
+    pod in k8s.Pod(.namespace = namespace),
     // No need to process Pod when it's not scheduled.
     pod.spec.nodeName != "",
     k8s.labelSelectorMatches(podSelector, pod.labels).

--- a/test/antrea/networkpolicy_controller.dump.expected
+++ b/test/antrea/networkpolicy_controller.dump.expected
@@ -3,12 +3,12 @@ Ok8spolicy.Namespace:
 k8spolicy_Namespace{.name = "ns1", .uid = k8spolicy_UID{.uid = "e340296d-84e2-48b2-9b7a-91641db60db5"}, .labels = [("l1", "l1v1")]}: +1
 k8spolicy_Namespace{.name = "ns2", .uid = k8spolicy_UID{.uid = "37e6f556-02f3-4775-93a7-ec924ee78810"}, .labels = []}: +1
 Ok8spolicy.Pod:
-k8spolicy_Pod{.name = std_Some{.x = "<top>.pod1"}, .namespace = std_None{}, .uid = k8spolicy_UID{.uid = "a5f3a901-040d-407c-a842-918e250f79de"}, .labels = [], .spec = k8spolicy_PodSpec{.nodeName = "node1"}, .status = k8spolicy_PodStatus{.podIP = "192.168.1.1"}}: +1
-k8spolicy_Pod{.name = std_Some{.x = "<top>.pod2"}, .namespace = std_None{}, .uid = k8spolicy_UID{.uid = "23d84e05-e0b6-446d-a919-440d1b74ebfc"}, .labels = [], .spec = k8spolicy_PodSpec{.nodeName = "node2"}, .status = k8spolicy_PodStatus{.podIP = "192.168.1.2"}}: +1
-k8spolicy_Pod{.name = std_Some{.x = "ns1.pod1"}, .namespace = std_Some{.x = "ns1"}, .uid = k8spolicy_UID{.uid = "adb006eb-07fd-4a4b-9b09-d899267aeadc"}, .labels = [], .spec = k8spolicy_PodSpec{.nodeName = "node1"}, .status = k8spolicy_PodStatus{.podIP = "192.168.1.1"}}: +1
-k8spolicy_Pod{.name = std_Some{.x = "ns1.pod2"}, .namespace = std_Some{.x = "ns1"}, .uid = k8spolicy_UID{.uid = "17024561-7949-4f63-a248-bc29075f04b2"}, .labels = [], .spec = k8spolicy_PodSpec{.nodeName = "node2"}, .status = k8spolicy_PodStatus{.podIP = "192.168.1.2"}}: +1
-k8spolicy_Pod{.name = std_Some{.x = "ns2.pod1"}, .namespace = std_Some{.x = "ns2"}, .uid = k8spolicy_UID{.uid = "2fc100dd-a981-47e2-8a62-e9b2dff3a5d3"}, .labels = [], .spec = k8spolicy_PodSpec{.nodeName = "node1"}, .status = k8spolicy_PodStatus{.podIP = "192.168.1.1"}}: +1
-k8spolicy_Pod{.name = std_Some{.x = "ns2.pod2"}, .namespace = std_Some{.x = "ns2"}, .uid = k8spolicy_UID{.uid = "ad847460-cb25-43e7-a44c-d2ff7bdb65ac"}, .labels = [], .spec = k8spolicy_PodSpec{.nodeName = "node2"}, .status = k8spolicy_PodStatus{.podIP = "192.168.1.2"}}: +1
+k8spolicy_Pod{.name = "<top>.pod1", .namespace = "", .uid = k8spolicy_UID{.uid = "a5f3a901-040d-407c-a842-918e250f79de"}, .labels = [], .spec = k8spolicy_PodSpec{.nodeName = "node1"}, .status = k8spolicy_PodStatus{.podIP = "192.168.1.1"}}: +1
+k8spolicy_Pod{.name = "<top>.pod2", .namespace = "", .uid = k8spolicy_UID{.uid = "23d84e05-e0b6-446d-a919-440d1b74ebfc"}, .labels = [], .spec = k8spolicy_PodSpec{.nodeName = "node2"}, .status = k8spolicy_PodStatus{.podIP = "192.168.1.2"}}: +1
+k8spolicy_Pod{.name = "ns1.pod1", .namespace = "ns1", .uid = k8spolicy_UID{.uid = "adb006eb-07fd-4a4b-9b09-d899267aeadc"}, .labels = [], .spec = k8spolicy_PodSpec{.nodeName = "node1"}, .status = k8spolicy_PodStatus{.podIP = "192.168.1.1"}}: +1
+k8spolicy_Pod{.name = "ns1.pod2", .namespace = "ns1", .uid = k8spolicy_UID{.uid = "17024561-7949-4f63-a248-bc29075f04b2"}, .labels = [], .spec = k8spolicy_PodSpec{.nodeName = "node2"}, .status = k8spolicy_PodStatus{.podIP = "192.168.1.2"}}: +1
+k8spolicy_Pod{.name = "ns2.pod1", .namespace = "ns2", .uid = k8spolicy_UID{.uid = "2fc100dd-a981-47e2-8a62-e9b2dff3a5d3"}, .labels = [], .spec = k8spolicy_PodSpec{.nodeName = "node1"}, .status = k8spolicy_PodStatus{.podIP = "192.168.1.1"}}: +1
+k8spolicy_Pod{.name = "ns2.pod2", .namespace = "ns2", .uid = k8spolicy_UID{.uid = "ad847460-cb25-43e7-a44c-d2ff7bdb65ac"}, .labels = [], .spec = k8spolicy_PodSpec{.nodeName = "node2"}, .status = k8spolicy_PodStatus{.podIP = "192.168.1.2"}}: +1
 Adding policies
 LOG (0): createAppliedToGroup ns1.policy1
 LOG (0): createAppliedToGroup ns1.policy1


### PR DESCRIPTION
`Pod.name` and `Pod.namespace` cannot be `nil`, so we can declare them
as `string` instead of `Option<string>`.