### PR TITLE
Safe string wildcard comparison in install-dependencies.sh

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -5,9 +5,9 @@ echo "Installing dependencies for DDlog"
 echo "This script should be invoked with '. ./install-dependencies.sh' to set up the environment properly"
 
 case "$OSTYPE" in
-    linux*) ;;
-    osx*) ;;
-    *) echo "Unhandled operating system $OSTYPE"; exit 1;;
+    "linux*") ;;
+    "osx*") ;;
+    "*") echo "Unhandled operating system $OSTYPE"; exit 1;;
 esac
 
 RUST_VERSION="1.41.1"


### PR DESCRIPTION
Not quoting the strings causes the wildcards to be evaluated in some shells. On ZSH,
it crashed my terminal (iterm2, OSX).

Signed-off-by: Lalith Suresh <lsuresh@vmware.com>