### PR TITLE
Internment library.

### DIFF
--- a/lib/internment.dl
+++ b/lib/internment.dl
@@ -1,0 +1,39 @@
+/* Object interning library based on the `internment` crate.
+ */
+
+/* Interned object of type `'A`.
+ * While this type is defined for any `'A`, interning is only supported for strings.
+ * There is simply no way to obtain an interned object of a different type.
+ */
+#[size=8]
+extern type Intern<'A>
+
+/* Interned string
+ */
+typedef IString = Intern<string>
+
+/* Intern a value.
+ */
+extern function intern(s: 'A): Intern<'A>
+
+/* Extract an interned value.
+ */
+extern function ival(s: Intern<'A>): 'A
+
+/* Returns unique integer identifier of an interned object.
+ */
+//extern function iord(s: Intern<'A>): u64
+
+extern function istring_contains(s1: IString, s2: string): bool
+extern function istring_join(strings: Vec<IString>, sep: string): string
+extern function istring_len(s: IString): usize
+extern function istring_replace(s: IString, from: string, to: string): string
+extern function istring_split(s: IString, sep: string): Vec<string>
+extern function istring_starts_with(s: IString, prefix: string): bool
+extern function istring_ends_with(s: IString, suffix: string): bool
+extern function istring_substr(s: IString, start: usize, end: usize): string
+extern function istring_to_bytes(s: IString): Vec<u8>
+extern function istring_trim(s: IString): string
+extern function istring_to_lowercase(s: IString): string
+extern function istring_to_uppercase(s: IString): string
+extern function istring_reverse(s: IString): string

--- a/lib/internment.rs
+++ b/lib/internment.rs
@@ -1,0 +1,233 @@
+use differential_datalog::record;
+use differential_datalog::record::*;
+use internment::ArcIntern;
+use serde;
+use std::cmp;
+use std::fmt;
+
+#[cfg(feature = "flatbuf")]
+use flatbuf::{FromFlatBuffer, ToFlatBuffer, ToFlatBufferTable, ToFlatBufferVectorElement};
+
+/* `flatc`-generated declarations re-exported by `flatbuf.rs` */
+#[cfg(feature = "flatbuf")]
+use flatbuf::fb;
+
+/* FlatBuffers runtime */
+#[cfg(feature = "flatbuf")]
+use flatbuffers as fbrt;
+
+#[derive(Default, Eq, PartialOrd, PartialEq, Ord, Clone, Hash)]
+pub struct internment_Intern<A>
+where
+    A: Eq + Send + Hash + 'static,
+{
+    intern: ArcIntern<A>,
+}
+
+impl<A: Eq + Hash + Send + 'static> internment_Intern<A> {
+    pub fn new(x: A) -> internment_Intern<A> {
+        internment_Intern {
+            intern: ArcIntern::new(x),
+        }
+    }
+    pub fn as_ref(&self) -> &A {
+        self.intern.as_ref()
+    }
+}
+
+pub fn internment_intern<A: Eq + Hash + Send + Clone + 'static>(x: &A) -> internment_Intern<A> {
+    internment_Intern::new(x.clone())
+}
+
+pub fn internment_ival<A: Eq + Hash + Send + Clone>(x: &internment_Intern<A>) -> A {
+    x.intern.as_ref().clone()
+}
+
+/*pub fn intern_istring_ord(s: &intern_IString) -> u32 {
+    s.x
+}*/
+
+impl<A: fmt::Display + Eq + Hash + Send + Clone> fmt::Display for internment_Intern<A> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(self.as_ref(), f)
+        //record::format_ddlog_str(&intern_istring_str(self), f)
+    }
+}
+
+impl<A: fmt::Debug + Eq + Hash + Send + Clone> fmt::Debug for internment_Intern<A> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(self.as_ref(), f)
+        //record::format_ddlog_str(&intern_istring_str(self), f)
+    }
+}
+
+impl<A: Serialize + Eq + Hash + Send + Clone> serde::Serialize for internment_Intern<A> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.as_ref().serialize(serializer)
+    }
+}
+
+impl<'de, A: Deserialize<'de> + Eq + Hash + Send + 'static> serde::Deserialize<'de>
+    for internment_Intern<A>
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        A::deserialize(deserializer).map(|s| internment_Intern::new(s))
+    }
+}
+
+impl<A: FromRecord + Eq + Hash + Send + 'static> FromRecord for internment_Intern<A> {
+    fn from_record(val: &Record) -> Result<Self, String> {
+        A::from_record(val).map(|x| internment_Intern::new(x))
+    }
+}
+
+impl<A: IntoRecord + Eq + Hash + Send + Clone> IntoRecord for internment_Intern<A> {
+    fn into_record(self) -> Record {
+        internment_ival(&self).into_record()
+    }
+}
+
+impl<A> Mutator<internment_Intern<A>> for Record
+where
+    A: Clone + Eq + Send + Hash,
+    Record: Mutator<A>,
+{
+    fn mutate(&self, x: &mut internment_Intern<A>) -> Result<(), String> {
+        let mut v = internment_ival(x);
+        self.mutate(&mut v)?;
+        *x = internment_intern(&v);
+        Ok(())
+    }
+}
+
+#[cfg(feature = "flatbuf")]
+impl<A, FB> FromFlatBuffer<FB> for internment_Intern<A>
+where
+    A: Eq + Hash + Send + 'static,
+    A: FromFlatBuffer<FB>,
+{
+    fn from_flatbuf(fb: FB) -> Response<Self> {
+        Ok(internment_Intern::new(A::from_flatbuf(fb)?))
+    }
+}
+
+#[cfg(feature = "flatbuf")]
+impl<'b, A, T> ToFlatBuffer<'b> for internment_Intern<A>
+where
+    T: 'b,
+    A: Eq + Send + Hash + ToFlatBuffer<'b, Target = T>,
+{
+    type Target = T;
+
+    fn to_flatbuf(&self, fbb: &mut fbrt::FlatBufferBuilder<'b>) -> Self::Target {
+        self.as_ref().to_flatbuf(fbb)
+    }
+}
+
+/*#[cfg(feature = "flatbuf")]
+impl<'a> FromFlatBuffer<fb::__String<'a>> for intern_IString {
+    fn from_flatbuf(v: fb::__String<'a>) -> Response<Self> {
+        Ok(intern_string_intern(&String::from_flatbuf(v)?))
+    }
+}*/
+
+#[cfg(feature = "flatbuf")]
+impl<'b, A, T> ToFlatBufferTable<'b> for internment_Intern<A>
+where
+    T: 'b,
+    A: Eq + Send + Hash + ToFlatBufferTable<'b, Target = T>,
+{
+    type Target = T;
+    fn to_flatbuf_table(
+        &self,
+        fbb: &mut fbrt::FlatBufferBuilder<'b>,
+    ) -> fbrt::WIPOffset<Self::Target> {
+        self.as_ref().to_flatbuf_table(fbb)
+    }
+}
+
+#[cfg(feature = "flatbuf")]
+impl<'b, A, T> ToFlatBufferVectorElement<'b> for internment_Intern<A>
+where
+    T: 'b + fbrt::Push + Copy,
+    A: Eq + Send + Hash + ToFlatBufferVectorElement<'b, Target = T>,
+{
+    type Target = T;
+
+    fn to_flatbuf_vector_element(&self, fbb: &mut fbrt::FlatBufferBuilder<'b>) -> Self::Target {
+        self.as_ref().to_flatbuf_vector_element(fbb)
+    }
+}
+
+pub fn internment_istring_join(strings: &std_Vec<internment_IString>, sep: &String) -> String {
+    strings
+        .x
+        .iter()
+        .map(|s| s.as_ref())
+        .cloned()
+        .collect::<Vec<String>>()
+        .join(sep.as_str())
+}
+
+pub fn internment_istring_split(s: &internment_IString, sep: &String) -> std_Vec<String> {
+    std_Vec {
+        x: s.as_ref().split(sep).map(|x| x.to_owned()).collect(),
+    }
+}
+
+pub fn internment_istring_contains(s1: &internment_IString, s2: &String) -> bool {
+    s1.as_ref().contains(s2.as_str())
+}
+
+pub fn internment_istring_substr(
+    s: &internment_IString,
+    start: &std_usize,
+    end: &std_usize,
+) -> String {
+    let len = s.as_ref().len();
+    let from = cmp::min(*start as usize, len);
+    let to = cmp::max(from, cmp::min(*end as usize, len));
+    s.as_ref()[from..to].to_string()
+}
+
+pub fn internment_istring_replace(s: &internment_IString, from: &String, to: &String) -> String {
+    s.as_ref().replace(from, to)
+}
+
+pub fn internment_istring_starts_with(s: &internment_IString, prefix: &String) -> bool {
+    s.as_ref().starts_with(prefix)
+}
+
+pub fn internment_istring_ends_with(s: &internment_IString, suffix: &String) -> bool {
+    s.as_ref().ends_with(suffix)
+}
+
+pub fn internment_istring_trim(s: &internment_IString) -> String {
+    s.as_ref().trim().to_string()
+}
+
+pub fn internment_istring_len(s: &internment_IString) -> std_usize {
+    s.as_ref().len() as std_usize
+}
+
+pub fn internment_istring_to_bytes(s: &internment_IString) -> std_Vec<u8> {
+    std_Vec::from(s.as_ref().as_bytes())
+}
+
+pub fn internment_istring_to_lowercase(s: &internment_IString) -> String {
+    s.as_ref().to_lowercase()
+}
+
+pub fn internment_istring_to_uppercase(s: &internment_IString) -> String {
+    s.as_ref().to_uppercase()
+}
+
+pub fn internment_istring_reverse(s: &internment_IString) -> String {
+    s.as_ref().chars().rev().collect()
+}

