### PR TITLE
Include sys/types.h in ddlog.h

### DIFF
--- a/rust/template/ddlog.h
+++ b/rust/template/ddlog.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <sys/types.h>
 
 /*
  * *Note:* all functions in this library, with the exception of


### PR DESCRIPTION
ddlog.h uses the ssize_t type, which is not part of stdint.h. To avoid
issues for clients using this header, we include the sys/types.h header
(where ssize_t is defined) in ddlog.h.