### PR TITLE
OVSDB: Skip DeltaMinus for non-root tables.

### DIFF
--- a/rust/template/ddlog.h
+++ b/rust/template/ddlog.h
@@ -351,7 +351,7 @@ extern int ddlog_apply_ovsdb_updates(ddlog_prog hprog, const char *prefix,
 /*
  * Dump Delta-Plus, Delta-Minus, and Delta-Update tables for OVSDB table
  * `table` declared in DDlog module `module`, as a sequence of OVSDB insert,
- * delete, and update commands in * JSON format.
+ * delete, and update commands in JSON format.
  *
  * `module` must be a fully qualified name of a module.
  *

--- a/rust/template/src/ovsdb.rs
+++ b/rust/template/src/ovsdb.rs
@@ -149,15 +149,17 @@ fn dump_delta(
 
     /* DeltaMinus */
     let minus_cmds: Result<Vec<String>, String> = {
-        let minus_table_id = Relations::try_from(minus_table_name.as_str())
-            .map_err(|()| format!("unknown table {}", minus_table_name))?;
-        db.get_rel(minus_table_id as RelId)
-            .iter()
-            .map(|(v, w)| {
-                assert!(*w == 1);
-                record_into_delete_str(v.clone().into_record(), table_str)
-            })
-            .collect()
+        match Relations::try_from(minus_table_name.as_str()) {
+            Ok(minus_table_id) => db
+                .get_rel(minus_table_id as RelId)
+                .iter()
+                .map(|(v, w)| {
+                    assert!(*w == 1);
+                    record_into_delete_str(v.clone().into_record(), table_str)
+                })
+                .collect(),
+            Err(()) => Ok(vec![]),
+        }
     };
     let mut minus_cmds = minus_cmds?;
 

--- a/src/Language/DifferentialDatalog/OVSDB/Compile.hs
+++ b/src/Language/DifferentialDatalog/OVSDB/Compile.hs
@@ -143,12 +143,11 @@ mkTable isinput t@Table{..} = do
                let delta_update_rules = mkDeltaUpdateRules      t
                return $ (empty,
                          output,
-                         delta_plus          $+$
-                         delta_plus_rules    $+$
-                         delta_minus         $+$
-                         delta_minus_rules   $+$
-                         delta_update        $+$
-                         delta_update_rules  $+$
+                         (delta_plus   $+$ delta_plus_rules)                                   $+$
+                         -- Values from non-root tables will be deleted automatically by OVSDB,
+                         -- so we don't have to pay the cost of computing delta-minus tables.
+                         (if tableIsRoot t then delta_minus $+$ delta_minus_rules else empty)  $+$
+                         delta_update  $+$ delta_update_rules                                  $+$
                          input)
 
 mkTable' :: (?schema::OVSDBSchema, ?outputs::[(String, [String])], MonadError String me) => TableKind -> Table -> me Doc
@@ -313,3 +312,9 @@ tableGetNonROCols t =
          Just ro -> filter (\col -> notElem (name col) ro) ovscols
     where
     ovscols = tableGetCols t
+
+tableIsRoot :: Table -> Bool
+tableIsRoot Table{..} =
+    any (\case
+          RootProperty True -> True
+          _                 -> False) tableProperties


### PR DESCRIPTION
Resolves #655.

OVSDB has a "garbage collection" mechanism: in tables that have
"isRoot": false, ovsdb-server automatically deletes rows that don't have
any references from other rows. Currently, the OVSDB bindings for DDlog
still send "delete" operations for these tables. These can be omitted,
as the whole DeltaMinus table.

In addition to reducing memory and time, doing this will increase
reliability because it eliminates the possibility of DDlog trying to
delete a row that still has references.