--- a/lib/internment.toml
+++ b/lib/internment.toml
@@ -1,0 +1,2 @@
+[dependencies.internment]
+version = "0.3"

--- a/src/Language/DifferentialDatalog/FlatBuffer.hs
+++ b/src/Language/DifferentialDatalog/FlatBuffer.hs
@@ -141,7 +141,7 @@ flatBufferValidate d = do
     let ?d = d
     mapM_ (\case
             t@TOpaque{..} ->
-                check (elem typeName $ [rEF_TYPE, mAP_TYPE, iNTERNED_TYPE] ++ sET_TYPES) (pos t) $
+                check (elem typeName $ [rEF_TYPE, mAP_TYPE] ++ sET_TYPES ++ iNTERNED_TYPES) (pos t) $
                     "Cannot generate FlatBuffer schema for extern type " ++ show t
             _ -> return ())
           progTypesToSerialize
@@ -629,7 +629,7 @@ typeNormalizeForFlatBuf x = typeMap _typeNormalizeForFlatBuf $ typ x
 _typeNormalizeForFlatBuf :: (?d::DatalogProgram) => Type -> Type
 _typeNormalizeForFlatBuf t =
     case t' of
-         TOpaque{typeArgs = [innerType],..} | elem typeName [rEF_TYPE,  iNTERNED_TYPE]
+         TOpaque{typeArgs = [innerType],..} | elem typeName (rEF_TYPE : iNTERNED_TYPES)
                                             -> innerType
          _                  -> t'
     where t' = typ'' ?d t
