### PR TITLE
Partial Windows support.

### DIFF
--- a/rust/template/Cargo.toml
+++ b/rust/template/Cargo.toml
@@ -15,7 +15,7 @@ members = [
   "value"
 ]
 
-[build-dependencies]
+[target.'cfg(not(windows))'.build-dependencies]
 libtool = "0.1"
 
 [dependencies.differential_datalog]

--- a/rust/template/cmd_parser/lib.rs
+++ b/rust/template/cmd_parser/lib.rs
@@ -27,7 +27,9 @@ where
 {
     let mut buf: Vec<u8> = Vec::new();
 
-    let istty = unsafe { libc::isatty(libc::STDIN_FILENO as i32) } != 0;
+    let istty = unsafe {
+        libc::isatty(/*libc::STDIN_FILENO*/ 0 as i32)
+    } != 0;
     let mut input = if istty {
         let mut rl = Editor::<()>::new();
         let _ = rl.load_history(HISTORY_FILE);

--- a/rust/template/src/build.rs
+++ b/rust/template/src/build.rs
@@ -1,8 +1,14 @@
-use std::env;
-use std::fs;
-use std::path::{Path, PathBuf};
-
 fn main() {
+    #[cfg(not(windows))]
+    libtool();
+}
+
+#[cfg(not(windows))]
+fn libtool() {
+    use std::env;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+
     let topdir = env::var("CARGO_MANIFEST_DIR").unwrap();
     let fbufpath = format!("{}/src/flatbuf.rs", topdir);
 

--- a/rust/template/src/lib.rs
+++ b/rust/template/src/lib.rs
@@ -16,7 +16,6 @@
 use num::bigint::BigInt;
 use std::convert::TryFrom;
 use std::ops::Deref;
-use std::os::unix::io::IntoRawFd;
 use std::ptr;
 use std::result;
 use std::sync;


### PR DESCRIPTION
Addresses #640.
@d4hines, would you be able to confirm that this works for you?

This patch enables compilation of DDlog-generated Rust code on Windows.
The generated code is mostly portable with a few exceptions:
- libtool support in `build.rs`.  We disable this on Windows.
- `api.rs`: two API calls work take raw file descriptors.  On Windows,
  these must be converted to file handles.
- `cmd_parser/lib.rs`: we used a constant declaed in `libc` for STDIN
  file descriptor.  We use liteal `0` instead.

There is more non-portable code in distributed-ddlog and ovsdb, but this
is not a problem for clients who don't use these features.