### PR TITLE
program.rs: Advance epoch once per transaction.

### DIFF
--- a/rust/template/differential_datalog/program.rs
+++ b/rust/template/differential_datalog/program.rs
@@ -1389,12 +1389,11 @@ impl Program {
                                             }
                                         }
                                     };
-                                    epoch += 1;
-                                    //print!("epoch: {}\n", epoch);
-                                    Self::advance(&mut sessions, &mut traces, epoch);
                                 },
                                 Ok(Msg::Flush) => {
                                     //println!("flushing");
+                                    epoch += 1;
+                                    Self::advance(&mut sessions, &mut traces, epoch);
                                     Self::flush(&mut sessions, &probe, worker, &peers, &frontier_ts, &progress_barrier);
                                     //println!("flushed");
                                     reply_send.send(Reply::FlushAck).map_err(|e| format!("failed to send ACK: {}", e))?;


### PR DESCRIPTION
We used to advance the frontier on each `apply_updates` operation.  This
can create multiple timestamps per transaction, hindering DD's ability
to batch updates, which is completely unnecessary, since we only ever
observe final state in the end of each transaction, which is exactly the
same, whether data is logically pushed to DD in the same or multiple
epochs.

The fix is a tiny change that advances the before each `Msg::Flush`, which
indicates the end of a transaction, instead of `Msg::Update`.

As a side effect, this will lead to more meaningful timestamps in the new
`Inspect` operator (#618), with each top-level timestamp equal to the
sequential number of the transaction that generated the update.