### PR TITLE
ovsdb2ddlog: --rw option.

### DIFF
--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -2094,10 +2094,10 @@ mkArrangement d rel ArrangementSet{..} = do
     -- the pattern expression does not contain placeholders).
     let distinct_by_construction = relIsDistinct d rel && (not $ exprContainsPHolders arngPattern)
     return $
-        "Arrangement::Set{"                                                                                                         $$
-        "    name: r###\"" <> pp arngPattern <> " /*" <> (if arngDistinct then "antijon" else "semijoin") <> "*/\"###.to_string()," $$
-        (nest' $ "fmfun: &{fn __f(" <> vALUE_VAR <> ": DDValue) -> Option<DDValue>" $$ fmfun $$ "__f},")                            $$
-        "    distinct:" <+> (if arngDistinct && not distinct_by_construction then "true" else "false")                              $$
+        "Arrangement::Set{"                                                                                                          $$
+        "    name: r###\"" <> pp arngPattern <> " /*" <> (if arngDistinct then "antijoin" else "semijoin") <> "*/\"###.to_string()," $$
+        (nest' $ "fmfun: &{fn __f(" <> vALUE_VAR <> ": DDValue) -> Option<DDValue>" $$ fmfun $$ "__f},")                             $$
+        "    distinct:" <+> (if arngDistinct && not distinct_by_construction then "true" else "false")                               $$
         "}"
 
 -- Generate part of the arrangement computation that filters inputs and computes the key part of the


### PR DESCRIPTION
Resolves #659.

ovsdb2ddlog has a --ro option for tables that are partially read-write.
OVN has a couple of tables that only have one or two writable columns,
so it'd be nice to just specify those, e.g. with --rw in place of --ro.
It leads to easier maintenance as columns are added.

This commit introduces --rw option, which is mutually exclusive with
--ro, i.e., at most one of them can be used for a particular table.

@blp 