### PR TITLE
Access fields of stucts & tuples wrapped in Ref's.

### DIFF
--- a/doc/tutorial/tutorial.md
+++ b/doc/tutorial/tutorial.md
@@ -1393,6 +1393,17 @@ TopScore(school, top_score) :-
 
 We again use `&` to pattern match values stored by reference.
 
+As another syntactic convenience, DDlog allows accessing fields of structs and
+tuples wrapped in references directly, without dereferencing them first.
+The following rule is equivalent to the one above, but instead of opening up the
+`student` record, we use `.`-notation to access the `sat_score` field:
+
+```
+TopScore(school, top_score) :-
+    StudentInfo(student, &School{.name = school}),
+    var top_score = Aggregate((school), group_max(student.sat_score)).
+```
+
 ## A more imperative syntax
 
 Some people dislike Datalog because the evaluation order of rules is not always obvious.  DDlog

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -2184,7 +2184,6 @@ mkExpr' d _ EApply{..}  =
 -- Field access automatically dereferences subexpression
 mkExpr' _ _ EField{..} = (sel1 exprStruct <> "." <> pp exprField, ELVal)
 mkExpr' _ _ ETupField{..} = ("(" <> sel1 exprTuple <> "." <> pp exprTupField <> ")", ELVal)
-
 mkExpr' _ _ (EBool _ True) = ("true", EVal)
 mkExpr' _ _ (EBool _ False) = ("false", EVal)
 mkExpr' _ _ EInt{..} = (mkInt exprIVal, EVal)

--- a/test/datalog_tests/simple.ast.expected
+++ b/test/datalog_tests/simple.ast.expected
@@ -43,6 +43,7 @@ typedef ExternalId = ExternalId{host: bit<64>, id: (string, string)}
 typedef ExternalIds = ExternalIds{host: bit<64>, ids: std.Map<string,string>}
 typedef Filtered = Filtered{r: std.Ref<Referenced>}
 typedef Filtered2 = Filtered2{r: std.Ref<Referee2>}
+typedef Filtered3 = Filtered3{r: std.Ref<Referenced>}
 typedef FooStruct = Option1{f1: bigint, f2: IPAddr, f3: (bool, string)} | Option2{f4: bit<32>, f5: IPAddr}
 typedef Gangster = Gangster{nickname: string, name: string}
 typedef HostAddress = HostAddress{host: bit<64>, addr: string}
@@ -731,6 +732,7 @@ output relation ExternalId [ExternalId]
 input relation ExternalIds [ExternalIds]
 output relation Filtered [Filtered]
 output relation Filtered2 [Filtered2]
+output relation Filtered3 [Filtered3]
 input relation Gangster [Gangster]
 output relation HostAddress [HostAddress]
 input relation HostAddresses [HostAddresses]
