### PR TITLE
deserialize_from_array attribute.

### DIFF
--- a/doc/language_reference/language_reference.md
+++ b/doc/language_reference/language_reference.md
@@ -144,9 +144,9 @@ union_type       ::= (constructor "|")* constructor
 type_alias       ::= type_name           (* type name declared using typedef*)
                      ["<" type_spec [("," type_spec)*] ">"] (* type arguments *)
 
-constructor      ::= cons_name (* constructor without fields *)
-                   | cons_name "{" [field ("," field)*] "}"
-field            ::= field_name ":" simple_type_spec
+constructor      ::= [attributes] cons_name (* constructor without fields *)
+                   | [attributes] cons_name "{" [field ("," field)*] "}"
+field            ::= [attributes] field_name ":" simple_type_spec
 ```
 
 ### Constraints on types
@@ -590,8 +590,8 @@ rhs_clause ::= atom                                      (* 1.atom *)
              | "not" atom                                (* 2.negated atom *)
              | expr                                      (* 3.condition *)
              | expr "=" expr                             (* 4.assignment *)
-             | "FlatMap" "(" var_name "=" expr ")"       (* 5.flat map *)
-             | "var " var_name = "Aggregate" "("         (* 6.aggregation *)
+             | "var" var_name "=" "FlatMap" "(" expr ")" (* 5.flat map *)
+             | "var" var_name = "Aggregate" "("          (* 6.aggregation *)
                 "(" [var_name ("," var_name)*] ")" ","
                     func_name "(" expr ")" ")"
 ```
@@ -653,7 +653,7 @@ variable, e.g.:
 Logical_Switch_Port_ips(lsp, mac, ip) :-
     Logical_Switch_Port_addresses(lsp, addrs),
     (mac, ips) = extract_mac(addrs),
-    FlatMap(ip = extract_ips(ips))
+    var ip = FlatMap(extract_ips(ips))
 ```
 
 Here, `extract_ips` must return a *set* of IP addresses:
@@ -780,16 +780,4 @@ insertStatement ::= rel_name "(" expression ( "," expression )* ")"
 blockStatement ::= "{" statement ( ";" statement )* "}"
 
 emptyStatement ::= "skip"
-```
-
-# Supported meta-attributes
-
-Only one attribute is supported at the moment, namely the `size` attribute,
-applicable to `extern type` declarations.  It specifies the size of the
-corresponding Rust data type in bytes and serves as a hint to compiler
-to optimize data structures layout.
-
-```
-#[size=4]
-extern type IObj<'A>
 ```

--- a/rust/template/types/lib.rs
+++ b/rust/template/types/lib.rs
@@ -73,6 +73,38 @@ pub fn string_append(mut s1: String, s2: &String) -> String {
     s1
 }
 
+#[macro_export]
+macro_rules! deserialize_map_from_array {
+    ( $modname:ident, $ktype:ty, $vtype:ty, $kfunc:ident ) => {
+        mod $modname {
+            use super::*;
+            use serde::de::{Deserialize, Deserializer};
+            use serde::ser::Serializer;
+            use std::collections::BTreeMap;
+
+            pub fn serialize<S>(
+                map: &__std::std_Map<$ktype, $vtype>,
+                serializer: S,
+            ) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                serializer.collect_seq(map.x.values())
+            }
+
+            pub fn deserialize<'de, D>(
+                deserializer: D,
+            ) -> Result<__std::std_Map<$ktype, $vtype>, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                let v = Vec::<$vtype>::deserialize(deserializer)?;
+                Ok(v.into_iter().map(|item| ($kfunc(&item), item)).collect())
+            }
+        }
+    };
+}
+
 /*- !!!!!!!!!!!!!!!!!!!! -*/
 // Don't edit this line
 // Code below this point is needed to test-compile template

