### PR TITLE
ovsdb2ddlog: Encode optional columns as Option<>.

### DIFF
--- a/lib/std.dl
+++ b/lib/std.dl
@@ -19,7 +19,7 @@ typedef s128 = signed<128>
 
 typedef usize = u64
 
-/* 
+/*
  * Weight of a record in a DDlog collection.  This type is internal to the 
  * DDlog engine and is only visible to the programmer inside the `Inspect`
  * operator.  Positive weight indicates that the record is being added
@@ -80,6 +80,8 @@ extern function pow32(base:'A, exp: bit<32>): 'A
  */
 
 #[rust="serde(from=\"Option<A>\", into=\"Option<A>\", bound(serialize=\"A: Clone+Serialize\"))"]
+// This type has a custrom FromRecord implementation in std.rs.
+#[custom_from_record]
 typedef Option<'A> = None
                    | Some{x: 'A}
 

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -623,7 +623,7 @@ mkTypedef d tdef@TypeDef{..} =
                              (nest' $ vcat $ punctuate comma fields)                                   $$
                              "}"                                                                       $$
                              impl_abomonate                                                            $$
-                             mkFromRecord tdef                                                         $$
+                             mkFromRecord d tdef                                                       $$
                              mkStructIntoRecord tdef                                                   $$
                              mkStructMutator tdef                                                      $$
                              display                                                                   $$
@@ -635,7 +635,7 @@ mkTypedef d tdef@TypeDef{..} =
                              (nest' $ vcat $ punctuate comma constructors)                             $$
                              "}"                                                                       $$
                              impl_abomonate                                                            $$
-                             mkFromRecord tdef                                                         $$
+                             mkFromRecord d tdef                                                       $$
                              mkEnumIntoRecord tdef                                                     $$
                              mkEnumMutator tdef                                                        $$
                              display                                                                   $$
@@ -765,8 +765,9 @@ impl <T: FromRecord> FromRecord for DummyEnum<T> {
     }
 }
 -}
-mkFromRecord :: TypeDef -> Doc
-mkFromRecord t@TypeDef{..} =
+mkFromRecord :: DatalogProgram -> TypeDef -> Doc
+mkFromRecord d t@TypeDef{..} | tdefGetCustomFromRecord d t = empty
+                             | otherwise =
     "impl" <+> targs_bounds <+> "record::FromRecord for" <+> rname (name t) <> targs <+> "{"                                    $$
     "    fn from_record(val: &record::Record) -> result::Result<Self, String> {"                                                $$
     "        match val {"                                                                                                       $$

--- a/src/Language/DifferentialDatalog/OVSDB/Compile.hs
+++ b/src/Language/DifferentialDatalog/OVSDB/Compile.hs
@@ -320,7 +320,7 @@ mkComplexType tkind t@ComplexType{..} = do
     key <- mkBaseType tkind keyComplexType
     case (min_bound, max_bound) of
          (1,1) -> return key
-         --(0,1) -> return $ "option_t<" <> key <> ">"
+         (0,1) -> return $ "Option<" <> key <> ">"
          _     -> do
              case valueComplexType of
                   Nothing -> return $ "Set<" <> key <> ">"

--- a/test/test-ovn.sh
+++ b/test/test-ovn.sh
@@ -18,7 +18,7 @@ set -e
  git checkout ddlog_ci3 &&
  ./boot.sh &&
  ./configure --with-ddlog=../../lib --with-ovs-source=../ovs --enable-shared &&
- (make northd/ddlog.stamp && make check -j1 NORTHD_CLI=1 TESTSUITEFLAGS="31 33 35 37 39 41 43 45 47 49 51 53 55 57 59 61 63 65 67 69 71 73 75 77 79 81 83 85 87 89 91 93 95 97 99 101 103 105 107 109 111 113 115 117 119 121 123 125 127 129 131 133 135 137 139 141 143 145 147 149 151 153 155 157 159 161 163 165 167 169 171 175 177 179 183 185 187 189 191 193 195 197 199 205 207 209 211 213 215 217 219 221 223 225 227 231 232 234 236 238 240 242 244 246 248 250 252 254 256 258 260 262 264 266 268 270" ||
+ (make northd/ddlog.stamp && make check -j1 NORTHD_CLI=1 ||
  (find tests/testsuite.dir/ \( -name testsuite.log -o -name ovn-northd.log \) -exec echo '{}' \; -exec cat '{}' \; && false))
 )
 

--- a/test/test-ovn.sh
+++ b/test/test-ovn.sh
@@ -15,7 +15,7 @@ set -e
 # TODO: use -j6 once build script is fixed
 # TODO: use primary OVN repo
 (cd ovn &&
- git checkout ddlog_ci3 &&
+ git checkout ddlog_ci4 &&
  ./boot.sh &&
  ./configure --with-ddlog=../../lib --with-ovs-source=../ovs --enable-shared &&
  (make northd/ddlog.stamp && make check -j1 NORTHD_CLI=1 ||


### PR DESCRIPTION
OVSDB columns representing sets are normally encoded as a DDlog sets.
However in the special case where column's multiplicity bounds are min: 0 an
max: 1, `Option<>` is a more natural representation.  This commit
implements this optimization.

But now we have to deal with the complication that the Rust code that
converts OVSDB JSON to DDlog records must correctly deserialize
arrays into `Option<>`.  This code is agnostic of the OVSDB schema and
cannot easily tell what the target type is.  We therefore change the
`FromRecord` implementation for `Option<>` to handle this case.  This in
turn required adding a new attributes `#[custom_from_record]` to
override the autogenerated implementation of `FromRecord` created by
DDlog.