### PR TITLE
Fixed bigint to signed<N> conversion.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -71,7 +71,7 @@ test-simple:
     tags:
         - ddlog-ci-1
     script:
-    - stack --no-terminal test --ta "-p simple"
+    - stack --no-terminal test --ta '-p "$(NF) == \"generate simple\" || ($(NF-1) == \"compiler tests\" && $(NF) == \"simple\")"'
     - cd test/datalog_tests/simple_ddlog/ && LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/ cargo build --features='profile'
 
 test-simple2:

--- a/lib/souffle_lib.dl
+++ b/lib/souffle_lib.dl
@@ -27,20 +27,19 @@ function land(l: Tnumber, r: Tnumber): Tnumber = if (l != 0 and r != 0) 1 else 0
 function lor(l: Tnumber, r: Tnumber): Tnumber = if (l == 0 and r == 0) 0 else 1
 function lnot(l: Tnumber): Tnumber = if (l != 0) 0 else 1
 function group_count32(g: Group<'K, 'V>): Tnumber = castTo32(group_count(g))
-//function ftoi(l: double): signed<32> = {
-//    match (int_from_d(l)) {
-//        None -> 0,
-//        Some{x} -> x as signed<32>
-//    }
-//}
+function ftoi(l: double): signed<32> = {
+    match (int_from_d(l)) {
+        None -> 0,
+        Some{x} -> x as signed<32>
+    }
+}
 function itof(l: signed<32>): double = l as double
 function itou(l: signed<32>): bit<32> = l as bit<32>
 function utoi(l: bit<32>): signed<32> = l as signed<32>
 function utof(l: bit<32>): double = l as double
-//function ftou(l: double): bit<32>  = {
-//    match (int_from_d(l)) {
-//        None -> 0,
-//        Some{x} -> x as signed<32> as bit<32>
-//    }
-//}
-//
+function ftou(l: double): bit<32>  = {
+    match (int_from_d(l)) {
+        None -> 0,
+        Some{x} -> x as signed<32> as bit<32>
+    }
+}