--- a/src/Language/DifferentialDatalog/Attribute.hs
+++ b/src/Language/DifferentialDatalog/Attribute.hs
@@ -1,0 +1,158 @@
+{-
+Copyright (c) 2020 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-}
+
+-- Functions for working with attributes specified for various DDlog program
+-- entities using annotations.
+
+{-# LANGUAGE RecordWildCards, FlexibleContexts #-}
+module Language.DifferentialDatalog.Attribute where
+
+import Data.Maybe
+import Control.Monad.Except
+
+import Language.DifferentialDatalog.Name
+import Language.DifferentialDatalog.NS
+import Language.DifferentialDatalog.Pos
+import Language.DifferentialDatalog.Syntax
+import Language.DifferentialDatalog.Type
+import Language.DifferentialDatalog.Util
+
+progValidateAttributes :: (MonadError String me) => DatalogProgram -> me ()
+progValidateAttributes d = do
+    mapM_ (typedefValidateAttrs d) $ progTypedefs d
+    mapM_ (indexValidateAttrs d) $ progIndexes d
+
+typedefValidateAttrs :: (MonadError String me) => DatalogProgram -> TypeDef -> me ()
+typedefValidateAttrs d tdef@TypeDef{..} = do
+    uniqNames ("Multiple definitions of attribute " ++) tdefAttrs
+    mapM_ (typedefValidateAttr d tdef) tdefAttrs
+    _ <- tdefCheckSizeAttr tdef
+    _ <- checkRustAttrs tdefAttrs
+    maybe (return ()) (typeValidateAttrs d) tdefType
+    return ()
+
+typedefValidateAttr :: (MonadError String me) => DatalogProgram -> TypeDef -> Attribute -> me ()
+typedefValidateAttr _ TypeDef{..} attr = do
+    case name attr of
+         "size" -> do
+            check (isNothing tdefType) (pos attr)
+                $ "Only extern types can have a \"size\" attribute"
+         "rust" -> do
+            check (isJust tdefType) (pos attr)
+                $ "Extern types cannot have a \"rust\" attribute"
+         n -> err (pos attr) $ "Unknown attribute " ++ n
+
+typeValidateAttrs :: (MonadError String me) => DatalogProgram -> Type -> me ()
+typeValidateAttrs d struct@TStruct{..} =
+    mapM_ (consValidateAttrs d struct) typeCons
+typeValidateAttrs _ _ = return ()
+
+consValidateAttrs :: (MonadError String me) => DatalogProgram -> Type -> Constructor -> me ()
+consValidateAttrs d struct cons@Constructor{..} = do
+    mapM_ (consValidateAttr d struct cons) consAttrs
+    _ <- checkRustAttrs consAttrs
+    mapM_ (fieldValidateAttrs d) consArgs
+    return ()
+
+consValidateAttr :: (MonadError String me) => DatalogProgram -> Type -> Constructor -> Attribute -> me ()
+consValidateAttr _ struct Constructor{..} attr = do
+    let TStruct{..} = struct
+    case name attr of
+         "rust" -> check (length typeCons > 1) (pos attr) $ "Per-constructor 'rust' attributes are only supported for types with multiple constructors"
+         n -> err (pos attr) $ "Unknown attribute " ++ n
+
+indexValidateAttrs :: (MonadError String me) => DatalogProgram -> Index -> me ()
+indexValidateAttrs d Index{..} = mapM_ (fieldValidateAttrs d) idxVars
+
+fieldValidateAttrs :: (MonadError String me) => DatalogProgram -> Field -> me ()
+fieldValidateAttrs d field@Field{..} = do
+    mapM_ (fieldValidateAttr d) fieldAttrs
+    _ <- checkRustAttrs fieldAttrs
+    _ <- fieldCheckDeserializeArrayAttr d field
+    return ()
+
+fieldValidateAttr :: (MonadError String me) => DatalogProgram -> Attribute -> me ()
+fieldValidateAttr _ attr = do
+    case name attr of
+         "rust" -> return ()
+         "deserialize_from_array" -> return ()
+         n -> err (pos attr) $ "Unknown attribute " ++ n
+
+{- `size` attribute: Gives DDlog a hint about the size of an extern data type in bytes. -}
+
+tdefCheckSizeAttr :: (MonadError String me) => TypeDef -> me (Maybe Int)
+tdefCheckSizeAttr TypeDef{..} =
+    case filter ((== "size") . name) tdefAttrs of
+         []                   -> return Nothing
+         [Attribute{attrVal = E (EInt _ nbytes)}] | nbytes <= toInteger (maxBound::Int)
+                              -> return $ Just $ fromInteger nbytes
+         [Attribute{..}] -> err attrPos $ "Invalid 'size' attribute: size must be an integer between 0 and " ++ show (maxBound::Int)
+         _                    -> err tdefPos $ "Multiple 'size' attributes are not allowed"
+
+tdefGetSizeAttr :: TypeDef -> Maybe Int
+tdefGetSizeAttr tdef =
+    case tdefCheckSizeAttr tdef of
+         Left e   -> error e
+         Right sz -> sz
+
+{- `rust` attribute is transferred directly to the generated Rust code. -}
+
+checkRustAttrs :: (MonadError String me) => [Attribute] -> me [String]
+checkRustAttrs attrs =
+    mapM (\Attribute{..} ->
+            case attrVal of
+                 E (EString _ str) -> return str
+                 _ -> err attrPos $ "Invalid 'rust' attribute: the value of the attribute must be a string literal, e.g., #[rust=\"serde(tag = \\\"type\\\"\")]")
+         $ filter ((== "rust") . name) attrs
+
+getRustAttrs :: [Attribute] -> [String]
+getRustAttrs attrs =
+    case checkRustAttrs attrs of
+         Left e   -> error e
+         Right as -> as
+
+{- `deserialize_from_array` attribute: specifies key function to be used to
+   deserialize array into a map. -}
+
+fieldCheckDeserializeArrayAttr :: (MonadError String me) => DatalogProgram -> Field -> me (Maybe String)
+fieldCheckDeserializeArrayAttr d field@Field{..} =
+    case filter ((== "deserialize_from_array") . name) fieldAttrs of
+         []                   -> return Nothing
+         [attr@Attribute{attrVal = E (EApply _ fname _)}] -> do
+             check (isMap d field) (pos attr) $ "'deserialize_from_array' attribute is only applicable to fields of type 'Map<>'."
+             let TOpaque _ _ [ktype, vtype] = typ' d field
+             kfunc@Function{..} <- checkFunc (pos attr) d fname
+             let nargs = length funcArgs
+             check (nargs == 1) (pos attr)
+                 $ "Key function '" ++ fname ++ "' must take one argument of type '" ++ show (fieldType) ++ "', but it takes " ++ show nargs ++ "arguments."
+             _ <- funcTypeArgSubsts d (pos attr) kfunc [vtype, ktype]
+             return $ Just fname
+         [Attribute{..}] -> err attrPos
+             $ "Invalid 'deserialize_from_array' attribute value '" ++ show attrVal ++ "': the value of the attribute must be the name of the key function, e.g.: \"deserialize_from_array=key_func()\"."
+         _               -> err (pos field) $ "Multiple 'deserialize_from_array' attributes are not allowed."
+
+fieldGetDeserializeArrayAttr :: DatalogProgram -> Field -> Maybe String
+fieldGetDeserializeArrayAttr d field =
+    case fieldCheckDeserializeArrayAttr d field of
+         Left e      -> error e
+         Right fname -> fname

--- a/src/Language/DifferentialDatalog/Module.hs
+++ b/src/Language/DifferentialDatalog/Module.hs
@@ -225,7 +225,16 @@ flattenNamespace1 mmap mod@DatalogModule{..} = do
                                      f' <- flattenFuncName mmap mod (pos rhsAggExpr) rhsAggFunc
                                      return $ rhs{rhsAggFunc = f'}
                                  rhs -> return rhs)
-    return prog5
+    prog6 <- progAttributeMapM prog5 (attrFlatten mod mmap)
+    return prog6
+
+attrFlatten :: (MonadError String me) => DatalogModule -> MMap -> Attribute -> me Attribute
+attrFlatten mod mmap a@Attribute{attrName="deserialize_from_array", attrVal=(E EApply{..})} = do
+    -- The value of deserialize_from_array attribute is the name of the key
+    -- function.
+    f' <- flattenFuncName mmap mod (pos a) exprFunc
+    return $ a{attrVal = eApply f' exprArgs}
+attrFlatten _   _    a = return a
 
 applyFlattenNames :: (MonadError String me) => DatalogModule -> MMap -> Apply -> me Apply
 applyFlattenNames mod mmap a@Apply{..} = do

--- a/src/Language/DifferentialDatalog/Type.hs
+++ b/src/Language/DifferentialDatalog/Type.hs
@@ -1,5 +1,5 @@
 {-
-Copyright (c) 2018 VMware, Inc.
+Copyright (c) 2018-2020 VMware, Inc.
 SPDX-License-Identifier: MIT
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/test/datalog_tests/json_test.dl
+++ b/test/datalog_tests/json_test.dl
@@ -135,3 +135,23 @@ JsonTest(optional3(),
          to_json_string_or_default(from_json_string(optional3()): Result<Optional, string>)).
 JsonTest(optional4(),
          to_json_string_or_default(from_json_string(optional4()): Result<Optional, string>)).
+
+typedef StructWithKey = StructWithKey {
+    key: u64,
+    payload: string
+}
+
+function key_structWithKey(x: StructWithKey): u64 =
+{
+    x.key
+}
+
+typedef StructWithMap = StructWithMap {
+    #[deserialize_from_array=key_structWithKey()]
+    f: Map<u64, StructWithKey>
+}
+
+function struct_with_map1(): string = [|{"f": [{"key": 100, "payload": "foo"}]}|]
+
+JsonTest(struct_with_map1(),
+         to_json_string_or_default(from_json_string(struct_with_map1()): Result<StructWithMap, string>)).

--- a/test/datalog_tests/json_test.dump.expected
+++ b/test/datalog_tests/json_test.dump.expected
@@ -12,6 +12,7 @@ json_test.JsonTest{.description = "{\"Variant1\": {\"b\": true}}", .value = "{\"
 json_test.JsonTest{.description = "{\"Variant2\": {\"u\": 100}}", .value = "{\"std_Ok\":{\"res\":{\"Variant2\":{\"u\":100}}}}"}
 json_test.JsonTest{.description = "{\"b\":true, \"foo\":\"bar\"}", .value = "{\"std_Ok\":{\"res\":{\"b\":true}}}"}
 json_test.JsonTest{.description = "{\"b\":true}", .value = "{\"std_Ok\":{\"res\":{\"b\":true}}}"}
+json_test.JsonTest{.description = "{\"f\": [{\"key\": 100, \"payload\": \"foo\"}]}", .value = "{\"std_Ok\":{\"res\":{\"f\":[{\"key\":100,\"payload\":\"foo\"}]}}}"}
 json_test.JsonTest{.description = "{\"foo\":\"bar\"}", .value = "{\"std_Err\":{\"err\":\"missing field `b` at line 1 column 13\"}}"}
 json_test.JsonTest{.description = "{\"s\": \"foo\", \"i\": 100000, \"v\": 2.5}", .value = "{\"std_Ok\":{\"res\":{\"s\":\"foo\",\"i\":100000,\"v\":2.5}}}"}
 json_test.JsonTest{.description = "{\"s\": \"foo\", \"i\": 100000}", .value = "{\"std_Ok\":{\"res\":{\"s\":\"foo\",\"i\":100000,\"v\":null}}}"}

--- a/test/datalog_tests/tutorial.dat
+++ b/test/datalog_tests/tutorial.dat
@@ -143,6 +143,16 @@ echo HostIPVSep:;
 dump HostIPVSep;
 
 start;
+insert Library(Book{"Ernest Hemingway", "For Whom the Bell Tolls"}),
+insert Library(Book{"Dav Pilkey", "For Whom the Ball Rolls"}),
+insert Author("Ernest Hemingway", 1899),
+insert Author("Dav Pilkey", 1966),
+commit;
+
+echo BookByAuthor;
+dump BookByAuthor;
+
+start;
 insert EvensAndOdds([0,1,2,3,4,5]),
 insert EvensAndOdds([1,3,5,7]),
 commit;

--- a/test/datalog_tests/tutorial.dl
+++ b/test/datalog_tests/tutorial.dl
@@ -165,6 +165,25 @@ SanitizedEndpoint(endpoint) :-
     not Blacklisted(endpoint).
 
 /*
+ * Example: @-bindings.
+ */
+typedef Book = Book {
+    author: string,
+    title: string
+}
+
+input relation Library(book: Book)
+input relation Author(name: string, born: u32)
+
+output relation BookByAuthor(book: Book, author: Author)
+
+BookByAuthor(b, author) :-
+    // Variable `b` will be bound to the entire `Book` struct;
+    // `author_name` will be bound to `b.author`.
+    Library(.book = b@Book{.author = author_name}),
+    author in Author(.name = author_name).
+
+/*
  * Example: recursion
  * (see path.dl)
  */

--- a/test/datalog_tests/tutorial.dump.expected
+++ b/test/datalog_tests/tutorial.dump.expected
@@ -70,6 +70,9 @@ HostIPVSep:
 HostIPVSep{.host = 1, .addrs = "10.10.10.101\n10.10.10.102\n"}
 HostIPVSep{.host = 2, .addrs = "192.168.0.1\n"}
 HostIPVSep{.host = 3, .addrs = "192.168.0.3\n192.168.0.4\n192.168.0.5\n192.168.0.6\n"}
+BookByAuthor
+BookByAuthor{.book = Book{.author = "Dav Pilkey", .title = "For Whom the Ball Rolls"}, .author = Author{.name = "Dav Pilkey", .born = 1966}}
+BookByAuthor{.book = Book{.author = "Ernest Hemingway", .title = "For Whom the Bell Tolls"}, .author = Author{.name = "Ernest Hemingway", .born = 1899}}
 Evens:
 Evens{.evens_and_odds = [0, 1, 2, 3, 4, 5], .evens = [0, 2, 4]}
 Evens{.evens_and_odds = [1, 3, 5, 7], .evens = []}


### PR DESCRIPTION
When working with JSON, it is common to have to deserialize an array of
entities that encodes a map with each entity containing a unique
key.  Deserializing directly to a map rather than a vector (which would
be the default representation) can be beneficial for performance if
frequent map lookups are required.  serde does not support this
directly, but it allows attaching custom serialization/deserialization
functions to struct fields.

We take advantage of this feature to implement a `deserialize_from_array`
annotation that can be associated with a field of a struct of type
`Map<'K,'V>`. The annotation takes a function name as its value.  The function,
whose signature must be: `function f(V): K` is used to project each
value `V` to key `K`.

Example:

```
// We will be deserializing a JSON array of these structures.
typedef StructWithKey = StructWithKey {
    key: u64,
    payload: string
}

// Key function.
function key_structWithKey(x: StructWithKey): u64 = {
    x.key
}

// This struct's serialized representaion is an array of
// `StructWithKey`; however it is deserialized into a map rather than
// vector.
typedef StructWithMap = StructWithMap {
    #[deserialize_from_array=key_structWithKey()]
    f: Map<u64, StructWithKey>
}

Example JSON representation of `StructWithMap`
{"f": [{"key": 100, "payload": "foo"}]}
```