### PR TITLE
JSON: (De)serialization of Option<> types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Build Status](https://travis-ci.com/vmware/differential-datalog.svg?branch=master)](https://travis-ci.com/vmware/differential-datalog)
 [![pipeline status](https://gitlab.com/ddlog/differential-datalog/badges/master/pipeline.svg)](https://gitlab.com/ddlog/differential-datalog/commits/master)
-[![rustc](https://img.shields.io/badge/rustc-1.39+-blue.svg)](https://blog.rust-lang.org/2019/11/07/Rust-1.39.0.html)
+[![rustc](https://img.shields.io/badge/rustc-1.41+-blue.svg)](https://blog.rust-lang.org/2020/03/12/Rust-1.42.html)
 
 # Differential Datalog (DDlog)
 
@@ -94,7 +94,7 @@ You are now ready to [start coding in DDlog](doc/tutorial/tutorial.md).
   ```
   wget -qO- https://get.haskellstack.org/ | sh
   ```
-- Rust toolchain v1.39 or later:
+- Rust toolchain v1.41 or later:
   ```
   curl https://sh.rustup.rs -sSf | sh
   . $HOME/.cargo/env

--- a/default.nix
+++ b/default.nix
@@ -7,7 +7,7 @@ let
 
   ghc = args.ghc or pkgs.haskell.compiler.ghc865;
   java = pkgs.adoptopenjdk-bin;
-  rust-toolchain = "1.39.0";
+  rust-toolchain = "1.41.1";
   lib = pkgs.lib;
 
   flatbuffers-java = pkgs.runCommand "flatbuffers-java" {

--- a/lib/std.dl
+++ b/lib/std.dl
@@ -41,7 +41,7 @@ extern function pow32(base:'A, exp: bit<32>): 'A
  * Option
  */
 
-//#[rust="serde(from=\"Option<A>\", into=\"Option<A>\")"]
+#[rust="serde(from=\"Option<A>\", into=\"Option<A>\", bound(serialize=\"A: Clone+Serialize\"))"]
 typedef Option<'A> = None
                    | Some{x: 'A}
 

--- a/lib/std.rs
+++ b/lib/std.rs
@@ -138,12 +138,12 @@ impl<T> From<Option<T>> for std_Option<T> {
     }
 }
 
-/* // this requires Rust 1.41+
-   impl<T> From<std_Option<T>> for Option<T> {
+// this requires Rust 1.41+
+impl<T> From<std_Option<T>> for Option<T> {
     fn from(x: std_Option<T>) -> Self {
         std2option(x)
     }
-}*/
+}
 
 pub fn std_option_unwrap_or_default<T: Default + Clone>(opt: &std_Option<T>) -> T {
     match opt {

--- a/test/datalog_tests/api.ast.expected
+++ b/test/datalog_tests/api.ast.expected
@@ -5,6 +5,7 @@ typedef log.module_t = signed<32>
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
 extern type std.Group<'K,'V>
 extern type std.Map<'K,'V>
+#[rust = "serde(from=\"Option<A>\", into=\"Option<A>\", bound(serialize=\"A: Clone+Serialize\"))"]
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
 extern type std.Ref<'A>

--- a/test/datalog_tests/dcm1.ast.expected
+++ b/test/datalog_tests/dcm1.ast.expected
@@ -46,6 +46,7 @@ typedef log.module_t = signed<32>
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
 extern type std.Group<'K,'V>
 extern type std.Map<'K,'V>
+#[rust = "serde(from=\"Option<A>\", into=\"Option<A>\", bound(serialize=\"A: Clone+Serialize\"))"]
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
 extern type std.Ref<'A>

--- a/test/datalog_tests/json_test.dl
+++ b/test/datalog_tests/json_test.dl
@@ -115,3 +115,23 @@ JsonTest(scalar5(),
 input relation Deserialized[TaggedEnum]
 output relation ODeserialized[TaggedEnum]
 ODeserialized[x] :- Deserialized[x].
+
+typedef Optional = Optional {
+    s: Option<string>,
+    i: Option<u64>,
+    v: Option<JsonValue>
+}
+
+function optional1(): string = [|{}|]
+function optional2(): string = [|{"s": "foo"}|]
+function optional3(): string = [|{"s": "foo", "i": 100000}|]
+function optional4(): string = [|{"s": "foo", "i": 100000, "v": 2.5}|]
+
+JsonTest(optional1(),
+         to_json_string_or_default(from_json_string(optional1()): Result<Optional, string>)).
+JsonTest(optional2(),
+         to_json_string_or_default(from_json_string(optional2()): Result<Optional, string>)).
+JsonTest(optional3(),
+         to_json_string_or_default(from_json_string(optional3()): Result<Optional, string>)).
+JsonTest(optional4(),
+         to_json_string_or_default(from_json_string(optional4()): Result<Optional, string>)).

--- a/test/datalog_tests/json_test.dump.expected
+++ b/test/datalog_tests/json_test.dump.expected
@@ -13,6 +13,10 @@ json_test.JsonTest{.description = "{\"Variant2\": {\"u\": 100}}", .value = "{\"s
 json_test.JsonTest{.description = "{\"b\":true, \"foo\":\"bar\"}", .value = "{\"std_Ok\":{\"res\":{\"b\":true}}}"}
 json_test.JsonTest{.description = "{\"b\":true}", .value = "{\"std_Ok\":{\"res\":{\"b\":true}}}"}
 json_test.JsonTest{.description = "{\"foo\":\"bar\"}", .value = "{\"std_Err\":{\"err\":\"missing field `b` at line 1 column 13\"}}"}
+json_test.JsonTest{.description = "{\"s\": \"foo\", \"i\": 100000, \"v\": 2.5}", .value = "{\"std_Ok\":{\"res\":{\"s\":\"foo\",\"i\":100000,\"v\":2.5}}}"}
+json_test.JsonTest{.description = "{\"s\": \"foo\", \"i\": 100000}", .value = "{\"std_Ok\":{\"res\":{\"s\":\"foo\",\"i\":100000,\"v\":null}}}"}
+json_test.JsonTest{.description = "{\"s\": \"foo\"}", .value = "{\"std_Ok\":{\"res\":{\"s\":\"foo\",\"i\":null,\"v\":null}}}"}
 json_test.JsonTest{.description = "{\"t\":\"foo\", \"@id\":\"1001001001\", \"x\": \"x\", \"z\": 100000}", .value = "{\"std_Ok\":{\"res\":{\"t\":\"foo\",\"@id\":\"1001001001\",\"x\":\"x\",\"z\":100000}}}"}
 json_test.JsonTest{.description = "{\"t\":\"foo\", \"id\":\"1001001001\", \"nested\": {\"x\": \"x\", \"z\": 100000}}", .value = "{\"std_Ok\":{\"res\":{\"t\":\"foo\",\"id\":\"1001001001\",\"nested\":{\"x\":\"x\",\"z\":100000}}}}"}
+json_test.JsonTest{.description = "{}", .value = "{\"std_Ok\":{\"res\":{\"s\":null,\"i\":null,\"v\":null}}}"}
 json_test.TVariant1{.b = true}

--- a/test/datalog_tests/modules.ast.expected
+++ b/test/datalog_tests/modules.ast.expected
@@ -23,6 +23,7 @@ typedef redist.tnid_t = bit<16>
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
 extern type std.Group<'K,'V>
 extern type std.Map<'K,'V>
+#[rust = "serde(from=\"Option<A>\", into=\"Option<A>\", bound(serialize=\"A: Clone+Serialize\"))"]
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
 extern type std.Ref<'A>

--- a/test/datalog_tests/ovn.ast.expected
+++ b/test/datalog_tests/ovn.ast.expected
@@ -73,6 +73,7 @@ typedef port_t = bit<16>
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
 extern type std.Group<'K,'V>
 extern type std.Map<'K,'V>
+#[rust = "serde(from=\"Option<A>\", into=\"Option<A>\", bound(serialize=\"A: Clone+Serialize\"))"]
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
 extern type std.Ref<'A>

--- a/test/datalog_tests/ovn_ftl.ast.expected
+++ b/test/datalog_tests/ovn_ftl.ast.expected
@@ -11,6 +11,7 @@ typedef stage = LS_IN_ACL{} | LS_OUT_ACL{} | LR_IN_ADMISSION{} | LR_IN_IP_INPUT{
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
 extern type std.Group<'K,'V>
 extern type std.Map<'K,'V>
+#[rust = "serde(from=\"Option<A>\", into=\"Option<A>\", bound(serialize=\"A: Clone+Serialize\"))"]
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
 extern type std.Ref<'A>

--- a/test/datalog_tests/path.ast.expected
+++ b/test/datalog_tests/path.ast.expected
@@ -6,6 +6,7 @@ typedef node = string
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
 extern type std.Group<'K,'V>
 extern type std.Map<'K,'V>
+#[rust = "serde(from=\"Option<A>\", into=\"Option<A>\", bound(serialize=\"A: Clone+Serialize\"))"]
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
 extern type std.Ref<'A>

--- a/test/datalog_tests/redist.ast.expected
+++ b/test/datalog_tests/redist.ast.expected
@@ -13,6 +13,7 @@ typedef log.module_t = signed<32>
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
 extern type std.Group<'K,'V>
 extern type std.Map<'K,'V>
+#[rust = "serde(from=\"Option<A>\", into=\"Option<A>\", bound(serialize=\"A: Clone+Serialize\"))"]
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
 extern type std.Ref<'A>

--- a/test/datalog_tests/redist_opt.ast.expected
+++ b/test/datalog_tests/redist_opt.ast.expected
@@ -27,6 +27,7 @@ typedef log.module_t = signed<32>
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
 extern type std.Group<'K,'V>
 extern type std.Map<'K,'V>
+#[rust = "serde(from=\"Option<A>\", into=\"Option<A>\", bound(serialize=\"A: Clone+Serialize\"))"]
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
 extern type std.Ref<'A>

--- a/test/datalog_tests/server_api.ast.expected
+++ b/test/datalog_tests/server_api.ast.expected
@@ -3,6 +3,7 @@ typedef log.module_t = signed<32>
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
 extern type std.Group<'K,'V>
 extern type std.Map<'K,'V>
+#[rust = "serde(from=\"Option<A>\", into=\"Option<A>\", bound(serialize=\"A: Clone+Serialize\"))"]
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
 extern type std.Ref<'A>

--- a/test/datalog_tests/server_api_1.ast.expected
+++ b/test/datalog_tests/server_api_1.ast.expected
@@ -3,6 +3,7 @@ typedef log.module_t = signed<32>
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
 extern type std.Group<'K,'V>
 extern type std.Map<'K,'V>
+#[rust = "serde(from=\"Option<A>\", into=\"Option<A>\", bound(serialize=\"A: Clone+Serialize\"))"]
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
 extern type std.Ref<'A>

--- a/test/datalog_tests/server_api_2.ast.expected
+++ b/test/datalog_tests/server_api_2.ast.expected
@@ -3,6 +3,7 @@ typedef log.module_t = signed<32>
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
 extern type std.Group<'K,'V>
 extern type std.Map<'K,'V>
+#[rust = "serde(from=\"Option<A>\", into=\"Option<A>\", bound(serialize=\"A: Clone+Serialize\"))"]
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
 extern type std.Ref<'A>

--- a/test/datalog_tests/server_api_3.ast.expected
+++ b/test/datalog_tests/server_api_3.ast.expected
@@ -3,6 +3,7 @@ typedef log.module_t = signed<32>
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
 extern type std.Group<'K,'V>
 extern type std.Map<'K,'V>
+#[rust = "serde(from=\"Option<A>\", into=\"Option<A>\", bound(serialize=\"A: Clone+Serialize\"))"]
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
 extern type std.Ref<'A>

--- a/test/datalog_tests/simple.ast.expected
+++ b/test/datalog_tests/simple.ast.expected
@@ -163,6 +163,7 @@ typedef station = string
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
 extern type std.Group<'K,'V>
 extern type std.Map<'K,'V>
+#[rust = "serde(from=\"Option<A>\", into=\"Option<A>\", bound(serialize=\"A: Clone+Serialize\"))"]
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
 extern type std.Ref<'A>

--- a/test/datalog_tests/span_string.ast.expected
+++ b/test/datalog_tests/span_string.ast.expected
@@ -13,6 +13,7 @@ typedef log.module_t = signed<32>
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
 extern type std.Group<'K,'V>
 extern type std.Map<'K,'V>
+#[rust = "serde(from=\"Option<A>\", into=\"Option<A>\", bound(serialize=\"A: Clone+Serialize\"))"]
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
 extern type std.Ref<'A>

--- a/test/datalog_tests/span_uuid.ast.expected
+++ b/test/datalog_tests/span_uuid.ast.expected
@@ -13,6 +13,7 @@ typedef log.module_t = signed<32>
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
 extern type std.Group<'K,'V>
 extern type std.Map<'K,'V>
+#[rust = "serde(from=\"Option<A>\", into=\"Option<A>\", bound(serialize=\"A: Clone+Serialize\"))"]
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
 extern type std.Ref<'A>

--- a/test/datalog_tests/three.ast.expected
+++ b/test/datalog_tests/three.ast.expected
@@ -6,6 +6,7 @@ typedef log.module_t = signed<32>
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
 extern type std.Group<'K,'V>
 extern type std.Map<'K,'V>
+#[rust = "serde(from=\"Option<A>\", into=\"Option<A>\", bound(serialize=\"A: Clone+Serialize\"))"]
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
 extern type std.Ref<'A>

--- a/test/datalog_tests/tutorial.ast.expected
+++ b/test/datalog_tests/tutorial.ast.expected
@@ -68,6 +68,7 @@ typedef stage = LS_IN_PRE_LB{} | LS_OUT_PRE_LB{}
 typedef std.Either<'A,'B> = std.Left{l: 'A} | std.Right{r: 'B}
 extern type std.Group<'K,'V>
 extern type std.Map<'K,'V>
+#[rust = "serde(from=\"Option<A>\", into=\"Option<A>\", bound(serialize=\"A: Clone+Serialize\"))"]
 typedef std.Option<'A> = std.None{} | std.Some{x: 'A}
 #[size = 8]
 extern type std.Ref<'A>

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -33,7 +33,7 @@ ENV PATH=/root/.local/bin:/root/.cargo/bin:$PATH
 ENV CLASSPATH=$CLASSPATH:/flatbuffers/java
 
 # Install Rust
-RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.39.0 -y
+RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.41.1 -y
 RUN rustup component add rustfmt
 RUN rustup component add clippy
 


### PR DESCRIPTION
`Option<>` types should be handled in a special way during
serialization/deserialization.  In particular, when deserializing, a
missing field of type `Option<T>` should deserialize as `None`, as
opposed to returuning an error.  The `serde` crate already implements
this behavior for the Rust `Option<>` type, but this is not the same as
`Option` in DDlog, which actually compiles to `std_Option`.

The solution is to implement `From/Into` conversion between `Option` and
`std_Option` types and to annotate the DDlog `Option` declaration with:

```
 #[rust="serde(from=\"Option<A>\", into=\"Option<A>\", bound(serialize=\"A: Clone+Serialize\"))"]
 typedef Option<'A> = None
                    | Some{x: 'A}
```

The tricky part is the `A: Clone` trait bound, as `serde` requires any type
annotated by `serde(into)` to implement `Clone`.

One side effect of this patch is that we now require Rust 1.41+, before
which the following was considered an orphan implementation.

```
impl<T> From<std_Option<T>> for Option<T>
```

so we also update docker, nix config, and README to Rust 1.41.