@@ -1681,7 +1681,7 @@ rustTypeFromFlatbuf t@TTuple{..} =
 -- and 'ToFlatBuffer<>' for containers in their corresponding libraries.  Here we
 -- additionally generate 'FromFlatBuffer<fb::>' for wrapper tables,
 -- 'ToFlatBufferVectorElement<>', and 'ToFlatBufferTable<>'.
-rustTypeFromFlatbuf t@TOpaque{..} | elem typeName [rEF_TYPE, iNTERNED_TYPE] = empty
+rustTypeFromFlatbuf t@TOpaque{..} | elem typeName (rEF_TYPE : iNTERNED_TYPES) = empty
                                   | otherwise =
     "impl <'a> FromFlatBuffer<fb::" <> tname <> "<'a>> for" <+> rtype <+> "{"                               $$
     "    fn from_flatbuf(v: fb::" <> tname <> "<'a>) -> Response<Self> {"                                   $$

--- a/src/Language/DifferentialDatalog/Type.hs
+++ b/src/Language/DifferentialDatalog/Type.hs
@@ -53,7 +53,7 @@ module Language.DifferentialDatalog.Type(
     funcGroupArgTypes,
     sET_TYPES,
     mAP_TYPE,
-    iNTERNED_TYPE,
+    iNTERNED_TYPES,
     gROUP_TYPE,
     rEF_TYPE,
     checkIterable,
@@ -93,8 +93,8 @@ rEF_TYPE = "std.Ref"
 mAP_TYPE :: String
 mAP_TYPE = "std.Map"
 
-iNTERNED_TYPE :: String
-iNTERNED_TYPE = "intern.IObj"
+iNTERNED_TYPES :: [String]
+iNTERNED_TYPES = ["intern.IObj", "internment.Intern"]
 
 -- | An object with type
 class WithType a where

--- a/test/datalog_tests/internment_test.dat
+++ b/test/datalog_tests/internment_test.dat
@@ -1,0 +1,6 @@
+start;
+
+insert internment_test.IInternedString("foo"),
+insert internment_test.IInternedString("bar"),
+
+commit dump_changes;

--- a/test/datalog_tests/internment_test.dl
+++ b/test/datalog_tests/internment_test.dl
@@ -1,0 +1,12 @@
+import internment
+
+input relation IInternedString(ix: IString)
+
+output relation OInternedString(x: string, ix: IString)
+
+OInternedString(ival(s), s) :-
+    IInternedString(s).
+
+OInternedString(ival(s1) ++ " " ++ ival(s2), intern(ival(s1) ++ " " ++ ival(s2))) :-
+    IInternedString(s1), 
+    IInternedString(s2).

--- a/test/datalog_tests/internment_test.dump.expected
+++ b/test/datalog_tests/internment_test.dump.expected
@@ -1,0 +1,7 @@
+internment_test.OInternedString:
+internment_test.OInternedString{.x = "bar", .ix = "bar"}: +1
+internment_test.OInternedString{.x = "bar bar", .ix = "bar bar"}: +1
+internment_test.OInternedString{.x = "bar foo", .ix = "bar foo"}: +1
+internment_test.OInternedString{.x = "foo", .ix = "foo"}: +1
+internment_test.OInternedString{.x = "foo bar", .ix = "foo bar"}: +1
+internment_test.OInternedString{.x = "foo foo", .ix = "foo foo"}: +1

--- a/test/datalog_tests/lib_test.dl
+++ b/test/datalog_tests/lib_test.dl
@@ -4,3 +4,4 @@ import net_test
 import json_test
 import fp_test
 import regex_test
+import internment_test

--- a/test/datalog_tests/test-libs.sh
+++ b/test/datalog_tests/test-libs.sh
@@ -19,6 +19,7 @@ test_lib net_test
 test_lib json_test
 test_lib fp_test
 test_lib regex_test
+test_lib internment_test
 
 # No flatbuf support for Time, Date, etc yet
 FLATBUF=0 ./run-test.sh time_test.dl release


### PR DESCRIPTION
This commit adds bindings for the Rust `internment` crate, which
implements reference-counted interned objects of arbitrary types.
Unlike the `intern.dl` library, `internment` garbage collects unused
objects.

We also add versions of standard string functions that accept interned
strings.

This is still work in progress.  In particular, some amount of language
support is needed to make interned strings (and other objects)
near-transparent, as well as to efficiently handle static strings.