### PR TITLE
ddlog_string_with_length: allow NULL ptr when len==0.

### DIFF
--- a/rust/template/ddlog.h
+++ b/rust/template/ddlog.h
@@ -681,8 +681,10 @@ extern ddlog_record* ddlog_string(const char *s);
  * Create a string value.
  *
  * `s` - points to the start of a UTF8 string.  The string does not have to be
- *       NULL-terminated.
- * `length` - length of string in bytes.
+ *       NULL-terminated.  The pointer must not be `NULL`, unless `len==0`, in
+ *       which case the function ignores the value of the pointer and returns
+ *       a record containing an empty string.
+ * `len` - length of string in bytes.
  *
  * This function copies `s` to an internal buffer, so the caller is responsible for
  * deallocating `s` if it was dynamically allocated.

--- a/rust/template/differential_datalog/record.rs
+++ b/rust/template/differential_datalog/record.rs
@@ -320,6 +320,10 @@ pub unsafe extern "C" fn ddlog_string_with_length(
     s: *const raw::c_char,
     len: libc::size_t,
 ) -> *mut Record {
+    // If `len` is zero, return empty string even if `s` is `NULL`.
+    if len == 0 {
+        return Box::into_raw(Box::new(Record::String("".to_owned())));
+    };
     if s.is_null() {
         return null_mut();
     };
@@ -1591,7 +1595,7 @@ mod tests {
     #[test]
     fn strings_with_length2() {
         unsafe {
-            let string1 = ddlog_string_with_length("pod1".as_ptr() as *const i8, "pod1".len());
+            let string1 = ddlog_string_with_length(std::ptr::null(), 0);
             let boolean = ddlog_bool(true);
             let fields = &[string1, boolean];
             let structure = ddlog_struct_static_cons_with_length(
@@ -1604,7 +1608,7 @@ mod tests {
                 CString::from(CStr::from_ptr(ddlog_dump_record(structure)))
                     .into_string()
                     .unwrap(),
-                "Cons{\"pod1\", true}".to_string()
+                "Cons{\"\", true}".to_string()
             );
             ddlog_free(structure);
         }


### PR DESCRIPTION
The `ddlog_string_with_length` API returned `NULL` (indicating an error)
whenever the input pointer was `NULL`.  This is too strict when
`len==0`, in which case we should be returning an empty string
regardless of the value of the pointer.