### PR TITLE
json.dl: Serialize/deserialize integers from strings.

### DIFF
--- a/test/datalog_tests/json_test.dl
+++ b/test/datalog_tests/json_test.dl
@@ -155,3 +155,31 @@ function struct_with_map1(): string = [|{"f": [{"key": 100, "payload": "foo"}]}|
 
 JsonTest(struct_with_map1(),
          to_json_string_or_default(from_json_string(struct_with_map1()): Result<StructWithMap, string>)).
+
+
+typedef U64FromString = U64FromString {
+    x: string,
+    #[rust="serde(with=\"serde_string\")"]
+    y: u64
+}
+
+function u64FromString1(): string = [|{"x": "x", "y": "100000"}|]
+function u64FromString2(): string = [|{"x": "x", "y": "-100000"}|]
+
+JsonTest(u64FromString1(),
+         to_json_string_or_default(from_json_string(u64FromString1()): Result<U64FromString, string>)).
+JsonTest(u64FromString2(),
+         to_json_string_or_default(from_json_string(u64FromString2()): Result<U64FromString, string>)).
+
+typedef S32FromString = S32FromString {
+    #[rust="serde(with=\"serde_string\")"]
+    x: s32
+}
+
+function s32FromString1(): string = [|{"x": "-100000"}|]
+function s32FromString2(): string = [|{"x": "100000000000"}|]
+
+JsonTest(s32FromString1(),
+         to_json_string_or_default(from_json_string(s32FromString1()): Result<S32FromString, string>)).
+JsonTest(s32FromString2(),
+         to_json_string_or_default(from_json_string(s32FromString2()): Result<S32FromString, string>)).

--- a/test/datalog_tests/json_test.dump.expected
+++ b/test/datalog_tests/json_test.dump.expected
@@ -19,5 +19,9 @@ json_test.JsonTest{.description = "{\"s\": \"foo\", \"i\": 100000}", .value = "{
 json_test.JsonTest{.description = "{\"s\": \"foo\"}", .value = "{\"std_Ok\":{\"res\":{\"s\":\"foo\",\"i\":null,\"v\":null}}}"}
 json_test.JsonTest{.description = "{\"t\":\"foo\", \"@id\":\"1001001001\", \"x\": \"x\", \"z\": 100000}", .value = "{\"std_Ok\":{\"res\":{\"t\":\"foo\",\"@id\":\"1001001001\",\"x\":\"x\",\"z\":100000}}}"}
 json_test.JsonTest{.description = "{\"t\":\"foo\", \"id\":\"1001001001\", \"nested\": {\"x\": \"x\", \"z\": 100000}}", .value = "{\"std_Ok\":{\"res\":{\"t\":\"foo\",\"id\":\"1001001001\",\"nested\":{\"x\":\"x\",\"z\":100000}}}}"}
+json_test.JsonTest{.description = "{\"x\": \"-100000\"}", .value = "{\"std_Ok\":{\"res\":{\"x\":\"-100000\"}}}"}
+json_test.JsonTest{.description = "{\"x\": \"100000000000\"}", .value = "{\"std_Err\":{\"err\":\"number too large to fit in target type at line 1 column 21\"}}"}
+json_test.JsonTest{.description = "{\"x\": \"x\", \"y\": \"-100000\"}", .value = "{\"std_Err\":{\"err\":\"invalid digit found in string at line 1 column 26\"}}"}
+json_test.JsonTest{.description = "{\"x\": \"x\", \"y\": \"100000\"}", .value = "{\"std_Ok\":{\"res\":{\"x\":\"x\",\"y\":\"100000\"}}}"}
 json_test.JsonTest{.description = "{}", .value = "{\"std_Ok\":{\"res\":{\"s\":null,\"i\":null,\"v\":null}}}"}
 json_test.TVariant1{.b = true}


### PR DESCRIPTION
Some JSON schemas represent integers as strings.  This commit adds support to
serialize/deserialize integers or any other types that implement `FromStr` and
`ToString` traits to/from strings.  To use this feature, add the following
annotation to the DDlog field that needs to be deserialized from a string:

```
typedef U64FromString = U64FromString {
  #[rust="serde(with=\"serde_string\")"]
  y: u64
}
```