--- a/rust/template/differential_datalog/int.rs
+++ b/rust/template/differential_datalog/int.rs
@@ -81,17 +81,56 @@ impl Int {
     pub fn to_i8(&self) -> Option<i8> {
         self.x.to_i8()
     }
+    pub fn to_u8(&self) -> Option<u8> {
+        self.x.to_u8()
+    }
+    /* Extract 8 low-order bits and convert to u8 */
+    pub fn truncate_to_u8(&self) -> u8 {
+        (&self.x & &BigInt::from(0xffu8)).to_u8().unwrap()
+    }
     pub fn to_i16(&self) -> Option<i16> {
         self.x.to_i16()
+    }
+    pub fn to_u16(&self) -> Option<u16> {
+        self.x.to_u16()
+    }
+    /* Extract 16 low-order bits and convert to u16 */
+    pub fn truncate_to_u16(&self) -> u16 {
+        (&self.x & &BigInt::from(0xffffu16)).to_u16().unwrap()
     }
     pub fn to_i32(&self) -> Option<i32> {
         self.x.to_i32()
     }
+    pub fn to_u32(&self) -> Option<u32> {
+        self.x.to_u32()
+    }
+    /* Extract 32 low-order bits and convert to u32 */
+    pub fn truncate_to_u32(&self) -> u32 {
+        (&self.x & &BigInt::from(0xffff_ffffu32)).to_u32().unwrap()
+    }
     pub fn to_i64(&self) -> Option<i64> {
         self.x.to_i64()
     }
+    pub fn to_u64(&self) -> Option<u64> {
+        self.x.to_u64()
+    }
+    /* Extract 64 low-order bits and convert to u64 */
+    pub fn truncate_to_u64(&self) -> u64 {
+        (&self.x & &BigInt::from(0xffff_ffff_ffff_ffffu64))
+            .to_u64()
+            .unwrap()
+    }
     pub fn to_i128(&self) -> Option<i128> {
         self.x.to_i128()
+    }
+    pub fn to_u128(&self) -> Option<u128> {
+        self.x.to_u128()
+    }
+    /* Extract 128 low-order bits and convert to u128 */
+    pub fn truncate_to_u128(&self) -> u128 {
+        (&self.x & &BigInt::from(0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffffu128))
+            .to_u128()
+            .unwrap()
     }
     pub fn to_float(&self) -> OrderedFloat<f32> {
         match self.x.to_f32() {
@@ -260,6 +299,8 @@ forward_binop!(impl Sub for Int, sub);
 forward_binop!(impl Div for Int, div);
 forward_binop!(impl Rem for Int, rem);
 forward_binop!(impl Mul for Int, mul);
+forward_binop!(impl BitAnd for Int, bitand);
+forward_binop!(impl BitOr for Int, bitor);
 
 impl num::One for Int {
     fn one() -> Int {

--- a/rust/template/src/lib.rs
+++ b/rust/template/src/lib.rs
@@ -37,9 +37,9 @@ use differential_datalog::record::UpdCmd;
 use differential_datalog::uint::*;
 use differential_datalog::DDlogConvert;
 use num_traits::cast::FromPrimitive;
+use num_traits::identities::One;
 
 use fnv::FnvHashMap;
-use num_traits::identities::One;
 
 use types::*;
 pub use value::*;

--- a/rust/template/types/lib.rs
+++ b/rust/template/types/lib.rs
@@ -16,7 +16,7 @@
 
 use num::bigint::BigInt;
 use num::FromPrimitive;
-use num::One;
+use num_traits::identities::One;
 use ordered_float::OrderedFloat;
 use std::borrow;
 use std::fmt;

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -2382,6 +2382,12 @@ mkExpr' d ctx EAs{..} | bothIntegers && narrow_from && narrow_to && width_cmp /=
                       = ("(" <> val exprExpr <+>
                          "& ((" <> tfrom <> "::one() <<" <> pp (typeWidth to_type) <> ") -" <+> tfrom <> "::one()))"
                         , EVal)
+                      | bothIntegers && width_cmp == GT && isBigInt d from_type
+                      -- from_type is bigint, to_type is s8/16/32/64/128: truncate from_type,
+                      -- and convert to unsigned bit vector using `truncate_to_uN` method and then
+                      -- coerce to signed bit vector:
+                      -- e.truncate_to_uN() as <to_type>
+                      = ("(" <> val exprExpr <+> ".truncate_to_u" <> pp (typeWidth to_type) <> "() as" <+> tto <> ")", EVal)
                       | bothIntegers && width_cmp == GT
                       -- from_type is wider than to_type: truncate from_type and
                       -- then convert:

--- a/test/datalog_tests/simple.ast.expected
+++ b/test/datalog_tests/simple.ast.expected
@@ -26,7 +26,9 @@ typedef CMethod = CMethod{c1: Symbol, c2: Symbol}
 typedef Cast_bigint = Cast_bigint{description: string, expected: bigint, actual: bigint}
 typedef Cast_double = Cast_double{description: string, expected: double, actual: double}
 typedef Cast_float = Cast_float{description: string, expected: float, actual: float}
+typedef Cast_s128 = Cast_s128{description: string, expected: signed<128>, actual: signed<128>}
 typedef Cast_s32 = Cast_s32{description: string, expected: signed<32>, actual: signed<32>}
+typedef Cast_s8 = Cast_s8{description: string, expected: signed<8>, actual: signed<8>}
 typedef Cast_u24 = Cast_u24{description: string, expected: bit<24>, actual: bit<24>}
 typedef Cast_u256 = Cast_u256{description: string, expected: bit<256>, actual: bit<256>}
 typedef Cast_u32 = Cast_u32{description: string, actual: bit<32>, expected: bit<32>}
@@ -561,6 +563,16 @@ function souffle_lib.cat (s: intern.IString, t: intern.IString): intern.IString 
     intern.string_intern((intern.istring_str(s) ++ intern.istring_str(t)))
 function souffle_lib.contains (s: intern.IString, i: intern.IString): bool =
     std.string_contains(intern.istring_str(i), intern.istring_str(s))
+function souffle_lib.ftoi (l: double): signed<32> =
+    match (fp.int_from_d(l)) {
+        std.None{} -> 32'sd0,
+        std.Some{.x=var x} -> (x as signed<32>)
+    }
+function souffle_lib.ftou (l: double): bit<32> =
+    match (fp.int_from_d(l)) {
+        std.None{} -> 32'd0,
+        std.Some{.x=var x} -> ((x as signed<32>) as bit<32>)
+    }
 function souffle_lib.group_count32 (g: std.Group<'K,'V>): souffle_types.Tnumber =
     souffle_lib.castTo32(std.group_count(g))
 function souffle_lib.itof (l: signed<32>): double =
@@ -820,7 +832,9 @@ output relation CMethod [CMethod]
 output relation Cast_bigint [Cast_bigint]
 output relation Cast_double [Cast_double]
 output relation Cast_float [Cast_float]
+output relation Cast_s128 [Cast_s128]
 output relation Cast_s32 [Cast_s32]
+output relation Cast_s8 [Cast_s8]
 output relation Cast_u24 [Cast_u24]
 output relation Cast_u256 [Cast_u256]
 output relation Cast_u32 [Cast_u32]
@@ -1146,9 +1160,18 @@ Cast_s32(.description="32'sd100  as signed<32>", .expected=(32'sd100 as signed<3
 Cast_s32(.description="16'sd100  as signed<32>", .expected=(16'sd100 as signed<32>), .actual=32'sd100).
 Cast_s32(.description="8'sd100   as signed<32>", .expected=(8'sd100 as signed<32>), .actual=32'sd100).
 Cast_s32(.description="128'sd100 as signed<32>", .expected=(128'sd100 as signed<32>), .actual=32'sd100).
+Cast_s32(.description="(-1: bigint as signed<32>)", .expected=((- (1: bigint)) as signed<32>), .actual=(- 32'sd1)).
+Cast_s32(.description="('hffffffffff: bigint as signed<32>)", .expected=((1099511627775: bigint) as signed<32>), .actual=(- 32'sd1)).
+Cast_s32(.description="('hff000000ff: bigint as signed<32>)", .expected=((1095216660735: bigint) as signed<32>), .actual=32'sd255).
 Cast_s32(.description="64'shffffffffffff as signed<32>", .expected=(64'sd281474976710655 as signed<32>), .actual=32'sd4294967295).
 Cast_s32(.description="128'shffffffffffffffffffff as signed<32>", .expected=(128'sd1208925819614629174706175 as signed<32>), .actual=32'sd4294967295).
 Cast_s32(.description="(100: bit<32>) as signed<32>", .expected=((32'd100: bit<32>) as signed<32>), .actual=32'sd100).
+Cast_s8(.description="(-1: bigint as signed<8>)", .expected=((- (1: bigint)) as signed<8>), .actual=(- 8'sd1)).
+Cast_s8(.description="('hffffffffff: bigint as signed<8>)", .expected=((1099511627775: bigint) as signed<8>), .actual=(- 8'sd1)).
+Cast_s8(.description="('hff0000000f: bigint as signed<8>)", .expected=((1095216660495: bigint) as signed<8>), .actual=8'sd15).
+Cast_s128(.description="(-1: bigint as signed<128>)", .expected=((- (1: bigint)) as signed<128>), .actual=(- 128'sd1)).
+Cast_s128(.description="('hffffffffffffffffffffffffffffffffff: bigint as signed<128>)", .expected=((87112285931760246646623899502532662132735: bigint) as signed<128>), .actual=(- 128'sd1)).
+Cast_s128(.description="('hff000000000000000000000000000000ff: bigint as signed<8>)", .expected=((86772003564839308183160524895100893921535: bigint) as signed<128>), .actual=128'sd255).
 Cast_u24(.description="24'd100  as bit<24>", .expected=(24'd100 as bit<24>), .actual=24'd100).
 Cast_u24(.description="32'd100  as bit<24>", .expected=(32'd100 as bit<24>), .actual=24'd100).
 Cast_u24(.description="16'd100  as bit<24>", .expected=(16'd100 as bit<24>), .actual=24'd100).

--- a/test/datalog_tests/simple.dl
+++ b/test/datalog_tests/simple.dl
@@ -1014,6 +1014,9 @@ Cast_s32("32'sd100  as signed<32>", 32'sd100  as signed<32>, 100).
 Cast_s32("16'sd100  as signed<32>", 16'sd100  as signed<32>, 100).
 Cast_s32("8'sd100   as signed<32>", 8'sd100   as signed<32>, 100).
 Cast_s32("128'sd100 as signed<32>", 128'sd100 as signed<32>, 100).
+Cast_s32("(-1: bigint as signed<32>)", (-1: bigint) as signed<32>, -1).
+Cast_s32("('hffffffffff: bigint as signed<32>)", ('hffffffffff: bigint) as signed<32>, -1).
+Cast_s32("('hff000000ff: bigint as signed<32>)", ('hff000000ff: bigint) as signed<32>, 255).
 //Cast_s32("64'f3.5 as signed<32>",  64'f3.5 as signed<32>,  3).  // illegal
 //Cast_s32("32'f3.5 as signed<32>",  32'f3.5 as signed<32>,  3).  // illegal
 
@@ -1021,6 +1024,16 @@ Cast_s32("64'shffffffffffff as signed<32>", 64'shffffffffffff as signed<32>, 32'
 Cast_s32("128'shffffffffffffffffffff as signed<32>", 128'shffffffffffffffffffff as signed<32>, 32'shffffffff).
 
 Cast_s32("(100: bit<32>) as signed<32>", (100: bit<32>) as signed<32>, 100).
+
+output relation Cast_s8(description: string, expected: signed<8>, actual: signed<8>)
+Cast_s8("(-1: bigint as signed<8>)", (-1: bigint) as signed<8>, -1).
+Cast_s8("('hffffffffff: bigint as signed<8>)", ('hffffffffff: bigint) as signed<8>, -1).
+Cast_s8("('hff0000000f: bigint as signed<8>)", ('hff0000000f: bigint) as signed<8>, 15).
+
+output relation Cast_s128(description: string, expected: signed<128>, actual: signed<128>)
+Cast_s128("(-1: bigint as signed<128>)", (-1: bigint) as signed<128>, -1).
+Cast_s128("('hffffffffffffffffffffffffffffffffff: bigint as signed<128>)", ('hffffffffffffffffffffffffffffffffff: bigint) as signed<128>, -1).
+Cast_s128("('hff000000000000000000000000000000ff: bigint as signed<8>)", ('hff000000000000000000000000000000ff: bigint) as signed<128>, 255).
 
 output relation Cast_u24(description: string, expected: bit<24>, actual: bit<24>)
 

--- a/test/datalog_tests/simple.dump.expected
+++ b/test/datalog_tests/simple.dump.expected
@@ -111,7 +111,15 @@ Cast_float{.description = "512'd100 as float", .expected = 100, .actual = 100}
 Cast_float{.description = "64'f3.5  as float", .expected = 3.5, .actual = 3.5}
 Cast_float{.description = "8'd100   as float", .expected = 100, .actual = 100}
 
+Cast_s128:
+Cast_s128{.description = "('hff000000000000000000000000000000ff: bigint as signed<8>)", .expected = 255, .actual = 255}
+Cast_s128{.description = "('hffffffffffffffffffffffffffffffffff: bigint as signed<128>)", .expected = -1, .actual = -1}
+Cast_s128{.description = "(-1: bigint as signed<128>)", .expected = -1, .actual = -1}
+
 Cast_s32:
+Cast_s32{.description = "('hff000000ff: bigint as signed<32>)", .expected = 255, .actual = 255}
+Cast_s32{.description = "('hffffffffff: bigint as signed<32>)", .expected = -1, .actual = -1}
+Cast_s32{.description = "(-1: bigint as signed<32>)", .expected = -1, .actual = -1}
 Cast_s32{.description = "(100: bit<32>) as signed<32>", .expected = 100, .actual = 100}
 Cast_s32{.description = "128'sd100 as signed<32>", .expected = 100, .actual = 100}
 Cast_s32{.description = "128'shffffffffffffffffffff as signed<32>", .expected = -1, .actual = -1}
@@ -119,6 +127,11 @@ Cast_s32{.description = "16'sd100  as signed<32>", .expected = 100, .actual = 10
 Cast_s32{.description = "32'sd100  as signed<32>", .expected = 100, .actual = 100}
 Cast_s32{.description = "64'shffffffffffff as signed<32>", .expected = -1, .actual = -1}
 Cast_s32{.description = "8'sd100   as signed<32>", .expected = 100, .actual = 100}
+
+Cast_s8:
+Cast_s8{.description = "('hff0000000f: bigint as signed<8>)", .expected = 15, .actual = 15}
+Cast_s8{.description = "('hffffffffff: bigint as signed<8>)", .expected = -1, .actual = -1}
+Cast_s8{.description = "(-1: bigint as signed<8>)", .expected = -1, .actual = -1}
 
 Cast_u24:
 Cast_u24{.description = "(100: signed<32>) as bit<32> as bit<24>", .expected = 100, .actual = 100}
@@ -380,7 +393,15 @@ Cast_float{.description = "512'd100 as float", .expected = 100, .actual = 100}
 Cast_float{.description = "64'f3.5  as float", .expected = 3.5, .actual = 3.5}
 Cast_float{.description = "8'd100   as float", .expected = 100, .actual = 100}
 
+Cast_s128:
+Cast_s128{.description = "('hff000000000000000000000000000000ff: bigint as signed<8>)", .expected = 255, .actual = 255}
+Cast_s128{.description = "('hffffffffffffffffffffffffffffffffff: bigint as signed<128>)", .expected = -1, .actual = -1}
+Cast_s128{.description = "(-1: bigint as signed<128>)", .expected = -1, .actual = -1}
+
 Cast_s32:
+Cast_s32{.description = "('hff000000ff: bigint as signed<32>)", .expected = 255, .actual = 255}
+Cast_s32{.description = "('hffffffffff: bigint as signed<32>)", .expected = -1, .actual = -1}
+Cast_s32{.description = "(-1: bigint as signed<32>)", .expected = -1, .actual = -1}
 Cast_s32{.description = "(100: bit<32>) as signed<32>", .expected = 100, .actual = 100}
 Cast_s32{.description = "128'sd100 as signed<32>", .expected = 100, .actual = 100}
 Cast_s32{.description = "128'shffffffffffffffffffff as signed<32>", .expected = -1, .actual = -1}
@@ -388,6 +409,11 @@ Cast_s32{.description = "16'sd100  as signed<32>", .expected = 100, .actual = 10
 Cast_s32{.description = "32'sd100  as signed<32>", .expected = 100, .actual = 100}
 Cast_s32{.description = "64'shffffffffffff as signed<32>", .expected = -1, .actual = -1}
 Cast_s32{.description = "8'sd100   as signed<32>", .expected = 100, .actual = 100}
+
+Cast_s8:
+Cast_s8{.description = "('hff0000000f: bigint as signed<8>)", .expected = 15, .actual = 15}
+Cast_s8{.description = "('hffffffffff: bigint as signed<8>)", .expected = -1, .actual = -1}
+Cast_s8{.description = "(-1: bigint as signed<8>)", .expected = -1, .actual = -1}
 
 Cast_u24:
 Cast_u24{.description = "(100: signed<32>) as bit<32> as bit<24>", .expected = 100, .actual = 100}
@@ -1073,6 +1099,9 @@ Cast_u32{.description = "32'd100  as bit<32>", .actual = 100, .expected = 100}
 Cast_u32{.description = "64'hffffffffffff as bit<32>", .actual = 4294967295, .expected = 4294967295}
 Cast_u32{.description = "8'd100   as bit<32>", .actual = 100, .expected = 100}
 Cast_s32
+Cast_s32{.description = "('hff000000ff: bigint as signed<32>)", .expected = 255, .actual = 255}
+Cast_s32{.description = "('hffffffffff: bigint as signed<32>)", .expected = -1, .actual = -1}
+Cast_s32{.description = "(-1: bigint as signed<32>)", .expected = -1, .actual = -1}
 Cast_s32{.description = "(100: bit<32>) as signed<32>", .expected = 100, .actual = 100}
 Cast_s32{.description = "128'sd100 as signed<32>", .expected = 100, .actual = 100}
 Cast_s32{.description = "128'shffffffffffffffffffff as signed<32>", .expected = -1, .actual = -1}

--- a/test/datalog_tests/simple2.dat
+++ b/test/datalog_tests/simple2.dat
@@ -1,3 +1,5 @@
+dump RFloatToInt;
+
 start;
 
 insert Arrng1(TArrng2{true, TArrng1{true, 1000}}, 10),

--- a/test/datalog_tests/simple2.dl
+++ b/test/datalog_tests/simple2.dl
@@ -1,3 +1,6 @@
+import fp
+import log
+
 /* Test `arrangeInput` logic in Compile.hs */
 
 typedef TArrng1 = TArrng1{
@@ -42,3 +45,18 @@ output relation TArrng1Arrng2(x: bigint)
 TArrng1Arrng2(x.f2.f2) :-
     TArrng1[t],
     TArrng2[(x, t.0.f2.f2)].
+
+
+function ftoi_(l: double): signed<32> = {
+    match (int_from_d(l)) {
+        None -> 0,
+        Some{x} -> {
+            x as signed<32>
+        }
+    }
+}
+
+relation RFtoIDummy(x: signed<32>)
+RFtoIDummy(0).
+output relation RFloatToInt(_x:signed<32>)
+RFloatToInt(_x) :- RFtoIDummy(0), var _x = ftoi_((- (64'f333.36: double))).

--- a/test/datalog_tests/simple2.dump.expected
+++ b/test/datalog_tests/simple2.dump.expected
@@ -1,3 +1,4 @@
+RFloatToInt{._x = -333}
 Arrng1Arrng2:
 Arrng1Arrng2{.x = 5}: +1
 Arrng1Arrng2_2:


### PR DESCRIPTION
This code was untested and had multiple issues.  Most importantly, even
after truncating `bigint` to the right width, it cannot be safely
converted using `.to_sN`, as truncated negative number is interpreted as
a positive and may not fit in the `signed<N>` range, so we convert to
`bit<N>` first and then coerce to `signed<N>`.