### PR TITLE
Antrea: Merge output relations.

### DIFF
--- a/test/antrea/networkpolicy_controller.dl
+++ b/test/antrea/networkpolicy_controller.dl
@@ -8,12 +8,12 @@ import types
 import klog as klog
 
 /* In DDlog, we split the AppliedToGroup struct into three relations:
- * AppliedToGroup: stores group name, id, and GroupSelector
+ * AppliedToGroupDescr: stores group name, id, and GroupSelector
  * AppliedToGroupPodsByNode: stores the node-to-pods mapping.
  * AppliedToGroupSpan: group span (nodes where the group must be sent).
  */
 
-output relation AppliedToGroup (
+relation AppliedToGroupDescr (
     // UID is generated from the hash value of GroupSelector.NormalizedName.
     uid: k8s.UID,
     // Name of this group, currently it's same as UID.
@@ -23,19 +23,30 @@ output relation AppliedToGroup (
 )
 
 // PodsByNode is a mapping from nodeName to a set of Pods on the Node.
-output relation AppliedToGroupPodsByNode(appliedToGroup: k8s.UID, podsByNode: Map<string, Set<k8s.UID>>)
+relation AppliedToGroupPodsByNode(appliedToGroup: k8s.UID, podsByNode: Map<string, Set<k8s.UID>>)
 
 // AppliedToGroupSpan: set of node names that this AddressGroup should be sent to.
-output relation AppliedToGroupSpan(appliedToGroup: k8s.UID, span: Set<k8s.UID>)
+relation AppliedToGroupSpan(appliedToGroup: k8s.UID, span: Set<k8s.UID>)
+
+output relation AppliedToGroup (
+    descr: AppliedToGroupDescr,
+    podsByNode: Map<string, Set<k8s.UID>>,
+    span: Set<k8s.UID>
+)
+
+AppliedToGroup(descr, podsByNode, span) :-
+    descr in AppliedToGroupDescr(),
+    AppliedToGroupPodsByNode(descr.uid, podsByNode),
+    AppliedToGroupSpan(descr.uid, span).
 
 /* In DDlog, we split the AddressGroup struct into three relations:
- * AddressGroup: stores group name, id, and GroupSelector
+ * AddressGroupDescr: stores group name, id, and GroupSelector
  * AddressGroupAddress: stores addresses of nodes that match the group selector.
  * AddressGroupSpan: group span (nodes where the group must be sent).
  */
 
-// AddressGroup describes a set of addresses used as source or destination of Network Policy rules.
-output relation AddressGroup (
+// AddressGroupDescr describes a set of addresses used as source or destination of Network Policy rules.
+relation AddressGroupDescr (
     // UID is generated from the hash value of GroupSelector.NormalizedName.
     uid: k8s.UID,
     // Name of this group, currently it's same as UID.
@@ -45,13 +56,35 @@ output relation AddressGroup (
 )
 
 // Addresses is a set of IP addresses selected by this group.
-output relation AddressGroupAddress(addresGroup: k8s.UID, address: string)
+relation AddressGroupAddress(addressGroup: k8s.UID, address: string)
+
+// Aggregate all addresses for an address group in one record.
+relation AddressGroupAddresses(addressGroup: k8s.UID, addresses: Set<string>)
+AddressGroupAddresses(addressGroup, addresses) :-
+    AddressGroupAddress(addressGroup, address),
+    var addresses = Aggregate((addressGroup), group2set(address)).
+
+// Handle the case when the group is empty.
+AddressGroupAddresses(gid, set_empty()) :-
+    AddressGroupDescr(.uid = gid),
+    not AddressGroupAddress(.addressGroup = gid).
 
 // AddressGroupSpan: set of node names that this AddressGroup should be sent to.
-output relation AddressGroupSpan(addressGroup: k8s.UID, span: Set<k8s.UID>)
+relation AddressGroupSpan(addressGroup: k8s.UID, span: Set<k8s.UID>)
+
+output relation AddressGroup (
+    descr: AddressGroupDescr,
+    addresses: Set<string>,
+    span: Set<k8s.UID>
+)
+
+AddressGroup(descr, addresses, span) :-
+    descr in AddressGroupDescr(),
+    AddressGroupAddresses(descr.uid, addresses),
+    AddressGroupSpan(descr.uid, span).
 
 // NetworkPolicy describes what network traffic is allowed for a set of Pods.
-output relation NetworkPolicy (
+relation NetworkPolicyDescr (
     // UID of the original K8s Network Policy.
     uid: k8s.UID,
     // Name of the original K8s Network Policy.
@@ -64,24 +97,32 @@ output relation NetworkPolicy (
     appliedToGroups: Vec<string>
 )
 
-// NetworkPolicySpan: set of node names that this NetworkPolicy should be sent to.
-output relation NetworkPolicySpan(policy: k8s.UID, span: Set<k8s.UID>)
+// NetworkPolicySpan: set of node names that this NetworkPolicyDescr should be sent to.
+relation NetworkPolicySpan(policy: k8s.UID, span: Set<k8s.UID>)
 
-// createAppliedToGroup creates an AppliedToGroup object.
-function createAppliedToGroup(np: k8s.NetworkPolicy): AppliedToGroup =
+output relation NetworkPolicy(
+    descr: NetworkPolicyDescr,
+    span: Set<k8s.UID>)
+
+NetworkPolicy(descr, span) :-
+    descr in NetworkPolicyDescr(),
+    NetworkPolicySpan(descr.uid, span).
+
+// createAppliedToGroup creates an AppliedToGroupDescr object.
+function createAppliedToGroup(np: k8s.NetworkPolicy): AppliedToGroupDescr =
 {
     klog.info("createAppliedToGroup ${np.name}");
     var groupSelector = toGroupSelector(np.namespace, Some{np.spec.podSelector}, None);
     var appliedToGroupUID = getNormalizedUID(groupSelector.normalizedName);
-    // Construct a new AppliedToGroup.
-    AppliedToGroup {
+    // Construct a new AppliedToGroupDescr.
+    AppliedToGroupDescr {
         .name       = appliedToGroupUID,
         .uid        = k8s.UID{appliedToGroupUID},
         .selector   = groupSelector
     }
 }
 
-function toAntreaPeer(peers: Vec<k8s.NetworkPolicyPeer>, np: k8s.NetworkPolicy): (NetworkPolicyPeer, Vec<AddressGroup>) =
+function toAntreaPeer(peers: Vec<k8s.NetworkPolicyPeer>, np: k8s.NetworkPolicy): (NetworkPolicyPeer, Vec<AddressGroupDescr>) =
 {
     // Empty NetworkPolicyPeer is supposed to match all addresses.
     // See https://kubernetes.io/docs/concepts/services-networking/network-policies/#default-allow-all-ingress-traffic.
@@ -91,7 +132,7 @@ function toAntreaPeer(peers: Vec<k8s.NetworkPolicyPeer>, np: k8s.NetworkPolicy):
     } else {
         var ipBlocks: Vec<IPBlock> = vec_empty();
         var addressGroupNames: Vec<string> = vec_empty();
-        var addressGroups: Vec<AddressGroup> = vec_empty();
+        var addressGroups: Vec<AddressGroupDescr> = vec_empty();
 
         for (peer in peers) {
             // A networking.NetworkPolicyPeer will either have an IPBlock or a
@@ -176,17 +217,17 @@ function toAntreaIPBlock(ipBlock: k8s.IPBlock): Result<IPBlock,string> =
     }
 }
 
-// createAddressGroup creates an AddressGroup object corresponding to a
+// createAddressGroup creates an AddressGroupDescr object corresponding to a
 // NetworkPolicyPeer object in NetworkPolicyRule. This function simply
 // creates the object without actually populating the PodAddresses as the
 // affected Pods are calculated during sync process.
-function createAddressGroup(peer: k8s.NetworkPolicyPeer, np: k8s.NetworkPolicy): AddressGroup =
+function createAddressGroup(peer: k8s.NetworkPolicyPeer, np: k8s.NetworkPolicy): AddressGroupDescr =
 {
     var groupSelector = toGroupSelector(np.namespace, peer.podSelector, peer.namespaceSelector);
     var normalizedUID = getNormalizedUID(groupSelector.normalizedName);
 
-    // Create an AddressGroup object per Peer object.
-    AddressGroup{
+    // Create an AddressGroupDescr object per Peer object.
+    AddressGroupDescr{
         .uid        = k8s.UID{normalizedUID},
         .name       = normalizedUID,
         .selector   = groupSelector
@@ -198,11 +239,11 @@ function createAddressGroup(peer: k8s.NetworkPolicyPeer, np: k8s.NetworkPolicy):
 // internal NetworkPolicy in store, instead returns an instance to the caller
 // wherein, it will be either stored as a new Object in case of ADD event or
 // modified and store the updated instance, in case of an UPDATE event.
-function processNetworkPolicy(np: k8s.NetworkPolicy): (NetworkPolicy, AppliedToGroup, Vec<AddressGroup>) =
+function processNetworkPolicy(np: k8s.NetworkPolicy): (NetworkPolicyDescr, AppliedToGroupDescr, Vec<AddressGroupDescr>) =
 {
     var appliedToGroup = createAppliedToGroup(np);
     var rules: Vec<NetworkPolicyRule> = vec_empty();
-    var addressGroups: Vec<AddressGroup> = vec_empty();
+    var addressGroups: Vec<AddressGroupDescr> = vec_empty();
     var ingressRuleExists = false;
     var egressRuleExists  = false;
 
@@ -252,7 +293,7 @@ function processNetworkPolicy(np: k8s.NetworkPolicy): (NetworkPolicy, AppliedToG
         vec_push(rules, denyAllEgressRule())
     };
 
-    var policy = NetworkPolicy {
+    var policy = NetworkPolicyDescr {
         .name               = np.name,
         .namespace          = np.namespace,
         .uid                = np.uid,
@@ -266,31 +307,31 @@ function processNetworkPolicy(np: k8s.NetworkPolicy): (NetworkPolicy, AppliedToG
 // Intermediate relation that stores policy and all associated address groups.
 // This relation does not get indexed and therefore should not take any memory.
 relation NetworkPolicyExt(
-    policy: NetworkPolicy,
-    addressGroups: Vec<AddressGroup>
+    policy: NetworkPolicyDescr,
+    addressGroups: Vec<AddressGroupDescr>
 )
 
 NetworkPolicyExt(internalPolicy, addrGroups),
-AppliedToGroup[appliedTo] :-
+AppliedToGroupDescr[appliedTo] :-
     k8s.NetworkPolicy[policy],
     (var internalPolicy, var appliedTo, var addrGroups) = processNetworkPolicy(policy).
 
-NetworkPolicy[policy] :- NetworkPolicyExt(policy, _).
+NetworkPolicyDescr[policy] :- NetworkPolicyExt(policy, _).
 
-AddressGroup[group] :-
+AddressGroupDescr[group] :-
     NetworkPolicyExt(_, groups),
     var group = FlatMap(groups).
 
 AddressGroupAddress(addressGroup.uid, pod.status.podIP) :-
     // Namespace presence indicates Pods must be selected from the same Namespace.
-    addressGroup in AddressGroup(.selector = GroupSelector{.nsSelector = NSSelectorNS{ns}}),
+    addressGroup in AddressGroupDescr(.selector = GroupSelector{.nsSelector = NSSelectorNS{ns}}),
     pod in k8s.Pod(.namespace = ns),
     pod.status.podIP != "",
     k8s.labelSelectorMatches(addressGroup.selector.podSelector, pod.labels).
 
 AddressGroupAddress(addressGroup.uid, pod.status.podIP) :-
     // Pods must be selected from Namespaces matching nsSelector.
-    addressGroup in AddressGroup(.selector = GroupSelector{.nsSelector = NSSelectorLS{namespaceSelector}, .podSelector = podSelector}),
+    addressGroup in AddressGroupDescr(.selector = GroupSelector{.nsSelector = NSSelectorLS{namespaceSelector}, .podSelector = podSelector}),
     namespace in k8s.Namespace(),
     k8s.labelSelectorMatches(Some{namespaceSelector}, namespace.labels),
     pod in k8s.Pod(.namespace = namespace.name),
@@ -302,7 +343,7 @@ AddressGroupAddress(addressGroup.uid, pod.status.podIP) :-
 relation NetworkPolicyAddressGroup(np: k8s.UID, addressGroup: string)
 
 NetworkPolicyAddressGroup(np, addressGroup) :-
-    NetworkPolicy(.uid = np, .rules = rules),
+    NetworkPolicyDescr(.uid = np, .rules = rules),
     var addressGroups = {
         var addressGroups: Vec<string> = vec_empty();
         for (rule in rules) {
@@ -314,11 +355,17 @@ NetworkPolicyAddressGroup(np, addressGroup) :-
     var addressGroup = FlatMap(addressGroups).
 
 AddressGroupSpan(k8s.UID{addressGroup}, span) :-
-    AddressGroup(.uid = k8s.UID{addressGroup}),
-    // Get all internal NetworkPolicy objects that refers this AddressGroup.
+    AddressGroupDescr(.uid = k8s.UID{addressGroup}),
+    // Get all internal NetworkPolicy objects that refers this AddressGroupDescr.
     NetworkPolicyAddressGroup(np, addressGroup),
     NetworkPolicySpan(np, npSpan),
     var span = Aggregate((addressGroup), group_set_unions(npSpan)).
+
+// Handle the case when the address group is not refered to by any NetworkPolicy
+// objects.
+AddressGroupSpan(k8s.UID{addressGroup}, set_empty()) :-
+    AddressGroupDescr(.uid = k8s.UID{addressGroup}),
+    not NetworkPolicyAddressGroup(.addressGroup = addressGroup).
 
 // AppliedToGroupPod: pods that belong to a group along with nodes
 // where the pod is scheduled;
@@ -327,8 +374,8 @@ relation AppliedToGroupPod(appliedToGroup: k8s.UID, pod: k8s.UID, nodeName: stri
 
 AppliedToGroupPod(appliedToGroup, pod.uid, pod.spec.nodeName) :-
     // TODO(leonid): Is it correct that we only consider selectors with namespace name set?
-    AppliedToGroup(.uid = appliedToGroup,
-                   .selector = GroupSelector{.nsSelector = NSSelectorNS{namespace}, .podSelector = podSelector}),
+    AppliedToGroupDescr(.uid = appliedToGroup,
+                        .selector = GroupSelector{.nsSelector = NSSelectorNS{namespace}, .podSelector = podSelector}),
     // Retrieve all Pods matching the podSelector.
     pod in k8s.Pod(.namespace = namespace),
     // No need to process Pod when it's not scheduled.
@@ -344,8 +391,18 @@ AppliedToGroupSpan(appliedToGroup, span) :-
     AppliedToGroupPod(appliedToGroup, pod, _),
     var span = Aggregate((appliedToGroup), group2set(pod)).
 
+// Handle the case when there are no pods in the group.
+AppliedToGroupSpan(uid, set_empty()),
+AppliedToGroupPodsByNode(uid, map_empty()) :-
+    AppliedToGroupDescr(.uid = uid),
+    not AppliedToGroupPod(.appliedToGroup = uid).
+
 NetworkPolicySpan(policy, span) :-
-    NetworkPolicy(.uid = policy, .appliedToGroups = appliedToGroups),
+    NetworkPolicyDescr(.uid = policy, .appliedToGroups = appliedToGroups),
     var appliedToGroup = FlatMap(appliedToGroups),
     AppliedToGroupSpan(k8s.UID{appliedToGroup}, groupSpan),
     var span = Aggregate((policy), group_set_unions(groupSpan)).
+
+// Handle the case when `apliedToGroups` is empty.
+NetworkPolicySpan(policy, set_empty()) :-
+    NetworkPolicyDescr(.uid = policy, .appliedToGroups = vec_empty()).

--- a/test/antrea/networkpolicy_controller.dump.expected
+++ b/test/antrea/networkpolicy_controller.dump.expected
@@ -13,11 +13,21 @@ Adding policies
 LOG (0): createAppliedToGroup ns1.policy1
 LOG (0): createAppliedToGroup ns1.policy1
 AppliedToGroup:
-AppliedToGroup{.uid = k8spolicy_UID{.uid = "dbd5cd23-1488-56b6-925e-7354a2189c7d"}, .name = "dbd5cd23-1488-56b6-925e-7354a2189c7d", .selector = types_GroupSelector{.normalizedName = "namespace=ns1 And podSelector=l1 In [l1v1]", .nsSelector = types_NSSelectorNS{.ns = "ns1"}, .podSelector = std_Some{.x = k8spolicy_LabelSelector{.matchLabels = [("l1", "l1v1")], .matchExpressions = []}}}}: +1
+AppliedToGroup{.descr = AppliedToGroupDescr{.uid = k8spolicy_UID{.uid = "dbd5cd23-1488-56b6-925e-7354a2189c7d"}, .name = "dbd5cd23-1488-56b6-925e-7354a2189c7d", .selector = types_GroupSelector{.normalizedName = "namespace=ns1 And podSelector=l1 In [l1v1]", .nsSelector = types_NSSelectorNS{.ns = "ns1"}, .podSelector = std_Some{.x = k8spolicy_LabelSelector{.matchLabels = [("l1", "l1v1")], .matchExpressions = []}}}}, .podsByNode = [], .span = []}: +1
+AppliedToGroupDescr:
+AppliedToGroupDescr{.uid = k8spolicy_UID{.uid = "dbd5cd23-1488-56b6-925e-7354a2189c7d"}, .name = "dbd5cd23-1488-56b6-925e-7354a2189c7d", .selector = types_GroupSelector{.normalizedName = "namespace=ns1 And podSelector=l1 In [l1v1]", .nsSelector = types_NSSelectorNS{.ns = "ns1"}, .podSelector = std_Some{.x = k8spolicy_LabelSelector{.matchLabels = [("l1", "l1v1")], .matchExpressions = []}}}}: +1
+AppliedToGroupPodsByNode:
+AppliedToGroupPodsByNode{.appliedToGroup = k8spolicy_UID{.uid = "dbd5cd23-1488-56b6-925e-7354a2189c7d"}, .podsByNode = []}: +1
+AppliedToGroupSpan:
+AppliedToGroupSpan{.appliedToGroup = k8spolicy_UID{.uid = "dbd5cd23-1488-56b6-925e-7354a2189c7d"}, .span = []}: +1
 NetworkPolicy:
-NetworkPolicy{.uid = k8spolicy_UID{.uid = "156bc79a-ee16-47d9-82b6-8bc48849af74"}, .name = "ns1.policy1", .namespace = "ns1", .rules = [], .appliedToGroups = ["dbd5cd23-1488-56b6-925e-7354a2189c7d"]}: +1
+NetworkPolicy{.descr = NetworkPolicyDescr{.uid = k8spolicy_UID{.uid = "156bc79a-ee16-47d9-82b6-8bc48849af74"}, .name = "ns1.policy1", .namespace = "ns1", .rules = [], .appliedToGroups = ["dbd5cd23-1488-56b6-925e-7354a2189c7d"]}, .span = []}: +1
+NetworkPolicyDescr:
+NetworkPolicyDescr{.uid = k8spolicy_UID{.uid = "156bc79a-ee16-47d9-82b6-8bc48849af74"}, .name = "ns1.policy1", .namespace = "ns1", .rules = [], .appliedToGroups = ["dbd5cd23-1488-56b6-925e-7354a2189c7d"]}: +1
 NetworkPolicyExt:
-NetworkPolicyExt{.policy = NetworkPolicy{.uid = k8spolicy_UID{.uid = "156bc79a-ee16-47d9-82b6-8bc48849af74"}, .name = "ns1.policy1", .namespace = "ns1", .rules = [], .appliedToGroups = ["dbd5cd23-1488-56b6-925e-7354a2189c7d"]}, .addressGroups = []}: +1
+NetworkPolicyExt{.policy = NetworkPolicyDescr{.uid = k8spolicy_UID{.uid = "156bc79a-ee16-47d9-82b6-8bc48849af74"}, .name = "ns1.policy1", .namespace = "ns1", .rules = [], .appliedToGroups = ["dbd5cd23-1488-56b6-925e-7354a2189c7d"]}, .addressGroups = []}: +1
+NetworkPolicySpan:
+NetworkPolicySpan{.policy = k8spolicy_UID{.uid = "156bc79a-ee16-47d9-82b6-8bc48849af74"}, .span = []}: +1
 Ok8spolicy.NetworkPolicy:
 k8spolicy_NetworkPolicy{.name = "ns1.policy1", .namespace = "ns1", .uid = k8spolicy_UID{.uid = "156bc79a-ee16-47d9-82b6-8bc48849af74"}, .spec = k8spolicy_NetworkPolicySpec{.podSelector = k8spolicy_LabelSelector{.matchLabels = [("l1", "l1v1")], .matchExpressions = []}, .ingress = [], .egress = [], .policyTypes = []}}: +1
 Making changes
@@ -26,15 +36,24 @@ LOG (0): createAppliedToGroup ns1.policy1
 LOG (0): createAppliedToGroup ns1.policy1
 LOG (0): createAppliedToGroup ns1.policy1
 AddressGroup:
-AddressGroup{.uid = k8spolicy_UID{.uid = "df49fa6b-0346-5dc9-9bb2-3da4fdbe8dd8"}, .name = "df49fa6b-0346-5dc9-9bb2-3da4fdbe8dd8", .selector = types_GroupSelector{.normalizedName = "namespaceSelector= And podSelector=l1 In [l1v1]", .nsSelector = types_NSSelectorLS{.selector = k8spolicy_LabelSelector{.matchLabels = [], .matchExpressions = []}}, .podSelector = std_Some{.x = k8spolicy_LabelSelector{.matchLabels = [("l1", "l1v1")], .matchExpressions = []}}}}: +1
+AddressGroup{.descr = AddressGroupDescr{.uid = k8spolicy_UID{.uid = "df49fa6b-0346-5dc9-9bb2-3da4fdbe8dd8"}, .name = "df49fa6b-0346-5dc9-9bb2-3da4fdbe8dd8", .selector = types_GroupSelector{.normalizedName = "namespaceSelector= And podSelector=l1 In [l1v1]", .nsSelector = types_NSSelectorLS{.selector = k8spolicy_LabelSelector{.matchLabels = [], .matchExpressions = []}}, .podSelector = std_Some{.x = k8spolicy_LabelSelector{.matchLabels = [("l1", "l1v1")], .matchExpressions = []}}}}, .addresses = [], .span = []}: +1
+AddressGroupAddresses:
+AddressGroupAddresses{.addressGroup = k8spolicy_UID{.uid = "df49fa6b-0346-5dc9-9bb2-3da4fdbe8dd8"}, .addresses = []}: +1
+AddressGroupDescr:
+AddressGroupDescr{.uid = k8spolicy_UID{.uid = "df49fa6b-0346-5dc9-9bb2-3da4fdbe8dd8"}, .name = "df49fa6b-0346-5dc9-9bb2-3da4fdbe8dd8", .selector = types_GroupSelector{.normalizedName = "namespaceSelector= And podSelector=l1 In [l1v1]", .nsSelector = types_NSSelectorLS{.selector = k8spolicy_LabelSelector{.matchLabels = [], .matchExpressions = []}}, .podSelector = std_Some{.x = k8spolicy_LabelSelector{.matchLabels = [("l1", "l1v1")], .matchExpressions = []}}}}: +1
+AddressGroupSpan:
+AddressGroupSpan{.addressGroup = k8spolicy_UID{.uid = "df49fa6b-0346-5dc9-9bb2-3da4fdbe8dd8"}, .span = []}: +1
 NetworkPolicy:
-NetworkPolicy{.uid = k8spolicy_UID{.uid = "156bc79a-ee16-47d9-82b6-8bc48849af74"}, .name = "ns1.policy1", .namespace = "ns1", .rules = [], .appliedToGroups = ["dbd5cd23-1488-56b6-925e-7354a2189c7d"]}: -1
-NetworkPolicy{.uid = k8spolicy_UID{.uid = "156bc79a-ee16-47d9-82b6-8bc48849af74"}, .name = "ns1.policy1", .namespace = "ns1", .rules = [types_NetworkPolicyRule{.direction = types_DirectionIn{}, .from = types_NetworkPolicyPeer{.addressGroups = ["df49fa6b-0346-5dc9-9bb2-3da4fdbe8dd8"], .ipBlocks = []}, .to = types_NetworkPolicyPeer{.addressGroups = [], .ipBlocks = []}, .services = [types_Service{.protocol = "TCP", .port = std_None{}}]}], .appliedToGroups = ["dbd5cd23-1488-56b6-925e-7354a2189c7d"]}: +1
+NetworkPolicy{.descr = NetworkPolicyDescr{.uid = k8spolicy_UID{.uid = "156bc79a-ee16-47d9-82b6-8bc48849af74"}, .name = "ns1.policy1", .namespace = "ns1", .rules = [], .appliedToGroups = ["dbd5cd23-1488-56b6-925e-7354a2189c7d"]}, .span = []}: -1
+NetworkPolicy{.descr = NetworkPolicyDescr{.uid = k8spolicy_UID{.uid = "156bc79a-ee16-47d9-82b6-8bc48849af74"}, .name = "ns1.policy1", .namespace = "ns1", .rules = [types_NetworkPolicyRule{.direction = types_DirectionIn{}, .from = types_NetworkPolicyPeer{.addressGroups = ["df49fa6b-0346-5dc9-9bb2-3da4fdbe8dd8"], .ipBlocks = []}, .to = types_NetworkPolicyPeer{.addressGroups = [], .ipBlocks = []}, .services = [types_Service{.protocol = "TCP", .port = std_None{}}]}], .appliedToGroups = ["dbd5cd23-1488-56b6-925e-7354a2189c7d"]}, .span = []}: +1
 NetworkPolicyAddressGroup:
 NetworkPolicyAddressGroup{.np = k8spolicy_UID{.uid = "156bc79a-ee16-47d9-82b6-8bc48849af74"}, .addressGroup = "df49fa6b-0346-5dc9-9bb2-3da4fdbe8dd8"}: +1
+NetworkPolicyDescr:
+NetworkPolicyDescr{.uid = k8spolicy_UID{.uid = "156bc79a-ee16-47d9-82b6-8bc48849af74"}, .name = "ns1.policy1", .namespace = "ns1", .rules = [], .appliedToGroups = ["dbd5cd23-1488-56b6-925e-7354a2189c7d"]}: -1
+NetworkPolicyDescr{.uid = k8spolicy_UID{.uid = "156bc79a-ee16-47d9-82b6-8bc48849af74"}, .name = "ns1.policy1", .namespace = "ns1", .rules = [types_NetworkPolicyRule{.direction = types_DirectionIn{}, .from = types_NetworkPolicyPeer{.addressGroups = ["df49fa6b-0346-5dc9-9bb2-3da4fdbe8dd8"], .ipBlocks = []}, .to = types_NetworkPolicyPeer{.addressGroups = [], .ipBlocks = []}, .services = [types_Service{.protocol = "TCP", .port = std_None{}}]}], .appliedToGroups = ["dbd5cd23-1488-56b6-925e-7354a2189c7d"]}: +1
 NetworkPolicyExt:
-NetworkPolicyExt{.policy = NetworkPolicy{.uid = k8spolicy_UID{.uid = "156bc79a-ee16-47d9-82b6-8bc48849af74"}, .name = "ns1.policy1", .namespace = "ns1", .rules = [], .appliedToGroups = ["dbd5cd23-1488-56b6-925e-7354a2189c7d"]}, .addressGroups = []}: -1
-NetworkPolicyExt{.policy = NetworkPolicy{.uid = k8spolicy_UID{.uid = "156bc79a-ee16-47d9-82b6-8bc48849af74"}, .name = "ns1.policy1", .namespace = "ns1", .rules = [types_NetworkPolicyRule{.direction = types_DirectionIn{}, .from = types_NetworkPolicyPeer{.addressGroups = ["df49fa6b-0346-5dc9-9bb2-3da4fdbe8dd8"], .ipBlocks = []}, .to = types_NetworkPolicyPeer{.addressGroups = [], .ipBlocks = []}, .services = [types_Service{.protocol = "TCP", .port = std_None{}}]}], .appliedToGroups = ["dbd5cd23-1488-56b6-925e-7354a2189c7d"]}, .addressGroups = [AddressGroup{.uid = k8spolicy_UID{.uid = "df49fa6b-0346-5dc9-9bb2-3da4fdbe8dd8"}, .name = "df49fa6b-0346-5dc9-9bb2-3da4fdbe8dd8", .selector = types_GroupSelector{.normalizedName = "namespaceSelector= And podSelector=l1 In [l1v1]", .nsSelector = types_NSSelectorLS{.selector = k8spolicy_LabelSelector{.matchLabels = [], .matchExpressions = []}}, .podSelector = std_Some{.x = k8spolicy_LabelSelector{.matchLabels = [("l1", "l1v1")], .matchExpressions = []}}}}]}: +1
+NetworkPolicyExt{.policy = NetworkPolicyDescr{.uid = k8spolicy_UID{.uid = "156bc79a-ee16-47d9-82b6-8bc48849af74"}, .name = "ns1.policy1", .namespace = "ns1", .rules = [], .appliedToGroups = ["dbd5cd23-1488-56b6-925e-7354a2189c7d"]}, .addressGroups = []}: -1
+NetworkPolicyExt{.policy = NetworkPolicyDescr{.uid = k8spolicy_UID{.uid = "156bc79a-ee16-47d9-82b6-8bc48849af74"}, .name = "ns1.policy1", .namespace = "ns1", .rules = [types_NetworkPolicyRule{.direction = types_DirectionIn{}, .from = types_NetworkPolicyPeer{.addressGroups = ["df49fa6b-0346-5dc9-9bb2-3da4fdbe8dd8"], .ipBlocks = []}, .to = types_NetworkPolicyPeer{.addressGroups = [], .ipBlocks = []}, .services = [types_Service{.protocol = "TCP", .port = std_None{}}]}], .appliedToGroups = ["dbd5cd23-1488-56b6-925e-7354a2189c7d"]}, .addressGroups = [AddressGroupDescr{.uid = k8spolicy_UID{.uid = "df49fa6b-0346-5dc9-9bb2-3da4fdbe8dd8"}, .name = "df49fa6b-0346-5dc9-9bb2-3da4fdbe8dd8", .selector = types_GroupSelector{.normalizedName = "namespaceSelector= And podSelector=l1 In [l1v1]", .nsSelector = types_NSSelectorLS{.selector = k8spolicy_LabelSelector{.matchLabels = [], .matchExpressions = []}}, .podSelector = std_Some{.x = k8spolicy_LabelSelector{.matchLabels = [("l1", "l1v1")], .matchExpressions = []}}}}]}: +1
 Ok8spolicy.Namespace:
 k8spolicy_Namespace{.name = "ns1", .uid = k8spolicy_UID{.uid = "e340296d-84e2-48b2-9b7a-91641db60db5"}, .labels = []}: -1
 k8spolicy_Namespace{.name = "ns1", .uid = k8spolicy_UID{.uid = "e340296d-84e2-48b2-9b7a-91641db60db5"}, .labels = [("l1", "l1v1")]}: +1


### PR DESCRIPTION
Merge output relations to ease integration with Antrea and testing:

- Merge `AppliedToGroup`, `AppliedToGroupPodsByNode` and `AppliedToGroupSpan`
  in a single output relation.
- Merge `AddressGroup`, `AddressGroupAddresses`, `AddressGroupSpan`.
- Merge `NetworkPolicy` and `NetworkPolicySpan`.