### PR TITLE
New syntax for functions.

### DIFF
--- a/doc/language_reference/language_reference.md
+++ b/doc/language_reference/language_reference.md
@@ -170,7 +170,7 @@ identical names, their types must be identical, e.g., the following is invalid:
 arguments matching its declaration:
     ```
     typedef type1<'A,'B>
-    function f(): bool = {
+    function f(): bool {
         var x: type1<bigint> // error: not enough type arguments
     }
     ```
@@ -192,14 +192,14 @@ arguments matching its declaration:
    by referring to them in function arguments.  They are used in the
    return type of the function and in its body:
    ```
-   function f(arg1: 'A, arg2: type2<'A,'B>): 'A = {
+   function f(arg1: 'A, arg2: type2<'A,'B>): 'A {
        var x: 'A = arg1;
        x
    }
    ```
    Examples of invalid use of type variables in functions:
    ```
-   function f(arg: 'A): 'B = /*error: type variable 'B is not defined here*/
+   function f(arg: 'A): 'B /*error: type variable 'B is not defined here*/
    {
        var x: 'C; /* error: type variable 'C is not defined here */
    }
@@ -217,7 +217,7 @@ body.
 ```EBNF
 function ::= "function" func_name "(" [arg(,arg)*]")"
               ":" simple_type_spec (* return type *)
-              ["=" expr]
+              "{" expr "}          (* body of the function *)
            | "extern function" func_name "(" [arg(,arg)*]")"
               ":" simple_type_spec
 ```
@@ -459,7 +459,7 @@ Compilation fails if a function with this name and signature is not found.
 For example, the last statement in
 ```
 typedef udf_t = Cons1 | Cons2{f: bigint}
-function udf_t2string(x: udf_t): string = ...
+function udf_t2string(x: udf_t): string { ... }
 x: udf_t;
 
 y = "x:{x}";
@@ -539,7 +539,7 @@ y = "x:{udf_t2string(x)}";
        C1{v} -> v       // variable v bound inside match pattern
    };
 
