### PR TITLE
regex.dl: More efficient API.

### DIFF
--- a/lib/regex.dl
+++ b/lib/regex.dl
@@ -5,23 +5,41 @@
  */
 
 /*
+ * Compiled regular expression.
+ */
+extern type Regex
+
+/*
+ * Compile pattern into a regex.  If the pattern is invalid, returns a regex
+ * that does not match any input strings.
+ */
+extern function regex(pattern: string): Regex
+
+/*
+ * Compile pattern into a regex.  Returns an error if the pattern is invalid.
+ */
+extern function regex_checked(pattern: string): Result<Regex, string>
+
+/*
  * Check if string matches regular expression.
  *
  * Returns true if the regex matches the string given.
  * Returns false if `regex` is not a valid regular expression or if no match was
  * found.
+ *
+ * Example: `regex_match(regex([|\d+|]), "a111b222c")` 
  */
-extern function regex_match(regex: string, text: string): bool
+extern function regex_match(regex: Regex, text: string): bool
 
 /*
  * Returns the leftmost-first match in `text`. If `regex` is not a valid regular
  * expression or no match exists, then `None` is returned.
  */
-extern function regex_first_match(regex: string, text: string): Option<string>
+extern function regex_first_match(regex: Regex, text: string): Option<string>
 
 /*
  * Returns all successive non-overlapping matches in `text`.
  * If `regex` is not a valid regular expression or no match exists,
  * an empty vector is returned.
  */
-extern function regex_all_matches(regex: string, text: string): Vec<string>
+extern function regex_all_matches(regex: Regex, text: string): Vec<string>

--- a/lib/regex.rs
+++ b/lib/regex.rs
@@ -1,28 +1,91 @@
 extern crate regex;
 
