### PR TITLE
std.dl: Vector sorting functions.

### DIFF
--- a/lib/std.dl
+++ b/lib/std.dl
@@ -185,7 +185,7 @@ extern function hash64(x: 'X): bit<64>
 extern function hash128(x: 'X): bit<128>
 
 /* The `Group` type is used exclusively in aggregation operations.  It
- * represents a non-empty list of objects sorted in ascending order.
+ * represents a non-empty list of objects.
  * `'K` is the type of group key, and `'V` is the type of value in the group.
  */
 extern type Group<'K,'V>
@@ -255,6 +255,8 @@ extern function vec_contains(v: Vec<'X>, x: 'X): bool
 extern function vec_is_empty(v: Vec<'X>): bool
 extern function vec_nth(v: Vec<'X>, n: bit<64>): Option<'X>
 extern function vec2set(s: Vec<'A>): Set<'A>
+extern function vec_sort(v: Vec<'X>): ()
+extern function vec_sort_imm(v: Vec<'X>): Vec<'X>
 
 /*
  * Map

--- a/lib/std.rs
+++ b/lib/std.rs
@@ -419,6 +419,16 @@ pub fn std_vec2set<X: Ord + Clone>(s: &std_Vec<X>) -> std_Set<X> {
     }
 }
 
+pub fn std_vec_sort<X: Ord>(v: &mut std_Vec<X>) {
+    v.x.as_mut_slice().sort();
+}
+
+pub fn std_vec_sort_imm<X: Ord + Clone>(v: &std_Vec<X>) -> std_Vec<X> {
+    let mut res = (*v).clone();
+    res.x.sort();
+    res
+}
+
 // Set
 
 #[derive(Eq, Ord, Clone, Hash, PartialEq, PartialOrd, Default)]

--- a/test/datalog_tests/lib_test.dl
+++ b/test/datalog_tests/lib_test.dl
@@ -1,3 +1,4 @@
+import std_test
 import uuid_test
 import net_test
 import json_test

--- a/test/datalog_tests/std_test.dat
+++ b/test/datalog_tests/std_test.dat
@@ -1,0 +1,8 @@
+start;
+
+insert std_test.Vector([5,4,3,2,1]),
+insert std_test.Vector([]),
+insert std_test.Vector([5]),
+insert std_test.Vector([0,100,-100]),
+
+commit dump_changes;

--- a/test/datalog_tests/std_test.dl
+++ b/test/datalog_tests/std_test.dl
@@ -1,0 +1,15 @@
+input relation Vector(v: Vec<bigint>)
+output relation SortedVector(v: Vec<bigint>)
+output relation SortedVectorInPlace(v: Vec<bigint>)
+
+SortedVector(sorted) :-
+    Vector(v),
+    var sorted = vec_sort_imm(v).
+
+SortedVectorInPlace(sorted) :-
+    Vector(v),
+    var sorted = {
+        var v2 = v;
+        vec_sort(v2);
+        v2
+    }.

--- a/test/datalog_tests/std_test.dump.expected
+++ b/test/datalog_tests/std_test.dump.expected
@@ -1,0 +1,10 @@
+std_test.SortedVector:
+std_test.SortedVector{.v = []}: +1
+std_test.SortedVector{.v = [-100, 0, 100]}: +1
+std_test.SortedVector{.v = [1, 2, 3, 4, 5]}: +1
+std_test.SortedVector{.v = [5]}: +1
+std_test.SortedVectorInPlace:
+std_test.SortedVectorInPlace{.v = []}: +1
+std_test.SortedVectorInPlace{.v = [-100, 0, 100]}: +1
+std_test.SortedVectorInPlace{.v = [1, 2, 3, 4, 5]}: +1
+std_test.SortedVectorInPlace{.v = [5]}: +1

--- a/test/datalog_tests/test-libs.sh
+++ b/test/datalog_tests/test-libs.sh
@@ -13,6 +13,7 @@ test_lib() {
     diff -q $1.dump.expected $1.dump
 }
 
+test_lib std_test
 test_lib uuid_test
 test_lib net_test
 test_lib json_test


### PR DESCRIPTION
In-place sorting:

```
extern function vec_sort(v: Vec<'X>): ()
```

Returns a sorted vector without changing `v`:

```
extern function vec_sort_imm(v: Vec<'X>): Vec<'X>
```

This commit also starts adding tests for the standard library.

@blp 