-   function shadow(a: string): () = {
+   function shadow(a: string): () {
        var v: string;
        var v = "foo"; // error: variable re-definition
        var a = "bar"  // error: variable shadows argument name

--- a/doc/tutorial/tutorial.md
+++ b/doc/tutorial/tutorial.md
@@ -440,7 +440,7 @@ Think of this declaration as a C struct with
 a single field of type `bit<32>`.  We can write a user-defined formatting method:
 
 ```
-function ip_addr_t2string(ip: ip_addr_t): string = {
+function ip_addr_t2string(ip: ip_addr_t): string {
     "${ip.addr[31:24]}.${ip.addr[23:16]}.${ip.addr[15:8]}.${ip.addr[7:0]}"
 }
 ```
@@ -459,7 +459,7 @@ representation:
 ```
 typedef mac_addr_t = MACAddr{addr: bit<48>}
 
-function mac_addr_t2string(mac: mac_addr_t): string = {
+function mac_addr_t2string(mac: mac_addr_t): string {
     "${hex(mac.addr[47:40])}:${hex(mac.addr[39:32])}:${hex(mac.addr[31:24])}:\
      \${hex(mac.addr[23:16])}:${hex(mac.addr[15:8])}:${hex(mac.addr[7:0])}"
 }
@@ -474,7 +474,7 @@ typedef nethost_t = NHost {
     mac: mac_addr_t
 }
 
-function nethost_t2string(h: nethost_t): string = {
+function nethost_t2string(h: nethost_t): string {
     "Host: IP=${h.ip}, MAC=${h.mac}"
 }
 ```
@@ -534,13 +534,13 @@ concatenation).
 ```
 // Form IP address from bytes using bit vector concatenation
 function ip_from_bytes(b3: bit<8>, b2: bit<8>, b1: bit<8>, b0: bit<8>)
-    : ip_addr_t =
+    : ip_addr_t
 {
     IPAddr{.addr = b3 ++ b2 ++ b1 ++ b0}
 }
 
 // Check for multicast IP address using bit slicing
-function is_multicast_addr(ip: ip_addr_t): bool = ip.addr[31:28] == 14
+function is_multicast_addr(ip: ip_addr_t): bool { ip.addr[31:28] == 14 }
 
 input relation Bytes(b3: bit<8>, b2: bit<8>, b1: bit<8>, b0: bit<8>)
 
@@ -631,7 +631,7 @@ Evaluation order can be controlled using several constructs:
 The following example illustrates the first four of these constructs.  Loops are explained [below](#container-types-flatmap-and-for-loops).
 
 ```
-function addr_port(ip: ip_addr_t, proto: string, preferred_port: bit<16>): string =
+function addr_port(ip: ip_addr_t, proto: string, preferred_port: bit<16>): string
 {
     var port: bit<16> = match (proto) {  // match protocol string
         "FTP"   -> 20,  // default FTP port
@@ -693,6 +693,23 @@ may not modify its arguments.  The body of a function is an expression
 whose type must match the function's return type.  A function call can
 be inserted anywhere an expression of the function's return type can
 be used.  DDlog currently does not allow recursive functions.
+
+> #### Legacy function syntax
+>
+> DDlog supports an alternative syntax for functions with equality sign between
+> function declaration and its body, which does not require curly braces:  
+>
+> ```
+> function myfunc(x: string): string = x
+> ```
+> 
+> However, this syntax can cause parsing ambiguities in some circumstances;
+> therefore the newer syntax is preferred: 
+>
+> ```
+> function myfunc(x: string): string { x }
+> ```
+
 
 ### Extern functions
 
@@ -831,8 +848,9 @@ pub fn split_ip_list(s: &String, sep: &String) -> Vec<String> {
 We define a DDlog function which splits IP addresses at spaces:
 
 ```
-function split_ip_list(x: string): Vec<string> =
+function split_ip_list(x: string): Vec<string> {
    split(x, " ")
+}
 ```
 
 Consider an input relation `HostAddress` associating each host with a
@@ -867,7 +885,7 @@ For-loops allow manipulating container types in a more procedural fashion, witho
 The following function concatenates a vector of strings, each starting at a new line.
 
 ```
-function vsep(strs: Vec<string>): string = {
+function vsep(strs: Vec<string>): string {
     var res = "";
     for (s in strs) {
         res = res ++ s ++ "\n"
@@ -885,7 +903,7 @@ current loop iteration:
 
 ```
 // Returns only even elements of the vector.
-function evens(vec: Vec<bigint>): Vec<bigint> = {
+function evens(vec: Vec<bigint>): Vec<bigint> {
     var res: Vec<bigint> = vec_empty();
     for (x in vec) {
         if (x % 2 != 0) { continue };
@@ -899,7 +917,7 @@ A `break` statement used anywhere inside the body of a loop terminates the loop:
 
 ```
 // Returns prefix of `vec` before the first occurrence of value `v`.
-function prefixBefore(vec: Vec<'A>, v: 'A): Vec<'A> = {
+function prefixBefore(vec: Vec<'A>, v: 'A): Vec<'A> {
     var res: Vec<'A> = vec_empty();
     for (x in vec) {
         if (x == v) { break };
@@ -1003,7 +1021,7 @@ aggregation functions:
 
 ```
 /* User-defined aggregate that picks a tuple with the smallest price */
-function best_vendor(g: Group<'K, (string, bit<64>)>): (string, bit<64>) =
+function best_vendor(g: Group<'K, (string, bit<64>)>): (string, bit<64>)
 {
     var min_vendor = "";
     var min_price: bit<64> = 'hffffffffffffffff;
@@ -1032,7 +1050,7 @@ vendor for each item and returns a string containing item name, vendor,
 and price:
 
 ```
-function best_vendor_string(g: Group<string, (string, bit<64>)>): string =
+function best_vendor_string(g: Group<string, (string, bit<64>)>): string
 {
     var min_vendor = "";
     var min_price: bit<64> = 'hffffffffffffffff;
@@ -1115,7 +1133,7 @@ The following function creates a packet with Ethernet, IPv6 and TCP headers:
 ```
 function tcp6_packet(ethsrc: bit<48>, ethdst: bit<48>,
                      ipsrc: ip6_addr_t, ipdst: ip6_addr_t,
-                     srcport: bit<16>, dstport: bit<16>): eth_pkt_t =
+                     srcport: bit<16>, dstport: bit<16>): eth_pkt_t
 {
     EthPacket {
         // Explicitly name constructor arguments for clarity
@@ -1154,7 +1172,7 @@ if the packet is not of type IPv4 (we will see a nicer way to deal with non-exis
 [below](#generic-types)):
 
 ```
-function pkt_ip4(pkt: eth_pkt_t): ip4_pkt_t = {
+function pkt_ip4(pkt: eth_pkt_t): ip4_pkt_t {
     match (pkt) {
         EthPacket{.payload = EthIP4{ip4}} -> ip4,
         _                                 -> IP4Pkt{0,0,0,IPOther}
@@ -1170,7 +1188,7 @@ matches both level-3 and level-4 protocol headers to extract destination UDP por
 packet.
 
 ```
-function pkt_udp_port(pkt: eth_pkt_t): bit<16> = {
+function pkt_udp_port(pkt: eth_pkt_t): bit<16> {
     match (pkt) {
         EthPacket{.payload = EthIP4{IP4Pkt{.payload = IPUDP{UDPPkt{.dst = port}}}}} -> port,
         EthPacket{.payload = EthIP6{IP6Pkt{.payload = IPUDP{UDPPkt{.dst = port}}}}} -> port,
@@ -1215,7 +1233,7 @@ group of related values of possibly different types.  A tuple type lists the typ
 For example, our IP address splitting function could return a tuple with four 8-bit fields:
 
 ```
-function addr_to_tuple(addr: bit<32>): (bit<8>, bit<8>, bit<8>, bit<8>) =
+function addr_to_tuple(addr: bit<32>): (bit<8>, bit<8>, bit<8>, bit<8>)
 {
     // construct an instance of a tuple
     (addr[31:24], addr[23:16], addr[15:8], addr[7:0])
@@ -1261,7 +1279,7 @@ packet.  If the packet does not have an IPv4 header, it returns a default value 
 to 0:
 
 ```
-function pkt_ip4(pkt: eth_pkt_t): ip4_pkt_t = {
+function pkt_ip4(pkt: eth_pkt_t): ip4_pkt_t {
     match (pkt) {
         EthPacket{.payload = EthIP4{ip4}} -> ip4,
         _                                 -> IP4Pkt{0,0,0,IPOther}
@@ -1292,7 +1310,7 @@ Here `'A` is a *type argument* that must be replaced with a concrete type to cre
 instantiation of `Option`.  We can now rewrite the `pkt_ip4()` function using `Option`:
 
 ```
-function pkt_ip4(pkt: eth_pkt_t): Option<ip4_pkt_t> = {
+function pkt_ip4(pkt: eth_pkt_t): Option<ip4_pkt_t> {
     match (pkt) {
         EthPacket{.payload = EthIP4{ip4}} -> Some{ip4},
         _                                 -> None
@@ -1318,7 +1336,7 @@ arguments; however a better software engineering practice is to pass the entire 
 the function:
 
 ```
-function is_target_audience(person: Person): bool = {
+function is_target_audience(person: Person): bool {
     (person.nationality == "USA") and
     (person.occupation == "student")
 }
@@ -1706,7 +1724,7 @@ typedef StructWithKey = StructWithKey {
 }
 
 // Key function.
-function key_structWithKey(x: StructWithKey): u64 = {
+function key_structWithKey(x: StructWithKey): u64 {
     x.key
 }
 

--- a/src/Language/DifferentialDatalog/Parse.hs
+++ b/src/Language/DifferentialDatalog/Parse.hs
@@ -297,7 +297,7 @@ func = (Function nopos <$  (try $ reserved "extern" *> reserved "function")
                        <*> funcIdent
                        <*> (parens $ commaSep farg)
                        <*> (colon *> typeSpecSimple)
-                       <*> (Just <$ reservedOp "=" <*> expr))
+                       <*> (Just <$> ((reservedOp "=" *> expr) <|> (braces expr))))
 
 farg = withPos $ (FuncArg nopos) <$> varIdent <*> (colon *> option False (True <$ reserved "mut")) <*> typeSpecSimple
 

--- a/src/Language/DifferentialDatalog/Syntax.hs
+++ b/src/Language/DifferentialDatalog/Syntax.hs
@@ -813,10 +813,9 @@ instance PP Function where
     pp Function{..} = (maybe "extern" (\_ -> empty) funcDef) <+>
                       ("function" <+> pp funcName
                        <+> (parens $ commaSep $ map pp funcArgs)
-                       <> colon <+> pp funcType
-                       <+> (maybe empty (\_ -> "=") funcDef))
+                       <> colon <+> pp funcType)
                       $$
-                       (maybe empty (nest' . pp) funcDef)
+                       (maybe empty (braces' . pp) funcDef)
 
 instance Show Function where
     show = render . pp

--- a/test/datalog_tests/dupfield.fail.ast.expected
+++ b/test/datalog_tests/dupfield.fail.ast.expected
@@ -4,4 +4,4 @@ error: ./test/datalog_tests/dupfield.fail.dl:2:22-2:31: Multiple definitions of 
 
 Failed to parse input file: "./test/datalog_tests/dupfield.fail.dl" (line 6, column 1):
 unexpected end of input
-expecting "="
+expecting "=" or "{"

--- a/test/datalog_tests/function.fail.ast.expected
+++ b/test/datalog_tests/function.fail.ast.expected
@@ -23,7 +23,7 @@ error: ./test/datalog_tests/function.fail.dl:8:16-8:27: Type constructor in the 
 
 Failed to parse input file: "./test/datalog_tests/function.fail.dl" (line 5, column 1):
 unexpected "f"
-expecting "="
+expecting "=" or "{"
 
 error: ./test/datalog_tests/function.fail.dl:4:5-4:6: Expression is not a struct
 

--- a/test/datalog_tests/simple2.dat
+++ b/test/datalog_tests/simple2.dat
@@ -9,3 +9,5 @@ insert TArrng1[(TArrng2{true, TArrng1{true, 1000}}, 10)],
 insert TArrng2[(TArrng2{true, TArrng1{true, 5}}, 1000)],
 
 commit dump_changes;
+
+dump FuncTest;

--- a/test/datalog_tests/simple2.dl
+++ b/test/datalog_tests/simple2.dl
@@ -79,3 +79,9 @@ function agg_avg_double_N(aggregate: Option<(double, double)>, item: Option<doub
         (Some{x}, None)    -> Some{x},
         (Some{(sum,ct)}, Some{y}) -> Some{(sum + y, ct + 1)}
     }
+
+
+/* See #603. New function syntax avoids ambiguity. */
+output relation &FuncTest(x: string)
+function myfunc(x: string): string { x }
+&FuncTest("foo").

--- a/test/datalog_tests/simple2.dump.expected
+++ b/test/datalog_tests/simple2.dump.expected
@@ -5,3 +5,4 @@ Arrng1Arrng2_2:
 Arrng1Arrng2_2{.x = 5}: +1
 TArrng1Arrng2:
 TArrng1Arrng2{.x = 5}: +1
+FuncTest{.x = "foo"}

--- a/test/datalog_tests/tutorial.dl
+++ b/test/datalog_tests/tutorial.dl
@@ -69,11 +69,11 @@ Pow2("The square of ${x} is ${x*x}") :- Number(x).
 typedef ip_addr_t = IPAddr{addr: bit<32>}
 typedef mac_addr_t = MACAddr{addr: bit<48>}
 
-function ip_addr_t2string(ip: ip_addr_t): string = {
+function ip_addr_t2string(ip: ip_addr_t): string {
     "${ip.addr[31:24]}.${ip.addr[23:16]}.${ip.addr[15:8]}.${ip.addr[7:0]}"
 }
 
-function mac_addr_t2string(mac: mac_addr_t): string = {
+function mac_addr_t2string(mac: mac_addr_t): string {
     "${hex(mac.addr[47:40])}:${hex(mac.addr[39:32])}:${hex(mac.addr[31:24])}:\
     \${hex(mac.addr[23:16])}:${hex(mac.addr[15:8])}:${hex(mac.addr[7:0])}"
 }
@@ -83,7 +83,7 @@ typedef nethost_t = NHost {
     mac: mac_addr_t
 }
 
-function nethost_t2string(h: nethost_t): string = {
+function nethost_t2string(h: nethost_t): string {
     "Host: IP=${h.ip}, MAC=${h.mac}"
 }
 
@@ -98,13 +98,13 @@ NetHostString(id, "${h}") :- NetHost(id, h).
 
 // Form IP address from bytes using bit vector concatenation
 function ip_from_bytes(b3: bit<8>, b2: bit<8>, b1: bit<8>, b0: bit<8>)
-    : ip_addr_t =
+    : ip_addr_t
 {
     IPAddr{.addr = b3 ++ b2 ++ b1 ++ b0}
 }
 
 // Check for multicast IP address using bit slicing
-function is_multicast_addr(ip: ip_addr_t): bool = ip.addr[31:28] == 14
+function is_multicast_addr(ip: ip_addr_t): bool { ip.addr[31:28] == 14 }
 
 input relation Bytes(b3: bit<8>, b2: bit<8>, b1: bit<8>, b0: bit<8>)
 output relation Address(addr: ip_addr_t)
@@ -119,7 +119,7 @@ MCastAddress(a) :- Address(a), is_multicast_addr(a).
 
 function addr_port(ip: ip_addr_t,
                    proto: string,
-                   preferred_port: bit<16>): string = {
+                   preferred_port: bit<16>): string {
     var port: bit<16> =
         match (proto) {
             "FTP"   -> 20,
@@ -193,8 +193,9 @@ BookByAuthor(b, author) :-
  */
 
 extern function split(s: string, sep: string): Vec<string>
-function split_ip_list(x: string): Vec<string> =
+function split_ip_list(x: string): Vec<string> {
    split(x, " ")
+}
 
 input relation HostAddress(host: bit<64>, addrs: string)
 output relation HostIP(host: bit<64>, addr: string)
@@ -202,7 +203,7 @@ output relation HostIP(host: bit<64>, addr: string)
 HostIP(host, addr) :- HostAddress(host, addrs),
                       var addr = FlatMap(split_ip_list(addrs)).
 
-function vsep(strs: Vec<string>): string = {
+function vsep(strs: Vec<string>): string {
     var res = "";
     for (s in strs) {
         res = res ++ s ++ "\n"
@@ -220,7 +221,7 @@ HostIPVSep(host, vaddrs) :- HostAddress(host, addrs),
  */
 
 // Returns only even elements of the vector.
-function evens(vec: Vec<bigint>): Vec<bigint> = {
+function evens(vec: Vec<bigint>): Vec<bigint> {
     var res: Vec<bigint> = vec_empty();
     for (x in vec) {
         if (x % 2 != 0) { continue };
@@ -235,7 +236,7 @@ output relation Evens(evens_and_odds: Vec<bigint>, evens: Vec<bigint>)
 Evens(vec, evens(vec)) :- EvensAndOdds(vec).
 
 // Returns prefix of `vec` before the first occurrence of value `v`.
-function prefixBefore(vec: Vec<'A>, v: 'A): Vec<'A> = {
+function prefixBefore(vec: Vec<'A>, v: 'A): Vec<'A> {
     var res: Vec<'A> = vec_empty();
     for (x in vec) {
         if (x == v) { break };
@@ -279,7 +280,7 @@ WorstPrice(item, best_price) :-
 
 output relation BestVendor(item: string, vendor: string, price: bit<64>)
 
-function best_vendor(g: Group<'K, (string, bit<64>)>): (string, bit<64>) =
+function best_vendor(g: Group<'K, (string, bit<64>)>): (string, bit<64>)
 {
     var min_vendor = "";
     var min_price: bit<64> = 'hffffffffffffffff;
@@ -297,7 +298,7 @@ BestVendor(item, best_vendor, best_price) :-
     var best_vendor_price = Aggregate((item), best_vendor((vendor, price))),
     (var best_vendor, var best_price) = best_vendor_price.
 
-function best_vendor_string(g: Group<string, (string, bit<64>)>): string =
+function best_vendor_string(g: Group<string, (string, bit<64>)>): string
 {
     var min_vendor = "";
     var min_price: bit<64> = 'hffffffffffffffff;
@@ -355,7 +356,7 @@ typedef udp_pkt_t = UDPPkt { src     : bit<16>
 
 function tcp6_packet(ethsrc: bit<48>, ethdst: bit<48>,
                      ipsrc: ip6_addr_t, ipdst: ip6_addr_t,
-                     srcport: bit<16>, dstport: bit<16>): eth_pkt_t =
+                     srcport: bit<16>, dstport: bit<16>): eth_pkt_t
 {
     EthPacket {
         // Explicitly name constructor arguments for clarity
@@ -379,14 +380,14 @@ function tcp6_packet(ethsrc: bit<48>, ethdst: bit<48>,
     }
 }
 
-function pkt_ip4(pkt: eth_pkt_t): ip4_pkt_t = {
+function pkt_ip4(pkt: eth_pkt_t): ip4_pkt_t {
     match (pkt) {
         EthPacket{.payload = EthIP4{ip4}} -> ip4,
         _                                 -> IP4Pkt{0,0,0,IPOther}
     }
 }
 
-function pkt_ip4_(pkt: eth_pkt_t): Option<ip4_pkt_t> = {
+function pkt_ip4_(pkt: eth_pkt_t): Option<ip4_pkt_t> {
     match (pkt) {
         EthPacket{.payload = EthIP4{ip4}} -> Some{ip4},
         _                                 -> None
@@ -401,7 +402,7 @@ output relation TCPDstPort(port: bit<16>)
 TCPDstPort(port) :- Packet(EthPacket{.payload = EthIP4{IP4Pkt{.payload = IPTCP{TCPPkt{.dst = port}}}}}).
 TCPDstPort(port) :- Packet(EthPacket{.payload = EthIP6{IP6Pkt{.payload = IPTCP{TCPPkt{.dst = port}}}}}).
 
-function pkt_udp_port(pkt: eth_pkt_t): bit<16> = {
+function pkt_udp_port(pkt: eth_pkt_t): bit<16> {
     match (pkt) {
         EthPacket{.payload = EthIP4{IP4Pkt{.payload = IPUDP{UDPPkt{.dst = port}}}}} -> port,
         EthPacket{.payload = EthIP6{IP6Pkt{.payload = IPUDP{UDPPkt{.dst = port}}}}} -> port,
@@ -413,7 +414,7 @@ output relation UDPDstPort(port: bit<16>)
 
 UDPDstPort(port) :- Packet(pkt), var port = pkt_udp_port(pkt), port != 0.
 
-function pkt_udp_port2(pkt: eth_pkt_t): Option<bit<16>> = {
+function pkt_udp_port2(pkt: eth_pkt_t): Option<bit<16>> {
     match (pkt) {
         EthPacket{.payload = EthIP4{IP4Pkt{.payload = IPUDP{UDPPkt{.dst = port}}}}} -> Some{port},
         EthPacket{.payload = EthIP6{IP6Pkt{.payload = IPUDP{UDPPkt{.dst = port}}}}} -> Some{port},
@@ -431,7 +432,7 @@ UDPDstPort2(port) :- Packet(pkt), Some{var port} = pkt_udp_port2(pkt).
 
 input relation KnownHost(addr: ip4_addr_t)
 
-function addr_to_tuple(addr: ip4_addr_t): (bit<8>, bit<8>, bit<8>, bit<8>) = {
+function addr_to_tuple(addr: ip4_addr_t): (bit<8>, bit<8>, bit<8>, bit<8>) {
     (addr[31:24], addr[23:16], addr[15:8], addr[7:0])
 }
 
@@ -455,7 +456,7 @@ IntranetHost3(addr) :- KnownHost(addr),
 
 input relation Person (name: string, nationality: string, occupation: string)
 
-function is_target_audience(person: Person): bool = {
+function is_target_audience(person: Person): bool {
     (person.nationality == "USA") and
     (person.occupation == "student")
 }


### PR DESCRIPTION
(Addresses #603)

This code

```
relation &X(x: string)
function myfunc(x: string): string = { x }
&X("foo").
```

fails to compile with:

```
ddlog: Failed to parse input file: "playpen3.dl" (line 3, column 3):
unexpected '('
expecting "#", "import", "typedef", "extern", "input", "output", "relation", "index", "function", "transformer", variable name, "&", relation name, "apply", "for" or end of input
```

The problem is that the syntax with optional curly braces is
inherently ambiguous.  In addition, the `=` between function
declaration and body is bad aesthetically in most cases.

We introduce new, more conventional, syntax without `=` and with
mandatory braces.  It eliminates the ambiguity and looks better imo.

We still support the old syntax to avoid breaking people's code.  We may
phase it out in the future, but I don't see much harm in it.