-pub fn regex_regex_match(regex: &String, s: &String) -> bool {
-    match regex::Regex::new(regex.as_str()) {
-        Result::Err(_) => false,
-        Result::Ok(re) => re.is_match(&s.as_str()),
+#[derive(Clone)]
+pub struct regex_Regex {
+    re: regex::Regex,
+}
+
+impl regex_Regex {
+    pub fn new(re: &str) -> Result<Self, regex::Error> {
+        Ok(regex_Regex {
+            re: regex::Regex::new(re)?,
+        })
     }
 }
 
-pub fn regex_regex_first_match(regex: &String, s: &String) -> std_Option<String> {
-    match regex::Regex::new(regex.as_str()) {
-        Result::Err(_) => std_Option::std_None,
-        Result::Ok(re) => std_Option::from(re.find(&s.as_str()).map(|m| m.as_str().to_string())),
+impl Deref for regex_Regex {
+    type Target = regex::Regex;
+
+    fn deref(&self) -> &regex::Regex {
+        &self.re
     }
 }
 
-pub fn regex_regex_all_matches(regex: &String, s: &String) -> std_Vec<String> {
-    match regex::Regex::new(regex.as_str()) {
-        Result::Err(_) => std_Vec::new(),
-        Result::Ok(re) => {
-            let v: Vec<_> = re
-                .find_iter(&s.as_str())
-                .map(|m| m.as_str().to_string())
-                .collect();
-            std_Vec::from(v)
-        }
+impl PartialOrd for regex_Regex {
+    fn partial_cmp(&self, other: &regex_Regex) -> Option<std::cmp::Ordering> {
+        self.as_str().partial_cmp(other.as_str())
     }
+}
+
+impl Ord for regex_Regex {
+    fn cmp(&self, other: &regex_Regex) -> std::cmp::Ordering {
+        self.as_str().cmp(other.as_str())
+    }
+}
+
+impl PartialEq for regex_Regex {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+impl Eq for regex_Regex {}
+
+impl Hash for regex_Regex {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.as_str().hash(state);
+    }
+}
+
+impl Serialize for regex_Regex {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.as_str().serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for regex_Regex {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let re = String::deserialize(deserializer)?;
+        regex_Regex::new(re.as_str()).map_err(|e| serde::de::Error::custom(e))
+    }
+}
+
+pub fn regex_regex(regex: &String) -> regex_Regex {
+    regex_Regex::new(regex.as_str()).unwrap_or_else(|_|/* Reject everything. */
+                        regex_Regex::new(r"a^").unwrap())
+}
+
+pub fn regex_regex_checked(regex: &String) -> std_Result<regex_Regex, String> {
+    res2std(regex_Regex::new(regex.as_str()))
+}
+
+pub fn regex_regex_match(regex: &regex_Regex, s: &String) -> bool {
+    regex.is_match(&s.as_str())
+}
+
+pub fn regex_regex_first_match(regex: &regex_Regex, s: &String) -> std_Option<String> {
+    std_Option::from(regex.find(&s.as_str()).map(|m| m.as_str().to_string()))
+}
+
+pub fn regex_regex_all_matches(regex: &regex_Regex, s: &String) -> std_Vec<String> {
+    let v: Vec<_> = regex
+        .find_iter(&s.as_str())
+        .map(|m| m.as_str().to_string())
+        .collect();
+    std_Vec::from(v)
 }

--- a/lib/souffle_lib.dl
+++ b/lib/souffle_lib.dl
@@ -29,7 +29,7 @@ function contains(s: IString, i: IString): bool {
 }
 // Souffle match must match the whole string
 function re_match(pattern: IString, s: IString): bool {
-    regex_match("^" ++ istring_str(pattern) ++ "$", istring_str(s))
+    regex_match(regex("^" ++ istring_str(pattern) ++ "$"), istring_str(s))
 }
 function to_number(s: IString): Tnumber {
     match (parse_dec_i64(istring_str(s))) {

--- a/test/datalog_tests/internment_test.dl
+++ b/test/datalog_tests/internment_test.dl
@@ -32,17 +32,17 @@ typedef IStruct = IStruct {
 
 input relation IStruct[Intern<IStruct>]
 
-output relation Projections(inp: Intern<IStruct>, p: string)
+output relation Projections(inp: IStruct, p: string)
 
 Projections(i, "x=${i.x}") :-
-    IStruct[i].
-Projections(i, "t.0=${i.t.0}") :-
+    IStruct[&i].
+Projections(ival(i), "t.0=${i.t.0}") :-
     i in &IStruct().
-Projections(i, "t.1=${i.t.1}") :-
+Projections(ival(i), "t.1=${i.t.1}") :-
     i in &IStruct(.t=&(_, d)).
-Projections(i, "f1=${f1}") :-
+Projections(ival(i), "f1=${f1}") :-
     i in &IStruct(.u=&Tag1{f1}).
-Projections(i, "f2=${f2}") :-
+Projections(ival(i), "f2=${f2}") :-
     i in &IStruct(.u=&t@Tag2{.f2=f2}).
-Projections(i, "f3=${f3}") :-
+Projections(ival(i), "f3=${f3}") :-
     i in &IStruct(.u=t@ &Tag2{.f3=f3}).

--- a/test/datalog_tests/internment_test.dump.expected
+++ b/test/datalog_tests/internment_test.dump.expected
@@ -30,12 +30,12 @@ internment_test.OInternedString{.x = "ifoo25! foo", .ix = "ifoo25! foo"}: +1
 internment_test.OInternedString{.x = "static foo bar", .ix = "static foo bar"}: +1
 internment_test.OInternedString{.x = "static foo foo", .ix = "static foo foo"}: +1
 internment_test.Projections:
-internment_test.Projections{.inp = internment_test.IStruct{.u = internment_test.Tag1{.f1 = true}, .t = (-5, 5.5), .x = 10000000000000000000000000}, .p = "f1=true"}: +1
-internment_test.Projections{.inp = internment_test.IStruct{.u = internment_test.Tag1{.f1 = true}, .t = (-5, 5.5), .x = 10000000000000000000000000}, .p = "t.0=-5"}: +1
-internment_test.Projections{.inp = internment_test.IStruct{.u = internment_test.Tag1{.f1 = true}, .t = (-5, 5.5), .x = 10000000000000000000000000}, .p = "t.1=5.5"}: +1
-internment_test.Projections{.inp = internment_test.IStruct{.u = internment_test.Tag1{.f1 = true}, .t = (-5, 5.5), .x = 10000000000000000000000000}, .p = "x=10000000000000000000000000"}: +1
 internment_test.Projections{.inp = internment_test.IStruct{.u = internment_test.Tag2{.f2 = 10, .f3 = "foo"}, .t = (5000, -1.2345), .x = -10000000000000000000000000}, .p = "f2=10"}: +1
 internment_test.Projections{.inp = internment_test.IStruct{.u = internment_test.Tag2{.f2 = 10, .f3 = "foo"}, .t = (5000, -1.2345), .x = -10000000000000000000000000}, .p = "f3=foo"}: +1
 internment_test.Projections{.inp = internment_test.IStruct{.u = internment_test.Tag2{.f2 = 10, .f3 = "foo"}, .t = (5000, -1.2345), .x = -10000000000000000000000000}, .p = "t.0=5000"}: +1
 internment_test.Projections{.inp = internment_test.IStruct{.u = internment_test.Tag2{.f2 = 10, .f3 = "foo"}, .t = (5000, -1.2345), .x = -10000000000000000000000000}, .p = "t.1=-1.2345"}: +1
 internment_test.Projections{.inp = internment_test.IStruct{.u = internment_test.Tag2{.f2 = 10, .f3 = "foo"}, .t = (5000, -1.2345), .x = -10000000000000000000000000}, .p = "x=-10000000000000000000000000"}: +1
+internment_test.Projections{.inp = internment_test.IStruct{.u = internment_test.Tag1{.f1 = true}, .t = (-5, 5.5), .x = 10000000000000000000000000}, .p = "f1=true"}: +1
+internment_test.Projections{.inp = internment_test.IStruct{.u = internment_test.Tag1{.f1 = true}, .t = (-5, 5.5), .x = 10000000000000000000000000}, .p = "t.0=-5"}: +1
+internment_test.Projections{.inp = internment_test.IStruct{.u = internment_test.Tag1{.f1 = true}, .t = (-5, 5.5), .x = 10000000000000000000000000}, .p = "t.1=5.5"}: +1
+internment_test.Projections{.inp = internment_test.IStruct{.u = internment_test.Tag1{.f1 = true}, .t = (-5, 5.5), .x = 10000000000000000000000000}, .p = "x=10000000000000000000000000"}: +1

--- a/test/datalog_tests/regex_test.dl
+++ b/test/datalog_tests/regex_test.dl
@@ -8,17 +8,20 @@ relation RegexTestInput(
 RegexTestInput([|\d+|], "a111b222c").
 RegexTestInput([|\b\w{13}\b|], "I categorically deny having triskaidekaphobia.").
 RegexTestInput([|'([^']+)'\s+\((\d{4})\)|], "Not my favorite movie: 'Citizen Kane' (1941).").
+RegexTestInput("[", "foo").
 
 output relation RegexTestOutput(
     regex: string,
     text: string,
     match_found: bool,
+    match_found_checked: bool,
     first_match: Option<string>,
     all_matches: Vec<string>)
 
 RegexTestOutput(regex,
                 text,
-                regex_match(regex, text),
-                regex_first_match(regex, text),
-                regex_all_matches(regex, text)) :-
+                regex_match(regex(regex), text),
+                regex_match(result_unwrap_or(regex_checked(regex), regex("")), text),
+                regex_first_match(regex(regex), text),
+                regex_all_matches(regex(regex), text)) :-
     RegexTestInput(regex, text).

--- a/test/datalog_tests/regex_test.dump.expected
+++ b/test/datalog_tests/regex_test.dump.expected
@@ -1,3 +1,4 @@
-regex_test.RegexTestOutput{.regex = "'([^']+)'\\s+\\((\\d{4})\\)", .text = "Not my favorite movie: 'Citizen Kane' (1941).", .match_found = true, .first_match = std.Some{.x = "'Citizen Kane' (1941)"}, .all_matches = ["'Citizen Kane' (1941)"]}
-regex_test.RegexTestOutput{.regex = "\\b\\w{13}\\b", .text = "I categorically deny having triskaidekaphobia.", .match_found = true, .first_match = std.Some{.x = "categorically"}, .all_matches = ["categorically"]}
-regex_test.RegexTestOutput{.regex = "\\d+", .text = "a111b222c", .match_found = true, .first_match = std.Some{.x = "111"}, .all_matches = ["111", "222"]}
+regex_test.RegexTestOutput{.regex = "'([^']+)'\\s+\\((\\d{4})\\)", .text = "Not my favorite movie: 'Citizen Kane' (1941).", .match_found = true, .match_found_checked = true, .first_match = std.Some{.x = "'Citizen Kane' (1941)"}, .all_matches = ["'Citizen Kane' (1941)"]}
+regex_test.RegexTestOutput{.regex = "[", .text = "foo", .match_found = false, .match_found_checked = true, .first_match = std.None{}, .all_matches = []}
+regex_test.RegexTestOutput{.regex = "\\b\\w{13}\\b", .text = "I categorically deny having triskaidekaphobia.", .match_found = true, .match_found_checked = true, .first_match = std.Some{.x = "categorically"}, .all_matches = ["categorically"]}
+regex_test.RegexTestOutput{.regex = "\\d+", .text = "a111b222c", .match_found = true, .match_found_checked = true, .first_match = std.Some{.x = "111"}, .all_matches = ["111", "222"]}

--- a/test/datalog_tests/simple.dl
+++ b/test/datalog_tests/simple.dl
@@ -953,12 +953,12 @@ output relation Power3(y: bigint)
 Power3(pow32(x, 3)) :- Numbers(x).
 
 /* Regular expressions */
-import regex
+import regex as re
 
 input relation Regex(regex: string, text: string)
 output relation RegexMatch(regex: string, text: string, m: bool)
 
-RegexMatch(regex, text, regex_match(regex, text)) :- Regex(regex, text).
+RegexMatch(regex, text, re.regex_match(re.regex(regex), text)) :- Regex(regex, text).
 
 output relation Arithm(n:bit<32>)
 Arithm(0).


### PR DESCRIPTION
The regex library used to compile regular expression on every
invocation, which is really inefficient and can significantly slow down
tests that are heavy on regex matching.

The new API separates the two steps.  It introduces `Regex` type that
represents a compiled regular expression.  There are two ways to create
a `Regex`:

```
/* Compile pattern into a regex.  If the pattern is invalid, returns a regex
 * that does not match any input strings. */
extern function regex(pattern: string): Regex

/* Compile pattern into a regex.  Returns an error if the pattern is invalid. */
extern function regex_checked(pattern: string): Result<Regex, string>
```

Conveniently, when using a static pattern, static evaluation ensures
that the pattern is compiled exactly once even when using a one-liner
like this:

```
regex_match(regex([|\d+|]), text)
```