### PR TITLE
Two fixes in FP support.

### DIFF
--- a/rust/template/value/Cargo.toml
+++ b/rust/template/value/Cargo.toml
@@ -21,6 +21,7 @@ serde = {version = "1.0", features = ["derive"]}
 timely = "0.11"
 twox-hash = "1.1"
 typetag = "0.1"
+ordered-float = {version = "1.0.2", features = ["serde"]}
 
 # FlatBuffers dependency enabled by the `flatbuf` feature.
 # flatbuffers crate version must be in sync with the flatc compiler and Java

--- a/rust/template/value/lib.rs
+++ b/rust/template/value/lib.rs
@@ -36,6 +36,7 @@ use differential_datalog::uint::*;
 
 use fnv::FnvHashMap;
 use lazy_static::lazy_static;
+use ordered_float::OrderedFloat;
 
 use types::*;
 

--- a/src/Language/DifferentialDatalog/FlatBuffer.hs
+++ b/src/Language/DifferentialDatalog/FlatBuffer.hs
@@ -790,6 +790,8 @@ jConvObjType in_array_context rw x =
                             -> "Integer"
          TSigned{..} | typeWidth <= 64
                             -> "Long"
+         TFloat{}           -> "Float"
+         TDouble{}          -> "Double"
          _                  -> jConvType rw x
 
 

--- a/test/datalog_tests/simple2.dat
+++ b/test/datalog_tests/simple2.dat
@@ -11,3 +11,9 @@ insert TArrng2[(TArrng2{true, TArrng1{true, 5}}, 1000)],
 commit dump_changes;
 
 dump FuncTest;
+
+start;
+
+insert Doubles([1.0, 2.0, 3.5]),
+
+commit dump_changes;

--- a/test/datalog_tests/simple2.dl
+++ b/test/datalog_tests/simple2.dl
@@ -85,3 +85,13 @@ function agg_avg_double_N(aggregate: Option<(double, double)>, item: Option<doub
 output relation &FuncTest(x: string)
 function myfunc(x: string): string { x }
 &FuncTest("foo").
+
+output relation SumsOfDoubles(x: double, y: double, sum: double)
+input relation Doubles(xs: Vec<double>)
+
+SumsOfDoubles(x, y, z) :-
+    Doubles(xs),
+    var x = FlatMap(xs),
+    Doubles(ys),
+    var y = FlatMap(ys),
+    var z = x + y.

--- a/test/datalog_tests/simple2.dump.expected
+++ b/test/datalog_tests/simple2.dump.expected
@@ -6,3 +6,13 @@ Arrng1Arrng2_2{.x = 5}: +1
 TArrng1Arrng2:
 TArrng1Arrng2{.x = 5}: +1
 FuncTest{.x = "foo"}
+SumsOfDoubles:
+SumsOfDoubles{.x = 1, .y = 1, .sum = 2}: +1
+SumsOfDoubles{.x = 1, .y = 2, .sum = 3}: +1
+SumsOfDoubles{.x = 1, .y = 3.5, .sum = 4.5}: +1
+SumsOfDoubles{.x = 2, .y = 1, .sum = 3}: +1
+SumsOfDoubles{.x = 2, .y = 2, .sum = 4}: +1
+SumsOfDoubles{.x = 2, .y = 3.5, .sum = 5.5}: +1
+SumsOfDoubles{.x = 3.5, .y = 1, .sum = 4.5}: +1
+SumsOfDoubles{.x = 3.5, .y = 2, .sum = 5.5}: +1
+SumsOfDoubles{.x = 3.5, .y = 3.5, .sum = 7}: +1


### PR DESCRIPTION
The `value` crate can contain references to `OrderedFloat`, but it did
not import it.  This did not come up in testing.

In addition, FlatBuffer.hs generated incorrect signature for containers
of floats.