### PR TITLE
api.rs: ddlog_transaction_commit_dump_changes_as_array (untested).

### DIFF
--- a/rust/template/differential_datalog/valmap.rs
+++ b/rust/template/differential_datalog/valmap.rs
@@ -31,6 +31,15 @@ impl<V> AsRef<BTreeMap<RelId, BTreeMap<V, isize>>> for DeltaMap<V> {
     }
 }
 
+impl<V> IntoIterator for DeltaMap<V> {
+    type Item = (RelId, BTreeMap<V, isize>);
+    type IntoIter = std::collections::btree_map::IntoIter<RelId, BTreeMap<V, isize>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.map.into_iter()
+    }
+}
+
 impl<V: Display + Ord + Clone> DeltaMap<V> {
     pub fn new() -> Self {
         Self {


### PR DESCRIPTION
When DDlog generates many updates, it can be expensive to send them all
via FFI to Java or Go.  The new method returns all updates generated by
a transaction in a single array.

@antoninbas , can you let me know if the new `ddlog_transaction_commit_dump_changes_as_array`/`ddlog_free_record_updates` API works for you (in terms of functionality and in terms of feasibility of creating Go bindings)? 