### PR TITLE
Deserialize records on the fly.

### DIFF
--- a/lib/json.toml
+++ b/lib/json.toml
@@ -1,2 +1,0 @@
-[dependencies.serde_json]
-version = "1.0"

--- a/rust/template/types/Cargo.toml
+++ b/rust/template/types/Cargo.toml
@@ -18,6 +18,7 @@ lazy_static = "1.3"
 libc = "0.2"
 num-traits = "0.2"
 serde = {version = "1.0", features = ["derive"]}
+serde_json = "1.0"
 timely = "0.11"
 twox-hash = "1.1"
 

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -713,15 +713,22 @@ mkFromRecord t@TypeDef{..} =
     "                    c => result::Result::Err(format!(\"unknown constructor {} of type" <+> rname (name t) <+> "in {:?}\", c, *val))" $$
     "                }"                                                                                                         $$
     "            },"                                                                                                            $$
+    "            record::Record::Serialized(format, s) => {"                                                                    $$
+    "                if format == \"json\" {"                                                                                   $$
+    "                    serde_json::from_str(&*s).map_err(|e|format!(\"{}\", e))"                                              $$
+    "                } else {"                                                                                                  $$
+    "                    result::Result::Err(format!(\"unsupported serialization format '{}'\", format))"                       $$
+    "                }"                                                                                                         $$
+    "            },"                                                                                                            $$
     "            v => {"                                                                                                        $$
-    "                result::Result::Err(format!(\"not a struct {:?}\", *v))"                                                           $$
+    "                result::Result::Err(format!(\"not a struct {:?}\", *v))"                                                   $$
     "            }"                                                                                                             $$
     "        }"                                                                                                                 $$
     "    }"                                                                                                                     $$
     "}"
     where
     targs = "<" <> (hcat $ punctuate comma $ map pp tdefArgs) <> ">"
-    targs_bounds = "<" <> (hcat $ punctuate comma $ map ((<> ": record::FromRecord + Default") . pp) tdefArgs) <> ">"
+    targs_bounds = "<" <> (hcat $ punctuate comma $ map ((<> ": record::FromRecord + serde::de::DeserializeOwned + Default") . pp) tdefArgs) <> ">"
     pos_constructors = vcat $ map mkposcons $ typeCons $ fromJust tdefType
     mkposcons :: Constructor -> Doc
     mkposcons c@Constructor{..} =

--- a/test/datalog_tests/json_test.dat
+++ b/test/datalog_tests/json_test.dat
@@ -1,1 +1,7 @@
 dump json_test.JsonTest;
+
+start;
+insert json_test.Deserialized[@json"{\"@type\": \"t.V1\", \"b\": true}"],
+commit;
+
+dump json_test.ODeserialized;

--- a/test/datalog_tests/json_test.dl
+++ b/test/datalog_tests/json_test.dl
@@ -108,3 +108,7 @@ JsonTest(scalar3(),
          to_json_string_or_default(from_json_string(scalar3()): Result<JsonValue, string>)).
 JsonTest(scalar4(),
          to_json_string_or_default(from_json_string(scalar4()): Result<JsonValue, string>)).
+
+input relation Deserialized[TaggedEnum]
+output relation ODeserialized[TaggedEnum]
+ODeserialized[x] :- Deserialized[x].

--- a/test/datalog_tests/json_test.dump.expected
+++ b/test/datalog_tests/json_test.dump.expected
@@ -14,3 +14,4 @@ json_test.JsonTest{.description = "{\"b\":true}", .value = "{\"std_Ok\":{\"res\"
 json_test.JsonTest{.description = "{\"foo\":\"bar\"}", .value = "{\"std_Err\":{\"err\":\"missing field `b` at line 1 column 13\"}}"}
 json_test.JsonTest{.description = "{\"t\":\"foo\", \"@id\":\"1001001001\", \"x\": \"x\", \"z\": 100000}", .value = "{\"std_Ok\":{\"res\":{\"t\":\"foo\",\"@id\":\"1001001001\",\"x\":\"x\",\"z\":100000}}}"}
 json_test.JsonTest{.description = "{\"t\":\"foo\", \"id\":\"1001001001\", \"nested\": {\"x\": \"x\", \"z\": 100000}}", .value = "{\"std_Ok\":{\"res\":{\"t\":\"foo\",\"id\":\"1001001001\",\"nested\":{\"x\":\"x\",\"z\":100000}}}}"}
+json_test.TVariant1{.b = true}


### PR DESCRIPTION
Consider a scenario where input relations contain JSON strings.  These
strings are parsed using the recently added JSON lib and then DDlog goes
on to compute on the parsed data.  When working with large JSON
documents where only a handful of attributes are actually used by DDlog,
DDlog's memory footprint is dominated by unparsed JSON inputs.

To avoid this waste, we introduce a new record type that contains
serialized data represented as a string.  DDlog parses this string using
appropriate deserializer (currently, only json is supported) and drops
the string on the floor, keeping only the extracted data in memory.

Syntactically, the new type of record is written down as
`@<format><string_token>`, where `<string_token>` can be either a quoted
string literal or a reference to a file, e.g.:

```
insert json_test.Deserialized[@json"{\"@type\": \"t.V1\", \"b\": true}"]
```