### PR TITLE
simple.dl: Remove non-deterministic test.

### DIFF
--- a/test/datalog_tests/simple.ast.expected
+++ b/test/datalog_tests/simple.ast.expected
@@ -104,7 +104,6 @@ typedef Signed64 = Signed64{x: signed<64>}
 typedef Signed8 = Signed8{x: signed<8>}
 typedef Span = Span{entity: entid_t, tns: std.Set<tnid_t>}
 typedef String2 = String2{s: string}
-typedef StringOrd = StringOrd{s: string, ord: bit<32>}
 typedef Strings = Strings{s: string}
 typedef Sum = Sum{x: string, sum: bit<32>}
 typedef Suspect = Suspect{name: string}
@@ -925,7 +924,6 @@ input relation Signed64 [Signed64]
 input relation Signed8 [Signed8]
 output relation Span [Span]
 input relation String2 [String2]
-output relation StringOrd [StringOrd]
 input relation Strings [Strings]
 output relation Sum [Sum]
 input relation Suspect [Suspect]
@@ -1127,8 +1125,6 @@ Adjusted(.id=id, .alloc=alloc) :- Alloc(.id=id, .allocated=allocated, .toallocat
 YX(.y=y, .x=x) :- XY(.x=x, .y=y), YZX(.y=y, .z=z, .x=x).
 IConcatString(.s=intern.string_intern((intern.istring_str(s1) ++ s2))) :- IString1(.s=s1), String2(.s=s2).
 ConcatString(.s=intern.istring_str(s)) :- IConcatString(.s=s).
-StringOrd(.s=intern.istring_str(s), .ord=intern.istring_ord(s)) :- IString1(.s=s).
-StringOrd(.s=intern.istring_str(s), .ord=intern.istring_ord(s)) :- IConcatString(.s=s).
 Ris_true(._s=intern.string_intern("true")).
 Re(._x=(32'd10 % 32'd3), ._t=intern.string_intern("10%3"), ._y=32'd1) :- Ris_true(._s=_).
 CMethod(.c1=a, .c2=b) :- BMethod(.b1=intern.string_intern("c"), .b2=b), AMethod(.a1=b, .a2=a).

--- a/test/datalog_tests/simple.dat
+++ b/test/datalog_tests/simple.dat
@@ -483,9 +483,6 @@ commit dump_changes;
 echo ConcatString;
 dump ConcatString;
 
-echo StringOrd;
-dump StringOrd;
-
 start;
 
 insert BMethod("d", "???"),

--- a/test/datalog_tests/simple.dl
+++ b/test/datalog_tests/simple.dl
@@ -919,10 +919,10 @@ output relation ConcatString(s: string)
 
 ConcatString(istring_str(s)) :- IConcatString(s).
 
-output relation StringOrd(s: string, ord: bit<32>)
+//output relation StringOrd(s: string, ord: bit<32>)
 
-StringOrd(istring_str(s), istring_ord(s)) :- IString1(s).
-StringOrd(istring_str(s), istring_ord(s)) :- IConcatString(s).
+//StringOrd(istring_str(s), istring_ord(s)) :- IString1(s).
+//StringOrd(istring_str(s), istring_ord(s)) :- IConcatString(s).
 
 import souffle_lib
 typedef Tnumber = bit<32>

--- a/test/datalog_tests/simple.dump.expected
+++ b/test/datalog_tests/simple.dump.expected
@@ -993,25 +993,11 @@ ConcatString{.s = "Foo bar"}: +1
 ConcatString{.s = "Foo world"}: +1
 ConcatString{.s = "Hello, bar"}: +1
 ConcatString{.s = "Hello, world"}: +1
-StringOrd:
-StringOrd{.s = "Foo ", .ord = 3}: +1
-StringOrd{.s = "Foo bar", .ord = 6}: +1
-StringOrd{.s = "Foo world", .ord = 7}: +1
-StringOrd{.s = "Hello, ", .ord = 2}: +1
-StringOrd{.s = "Hello, bar", .ord = 4}: +1
-StringOrd{.s = "Hello, world", .ord = 5}: +1
 ConcatString
 ConcatString{.s = "Foo bar"}
 ConcatString{.s = "Foo world"}
 ConcatString{.s = "Hello, bar"}
 ConcatString{.s = "Hello, world"}
-StringOrd
-StringOrd{.s = "Foo ", .ord = 3}
-StringOrd{.s = "Foo bar", .ord = 6}
-StringOrd{.s = "Foo world", .ord = 7}
-StringOrd{.s = "Hello, ", .ord = 2}
-StringOrd{.s = "Hello, bar", .ord = 4}
-StringOrd{.s = "Hello, world", .ord = 5}
 CMethod:
 CMethod{.c1 = "bar", .c2 = "foo"}: +1
 CMethod{.c1 = "buzz", .c2 = "foo"}: +1


### PR DESCRIPTION
Remove test that relied on interned string id's to be deterministic across runs, which is not the case.