### PR TITLE
ddlog.h: Functions to pass non-C strings to DDlog.

### DIFF
--- a/java/ddlogapi.c
+++ b/java/ddlogapi.c
@@ -751,8 +751,8 @@ const jstring toJString(JNIEnv* env, const char* nonNullStr, size_t size) {
 
 JNIEXPORT jstring JNICALL Java_ddlogapi_DDlogAPI_ddlog_1get_1str(
     JNIEnv *env, jclass obj, long handle) {
-    const char *s = ddlog_get_str_non_nul((const ddlog_record*)handle);
-    size_t size = ddlog_get_strlen((const ddlog_record*)handle);
+    size_t size;
+    const char *s = ddlog_get_str_with_length((const ddlog_record*)handle, &size);
     return toJString(env, s, size);
 }
 
@@ -829,7 +829,7 @@ JNIEXPORT jboolean JNICALL Java_ddlogapi_DDlogAPI_ddlog_1is_1struct(
 JNIEXPORT jstring JNICALL Java_ddlogapi_DDlogAPI_ddlog_1get_1constructor(
     JNIEnv *env, jclass obj, jlong handle) {
     size_t size;
-    const char *s = ddlog_get_constructor_non_null((const ddlog_record*)handle, &size);
+    const char *s = ddlog_get_constructor_with_length((const ddlog_record*)handle, &size);
     return toJString(env, s, size);
 }
 

--- a/rust/template/ddlog.h
+++ b/rust/template/ddlog.h
@@ -52,7 +52,12 @@ typedef void ddlog_record;
 
 
 /*
- * Get DDlog table id by name.
+ * Get DDlog table id by name.  The table name is a null-terminated UTF8
+ * string.
+ *
+ * NOTE: for tables declared outside of the main DDlog module, fully qualified
+ * module names must be used, e.g., the fully qualified name of a table named
+ * "Pod" declared inside the "k8spolicy" module is "k8spolicy.Pod".
  *
  * On error, returns -1.
  */
@@ -61,7 +66,7 @@ extern table_id ddlog_get_table_id(const char* tname);
 /*
  * Get DDlog table name from id.
  *
- * On error, returns NULL.
+ * Returns a null-terminated UTF8 string on success or NULL on error.
  */
 extern const char* ddlog_get_table_name(table_id id);
 
@@ -460,7 +465,7 @@ extern int ddlog_enable_cpu_profiling(ddlog_prog prog, bool enable);
 /*
  * Returns DDlog program runtime profile as a C string.
  *
- * The returned string must be deallocated using ddlog_string_free().
+ * The returned string must be deallocated using `ddlog_string_free()`.
  */
 extern char* ddlog_profile(ddlog_prog prog);
 
@@ -532,7 +537,7 @@ extern char* ddlog_profile(ddlog_prog prog);
  */
 
 /*
- * Dump record into a string for debug printing.
+ * Dump record into a C string for debug printing.
  *
  * Returns `NULL` on error.
  *
@@ -546,7 +551,7 @@ extern char* ddlog_dump_record(const ddlog_record *rec);
 extern void ddlog_free(ddlog_record *rec);
 
 /*
- * Deallocate a string returned by DDlog
+ * Deallocate a C string returned by DDlog
  * (currently only applicable to the string returned by `ddlog_profile()` and
  * `ddlog_dump_record()`).
  */
@@ -664,13 +669,27 @@ extern ddlog_record* ddlog_i128(__int128_t v);
 extern __int128_t ddlog_get_i128(const ddlog_record *rec);
 
 /*
- * Create a string value.  This function copies `s` to an internal
- * buffer, so the caller is responsible for deallocating `s` if it was
- * dynamically allocated.
+ * Create a string value from a NULL-terminated string `s`.  This function
+ * copies `s` to an internal buffer, so the caller is responsible for
+ * deallocating `s` if it was dynamically allocated.
  *
  * Returns `NULL` if `s` is not a valid null-terminated UTF8 string.
  */
 extern ddlog_record* ddlog_string(const char *s);
+
+/*
+ * Create a string value.
+ *
+ * `s` - points to the start of a UTF8 string.  The string does not have to be
+ *       NULL-terminated.
+ * `length` - length of string in bytes.
+ *
+ * This function copies `s` to an internal buffer, so the caller is responsible for
+ * deallocating `s` if it was dynamically allocated.
+ *
+ * Returns `NULL` if `s` is not a valid UTF8 string.
+ */
+extern ddlog_record* ddlog_string_with_length(const char * s, size_t len);
 
 /*
  * Returns `true` if `rec` is a string and `false` otherwise
@@ -678,25 +697,29 @@ extern ddlog_record* ddlog_string(const char *s);
 extern bool ddlog_is_string(const ddlog_record *rec);
 
 /*
- * Retrieves the length of a string.
+ * Retrieves the length of a string in bytes.
  *
  * Returns `0` if `rec` is not a string.
  */
 extern size_t ddlog_get_strlen(const ddlog_record *rec);
 
 /*
- * Returns the content of a DDlog string.
+ * Returns the contents of a DDlog string.
  *
- * WARNING: DDlog strings are _not_ null-terminated; use `ddlog_get_strlen()`
- * to determine the length of the string.
+ * On success, returns pointer to the string and stores the length of the
+ * string in bytes in `len`.
+ *
+ * If `rec` is not a record of type string, returns `NULL`.
+ *
+ * IMPORTANT: The returned string is _not_ null-terminated.
  *
  * The pointer returned by this function points to an internal DDlog
- * buffer. The caller must not modify the content of the string or
+ * buffer. The caller must not modify the contents of the string or
  * deallocate this pointer.  The lifetime of the pointer coincides with
  * the lifetime of the record it was obtained from, e.g., the pointer is
  * invalidated when the value is written to the database.
  */
-extern const char * ddlog_get_str_non_nul(const ddlog_record *rec);
+extern const char * ddlog_get_str_with_length(const ddlog_record *rec, size_t *len);
 
 /*
  * Create a tuple with specified fields.
@@ -963,12 +986,32 @@ extern ddlog_record* ddlog_struct(const char* constructor,
                                   ddlog_record ** args, size_t len);
 
 /*
- * Same as ddlog_struct(), but assumes that `constructor` is a statically
+ * Same as `ddlog_struct()`, but passes constructor name as
+ * non-null-terminated string represented by its start address and length in
+ * bytes.
+ */
+extern ddlog_record* ddlog_struct_with_length(const char* constructor,
+                                              size_t constructor_len,
+                                              ddlog_record ** args,
+                                              size_t len);
+
+/*
+ * Same as `ddlog_struct()`, but assumes that `constructor` is a statically
  * allocated string and stores the pointer internally instead of copying it to
  * another buffer.
  */
 extern ddlog_record* ddlog_struct_static_cons(const char *constructor,
                                               ddlog_record **args, size_t len);
+
+/*
+ * Same as ddlog_struct_static_cons(), but passes constructor name as
+ * non-null-terminated string represented by its start address and length in
+ * bytes.
+ */
+extern ddlog_record* ddlog_struct_static_cons_with_length(
+        const char *constructor,
+        size_t constructor_len,
+        ddlog_record **args, size_t args_len);
 
 /*
  * Returns `true` if `rec` is a struct.
@@ -977,13 +1020,12 @@ extern bool ddlog_is_struct(const ddlog_record *rec);
 
 /*
  * Retrieves constructor name as a non-null-terminated string.  Returns
- * string length in `len`.
+ * string length in bytes in `len`.
  *
  * Returns NULL if `rec` is not a struct.
  */
-extern const char * ddlog_get_constructor_non_null(const ddlog_record *rec,
-                                                   size_t *len);
-
+extern const char * ddlog_get_constructor_with_length(const ddlog_record *rec,
+                                                      size_t *len);
 
 /*
  * Retrieves `i`th argument of a struct.


### PR DESCRIPTION
`ddlog.h` can be used when invoking ddlog from other programming
languages. Such languages - such as Go - may not be able to easily /
cheaply generate a null-terminated string from their own string type.

For example Go provides `_GoStringPtr` (https://golang.org/cmd/cgo/)
which gives access to the underlying byte array (should be treated as
immutable), but that array may not be null-terminated. Which means that
in order to call `ddlog_string`, one has to make a copy of the string
first (e.g. with `CString`) and ensure it is null terminated. Given that
ddlog makes its own copy of the string when building the record, we are
up to 2 copies.

This commit adds three functions that accept non-null-terminated
strings:

```
/*
 * Create a string value.
 *
 * `s` - points to the start of a UTF8 string.  The string does not have to be
 *       NULL-terminated.
 * `length` - length of string in bytes.
 *
 * This function copies `s` to an internal buffer, so the caller is responsible for
 * deallocating `s` if it was dynamically allocated.
 *
 * Returns `NULL` if `s` is not a valid UTF8 string.
 */
extern ddlog_record* ddlog_string_with_length(const char * s, size_t len);

/*
 * Same as `ddlog_struct()`, but passes constructor name as
 * non-null-terminated string represented by its start address and length in
 * bytes.
 */
extern ddlog_record* ddlog_struct_with_length(const char* constructor,
                                              size_t constructor_len,
                                              ddlog_record ** args,
                                              size_t len);

/*
 * Same as ddlog_struct_static_cons(), but passes constructor name as
 * non-null-terminated string represented by its start address and length in
 * bytes.
 */
extern ddlog_record* ddlog_struct_static_cons_with_length(
        const char *constructor,
        size_t constructor_len,
        ddlog_record **args, size_t args_len);
```

In addition, `ddlog_get_str_with_length()` was modified to return string length
along with pointer, which may be more convenient than calling
`ddlog_get_strlen()` in some cases.

Resolves #515.