@@ -968,6 +970,7 @@ Referee(.r=std.ref_new(r)) :- Referenced[(r@ Referenced{.x=_, .y=std.Some{.x=_}}
 Filtered(.r=r.r) :- Referee[(r@ Referee{.r=(&Referenced{.x=true, .y=_})})].
 Referee2[std.ref_new(Referee2{.r=r})] :- Referenced[r].
 Filtered2(.r=r) :- Referee2[(r@ (&Referee2{.r=Referenced{.x=true, .y=_}}))].
+Filtered3(.r=r.r) :- Referee[(r@ Referee{.r=_})], (r.r.x == true).
 NewAllocation(.id=id, .alloc=alloc) :- Alloc(.id=id, .allocated=allocated, .toallocate=toallocate, .min_val=min_val, .max_val=max_val), var allocated_nums = ((var allocated_nums: std.Set<bit<32>>) = std.set_empty();
                                                                                                                                                               (for (a in allocated) {
                                                                                                                                                                    ((_, var num) = a;

--- a/test/datalog_tests/simple.dl
+++ b/test/datalog_tests/simple.dl
@@ -827,6 +827,10 @@ output relation Filtered2(r: Ref<Referee2>)
 
 Filtered2(r) :- r in &Referee2(.r = Referenced{.x = true}).
 
+output relation Filtered3(r: Ref<Referenced>)
+Filtered3(r.r) :- r in Referee(), r.r.x==true.
+
+
 /* More allocator tests */
 input relation Alloc(id: bigint,
                      allocated: Map<string, bit<32>>,

--- a/test/datalog_tests/simple.dump.expected
+++ b/test/datalog_tests/simple.dump.expected
@@ -680,6 +680,8 @@ Filtered:
 Filtered{.r = Referenced{.x = true, .y = std_Some{.x = "hello"}}}: +1
 Filtered2:
 Filtered2{.r = Referee2{.r = Referenced{.x = true, .y = std_Some{.x = "hello"}}}}: +1
+Filtered3:
+Filtered3{.r = Referenced{.x = true, .y = std_Some{.x = "hello"}}}: +1
 Referee:
 Referee{.r = Referenced{.x = true, .y = std_Some{.x = "hello"}}}: +1
 Referee2:

--- a/test/datalog_tests/tutorial.ast.expected
+++ b/test/datalog_tests/tutorial.ast.expected
@@ -392,6 +392,7 @@ IntranetHost3(.addr=addr) :- KnownHost(.addr=addr), var t = addr_to_tuple(addr),
 TargetAudience[person] :- Person[person], is_target_audience(person).
 StudentInfo(.student=student, .school=school) :- Student[(student@ (&Student{.id=_, .name=_, .school=school_name, .sat_score=_}))], School[(school@ (&School{.name=school_name, .address=_}))].
 TopScore(.school=school, .top_score=top_score) :- StudentInfo(.student=(&Student{.id=_, .name=_, .school=_, .sat_score=sat}), .school=(&School{.name=school, .address=_})), var top_score = Aggregate((school), std.group_max(sat)).
+TopScore(.school=school, .top_score=top_score) :- StudentInfo(.student=student, .school=(&School{.name=school, .address=_})), var top_score = Aggregate((school), std.group_max(student.sat_score)).
 Flow(.lr=ls, .stage=LS_IN_PRE_LB{}, .prio=100, .matchStr=("ip4.dst == " ++ addresses), .actionStr="{ reg0[0] = 1; next; }") :- Load_Balancer(.lb=_, .ls=ls, .ip_addresses=addresses, .protocol=std.Some{.x=_}, .name=_).
 Flow(.lr=ls, .stage=LS_OUT_PRE_LB{}, .prio=100, .matchStr="ip4", .actionStr="{ reg0[0] = 1; next; }") :- Logical_Switch(.ls=ls), Load_Balancer(.lb=_, .ls=ls, .ip_addresses=_, .protocol=_, .name=_).
 Flow1(.lr=lb.ls, .stage=LS_IN_PRE_LB{}, .prio=100, .matchStr=("ip4.dst == " ++ a), .actionStr="{ reg0[0] = 1; next; }") :- Load_Balancer[(lb@ Load_Balancer{.lb=_, .ls=_, .ip_addresses=_, .protocol=_, .name=_})], var a = lb.ip_addresses, match (lb.protocol) {

--- a/test/datalog_tests/tutorial.dl
+++ b/test/datalog_tests/tutorial.dl
@@ -465,6 +465,11 @@ TopScore(school, top_score) :-
     StudentInfo(&Student{.sat_score = sat}, &School{.name = school}),
     var top_score = Aggregate((school), group_max(sat)).
 
+// Alternative syntax.
+TopScore(school, top_score) :-
+    StudentInfo(student, &School{.name = school}),
+    var top_score = Aggregate((school), group_max(student.sat_score)).
+
 /*
  * Example: Advanced features
  */


### PR DESCRIPTION
This commit addresses one of the awkward aspects of working with complex
types wrapped in `Ref<>`'s.  Ideally, we would like `Ref<>`'s to be as
transparent as possible, so that one could work with them as if they were
objects of the inner type wrapped in the `Ref`.  We're not quite there
yet.  One issue is that Rust does not allow matching on the contents of
a `Ref`.  The other issue is that accessing fields of structs or tuples
wrapped in a `Ref<>` requires either unwrapping it using `deref` or
using pattern matching syntax, as in:

```
relation StudentInfo(student: Ref<Student>, school: Ref<School>)

TopScore(school, top_score) :-
    StudentInfo(&Student{.sat_score = sat}, &School{.name = school}),
    // WE HAVE BOUND THE `.sat_score` FIELD OF Student TO `sat` AND CAN
    // USE IT BELOW.
    var top_score = Aggregate((school), group_max(sat)).
```

This commit extends the field access syntax `s.field` to perform automatic
dereferencing if `s` is a `Ref<>`, so the above rule can now be equivalently
re-written as:

```
TopScore(school, top_score) :-
    StudentInfo(student, &School{.name = school}),
    var top_score = Aggregate((school), group_max(student.sat_score)).
```