### PR TITLE
Do not use uint for indices

### DIFF
--- a/go/build-ddlog-prog.sh
+++ b/go/build-ddlog-prog.sh
@@ -15,7 +15,7 @@ DDLOGFLAGS="--output-input-relations=O --dynlib"
 
 echo "Running DDlog and generating .so for tests"
 
-(cd ${TEST_DIR} && ddlog -i ${TEST_NAME} -j ${DDLOGFLAGS} -L ${DDLOG_ROOT}/lib -o ${THIS_DIR})
+(cd ${TEST_DIR} && ddlog -i ${TEST_NAME} ${DDLOGFLAGS} -L ${DDLOG_ROOT}/lib -o ${THIS_DIR})
 
 (cd ${TEST_BASE}_ddlog && cargo build --release)
 

--- a/go/pkg/ddlog/record.go
+++ b/go/pkg/ddlog/record.go
@@ -95,8 +95,8 @@ type Record interface {
 	IsStruct() bool
 
 	// IntBits returns the minimum number of bits required to represent the record if it is an
-	// integer record. It returns 0 is the record is not an integer record.
-	IntBits() uint
+	// integer record. It returns 0 if the record is not an integer record.
+	IntBits() int
 
 	// ToBool returns the value of a boolean record. Behavior is undefined if the record is not
 	// a boolean.
@@ -184,9 +184,9 @@ type RecordTuple interface {
 	Push(rValue Record)
 	// At returns the i-th element of the tuple. Returns a NULL record if the tuple has fewer
 	// than i elements.
-	At(idx uint) Record
+	At(idx int) Record
 	// Size returns the number of elements in the tuple.
-	Size() uint
+	Size() int
 }
 
 // RecordVector extends the Record interface for DDlog records of type vector.
@@ -196,9 +196,9 @@ type RecordVector interface {
 	Push(rValue Record)
 	// At returns the i-th element of the vector. Returns a NULL record if the vector has fewer
 	// than i elements.
-	At(idx uint) Record
+	At(idx int) Record
 	// Size returns the number of elements in the vector.
-	Size() uint
+	Size() int
 }
 
 // RecordMap extends the Record interface for DDlog records of type map.
@@ -208,15 +208,15 @@ type RecordMap interface {
 	Push(rKey, rValue Record)
 	// KeyAt returns the i-th key of the map. Returns a NULL record if the map has fewer than i
 	// key-value pairs.
-	KeyAt(idx uint) Record
+	KeyAt(idx int) Record
 	// ValueAt returns the i-th value of the map. Returns a NULL record if the map has fewer
 	// than i key-value pairs.
-	ValueAt(idx uint) Record
+	ValueAt(idx int) Record
 	// At returns the i-th key-value pair of the map. Returns a NULL record if the map has fewer
 	// than i key-value pairs.
-	At(idx uint) (Record, Record)
+	At(idx int) (Record, Record)
 	// Size returns the number of key-value pairs in the map.
-	Size() uint
+	Size() int
 }
 
 // RecordSet extends the Record interface for DDlog records of type set.
@@ -226,9 +226,9 @@ type RecordSet interface {
 	Push(rValue Record)
 	// At returns the i-th element of the set. Returns a NULL record if the set has fewer than i
 	// elements.
-	At(idx uint) Record
+	At(idx int) Record
 	// Size returns the number of elements in the set.
-	Size() uint
+	Size() int
 }
 
 // RecordStruct extends the Record interface for DDlog records of type struct.
@@ -238,7 +238,7 @@ type RecordStruct interface {
 	Name() string
 	// At returns the i-th field of the struct. Returns a NULL record if the struct has fewer
 	// than i fields.
-	At(idx uint) Record
+	At(idx int) Record
 }
 
 type record struct {
@@ -315,8 +315,8 @@ func (r *record) IsStruct() bool {
 	return bool(C.ddlog_is_struct(r.ptr()))
 }
 
-func (r *record) IntBits() uint {
-	return uint(C.ddlog_int_bits(r.ptr()))
+func (r *record) IntBits() int {
+	return int(C.ddlog_int_bits(r.ptr()))
 }
 
 func (r *record) ToBool() bool {
@@ -526,7 +526,7 @@ func (rStruct *recordStruct) Name() string {
 	return C.GoStringN(cs, C.int(len))
 }
 
-func (rStruct *recordStruct) At(idx uint) Record {
+func (rStruct *recordStruct) At(idx int) Record {
 	r := C.ddlog_get_struct_field(rStruct.ptr(), C.size_t(idx))
 	return &record{r}
 }
@@ -551,13 +551,13 @@ func (rTuple *recordTuple) Push(rValue Record) {
 	C.ddlog_tuple_push(rTuple.ptr(), rValue.ptr())
 }
 
-func (rTuple *recordTuple) At(idx uint) Record {
+func (rTuple *recordTuple) At(idx int) Record {
 	r := C.ddlog_get_tuple_field(rTuple.ptr(), C.size_t(idx))
 	return &record{r}
 }
 
-func (rTuple *recordTuple) Size() uint {
-	return uint(C.ddlog_get_tuple_size(rTuple.ptr()))
+func (rTuple *recordTuple) Size() int {
+	return int(C.ddlog_get_tuple_size(rTuple.ptr()))
 }
 
 // NewRecordPair is a convenience way to create a 2-tuple. Such tuples are useful when constructing
@@ -592,22 +592,22 @@ func (rMap *recordMap) Push(rKey, rValue Record) {
 	C.ddlog_map_push(rMap.ptr(), rKey.ptr(), rValue.ptr())
 }
 
-func (rMap *recordMap) KeyAt(idx uint) Record {
+func (rMap *recordMap) KeyAt(idx int) Record {
 	r := C.ddlog_get_map_key(rMap.ptr(), C.size_t(idx))
 	return &record{r}
 }
 
-func (rMap *recordMap) ValueAt(idx uint) Record {
+func (rMap *recordMap) ValueAt(idx int) Record {
 	r := C.ddlog_get_map_val(rMap.ptr(), C.size_t(idx))
 	return &record{r}
 }
 
-func (rMap *recordMap) At(idx uint) (Record, Record) {
+func (rMap *recordMap) At(idx int) (Record, Record) {
 	return rMap.KeyAt(idx), rMap.ValueAt(idx)
 }
 
-func (rMap *recordMap) Size() uint {
-	return uint(C.ddlog_get_map_size(rMap.ptr()))
+func (rMap *recordMap) Size() int {
+	return int(C.ddlog_get_map_size(rMap.ptr()))
 }
 
 // NewRecordVector creates a vector record with specified elements.
@@ -631,13 +631,13 @@ func (rVec *recordVector) Push(rValue Record) {
 	C.ddlog_vector_push(rVec.ptr(), rValue.ptr())
 }
 
-func (rVec *recordVector) At(idx uint) Record {
+func (rVec *recordVector) At(idx int) Record {
 	r := C.ddlog_get_vector_elem(rVec.ptr(), C.size_t(idx))
 	return &record{r}
 }
 
-func (rVec *recordVector) Size() uint {
-	return uint(C.ddlog_get_vector_size(rVec.ptr()))
+func (rVec *recordVector) Size() int {
+	return int(C.ddlog_get_vector_size(rVec.ptr()))
 }
 
 // NewRecordSet creates a set record with specified elements.
@@ -661,13 +661,13 @@ func (rSet *recordSet) Push(rValue Record) {
 	C.ddlog_set_push(rSet.ptr(), rValue.ptr())
 }
 
-func (rSet *recordSet) At(idx uint) Record {
+func (rSet *recordSet) At(idx int) Record {
 	r := C.ddlog_get_set_elem(rSet.ptr(), C.size_t(idx))
 	return &record{r}
 }
 
-func (rSet *recordSet) Size() uint {
-	return uint(C.ddlog_get_set_size(rSet.ptr()))
+func (rSet *recordSet) Size() int {
+	return int(C.ddlog_get_set_size(rSet.ptr()))
 }
 
 // NewRecordSome is a convenience wrapper around NewRecordStructStatic for the std.Some

--- a/go/pkg/ddlog/record_test.go
+++ b/go/pkg/ddlog/record_test.go
@@ -23,7 +23,7 @@ func TestRecordInteger(t *testing.T) {
 	defer r.Free()
 
 	assert.True(t, r.IsInt())
-	assert.Equal(t, uint(49), r.IntBits())
+	assert.Equal(t, 49, r.IntBits())
 	assert.Equal(t, v, r.ToU64())
 	v64, err := r.ToU64Safe()
 	assert.Nil(t, err)
@@ -41,7 +41,7 @@ func TestRecordVector(t *testing.T) {
 
 	rVec.Push(NewRecordBool(false))
 
-	assert.Equal(t, uint(3), rVec.Size())
+	assert.Equal(t, 3, rVec.Size())
 	rBool := rVec.At(1) // true
 	assert.Equal(t, true, rBool.ToBool())
 
@@ -52,10 +52,10 @@ func TestRecordVector(t *testing.T) {
 	r := rVec.(Record)
 	assert.True(t, r.IsVector())
 	rVec = r.AsVector()
-	assert.Equal(t, uint(3), rVec.Size())
+	assert.Equal(t, 3, rVec.Size())
 	rVec, err := r.AsVectorSafe()
 	assert.Nil(t, err)
-	assert.Equal(t, uint(3), rVec.Size())
+	assert.Equal(t, 3, rVec.Size())
 }
 
 func TestRecordTuple(t *testing.T) {
@@ -65,7 +65,7 @@ func TestRecordTuple(t *testing.T) {
 
 	rTuple.Push(NewRecordBool(false))
 
-	assert.Equal(t, uint(3), rTuple.Size())
+	assert.Equal(t, 3, rTuple.Size())
 	rBool := rTuple.At(1) // true
 	assert.Equal(t, true, rBool.ToBool())
 
@@ -76,10 +76,10 @@ func TestRecordTuple(t *testing.T) {
 	r := rTuple.(Record)
 	assert.True(t, r.IsTuple())
 	rTuple = r.AsTuple()
-	assert.Equal(t, uint(3), rTuple.Size())
+	assert.Equal(t, 3, rTuple.Size())
 	rTuple, err := r.AsTupleSafe()
 	assert.Nil(t, err)
-	assert.Equal(t, uint(3), rTuple.Size())
+	assert.Equal(t, 3, rTuple.Size())
 }
 
 func TestRecordSet(t *testing.T) {
@@ -91,7 +91,7 @@ func TestRecordSet(t *testing.T) {
 	rSet.Push(NewRecordBool(false))
 
 	// DDlog does not filter duplicates when building records.
-	assert.Equal(t, uint(3), rSet.Size())
+	assert.Equal(t, 3, rSet.Size())
 	rBool := rSet.At(1) // true
 	assert.Equal(t, true, rBool.ToBool())
 
@@ -102,10 +102,10 @@ func TestRecordSet(t *testing.T) {
 	r := rSet.(Record)
 	assert.True(t, r.IsSet())
 	rSet = r.AsSet()
-	assert.Equal(t, uint(3), rSet.Size())
+	assert.Equal(t, 3, rSet.Size())
 	rSet, err := r.AsSetSafe()
 	assert.Nil(t, err)
-	assert.Equal(t, uint(3), rSet.Size())
+	assert.Equal(t, 3, rSet.Size())
 }
 
 func TestRecordMap(t *testing.T) {


### PR DESCRIPTION
Go uses int (and not uint) to index arrays and slices. It is much more
convenient to follow the same convention in the DDlog Go bindings. In
particular it makes writing loops over record vectors / maps / etc. much
easier.

This commit also ensures that we do not generate Java bindings when
testing the Go package, as they are not required and using the `-j` /
`--java` flag requires installing flat buffers.