### PR TITLE
Support DDlog u128 records in the Go library

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -12,7 +12,7 @@ following environment variables to be set at build time:
  * `CGO_LDFLAGS` must be set so that the linker searches the dynamic library
  generated for your program.
 
-For an example, refer to [cmd/example/](cmd/example], which is a Go program
+For an example, refer to [cmd/example/](cmd/example), which is a Go program
 using the DDlog Go bindings. This program assumes that the DDlog program
 [typesTest.dl](/test/types_test/typesTest.dl) is the one being used. The example
 can be built and run with `./run-example.sh`. Refer to this script to understand

--- a/go/go.mod
+++ b/go/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/google/uuid v1.1.1
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/stretchr/testify v1.5.1
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect

--- a/go/go.sum
+++ b/go/go.sum
@@ -3,6 +3,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/go/pkg/ddlog/record_test.go
+++ b/go/pkg/ddlog/record_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware/differential-datalog/go/pkg/uint128"
 )
 
 // In theory these tests do not depend on any specific DDlog program since DDlog does not perform
@@ -32,6 +34,23 @@ func TestRecordInteger(t *testing.T) {
 	v32, err := r.ToU32Safe()
 	assert.NotNil(t, err)
 	assert.Equal(t, uint32(0), v32)
+}
+
+func TestRecordUint128(t *testing.T) {
+	v := uint128.Uint128{Lo: 0xB65ABF568A99CCB5, Hi: 0x208F3AFD4FAF5761}
+	r := NewRecordU128(v)
+	defer r.Free()
+
+	assert.True(t, r.IsInt())
+	// 0x20 -> 0010 0000
+	assert.Equal(t, 126, r.IntBits())
+	assert.Equal(t, v, r.ToU128())
+	v128, err := r.ToU128Safe()
+	assert.Nil(t, err)
+	assert.Equal(t, v, v128)
+
+	_, err = r.ToU64Safe()
+	assert.NotNil(t, err)
 }
 
 func TestRecordVector(t *testing.T) {

--- a/go/pkg/uint128/uint128.go
+++ b/go/pkg/uint128/uint128.go
@@ -1,0 +1,71 @@
+package uint128
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+
+	"github.com/google/uuid"
+)
+
+// Uint128 stores a 128-bit unsigned integer as two 64-bit words. Two Uint128 values can be compared
+// with ==.
+type Uint128 struct {
+	// least significant word
+	Lo uint64
+	// most significant word
+	Hi uint64
+}
+
+// Zero is a Uint128 with numerical value 0.
+var Zero = Uint128{0, 0}
+
+// String returns the hexadecimal string representation for a Uint128.
+func (u Uint128) String() string {
+	var b [16]byte
+	u.PutBytesBE(b[:])
+	return hex.EncodeToString(b[:])
+}
+
+// FromBytesLE converts the provided slice to a Uint128. Bytes are read from the slice in
+// little-endian order. It will panic if the length of the slice is not 16.
+func FromBytesLE(b []byte) Uint128 {
+	return Uint128{
+		Lo: binary.LittleEndian.Uint64(b[:8]),
+		Hi: binary.LittleEndian.Uint64(b[8:]),
+	}
+}
+
+// FromBytesBE converts the provided slice to a Uint128. Bytes are read from the slice in big-endian
+// order. It will panic if the length of the slice is not 16.
+func FromBytesBE(b []byte) Uint128 {
+	return Uint128{
+		Lo: binary.BigEndian.Uint64(b[8:]),
+		Hi: binary.BigEndian.Uint64(b[:8]),
+	}
+}
+
+// PutBytesLE puts the bytes from the provided Uint128 in little-endian order. It will panic if the
+// length of the slice is not 16.
+func (u Uint128) PutBytesLE(b []byte) {
+	binary.LittleEndian.PutUint64(b[:8], u.Lo)
+	binary.LittleEndian.PutUint64(b[8:], u.Hi)
+}
+
+// PutBytesBE puts the bytes from the provided Uint128 in big-endian order. It will panic if the
+// length of the slice is not 16.
+func (u Uint128) PutBytesBE(b []byte) {
+	binary.BigEndian.PutUint64(b[:8], u.Hi)
+	binary.BigEndian.PutUint64(b[8:], u.Lo)
+}
+
+// AsUUID converts the provided Uint128 to a UUID.
+func (u Uint128) AsUUID() uuid.UUID {
+	var b [16]byte
+	u.PutBytesBE(b[:])
+	return b
+}
+
+// FromUUID converts the provided UUID to a Uint128.
+func FromUUID(UUID uuid.UUID) Uint128 {
+	return FromBytesBE(UUID[:])
+}

--- a/go/pkg/uint128/uint128_test.go
+++ b/go/pkg/uint128/uint128_test.go
@@ -1,0 +1,25 @@
+package uint128
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUUID(t *testing.T) {
+	s := "208f3afd-4faf-5761-b65a-bf568a99ccb5"
+	UUID, err := uuid.Parse(s)
+	require.Nil(t, err)
+
+	u := FromUUID(UUID)
+	assert.Equal(t, Uint128{Lo: 0xB65ABF568A99CCB5, Hi: 0x208F3AFD4FAF5761}, u)
+
+	assert.Equal(t, s, u.AsUUID().String())
+}
+
+func TestString(t *testing.T) {
+	u := Uint128{Lo: 0xB65ABF568A99CCB5, Hi: 0x208F3AFD4FAF5761}
+	assert.Equal(t, "208f3afd4faf5761b65abf568a99ccb5", u.String())
+}


### PR DESCRIPTION
Note that we only support unsigned 128-bit numbers for now.