### PR TITLE
Handle nulls in casts in SQL translator

### DIFF
--- a/sql/lib/sql.dl
+++ b/sql/lib/sql.dl
@@ -315,3 +315,14 @@ function avg_float_R(sum_count: (float, float)): float {
 function avg_double_R(sum_count: (double, double)): double {
     if (sum_count.1 == 64'f0.0) 64'f0.0 else (sum_count.0 / sum_count.1)
 }
+function concat(s0: string, s1: string): string {
+     s0 ++ s1
+}
+function concat_N(s0: Option<string>, s1: Option<string>): Option<string> {
+    match ((s0,s1)) {
+        (None, None)       -> None,
+        (None, Some{x})    -> None,
+        (Some{x}, None)    -> None,
+        (Some{x}, Some{y}) -> Some{x ++ y}
+    }
+}

--- a/sql/src/main/java/com/vmware/ddlog/ir/DDlogEMatch.java
+++ b/sql/src/main/java/com/vmware/ddlog/ir/DDlogEMatch.java
@@ -19,7 +19,7 @@ import java.util.List;
 
 public class DDlogEMatch extends DDlogExpression {
     public DDlogEMatch(@Nullable Node node, DDlogExpression matchExpr, List<Case> cases) {
-        super(node, DDlogType.reduceType(Linq.map(cases, c -> c.second.getType())));
+        super(node, DDlogType.sameType(Linq.map(cases, c -> c.second.getType())));
         this.matchExpr = matchExpr;
         this.cases = cases;
     }

--- a/sql/src/main/java/com/vmware/ddlog/ir/DDlogType.java
+++ b/sql/src/main/java/com/vmware/ddlog/ir/DDlogType.java
@@ -12,6 +12,7 @@
 package com.vmware.ddlog.ir;
 
 import com.facebook.presto.sql.tree.Node;
+import com.vmware.ddlog.translator.TranslationException;
 import com.vmware.ddlog.util.Linq;
 
 import javax.annotation.Nullable;
@@ -74,6 +75,22 @@ public abstract class DDlogType extends DDlogNode {
         return result;
     }
 
+    /**
+     * Given a set of types check that they are all the same.
+     * Return one of them.
+     */
+    public static DDlogType sameType(List<DDlogType> types) {
+        if (types.isEmpty())
+            throw new RuntimeException("Empty set of types");
+        DDlogType result = types.get(0);
+        for (int i = 1; i < types.size(); i++) {
+            DDlogType ti = types.get(i);
+            if (!result.same(ti))
+                throw new TranslationException("Incompatible types: " + result + " and " + ti, result.getNode());
+        }
+        return result;
+    }
+
     public static DDlogType reduceType(DDlogType... types) {
         return reduceType(Linq.list(types));
     }
@@ -110,7 +127,7 @@ public abstract class DDlogType extends DDlogNode {
     /**
      * Get the None{} value of the option type corresponding to this type.
      */
-    public DDlogExpression getNone(Node node) {
+    public DDlogExpression getNone(@Nullable Node node) {
         return new DDlogENull(node, this.setMayBeNull(true));
     }
 

--- a/sql/src/main/java/com/vmware/ddlog/translator/ExpressionTranslationVisitor.java
+++ b/sql/src/main/java/com/vmware/ddlog/translator/ExpressionTranslationVisitor.java
@@ -192,7 +192,7 @@ public class ExpressionTranslationVisitor extends AstVisitor<DDlogExpression, Tr
                     ex = new DDlogEString(node, "${" + e.toString() + "}");
                     exType = ex.getType();
                 }
-                if (eType.is(DDlogTString.class)) {
+                if (exType.is(DDlogTString.class)) {
                     String parseFunc;
                     switch (tu.getName()) {
                         case "Date":

--- a/sql/src/main/java/com/vmware/ddlog/translator/TranslationVisitor.java
+++ b/sql/src/main/java/com/vmware/ddlog/translator/TranslationVisitor.java
@@ -1065,6 +1065,7 @@ class TranslationVisitor extends AstVisitor<DDlogIRNode, TranslationContext> {
 
         Set<String> joinColumns = new HashSet<String>();
         switch (join.getType()) {
+            /*
             case FULL:
                 leftJoin = true;
                 // fall through
@@ -1073,6 +1074,7 @@ class TranslationVisitor extends AstVisitor<DDlogIRNode, TranslationContext> {
                 // fall through
             case LEFT:
                 // fall through
+              */
             case INNER:
                 if (join.getType() == LEFT)
                     leftJoin = true;

--- a/sql/src/test/java/ddlog/CastTest.java
+++ b/sql/src/test/java/ddlog/CastTest.java
@@ -145,4 +145,167 @@ public class CastTest extends BaseQueriesTest {
         String program = "";
         this.testTranslation(query, program);
     }
+    
+    @Test
+    public void testCastIntToFloatWithNull() {
+        String query = "create view v0 as SELECT DISTINCT CAST(t1.column1 AS FLOAT) AS f FROM t1";
+        String program = this.header(true) +
+                "typedef TRtmp = TRtmp{f:Option<float>}\n" +
+                this.relations(true) +
+                "relation Rtmp[TRtmp]\n" +
+                "output relation Rv0[TRtmp]\n" +
+                "Rv0[v1] :- Rt1[v],var v0 = TRtmp{.f = match(v.column1) {None{}: Option<signed<64>> -> None{}: Option<float>,\n" +
+                "Some{.x = var x} -> Some{.x = x as float}\n" +
+                "}},var v1 = v0.";
+        this.testTranslation(query, program, true);
+    }
+
+    @Test
+    public void testCastIntToStringWithNull() {
+        String query = "create view v0 as SELECT DISTINCT CAST(t1.column1 AS VARCHAR) AS s FROM t1";
+        String program = this.header(true) +
+                "typedef TRtmp = TRtmp{s:Option<string>}\n" +
+                this.relations(true) +
+                "relation Rtmp[TRtmp]\n" +
+                "output relation Rv0[TRtmp]\n" +
+                "Rv0[v1] :- Rt1[v],var v0 = TRtmp{.s = match(v.column1) {None{}: Option<signed<64>> -> None{}: Option<string>,\n" +
+                "Some{.x = var x} -> Some{.x = [|${x}|]}\n" +
+                "}},var v1 = v0.";
+        this.testTranslation(query, program, true);
+    }
+
+    @Test
+    public void testCastStringToIntWithNull() {
+        String query = "create view v0 as SELECT DISTINCT CAST(t1.column2 AS INT) AS i FROM t1";
+        String program = this.header(true) +
+                "typedef TRtmp = TRtmp{i:Option<signed<64>>}\n" +
+                this.relations(true) +
+                "relation Rtmp[TRtmp]\n" +
+                "output relation Rv0[TRtmp]\n" +
+                "Rv0[v1] :- Rt1[v],var v0 = TRtmp{.i = match(v.column2) {None{}: Option<string> -> None{}: Option<signed<64>>,\n" +
+                "Some{.x = var x} -> Some{.x = option_unwrap_or_default(parse_dec_i64(x))}\n" +
+                "}},var v1 = v0.";
+        this.testTranslation(query, program, true);
+    }
+
+    @Test
+    public void testCastStringToFloatWithNull() {
+        String query = "create view v0 as SELECT DISTINCT CAST(t1.column2 AS REAL) AS d FROM t1";
+        String program = this.header(true) +
+                "typedef TRtmp = TRtmp{d:Option<double>}\n" +
+                this.relations(true) +
+                "relation Rtmp[TRtmp]\n" +
+                "output relation Rv0[TRtmp]\n" +
+                "Rv0[v1] :- Rt1[v],var v0 = TRtmp{.d = match(v.column2) {None{}: Option<string> -> None{}: Option<double>,\n" +
+                "Some{.x = var x} -> Some{.x = result_unwrap_or_default(parse_d(x))}\n" +
+                "}},var v1 = v0.";
+        this.testTranslation(query, program, true);
+    }
+
+    @Test
+    public void testCastStringToDateWithNull() {
+        String query = "create view v0 as SELECT DISTINCT CAST(t1.column2 AS DATE) AS d FROM t1";
+        String program = this.header(true) +
+                "typedef TRtmp = TRtmp{d:Option<Date>}\n" +
+                this.relations(true) +
+                "relation Rtmp[TRtmp]\n" +
+                "output relation Rv0[TRtmp]\n" +
+                "Rv0[v1] :- Rt1[v],var v0 = TRtmp{.d = match(v.column2) {None{}: Option<string> -> None{}: Option<Date>,\n" +
+                "Some{.x = var x} -> Some{.x = result_unwrap_or_default(string2date(x))}\n" +
+                "}},var v1 = v0.";
+        this.testTranslation(query, program, true);
+    }
+
+    @Test
+    public void testCastIntToDateWithNull() {
+        String query = "create view v0 as SELECT DISTINCT CAST(t1.column1 AS DATE) AS d FROM t1";
+        String program = this.header(true) +
+                "typedef TRtmp = TRtmp{d:Option<Date>}\n" +
+                this.relations(true) +
+                "relation Rtmp[TRtmp]\n" +
+                "output relation Rv0[TRtmp]\n" +
+                "Rv0[v1] :- Rt1[v],var v0 = TRtmp{.d = match(v.column1) {None{}: Option<signed<64>> -> None{}: Option<Date>,\n" +
+                "Some{.x = var x} -> Some{.x = result_unwrap_or_default(string2date([|${v.column1}|]))}\n" +
+                "}},var v1 = v0.";
+        this.testTranslation(query, program, true);
+    }
+
+    @Test
+    public void testCastStringToDateTimeWithNull() {
+        String query = "create view v0 as SELECT DISTINCT CAST(t1.column2 AS TIMESTAMP) AS t FROM t1";
+        String program = this.header(true) +
+                "typedef TRtmp = TRtmp{t:Option<DateTime>}\n" +
+                this.relations(true) +
+                "relation Rtmp[TRtmp]\n" +
+                "output relation Rv0[TRtmp]\n" +
+                "Rv0[v1] :- Rt1[v],var v0 = TRtmp{.t = match(v.column2) {None{}: Option<string> -> None{}: Option<DateTime>,\n" +
+                "Some{.x = var x} -> Some{.x = result_unwrap_or_default(string2datetime(x))}\n" +
+                "}},var v1 = v0.";
+        this.testTranslation(query, program, true);
+    }
+
+    @Test
+    public void testCastFloatToIntWithNull() {
+        String query = "create view v0 as SELECT DISTINCT CAST(t1.column4 AS INTEGER) AS i FROM t1";
+        String program = this.header(true) +
+                "typedef TRtmp = TRtmp{i:Option<signed<64>>}\n" +
+                this.relations(true) +
+                "relation Rtmp[TRtmp]\n" +
+                "output relation Rv0[TRtmp]\n" +
+                "Rv0[v1] :- Rt1[v],var v0 = TRtmp{.i = match(v.column4) {None{}: Option<double> -> None{}: Option<signed<64>>,\n" +
+                "Some{.x = var x} -> Some{.x = option_unwrap_or_default(int_from_d(x)) as signed<64>}\n" +
+                "}},var v1 = v0.";
+        this.testTranslation(query, program, true);
+    }
+
+    @Test
+    public void testCastDateToStringWithNull() {
+        String query = "create view v0 as SELECT DISTINCT CAST(t3.d AS VARCHAR) AS s FROM t3";
+        String program = this.header(true) +
+                "typedef TRtmp = TRtmp{s:Option<string>}\n" +
+                this.relations(true) +
+                "relation Rtmp[TRtmp]\n" +
+                "output relation Rv0[TRtmp]\n" +
+                "Rv0[v1] :- Rt3[v],var v0 = TRtmp{.s = match(v.d) {None{}: Option<Date> -> None{}: Option<string>,\n" +
+                "Some{.x = var x} -> Some{.x = [|${x}|]}\n" +
+                "}},var v1 = v0.";
+        this.testTranslation(query, program, true);
+    }
+
+    @Test
+    public void testCastBoolToIntWithNull() {
+        String query = "create view v0 as SELECT DISTINCT CAST(t1.column3 AS INTEGER) AS i FROM t1";
+        String program = this.header(true) +
+                "typedef TRtmp = TRtmp{i:Option<signed<64>>}\n" +
+                this.relations(true) +
+                "relation Rtmp[TRtmp]\n" +
+                "output relation Rv0[TRtmp]\n" +
+                "Rv0[v1] :- Rt1[v],var v0 = TRtmp{.i = match(v.column3) {None{}: Option<bool> -> None{}: Option<signed<64>>,\n" +
+                "Some{.x = var x} -> Some{.x = if (x) {\n" +
+                "64'sd1} else {\n" +
+                "64'sd0}}\n" +
+                "}},var v1 = v0.";
+        this.testTranslation(query, program, true);
+    }
+
+    @Test
+    public void testCastIntToBoolWithNull() {
+        String query = "create view v0 as SELECT DISTINCT CAST(t1.column1 AS BOOLEAN) AS b FROM t1";
+        String program = this.header(true) +
+                "typedef TRtmp = TRtmp{b:Option<bool>}\n" +
+                this.relations(true) +
+                "relation Rtmp[TRtmp]\n" +
+                "output relation Rv0[TRtmp]\n" +
+                "Rv0[v1] :- Rt1[v],var v0 = TRtmp{.b = match(v.column1) {None{}: Option<signed<64>> -> None{}: Option<bool>,\n" +
+                "Some{.x = var x} -> Some{.x = (x != 64'sd0)}\n" +
+                "}},var v1 = v0.";
+        this.testTranslation(query, program, true);
+    }
+
+    @Test(expected = TranslationException.class)
+    public void testCastDateToBoolWithNull() {
+        String query = "create view v0 as SELECT DISTINCT CAST(t3.d AS BOOLEAN) AS b FROM t3";
+        String program = "";
+        this.testTranslation(query, program, true);
+    }
 }


### PR DESCRIPTION
I realized that nulls were not handled in casts.
Also, implemented the concat function.