### PR TITLE
Static evaluation of constant expressions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ but somewhat limits the flexibility, as changes to the relational schema or rule
 
 ### Installing DDlog from a binary release
 
-To install a precompiled version of DDlog, download the [latest binary release](https://github.com/vmware/differential-datalog/releases), extract it from archive and add `ddlog/bin` to your `$PATH`. You will also need to install the Rust toolchain (see instructions below).
+To install a precompiled version of DDlog, download the [latest binary release](https://github.com/vmware/differential-datalog/releases), extract it from archive, add `ddlog/bin` to your `$PATH`, and set `$DDLOG_HOME` to point to the `ddlog` directory. You will also need to install the Rust toolchain (see instructions below).
 
 You are now ready to [start coding in DDlog](doc/tutorial/tutorial.md).
 
@@ -139,13 +139,15 @@ Linux and MacOS.
 
 #### Building
 
-To rebuild the software once you've installed the dependencies using one of the
-above methods:
+To build the software once you've installed the dependencies using one of the
+above methods, clone this repository and set `$DDLOG_HOME` variable to point
+to the root of the repository.  Run
 
 ```
 stack build
 ```
 
+anywhere inside the repository to build the DDlog compiler.
 To install DDlog binaries in Haskell stack's default binary directory:
 
 ```
@@ -158,7 +160,7 @@ To install to a different location:
 stack install --local-bin-path <custom_path>
 ```
 
-To test basic DDlog functionality (complete test suite takes a long time):
+To test basic DDlog functionality:
 
 ```
 stack test --ta '-p path'

--- a/doc/tutorial/tutorial.md
+++ b/doc/tutorial/tutorial.md
@@ -1706,6 +1706,33 @@ to optimize data structures layout:
 extern type IObj<'A>
 ```
 
+### `#[has_side_effects]`
+
+Labels functions that have side effects, e.g., perform I/O.  The compiler will
+not perform certain optimizations such as static evaluation for such functions.
+This annotation is only required for extern functions with side effects. The
+compiler automatically derives this annotation for functions that invoke
+functions labeled with `#[has_side_effects]`.
+
+```
+#[has_side_effects]
+extern function log(module: module_t, level: log_level_t, msg: string): bool
+```
+
+### `#[return_by_ref]`
+
+Labels functions that return values by reference.  DDlog functions are compiled
+into Rust functions that take arguments by reference and return results by value.
+DDlog assumes the same calling convention for extern functions.  However it
+also supports extern functions that return references, which is often more efficient.
+The `#[return_by_ref]` annotation tells the compiler that the annotated extern
+function returns a reference in Rust:
+
+```
+#[return_by_ref]
+extern function deref(x: Ref<'A>): 'A
+```
+
 ### `#[deserialize_from_array=func()]`
 
 This attribute is used in conjunction with `json.dl` library (and potentially

--- a/lib/intern.dl
+++ b/lib/intern.dl
@@ -1,5 +1,12 @@
 /* Object interning library.
  * Generates a unique ID for an object, which can be converted back to the original value.
+ *
+ * This library is more lightweight than the standard `internment.dl` library in
+ * that interned object handles are only 32-bit wide (vs 64 bit with
+ * `internment.dl`).  In addition, this library does not implement reference
+ * counting, so interned object manipulation is more efficient.  On the flip side,
+ * it never deallocates interned objects, so unless you expect the set of
+ * interned objects to remain constant, you should use `internment.dl` instead.
  */
 
 /* Interned object of type `'A`.
@@ -24,4 +31,4 @@ extern function istring_str(s: IString): string
 /* Returns unique integer identifier of an interned string.
  * Identifiers are assigned in the order strings are fed to the interner.
  */
-extern function istring_ord(s: IString): bit<32>
+extern function istring_ord(s: IString): u32

--- a/lib/internment.dl
+++ b/lib/internment.dl
@@ -1,4 +1,6 @@
 /* Object interning library based on the `internment` crate.
+ *
+ * This library is automatically imported by all DDlog programs.
  */
 
 /* Interned object of type `'A`.

--- a/lib/internment.dl
+++ b/lib/internment.dl
@@ -10,7 +10,7 @@ extern type Intern<'A>
 
 /* Interned string
  */
-typedef IString = Intern<string>
+typedef istring = Intern<string>
 
 /* Intern a value.
  */
@@ -18,22 +18,23 @@ extern function intern(s: 'A): Intern<'A>
 
 /* Extract an interned value.
  */
+#[return_by_ref]
 extern function ival(s: Intern<'A>): 'A
 
 /* Returns unique integer identifier of an interned object.
  */
 //extern function iord(s: Intern<'A>): u64
 
-extern function istring_contains(s1: IString, s2: string): bool
-extern function istring_join(strings: Vec<IString>, sep: string): string
-extern function istring_len(s: IString): usize
-extern function istring_replace(s: IString, from: string, to: string): string
-extern function istring_split(s: IString, sep: string): Vec<string>
-extern function istring_starts_with(s: IString, prefix: string): bool
-extern function istring_ends_with(s: IString, suffix: string): bool
-extern function istring_substr(s: IString, start: usize, end: usize): string
-extern function istring_to_bytes(s: IString): Vec<u8>
-extern function istring_trim(s: IString): string
-extern function istring_to_lowercase(s: IString): string
-extern function istring_to_uppercase(s: IString): string
-extern function istring_reverse(s: IString): string
+extern function istring_contains(s1: istring, s2: string): bool
+extern function istring_join(strings: Vec<istring>, sep: string): string
+extern function istring_len(s: istring): usize
+extern function istring_replace(s: istring, from: string, to: string): string
+extern function istring_split(s: istring, sep: string): Vec<string>
+extern function istring_starts_with(s: istring, prefix: string): bool
+extern function istring_ends_with(s: istring, suffix: string): bool
+extern function istring_substr(s: istring, start: usize, end: usize): string
+extern function istring_to_bytes(s: istring): Vec<u8>
+extern function istring_trim(s: istring): string
+extern function istring_to_lowercase(s: istring): string
+extern function istring_to_uppercase(s: istring): string
+extern function istring_reverse(s: istring): string

--- a/lib/internment.rs
+++ b/lib/internment.rs
@@ -39,11 +39,11 @@ pub fn internment_intern<A: Eq + Hash + Send + Clone + 'static>(x: &A) -> intern
     internment_Intern::new(x.clone())
 }
 
-pub fn internment_ival<A: Eq + Hash + Send + Clone>(x: &internment_Intern<A>) -> A {
-    x.intern.as_ref().clone()
+pub fn internment_ival<A: Eq + Hash + Send + Clone>(x: &internment_Intern<A>) -> &A {
+    x.intern.as_ref()
 }
 
-/*pub fn intern_istring_ord(s: &intern_IString) -> u32 {
+/*pub fn intern_istring_ord(s: &intern_istring) -> u32 {
     s.x
 }*/
 
@@ -89,7 +89,7 @@ impl<A: FromRecord + Eq + Hash + Send + 'static> FromRecord for internment_Inter
 
 impl<A: IntoRecord + Eq + Hash + Send + Clone> IntoRecord for internment_Intern<A> {
     fn into_record(self) -> Record {
-        internment_ival(&self).into_record()
+        internment_ival(&self).clone().into_record()
     }
 }
 
@@ -99,7 +99,7 @@ where
     Record: Mutator<A>,
 {
     fn mutate(&self, x: &mut internment_Intern<A>) -> Result<(), String> {
-        let mut v = internment_ival(x);
+        let mut v = internment_ival(x).clone();
         self.mutate(&mut v)?;
         *x = internment_intern(&v);
         Ok(())
@@ -131,7 +131,7 @@ where
 }
 
 /*#[cfg(feature = "flatbuf")]
-impl<'a> FromFlatBuffer<fb::__String<'a>> for intern_IString {
+impl<'a> FromFlatBuffer<fb::__String<'a>> for intern_istring {
     fn from_flatbuf(v: fb::__String<'a>) -> Response<Self> {
         Ok(intern_string_intern(&String::from_flatbuf(v)?))
     }
@@ -165,7 +165,7 @@ where
     }
 }
 
-pub fn internment_istring_join(strings: &std_Vec<internment_IString>, sep: &String) -> String {
+pub fn internment_istring_join(strings: &std_Vec<internment_istring>, sep: &String) -> String {
     strings
         .x
         .iter()
@@ -175,18 +175,18 @@ pub fn internment_istring_join(strings: &std_Vec<internment_IString>, sep: &Stri
         .join(sep.as_str())
 }
 
-pub fn internment_istring_split(s: &internment_IString, sep: &String) -> std_Vec<String> {
+pub fn internment_istring_split(s: &internment_istring, sep: &String) -> std_Vec<String> {
     std_Vec {
         x: s.as_ref().split(sep).map(|x| x.to_owned()).collect(),
     }
 }
 
-pub fn internment_istring_contains(s1: &internment_IString, s2: &String) -> bool {
+pub fn internment_istring_contains(s1: &internment_istring, s2: &String) -> bool {
     s1.as_ref().contains(s2.as_str())
 }
 
 pub fn internment_istring_substr(
-    s: &internment_IString,
+    s: &internment_istring,
     start: &std_usize,
     end: &std_usize,
 ) -> String {
@@ -196,38 +196,38 @@ pub fn internment_istring_substr(
     s.as_ref()[from..to].to_string()
 }
 
-pub fn internment_istring_replace(s: &internment_IString, from: &String, to: &String) -> String {
+pub fn internment_istring_replace(s: &internment_istring, from: &String, to: &String) -> String {
     s.as_ref().replace(from, to)
 }
 
-pub fn internment_istring_starts_with(s: &internment_IString, prefix: &String) -> bool {
+pub fn internment_istring_starts_with(s: &internment_istring, prefix: &String) -> bool {
     s.as_ref().starts_with(prefix)
 }
 
-pub fn internment_istring_ends_with(s: &internment_IString, suffix: &String) -> bool {
+pub fn internment_istring_ends_with(s: &internment_istring, suffix: &String) -> bool {
     s.as_ref().ends_with(suffix)
 }
 
-pub fn internment_istring_trim(s: &internment_IString) -> String {
+pub fn internment_istring_trim(s: &internment_istring) -> String {
     s.as_ref().trim().to_string()
 }
 
-pub fn internment_istring_len(s: &internment_IString) -> std_usize {
+pub fn internment_istring_len(s: &internment_istring) -> std_usize {
     s.as_ref().len() as std_usize
 }
 
-pub fn internment_istring_to_bytes(s: &internment_IString) -> std_Vec<u8> {
+pub fn internment_istring_to_bytes(s: &internment_istring) -> std_Vec<u8> {
     std_Vec::from(s.as_ref().as_bytes())
 }
 
-pub fn internment_istring_to_lowercase(s: &internment_IString) -> String {
+pub fn internment_istring_to_lowercase(s: &internment_istring) -> String {
     s.as_ref().to_lowercase()
 }
 
-pub fn internment_istring_to_uppercase(s: &internment_IString) -> String {
+pub fn internment_istring_to_uppercase(s: &internment_istring) -> String {
     s.as_ref().to_uppercase()
 }
 
-pub fn internment_istring_reverse(s: &internment_IString) -> String {
+pub fn internment_istring_reverse(s: &internment_istring) -> String {
     s.as_ref().chars().rev().collect()
 }

--- a/lib/json.dl
+++ b/lib/json.dl
@@ -28,11 +28,11 @@ typedef JsonValue = // Represents a JSON null value.
                   | // Represents a JSON number, whether integer or floating point.
                     JsonNumber{n: JsonNum}
                   | // Represents a JSON string.
-                    JsonString{s: string}
+                    JsonString{s: istring}
                   | // Represents a JSON array.
                     JsonArray{a: Vec<JsonValue>}
                   | // Represents a JSON object.
-                    JsonObject{o: Map<string, JsonValue>}
+                    JsonObject{o: Map<istring, JsonValue>}
 
 /* Get JsonValue value as `bool`.  Returns `None` if value is not `JsonBool`.
  */
@@ -76,7 +76,7 @@ function jval_as_number_or(v: JsonValue, def: JsonNum): JsonNum =
 
 /* Get JsonValue value as string.  Returns `None` if value is not `JsonString`.
  */
-function jval_as_string(v: JsonValue): Option<string> =
+function jval_as_string(v: JsonValue): Option<istring> =
 {
     match (v) {
         JsonString{s} -> Some{s},
@@ -86,7 +86,7 @@ function jval_as_string(v: JsonValue): Option<string> =
 
 /* Get JsonValue value as string.  Returns `def` if value is not `JsonString`.
  */
-function jval_as_string_or(v: JsonValue, def: string): string =
+function jval_as_string_or(v: JsonValue, def: istring): istring =
 {
     match (v) {
         JsonString{s} -> s,
@@ -116,7 +116,7 @@ function jval_as_array_or(v: JsonValue, def: Vec<JsonValue>): Vec<JsonValue> =
 
 /* Get JsonValue value as object.  Returns `None` if value is not `JsonObject`.
  */
-function jval_as_object(v: JsonValue): Option<Map<string, JsonValue>> =
+function jval_as_object(v: JsonValue): Option<Map<istring, JsonValue>> =
 {
     match (v) {
         JsonObject{o} -> Some{o},
@@ -126,7 +126,7 @@ function jval_as_object(v: JsonValue): Option<Map<string, JsonValue>> =
 
 /* Get JsonValue value as object.  Returns `def` if value is not `JsonObject`.
  */
-function jval_as_object_or(v: JsonValue, def: Map<string, JsonValue>): Map<string, JsonValue> =
+function jval_as_object_or(v: JsonValue, def: Map<istring, JsonValue>): Map<istring, JsonValue> =
 {
     match (v) {
         JsonObject{o} -> o,
@@ -137,7 +137,7 @@ function jval_as_object_or(v: JsonValue, def: Map<string, JsonValue>): Map<strin
 /* Get attribute by name.  Returns `None` if value is not `JsonObject` or
  * does not have the specified attribute.
  */
-function jval_get(v: JsonValue, attr: string): Option<JsonValue> =
+function jval_get(v: JsonValue, attr: istring): Option<JsonValue> =
 {
     match (v) {
         JsonObject{o} -> map_get(o, attr),
@@ -148,7 +148,7 @@ function jval_get(v: JsonValue, attr: string): Option<JsonValue> =
 /* Get attribute by name.  Returns `def` if value is not `JsonObject` or
  * does not have the specified attribute.
  */
-function jval_get_or(v: JsonValue, attr: string, def: JsonValue): JsonValue =
+function jval_get_or(v: JsonValue, attr: istring, def: JsonValue): JsonValue =
 {
     match (v) {
         JsonObject{o} -> option_unwrap_or(map_get(o, attr), def),

--- a/lib/json.rs
+++ b/lib/json.rs
@@ -16,7 +16,9 @@ impl From<serde_json::value::Value> for json_JsonValue {
             serde_json::value::Value::Number(n) => json_JsonValue::json_JsonNumber {
                 n: json_JsonNum::from(n),
             },
-            serde_json::value::Value::String(s) => json_JsonValue::json_JsonString { s },
+            serde_json::value::Value::String(s) => json_JsonValue::json_JsonString {
+                s: internment_intern(&s),
+            },
             serde_json::value::Value::Array(a) => {
                 let v: Vec<json_JsonValue> =
                     a.into_iter().map(|v| json_JsonValue::from(v)).collect();
@@ -26,7 +28,7 @@ impl From<serde_json::value::Value> for json_JsonValue {
             }
             serde_json::value::Value::Object(o) => json_JsonValue::json_JsonObject {
                 o: o.into_iter()
-                    .map(|(k, v)| (k, json_JsonValue::from(v)))
+                    .map(|(k, v)| (internment_intern(&k), json_JsonValue::from(v)))
                     .collect(),
             },
         }
@@ -39,7 +41,9 @@ impl From<json_JsonValue> for serde_json::value::Value {
             json_JsonValue::json_JsonNull => serde_json::value::Value::Null,
             json_JsonValue::json_JsonBool { b } => serde_json::value::Value::Bool(b),
             json_JsonValue::json_JsonNumber { n } => json_val_from_num(n),
-            json_JsonValue::json_JsonString { s } => serde_json::value::Value::String(s),
+            json_JsonValue::json_JsonString { s } => {
+                serde_json::value::Value::String(internment_ival(&s).clone())
+            }
             json_JsonValue::json_JsonArray { a } => serde_json::value::Value::Array(
                 a.into_iter()
                     .map(|v| serde_json::value::Value::from(v))
@@ -47,7 +51,12 @@ impl From<json_JsonValue> for serde_json::value::Value {
             ),
             json_JsonValue::json_JsonObject { o } => serde_json::value::Value::Object(
                 o.into_iter()
-                    .map(|(k, v)| (k, serde_json::value::Value::from(v)))
+                    .map(|(k, v)| {
+                        (
+                            internment_ival(&k).clone(),
+                            serde_json::value::Value::from(v),
+                        )
+                    })
                     .collect(),
             ),
         }

--- a/lib/log.dl
+++ b/lib/log.dl
@@ -87,4 +87,5 @@ typedef log_level_t = signed<32>
  * This function returns a `bool` so that it can be used as a filter inside
  * DDlog rules.  It always returns `true`.
  */
+#[has_side_effects]
 extern function log(module: module_t, level: log_level_t, msg: string): bool

--- a/lib/std.dl
+++ b/lib/std.dl
@@ -26,6 +26,8 @@ typedef usize = u64
 extern type Ref<'A>
 
 extern function ref_new(x: 'A): Ref<'A>
+
+#[return_by_ref]
 extern function deref(x: Ref<'A>): 'A
 
 /*

--- a/rust/template/types/lib.rs
+++ b/rust/template/types/lib.rs
@@ -29,6 +29,8 @@ use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde::Serialize;
 
+use lazy_static::lazy_static;
+
 use differential_datalog::ddval::*;
 use differential_datalog::decl_enum_into_record;
 use differential_datalog::decl_record_mutator_enum;

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -99,12 +99,6 @@ vALUE_VAR2 = "__v2"
 gROUP_VAR :: Doc
 gROUP_VAR = "__group__"
 
--- Functions that return a Rust reference rather than a value.
--- FIXME: there should be a way to annotate function definitions
--- with this, but for now we only have one such function.
-fUNCS_RETURN_REF :: [String]
-fUNCS_RETURN_REF = ["std.deref"]
-
 -- Extract static template header before the "/*- !!!!!!!!!!!!!!!!!!!! -*/"
 -- separator from file; substitute "datalog_example" with 'specname' in
 -- the header.
@@ -2284,7 +2278,7 @@ mkExpr' d _ EApply{..}  =
                         $ zip exprArgs (map argMut $ funcArgs f)), kind)
     where
     f = getFunc d exprFunc
-    kind = if elem exprFunc fUNCS_RETURN_REF then EReference else EVal
+    kind = if funcGetReturnByRefAttr f then EReference else EVal
 
 -- Field access automatically dereferences subexpression
 mkExpr' _ _ EField{..} = (sel1 exprStruct <> "." <> pp exprField, ELVal)

--- a/src/Language/DifferentialDatalog/Expr.hs-boot
+++ b/src/Language/DifferentialDatalog/Expr.hs-boot
@@ -25,3 +25,4 @@ exprIsPattern :: Expr -> Bool
 exprIsDeconstruct :: DatalogProgram -> Expr -> Bool
 exprIsVarOrFieldLVal :: DatalogProgram -> ECtx -> Expr -> Bool
 exprTypeMapM :: (Monad m) => (Type -> m Type) -> Expr -> m Expr
+exprIsPure :: DatalogProgram -> Expr -> Bool

--- a/src/Language/DifferentialDatalog/Function.hs
+++ b/src/Language/DifferentialDatalog/Function.hs
@@ -1,0 +1,56 @@
+{-
+Copyright (c) 2020 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-}
+
+{-# LANGUAGE RecordWildCards, FlexibleContexts #-}
+
+module Language.DifferentialDatalog.Function(
+    funcTypeArgSubsts,
+    funcGroupArgTypes,
+    funcIsPure
+) where
+
+import Control.Monad.Except
+import Data.List
+import qualified Data.Map as M
+
+import Language.DifferentialDatalog.Pos
+import Language.DifferentialDatalog.Syntax
+import Language.DifferentialDatalog.Attribute
+import {-# SOURCE #-} Language.DifferentialDatalog.Expr
+import {-# SOURCE #-} Language.DifferentialDatalog.Type
+
+funcTypeArgSubsts :: (MonadError String me) => DatalogProgram -> Pos -> Function -> [Type] -> me (M.Map String Type)
+funcTypeArgSubsts d p f@Function{..} argtypes =
+    unifyTypes d p ("in call to " ++ funcShowProto f) (zip (map typ funcArgs ++ [funcType]) argtypes)
+
+-- | Functions that take an argument of type `Group<>` are treated in a special
+-- way in Compile.hs. This function returns the list of `Group` types passed as
+-- arguments to the function.
+funcGroupArgTypes :: DatalogProgram -> Function -> [Type]
+funcGroupArgTypes d Function{..} =
+    nub $ filter (isGroup d) $ map typ funcArgs
+
+funcIsPure :: DatalogProgram -> Function -> Bool
+funcIsPure d f =
+    (funcGetSideEffectAttr f == False) &&
+    (maybe True (exprIsPure d) $ funcDef f)

--- a/src/Language/DifferentialDatalog/Function.hs-boot
+++ b/src/Language/DifferentialDatalog/Function.hs-boot
@@ -1,0 +1,12 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+module Language.DifferentialDatalog.Function where
+
+import qualified Data.Map as M
+import Control.Monad.Except
+import Language.DifferentialDatalog.Pos
+import Language.DifferentialDatalog.Syntax
+
+funcTypeArgSubsts :: (MonadError String me) => DatalogProgram -> Pos -> Function -> [Type] -> me (M.Map String Type)
+funcGroupArgTypes :: DatalogProgram -> Function -> [Type]
+funcIsPure :: DatalogProgram -> Function -> Bool

--- a/src/Language/DifferentialDatalog/Parse.hs
+++ b/src/Language/DifferentialDatalog/Parse.hs
@@ -484,6 +484,7 @@ term' = withPos $
      <|> enumber
      <|> ebool
      <|> estring
+     <|> einterned_string
      <|> evar
      <|> ematch
      <|> eite
@@ -548,6 +549,10 @@ enumber  = lexeme enumber'
 estring =   equoted_string
         <|> eraw_string
         <|> einterpolated_raw_string
+
+einterned_string = do
+    e <- try $ string "i" *> estring
+    return $ E $ EApply (pos e) "intern" [e]
 
 eraw_string = eString <$> ((try $ string "[|") *> manyTill anyChar (try $ string "|]" *> whiteSpace))
 

--- a/src/Language/DifferentialDatalog/Type.hs
+++ b/src/Language/DifferentialDatalog/Type.hs
@@ -74,6 +74,7 @@ import Language.DifferentialDatalog.Syntax
 import Language.DifferentialDatalog.NS
 import Language.DifferentialDatalog.Pos
 import Language.DifferentialDatalog.Name
+import Language.DifferentialDatalog.Function
 import Language.DifferentialDatalog.ECtx
 --import {-# SOURCE #-} Relation
 
@@ -131,7 +132,6 @@ typeIsPolymorphic TTuple{..}  = any typeIsPolymorphic typeTupArgs
 typeIsPolymorphic TUser{..}   = any typeIsPolymorphic typeArgs
 typeIsPolymorphic TVar{}      = True
 typeIsPolymorphic TOpaque{..} = any typeIsPolymorphic typeArgs
-
 
 -- | Matches function parameter types against concrete argument types, e.g.,
 -- given
@@ -215,17 +215,6 @@ relKeyType d rel =
 -- is a conflict.
 exprNodeType :: (MonadError String me) => DatalogProgram -> ECtx -> ExprNode Type -> me Type
 exprNodeType d ctx e = fmap ((flip atPos) (pos e)) $ exprNodeType' d ctx (exprMap Just e)
-
-funcTypeArgSubsts :: (MonadError String me) => DatalogProgram -> Pos -> Function -> [Type] -> me (M.Map String Type)
-funcTypeArgSubsts d p f@Function{..} argtypes =
-    unifyTypes d p ("in call to " ++ funcShowProto f) (zip (map typ funcArgs ++ [funcType]) argtypes)
-
--- | Functions that take an argument of type `Group<>` are treated in a special
--- way in Compile.hs. This function returns the list of `Group` types passed as
--- arguments to the function.
-funcGroupArgTypes :: DatalogProgram -> Function -> [Type]
-funcGroupArgTypes d Function{..} =
-    nub $ filter (isGroup d) $ map typ funcArgs
 
 structTypeArgs :: (MonadError String me) => DatalogProgram -> Pos -> ECtx -> String -> [(String, Type)] -> me [Type]
 structTypeArgs d p ctx cname argtypes = do

--- a/src/Language/DifferentialDatalog/Type.hs-boot
+++ b/src/Language/DifferentialDatalog/Type.hs-boot
@@ -5,6 +5,7 @@ module Language.DifferentialDatalog.Type where
 import Control.Monad.Except
 import Language.DifferentialDatalog.Syntax
 import Language.DifferentialDatalog.Pos
+import qualified Data.Map as M
 
 class WithType a where
     typ  :: a -> Type
@@ -12,6 +13,7 @@ class WithType a where
 
 instance WithType Type where
 instance WithType Field where
+instance WithType FuncArg where
 
 ctxExpectType :: DatalogProgram -> ECtx -> Maybe Type
 exprType :: DatalogProgram -> ECtx -> Expr -> Type
@@ -21,3 +23,7 @@ gROUP_TYPE :: String
 checkIterable :: (MonadError String me, WithType a) => String -> Pos -> DatalogProgram -> a -> me ()
 typeIterType :: DatalogProgram -> Type -> Maybe Type
 exprTypeMaybe :: DatalogProgram -> ECtx -> Expr -> Maybe Type
+unifyTypes :: (MonadError String me) => DatalogProgram -> Pos -> String -> [(Type, Type)] -> me (M.Map String Type)
+isMap :: (WithType a) => DatalogProgram -> a -> Bool
+isGroup :: (WithType a) => DatalogProgram -> a -> Bool
+typ' :: (WithType a) => DatalogProgram -> a -> Type

--- a/src/Language/DifferentialDatalog/Validate.hs
+++ b/src/Language/DifferentialDatalog/Validate.hs
@@ -224,6 +224,7 @@ funcValidateProto d f@Function{..} = do
     let tvars = funcTypeVars f
     mapM_ (typeValidate d tvars . argType) funcArgs
     typeValidate d tvars funcType
+    
 
 funcValidateDefinition :: (MonadError String me) => DatalogProgram -> Function -> me ()
 funcValidateDefinition d f@Function{..} = do
@@ -428,7 +429,7 @@ applyValidate d a@Apply{..} = do
 hotypeValidate :: (MonadError String me) => DatalogProgram -> HOType -> me ()
 hotypeValidate d HOTypeFunction{..} = do
     -- FIXME: hacky way to validate function type by converting it into a function.
-    let f = Function hotPos "" hotArgs hotType Nothing
+    let f = Function hotPos [] "" hotArgs hotType Nothing
     funcValidateProto d f
 
 hotypeValidate d HOTypeRelation{..} = typeValidate d (typeTypeVars hotType) hotType

--- a/test/datalog_tests/internment_test.dl
+++ b/test/datalog_tests/internment_test.dl
@@ -1,5 +1,3 @@
-import internment
-
 input relation IInternedString(ix: IString)
 
 output relation OInternedString(x: string, ix: IString)

--- a/test/datalog_tests/internment_test.dl
+++ b/test/datalog_tests/internment_test.dl
@@ -2,7 +2,11 @@ input relation IInternedString(ix: istring)
 relation StaticInternedString(ix: istring)
 
 StaticInternedString(intern("static foo")).
-StaticInternedString(intern("static bar")).
+StaticInternedString(i"ifoo").
+StaticInternedString(i[|ibar|]).
+StaticInternedString(i"ifoo${25}").
+StaticInternedString(i"ifoo${25}" "!").
+StaticInternedString(i$[|ibar${2+2}|]).
 
 relation AllInternedString(ix: istring)
 AllInternedString(ix) :- IInternedString(ix).

--- a/test/datalog_tests/internment_test.dl
+++ b/test/datalog_tests/internment_test.dl
@@ -1,10 +1,18 @@
-input relation IInternedString(ix: IString)
+input relation IInternedString(ix: istring)
+relation StaticInternedString(ix: istring)
 
-output relation OInternedString(x: string, ix: IString)
+StaticInternedString(intern("static foo")).
+StaticInternedString(intern("static bar")).
+
+relation AllInternedString(ix: istring)
+AllInternedString(ix) :- IInternedString(ix).
+AllInternedString(ix) :- StaticInternedString(ix).
+
+output relation OInternedString(x: string, ix: istring)
 
 OInternedString(ival(s), s) :-
-    IInternedString(s).
+    AllInternedString(s).
 
 OInternedString(ival(s1) ++ " " ++ ival(s2), intern(ival(s1) ++ " " ++ ival(s2))) :-
-    IInternedString(s1), 
-    IInternedString(s2).
+    AllInternedString(s1),
+    AllInternedString(s2).

--- a/test/datalog_tests/internment_test.dump.expected
+++ b/test/datalog_tests/internment_test.dump.expected
@@ -2,6 +2,14 @@ internment_test.OInternedString:
 internment_test.OInternedString{.x = "bar", .ix = "bar"}: +1
 internment_test.OInternedString{.x = "bar bar", .ix = "bar bar"}: +1
 internment_test.OInternedString{.x = "bar foo", .ix = "bar foo"}: +1
+internment_test.OInternedString{.x = "bar static bar", .ix = "bar static bar"}: +1
+internment_test.OInternedString{.x = "bar static foo", .ix = "bar static foo"}: +1
 internment_test.OInternedString{.x = "foo", .ix = "foo"}: +1
 internment_test.OInternedString{.x = "foo bar", .ix = "foo bar"}: +1
 internment_test.OInternedString{.x = "foo foo", .ix = "foo foo"}: +1
+internment_test.OInternedString{.x = "foo static bar", .ix = "foo static bar"}: +1
+internment_test.OInternedString{.x = "foo static foo", .ix = "foo static foo"}: +1
+internment_test.OInternedString{.x = "static bar bar", .ix = "static bar bar"}: +1
+internment_test.OInternedString{.x = "static bar foo", .ix = "static bar foo"}: +1
+internment_test.OInternedString{.x = "static foo bar", .ix = "static foo bar"}: +1
+internment_test.OInternedString{.x = "static foo foo", .ix = "static foo foo"}: +1

--- a/test/datalog_tests/internment_test.dump.expected
+++ b/test/datalog_tests/internment_test.dump.expected
@@ -2,14 +2,30 @@ internment_test.OInternedString:
 internment_test.OInternedString{.x = "bar", .ix = "bar"}: +1
 internment_test.OInternedString{.x = "bar bar", .ix = "bar bar"}: +1
 internment_test.OInternedString{.x = "bar foo", .ix = "bar foo"}: +1
-internment_test.OInternedString{.x = "bar static bar", .ix = "bar static bar"}: +1
+internment_test.OInternedString{.x = "bar ibar", .ix = "bar ibar"}: +1
+internment_test.OInternedString{.x = "bar ibar4", .ix = "bar ibar4"}: +1
+internment_test.OInternedString{.x = "bar ifoo", .ix = "bar ifoo"}: +1
+internment_test.OInternedString{.x = "bar ifoo25", .ix = "bar ifoo25"}: +1
+internment_test.OInternedString{.x = "bar ifoo25!", .ix = "bar ifoo25!"}: +1
 internment_test.OInternedString{.x = "bar static foo", .ix = "bar static foo"}: +1
 internment_test.OInternedString{.x = "foo", .ix = "foo"}: +1
 internment_test.OInternedString{.x = "foo bar", .ix = "foo bar"}: +1
 internment_test.OInternedString{.x = "foo foo", .ix = "foo foo"}: +1
-internment_test.OInternedString{.x = "foo static bar", .ix = "foo static bar"}: +1
+internment_test.OInternedString{.x = "foo ibar", .ix = "foo ibar"}: +1
+internment_test.OInternedString{.x = "foo ibar4", .ix = "foo ibar4"}: +1
+internment_test.OInternedString{.x = "foo ifoo", .ix = "foo ifoo"}: +1
+internment_test.OInternedString{.x = "foo ifoo25", .ix = "foo ifoo25"}: +1
+internment_test.OInternedString{.x = "foo ifoo25!", .ix = "foo ifoo25!"}: +1
 internment_test.OInternedString{.x = "foo static foo", .ix = "foo static foo"}: +1
-internment_test.OInternedString{.x = "static bar bar", .ix = "static bar bar"}: +1
-internment_test.OInternedString{.x = "static bar foo", .ix = "static bar foo"}: +1
+internment_test.OInternedString{.x = "ibar bar", .ix = "ibar bar"}: +1
+internment_test.OInternedString{.x = "ibar foo", .ix = "ibar foo"}: +1
+internment_test.OInternedString{.x = "ibar4 bar", .ix = "ibar4 bar"}: +1
+internment_test.OInternedString{.x = "ibar4 foo", .ix = "ibar4 foo"}: +1
+internment_test.OInternedString{.x = "ifoo bar", .ix = "ifoo bar"}: +1
+internment_test.OInternedString{.x = "ifoo foo", .ix = "ifoo foo"}: +1
+internment_test.OInternedString{.x = "ifoo25 bar", .ix = "ifoo25 bar"}: +1
+internment_test.OInternedString{.x = "ifoo25 foo", .ix = "ifoo25 foo"}: +1
+internment_test.OInternedString{.x = "ifoo25! bar", .ix = "ifoo25! bar"}: +1
+internment_test.OInternedString{.x = "ifoo25! foo", .ix = "ifoo25! foo"}: +1
 internment_test.OInternedString{.x = "static foo bar", .ix = "static foo bar"}: +1
 internment_test.OInternedString{.x = "static foo foo", .ix = "static foo foo"}: +1

--- a/test/datalog_tests/simple2.dl
+++ b/test/datalog_tests/simple2.dl
@@ -95,3 +95,14 @@ SumsOfDoubles(x, y, z) :-
     Doubles(ys),
     var y = FlatMap(ys),
     var z = x + y.
+
+/* Attempt to confuse statics */
+
+function weird_zero(x: 'A): usize {
+    var empty_vec: Vec<'A> = vec_empty();
+    vec_len(empty_vec)
+}
+
+function zero_test(): usize {
+    weird_zero(32'd0)
+}

--- a/test/datalog_tests/tutorial.dat
+++ b/test/datalog_tests/tutorial.dat
@@ -45,6 +45,26 @@ dump TopScore;
 
 start;
 
+insert OnlineOrder(1, "milk"),
+insert OnlineOrder(1, "eggs"),
+insert OnlineOrder(1, "jackfruit"),
+
+insert OnlineOrder(2, "sursild"),
+insert OnlineOrder(2, "milk"),
+insert OnlineOrder(2, "eggs"),
+
+commit dump_changes;
+
+start;
+
+insert StoreInventory(StoreItem{"milk", "Just your regular cow milk"}),
+insert StoreInventory(StoreItem{"kumis", "Horse milk"}),
+insert StoreInventory(StoreItem{"goat milk", "Another milk variety"}),
+
+commit dump_changes;
+
+start;
+
 insert Logical_Switch(0),
 insert Logical_Switch(1),
 insert Load_Balancer(0, 0, "10.10.10.101", std.Some{"TCP"}, "lb1"),

--- a/test/datalog_tests/tutorial.dl
+++ b/test/datalog_tests/tutorial.dl
@@ -491,6 +491,41 @@ TopScore(school, top_score) :-
     var top_score = Aggregate((school), group_max(student.sat_score)).
 
 /*
+ * Example: interned values
+ */
+
+input relation OnlineOrder(order_id: u64, item: istring)
+output relation ItemInOrders(item: istring, orders: Vec<u64>)
+
+ItemInOrders(item, orders) :-
+    OnlineOrder(order, item),
+    var orders = Aggregate((item), group2vec(order)).
+
+output relation OrderFormatted(order: istring)
+
+OrderFormatted(formatted) :-
+    OnlineOrder(order, item),
+    var formatted: istring = intern("order: ${order}, item: ${ival(item)}").
+
+output relation MilkOrders(order: u64)
+MilkOrders(order) :- OnlineOrder(order, i"milk").
+
+typedef StoreItem = StoreItem {
+    name: string,
+    description: istring
+}
+
+typedef IStoreItem = Intern<StoreItem>
+
+input relation StoreInventory(item: IStoreItem)
+
+output relation InventoryItemName(name: istring)
+
+InventoryItemName(name) :-
+    StoreInventory(item),
+    var name = intern(ival(item).name).
+
+/*
  * Example: Advanced features
  */
 

--- a/test/datalog_tests/tutorial.dump.expected
+++ b/test/datalog_tests/tutorial.dump.expected
@@ -16,6 +16,25 @@ HostInSubnet{.host = 2, .subnet = 1}
 TopScore
 TopScore{.school = "school1", .top_score = 1400}
 TopScore{.school = "school2", .top_score = 1600}
+ItemInOrders:
+ItemInOrders{.item = "eggs", .orders = [1, 2]}: +1
+ItemInOrders{.item = "jackfruit", .orders = [1]}: +1
+ItemInOrders{.item = "milk", .orders = [1, 2]}: +1
+ItemInOrders{.item = "sursild", .orders = [2]}: +1
+MilkOrders:
+MilkOrders{.order = 1}: +1
+MilkOrders{.order = 2}: +1
+OrderFormatted:
+OrderFormatted{.order = "order: 1, item: eggs"}: +1
+OrderFormatted{.order = "order: 1, item: jackfruit"}: +1
+OrderFormatted{.order = "order: 1, item: milk"}: +1
+OrderFormatted{.order = "order: 2, item: eggs"}: +1
+OrderFormatted{.order = "order: 2, item: milk"}: +1
+OrderFormatted{.order = "order: 2, item: sursild"}: +1
+InventoryItemName:
+InventoryItemName{.name = "goat milk"}: +1
+InventoryItemName{.name = "kumis"}: +1
+InventoryItemName{.name = "milk"}: +1
 Flows:
 Flow{.lr = 0, .stage = LS_IN_PRE_LB{}, .prio = 100, .matchStr = "ip4.dst == 10.10.10.101", .actionStr = "{ reg0[0] = 1; next; }"}
 Flow{.lr = 0, .stage = LS_OUT_PRE_LB{}, .prio = 100, .matchStr = "ip4", .actionStr = "{ reg0[0] = 1; next; }"}

--- a/tools/vim/syntax/dl.vim
+++ b/tools/vim/syntax/dl.vim
@@ -42,7 +42,7 @@ syn keyword dlConstant         true false
 syn keyword dlOperator	        default
 
 "Keywords for ADTs
-syn keyword dlType	        bool string bigint bit signed type typedef
+syn keyword dlType	        bool istring string bigint bit signed type typedef
 
 syn sync lines=250
 


### PR DESCRIPTION
Implements RFC #633

This feature was proposed by @mbudiu-vmw

Rationale
--------

We would like to evaluate constant expressions, including complex ones
containing function calls, once, either at the start of the program or
even during compilation.  This commit addresses the former.  We may add
compile-time evaluation as a further optimization later, but it will be
applicable in restricted contexts, as, e.g., calls to extern functions
are difficult to evaluate in the compiler.

This feature is a prerequisite for several other useful features,
including efficient interning of string literals and support for
constants.

Design
---------

- The first question is: what expressions should be evaluated
  statically? For instance, given an expression `f1(C1) + f2(C2)`, the
  options are: 1. `f1(C1)` and `f2(C2)` are evaluated statically; the sum
  is evaluated dynamically 2. `f1(C1) + f2(C2)` is evaluated statically 3.
  `f1(C1)`, `f2(C2)`, `f1(C1)+f2(C2)` are all evaluated statically, with
  the sum expression being built out of statically computed results for
  `f1` and `f2`.

  Given that accessing a static expression is not free (see below), we
  go with option 1, i.e., statically pre-evaluate function
  calls on constant arguments.

  How about `f1(f2(C))`?  In this example, `f2(C)` and `f1(f2(C))` are both
  statics, with the latter referencing the former. There is a potential caveat:
  rust's lazy static evaluation can deadlock when evaluating mutually dependent
  statics, but as far as I can tell this can only occur in situations that would
  cause infinite recursion otherwise.

- Detecting constant sub-expressions is relatively straightforward.  The only
  caveat is that some extern functions, most notably logging functions, can have
  side effects and should not be evaluated statically. We handle this by introducing
  a new annotation: `#[has_side_effects]`.  Functions with this annotation as well
  as any functions that call them are not evaluated statically.

- Constant subexpressions are compiled to Rust lazy statics, which is the only Rust
  construct (a library, actually) that allows statically evaluating complex expressions
  with function calls. This introduces a bit of overhead on each access (checking an
  atomic variable).