### PR TITLE
Introduce insert-or-update command in the C API.

### DIFF
--- a/rust/template/cmd_parser/parse.rs
+++ b/rust/template/cmd_parser/parse.rs
@@ -197,6 +197,19 @@ fn test_command() {
         ))
     );
     assert_eq!(
+        parse_command(br"insert_or_update Rel1(true);"),
+        Ok((
+            &br""[..],
+            Command::Update(
+                UpdCmd::InsertOrUpdate(
+                    RelIdentifier::RelName(Cow::from("Rel1")),
+                    Record::PosStruct(Cow::from("Rel1"), vec![Record::Bool(true)])
+                ),
+                true
+            )
+        ))
+    );
+    assert_eq!(
         parse_command(br" insert Rel1[true];"),
         Ok((
             &br""[..],
@@ -275,9 +288,10 @@ fn test_command() {
 }
 
 named!(update<&[u8], UpdCmd>,
-    alt!(do_parse!(apply!(sym,"insert")     >> rec: rel_record >> (UpdCmd::Insert(RelIdentifier::RelName(rec.0), rec.1)))    |
-         do_parse!(apply!(sym,"delete")     >> rec: rel_record >> (UpdCmd::Delete(RelIdentifier::RelName(rec.0), rec.1)))    |
-         do_parse!(apply!(sym,"delete_key") >> rec: rel_key    >> (UpdCmd::DeleteKey(RelIdentifier::RelName(rec.0), rec.1))) |
+    alt!(do_parse!(apply!(sym,"insert")     >> rec: rel_record >> (UpdCmd::Insert(RelIdentifier::RelName(rec.0), rec.1)))               |
+         do_parse!(apply!(sym,"insert_or_update") >> rec: rel_record >> (UpdCmd::InsertOrUpdate(RelIdentifier::RelName(rec.0), rec.1))) |
+         do_parse!(apply!(sym,"delete")     >> rec: rel_record >> (UpdCmd::Delete(RelIdentifier::RelName(rec.0), rec.1)))               |
+         do_parse!(apply!(sym,"delete_key") >> rec: rel_key    >> (UpdCmd::DeleteKey(RelIdentifier::RelName(rec.0), rec.1)))            |
          do_parse!(apply!(sym,"modify") >>
                    rec: rel_key         >>
                    apply!(sym, "<-")    >>

--- a/rust/template/ddlog.h
+++ b/rust/template/ddlog.h
@@ -1062,6 +1062,17 @@ extern const ddlog_record* ddlog_get_struct_field(const ddlog_record* rec,
 extern ddlog_cmd* ddlog_insert_cmd(table_id table, ddlog_record *rec);
 
 /*
+ * Create an insert-or-update command.
+ *
+ * `table` is the table to insert to.  The table must have a primary key.
+ * `rec` is the record to insert.  The function takes ownership of this record.
+ *
+ * Returns pointer to a new command, which can be sent to DDlog by calling
+ * `ddlog_apply_updates()`.
+ */
+extern ddlog_cmd* ddlog_insert_or_update_cmd(table_id table, ddlog_record *rec);
+
+/*
  * Create delete-by-value command.
  *
  * `table` is the table to delete from. `rec` is the record to delete.

--- a/rust/template/differential_datalog/record.rs
+++ b/rust/template/differential_datalog/record.rs
@@ -146,6 +146,7 @@ impl fmt::Display for RelIdentifier {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum UpdCmd {
     Insert(RelIdentifier, Record),
+    InsertOrUpdate(RelIdentifier, Record),
     Delete(RelIdentifier, Record),
     DeleteKey(RelIdentifier, Record),
     Modify(RelIdentifier, Record, Record),
@@ -717,6 +718,18 @@ unsafe fn mk_record_vec(fields: *const *mut Record, len: libc::size_t) -> Vec<Re
 pub unsafe extern "C" fn ddlog_insert_cmd(table: libc::size_t, rec: *mut Record) -> *mut UpdCmd {
     let rec = Box::from_raw(rec);
     Box::into_raw(Box::new(UpdCmd::Insert(RelIdentifier::RelId(table), *rec)))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn ddlog_insert_or_update_cmd(
+    table: libc::size_t,
+    rec: *mut Record,
+) -> *mut UpdCmd {
+    let rec = Box::from_raw(rec);
+    Box::into_raw(Box::new(UpdCmd::InsertOrUpdate(
+        RelIdentifier::RelId(table),
+        *rec,
+    )))
 }
 
 #[no_mangle]

--- a/rust/template/differential_datalog/replay.rs
+++ b/rust/template/differential_datalog/replay.rs
@@ -139,6 +139,13 @@ pub trait RecordReplay: Write {
         write!(self, "insert {}[{}]", name, value)
     }
 
+    fn record_insert_or_update<V>(&mut self, name: &str, value: V) -> Result<()>
+    where
+        V: Display,
+    {
+        write!(self, "insert_or_update {}[{}]", name, value)
+    }
+
     /// Record an `UpdCmd`.
     fn record_upd_cmd<C>(&mut self, upd: &UpdCmd) -> Result<()>
     where
@@ -147,6 +154,9 @@ pub trait RecordReplay: Write {
         match upd {
             UpdCmd::Insert(rel, record) => {
                 self.record_insert(relident2name::<C>(rel).unwrap_or(&"???"), record)
+            }
+            UpdCmd::InsertOrUpdate(rel, record) => {
+                self.record_insert_or_update(relident2name::<C>(rel).unwrap_or(&"???"), record)
             }
             UpdCmd::Delete(rel, record) => write!(
                 self,
@@ -178,6 +188,9 @@ pub trait RecordReplay: Write {
         match upd {
             Update::Insert { relid, v } => {
                 self.record_insert(C::relid2name(*relid).unwrap_or(&"???"), v)
+            }
+            Update::InsertOrUpdate { relid, v } => {
+                self.record_insert_or_update(C::relid2name(*relid).unwrap_or(&"???"), v)
             }
             Update::DeleteValue { relid, v } => write!(
                 self,

--- a/rust/template/src/api.rs
+++ b/rust/template/src/api.rs
@@ -474,6 +474,15 @@ pub fn updcmd2upd(c: &record::UpdCmd) -> Result<Update<DDValue>, String> {
                 v: val,
             })
         }
+        record::UpdCmd::InsertOrUpdate(rident, rec) => {
+            let relid =
+                Relations::try_from(rident).map_err(|_| format!("Unknown relation {}", rident))?;
+            let val = relval_from_record(relid, rec)?;
+            Ok(Update::InsertOrUpdate {
+                relid: relid as RelId,
+                v: val,
+            })
+        }
         record::UpdCmd::Delete(rident, rec) => {
             let relid =
                 Relations::try_from(rident).map_err(|()| format!("Unknown relation {}", rident))?;

--- a/test/antrea/k8spolicy.dl
+++ b/test/antrea/k8spolicy.dl
@@ -47,6 +47,7 @@ input relation Pod (
     // Most recently observed status of the pod.
     status: PodStatus
 )
+primary key (x) (x.namespace, x.name)
 
 // Namespace provides a scope for Names.
 // Use of multiple namespaces is optional.
@@ -62,6 +63,7 @@ input relation Namespace (
     // +optional
     labels: Map<string, string>
 )
+primary key (x) x.name
 
 // A label selector is a label query over a set of resources. The result of matchLabels and
 // matchExpressions are ANDed. An empty label selector matches all objects. A null
@@ -259,6 +261,7 @@ input relation NetworkPolicy (
     // Specification of the desired behavior for this NetworkPolicy.
     spec: NetworkPolicySpec
 )
+primary key (x) (x.namespace, x.name)
 
 typedef Protocol = IString
 

--- a/test/antrea/networkpolicy_controller.dat
+++ b/test/antrea/networkpolicy_controller.dat
@@ -5,7 +5,7 @@ start;
 insert k8spolicy.Namespace(
     .name = "ns1",
     .uid = k8spolicy.UID{"e340296d-84e2-48b2-9b7a-91641db60db5"},
-    .labels = [("l1", "l1v1")]),
+    .labels = []),
 
 insert k8spolicy.Namespace(
     .name = "ns2",
@@ -80,6 +80,32 @@ insert k8spolicy.NetworkPolicy(
             .matchLabels = [("l1", "l1v1")],
             .matchExpressions = []
         },
+        .ingress = [],
+        .egress = [],
+        .policyType = []
+    }
+),
+
+
+commit dump_changes;
+
+echo Making changes;
+start;
+
+insert_or_update k8spolicy.Namespace(
+    .name = "ns1",
+    .uid = k8spolicy.UID{"e340296d-84e2-48b2-9b7a-91641db60db5"},
+    .labels = [("l1", "l1v1")]),
+
+insert_or_update k8spolicy.NetworkPolicy(
+    .name = "ns1.policy1",
+    .namespace = "ns1",
+    .uid = k8spolicy.UID{"156bc79a-ee16-47d9-82b6-8bc48849af74"},
+    .spec = k8spolicy.NetworkPolicySpec{
+        .podSelector = k8spolicy.LabelSelector{
+            .matchLabels = [("l1", "l1v1")],
+            .matchExpressions = []
+        },
         .ingress = [k8spolicy.NetworkPolicyIngressRule{
                         .ports = [k8spolicy.NetworkPolicyPort{
                                       .protocol = std.Some{"TCP"},
@@ -105,6 +131,7 @@ insert k8spolicy.NetworkPolicy(
         .policyType = []
     }
 ),
+
 
 
 commit dump_changes;

--- a/test/antrea/networkpolicy_controller.dump.expected
+++ b/test/antrea/networkpolicy_controller.dump.expected
@@ -1,6 +1,6 @@
 Adding namespace and pods
 Ok8spolicy.Namespace:
-k8spolicy_Namespace{.name = "ns1", .uid = k8spolicy_UID{.uid = "e340296d-84e2-48b2-9b7a-91641db60db5"}, .labels = [("l1", "l1v1")]}: +1
+k8spolicy_Namespace{.name = "ns1", .uid = k8spolicy_UID{.uid = "e340296d-84e2-48b2-9b7a-91641db60db5"}, .labels = []}: +1
 k8spolicy_Namespace{.name = "ns2", .uid = k8spolicy_UID{.uid = "37e6f556-02f3-4775-93a7-ec924ee78810"}, .labels = []}: +1
 Ok8spolicy.Pod:
 k8spolicy_Pod{.name = "<top>.pod1", .namespace = "", .uid = k8spolicy_UID{.uid = "a5f3a901-040d-407c-a842-918e250f79de"}, .labels = [], .spec = k8spolicy_PodSpec{.nodeName = "node1"}, .status = k8spolicy_PodStatus{.podIP = "192.168.1.1"}}: +1
@@ -12,15 +12,32 @@ k8spolicy_Pod{.name = "ns2.pod2", .namespace = "ns2", .uid = k8spolicy_UID{.uid 
 Adding policies
 LOG (0): createAppliedToGroup ns1.policy1
 LOG (0): createAppliedToGroup ns1.policy1
-AddressGroup:
-AddressGroup{.uid = k8spolicy_UID{.uid = "df49fa6b-0346-5dc9-9bb2-3da4fdbe8dd8"}, .name = "df49fa6b-0346-5dc9-9bb2-3da4fdbe8dd8", .selector = types_GroupSelector{.normalizedName = "namespaceSelector= And podSelector=l1 In [l1v1]", .nsSelector = types_NSSelectorLS{.selector = k8spolicy_LabelSelector{.matchLabels = [], .matchExpressions = []}}, .podSelector = std_Some{.x = k8spolicy_LabelSelector{.matchLabels = [("l1", "l1v1")], .matchExpressions = []}}}}: +1
 AppliedToGroup:
 AppliedToGroup{.uid = k8spolicy_UID{.uid = "dbd5cd23-1488-56b6-925e-7354a2189c7d"}, .name = "dbd5cd23-1488-56b6-925e-7354a2189c7d", .selector = types_GroupSelector{.normalizedName = "namespace=ns1 And podSelector=l1 In [l1v1]", .nsSelector = types_NSSelectorNS{.ns = "ns1"}, .podSelector = std_Some{.x = k8spolicy_LabelSelector{.matchLabels = [("l1", "l1v1")], .matchExpressions = []}}}}: +1
 NetworkPolicy:
+NetworkPolicy{.uid = k8spolicy_UID{.uid = "156bc79a-ee16-47d9-82b6-8bc48849af74"}, .name = "ns1.policy1", .namespace = "ns1", .rules = [], .appliedToGroups = ["dbd5cd23-1488-56b6-925e-7354a2189c7d"]}: +1
+NetworkPolicyExt:
+NetworkPolicyExt{.policy = NetworkPolicy{.uid = k8spolicy_UID{.uid = "156bc79a-ee16-47d9-82b6-8bc48849af74"}, .name = "ns1.policy1", .namespace = "ns1", .rules = [], .appliedToGroups = ["dbd5cd23-1488-56b6-925e-7354a2189c7d"]}, .addressGroups = []}: +1
+Ok8spolicy.NetworkPolicy:
+k8spolicy_NetworkPolicy{.name = "ns1.policy1", .namespace = "ns1", .uid = k8spolicy_UID{.uid = "156bc79a-ee16-47d9-82b6-8bc48849af74"}, .spec = k8spolicy_NetworkPolicySpec{.podSelector = k8spolicy_LabelSelector{.matchLabels = [("l1", "l1v1")], .matchExpressions = []}, .ingress = [], .egress = [], .policyTypes = []}}: +1
+Making changes
+LOG (0): createAppliedToGroup ns1.policy1
+LOG (0): createAppliedToGroup ns1.policy1
+LOG (0): createAppliedToGroup ns1.policy1
+LOG (0): createAppliedToGroup ns1.policy1
+AddressGroup:
+AddressGroup{.uid = k8spolicy_UID{.uid = "df49fa6b-0346-5dc9-9bb2-3da4fdbe8dd8"}, .name = "df49fa6b-0346-5dc9-9bb2-3da4fdbe8dd8", .selector = types_GroupSelector{.normalizedName = "namespaceSelector= And podSelector=l1 In [l1v1]", .nsSelector = types_NSSelectorLS{.selector = k8spolicy_LabelSelector{.matchLabels = [], .matchExpressions = []}}, .podSelector = std_Some{.x = k8spolicy_LabelSelector{.matchLabels = [("l1", "l1v1")], .matchExpressions = []}}}}: +1
+NetworkPolicy:
+NetworkPolicy{.uid = k8spolicy_UID{.uid = "156bc79a-ee16-47d9-82b6-8bc48849af74"}, .name = "ns1.policy1", .namespace = "ns1", .rules = [], .appliedToGroups = ["dbd5cd23-1488-56b6-925e-7354a2189c7d"]}: -1
 NetworkPolicy{.uid = k8spolicy_UID{.uid = "156bc79a-ee16-47d9-82b6-8bc48849af74"}, .name = "ns1.policy1", .namespace = "ns1", .rules = [types_NetworkPolicyRule{.direction = types_DirectionIn{}, .from = types_NetworkPolicyPeer{.addressGroups = ["df49fa6b-0346-5dc9-9bb2-3da4fdbe8dd8"], .ipBlocks = []}, .to = types_NetworkPolicyPeer{.addressGroups = [], .ipBlocks = []}, .services = [types_Service{.protocol = "TCP", .port = std_None{}}]}], .appliedToGroups = ["dbd5cd23-1488-56b6-925e-7354a2189c7d"]}: +1
 NetworkPolicyAddressGroup:
 NetworkPolicyAddressGroup{.np = k8spolicy_UID{.uid = "156bc79a-ee16-47d9-82b6-8bc48849af74"}, .addressGroup = "df49fa6b-0346-5dc9-9bb2-3da4fdbe8dd8"}: +1
 NetworkPolicyExt:
+NetworkPolicyExt{.policy = NetworkPolicy{.uid = k8spolicy_UID{.uid = "156bc79a-ee16-47d9-82b6-8bc48849af74"}, .name = "ns1.policy1", .namespace = "ns1", .rules = [], .appliedToGroups = ["dbd5cd23-1488-56b6-925e-7354a2189c7d"]}, .addressGroups = []}: -1
 NetworkPolicyExt{.policy = NetworkPolicy{.uid = k8spolicy_UID{.uid = "156bc79a-ee16-47d9-82b6-8bc48849af74"}, .name = "ns1.policy1", .namespace = "ns1", .rules = [types_NetworkPolicyRule{.direction = types_DirectionIn{}, .from = types_NetworkPolicyPeer{.addressGroups = ["df49fa6b-0346-5dc9-9bb2-3da4fdbe8dd8"], .ipBlocks = []}, .to = types_NetworkPolicyPeer{.addressGroups = [], .ipBlocks = []}, .services = [types_Service{.protocol = "TCP", .port = std_None{}}]}], .appliedToGroups = ["dbd5cd23-1488-56b6-925e-7354a2189c7d"]}, .addressGroups = [AddressGroup{.uid = k8spolicy_UID{.uid = "df49fa6b-0346-5dc9-9bb2-3da4fdbe8dd8"}, .name = "df49fa6b-0346-5dc9-9bb2-3da4fdbe8dd8", .selector = types_GroupSelector{.normalizedName = "namespaceSelector= And podSelector=l1 In [l1v1]", .nsSelector = types_NSSelectorLS{.selector = k8spolicy_LabelSelector{.matchLabels = [], .matchExpressions = []}}, .podSelector = std_Some{.x = k8spolicy_LabelSelector{.matchLabels = [("l1", "l1v1")], .matchExpressions = []}}}}]}: +1
+Ok8spolicy.Namespace:
+k8spolicy_Namespace{.name = "ns1", .uid = k8spolicy_UID{.uid = "e340296d-84e2-48b2-9b7a-91641db60db5"}, .labels = []}: -1
+k8spolicy_Namespace{.name = "ns1", .uid = k8spolicy_UID{.uid = "e340296d-84e2-48b2-9b7a-91641db60db5"}, .labels = [("l1", "l1v1")]}: +1
 Ok8spolicy.NetworkPolicy:
+k8spolicy_NetworkPolicy{.name = "ns1.policy1", .namespace = "ns1", .uid = k8spolicy_UID{.uid = "156bc79a-ee16-47d9-82b6-8bc48849af74"}, .spec = k8spolicy_NetworkPolicySpec{.podSelector = k8spolicy_LabelSelector{.matchLabels = [("l1", "l1v1")], .matchExpressions = []}, .ingress = [], .egress = [], .policyTypes = []}}: -1
 k8spolicy_NetworkPolicy{.name = "ns1.policy1", .namespace = "ns1", .uid = k8spolicy_UID{.uid = "156bc79a-ee16-47d9-82b6-8bc48849af74"}, .spec = k8spolicy_NetworkPolicySpec{.podSelector = k8spolicy_LabelSelector{.matchLabels = [("l1", "l1v1")], .matchExpressions = []}, .ingress = [k8spolicy_NetworkPolicyIngressRule{.ports = [k8spolicy_NetworkPolicyPort{.protocol = std_Some{.x = "TCP"}, .port = std_None{}}], .from = [k8spolicy_NetworkPolicyPeer{.podSelector = std_Some{.x = k8spolicy_LabelSelector{.matchLabels = [("l1", "l1v1")], .matchExpressions = []}}, .namespaceSelector = std_Some{.x = k8spolicy_LabelSelector{.matchLabels = [], .matchExpressions = []}}, .ipBlock = std_None{}}]}], .egress = [], .policyTypes = []}}: +1

--- a/test/datalog_tests/simple.dat
+++ b/test/datalog_tests/simple.dat
@@ -156,6 +156,12 @@ dump WithKeyDbg;
 
 start;
 
+insert_or_update WithKey(1, "bar3");
+
+commit dump_changes;
+
+start;
+
 insert Gangster("Billy Jack", "Vito Giacalone"),
 insert Gangster("Black Leo", "Leonardo Cellura"),
 insert Gangster("Black Sam", "Sam Todaro"),

--- a/test/datalog_tests/simple.dump.expected
+++ b/test/datalog_tests/simple.dump.expected
@@ -595,6 +595,9 @@ WithKeyDbg{.key = 4, .val = "hello"}: +1
 WithKeyDbg: +3, -2
 WithKeyDbg{1,"bar2"}
 WithKeyDbg{4,"hello"}
+WithKeyDbg:
+WithKeyDbg{.key = 1, .val = "bar2"}: -1
+WithKeyDbg{.key = 1, .val = "bar3"}: +1
 Innocent:
 Innocent{.name = "Bill Smith"}: +1
 Innocent{.name = "John Doe"}: +1


### PR DESCRIPTION
Introduce insert-or-update command.

The new command is useful when working with DDlog input relations with
primary keys.  Operations available on such relations so far are:

- insert - fails if a record with the same key exists
- delete-by-value, delete-by-key - fail if a record with the specified
  key does not exist
- modify - fails if a record with the specified key does not exist.

The new command is similar to insert, except that, if a record with the
same key as the one being inserted already exists, it replaces this
record with the new one instead of failing.  This is convenient in
scenarios where the client does not know if the key exists or cannot
easily issue a delete command.

The insert-or-update command is only applicable to input relations with
a primary key.

The CLI syntax for the new command is the same as for the `insert`
command, but using the `insert_ord_update` keyword:

```
insert_or_update WithKey(1, "bar3");
```

C API:

```
extern ddlog_cmd* ddlog_insert_or_update_cmd(table_id table, ddlog_record *rec);
```

This resolves #525. 