### PR TITLE
internment.rs: Use `arc-interner` crate.

### DIFF
--- a/lib/internment.toml
+++ b/lib/internment.toml
@@ -1,2 +1,2 @@
-[dependencies.internment]
-version = "0.3"
+[dependencies.arc-interner]
+version="0.1"


### PR DESCRIPTION
The `internment` crate that the internment library was originally based
on appears to contain at least one race condition.  While this can be
easily fixes, I am worried about unsafe code in that crate that hinges
on subtle reasoning about memory ordering.  I therefore implemented
a version of `internment::ArcIntern` that relies on `std::sync::Arc`
and `std::sync::Mutex` and does not contain any unsafe code, and
published it as a separate crate:

https://crates.io/crates/arc-interner