### PR TITLE
Performance regression

### DIFF
--- a/rust/template/distributed_datalog/src/instantiate.rs
+++ b/rust/template/distributed_datalog/src/instantiate.rs
@@ -149,7 +149,7 @@ where
 
                     sinks
                         .entry(rel_ids.clone())
-                        .or_insert_with(|| vec![])
+                        .or_insert_with(Vec::new)
                         .insert(0, (SinkRealization::Node(sender), subscription));
 
                     server
@@ -251,7 +251,7 @@ where
 
             sinks
                 .entry(rel_ids.clone())
-                .or_insert_with(|| vec![])
+                .or_insert_with(Vec::new)
                 .insert(0, (SinkRealization::File(sink), subscription));
 
             server
@@ -291,7 +291,7 @@ where
 
             sources
                 .entry(rel_ids.clone())
-                .or_insert_with(|| vec![])
+                .or_insert_with(Vec::new)
                 .insert(0, (SourceRealization::File(source), ()));
             Ok(())
         })

--- a/src/Language/DifferentialDatalog/Validate.hs
+++ b/src/Language/DifferentialDatalog/Validate.hs
@@ -276,7 +276,7 @@ atomValidate d ctx atom = do
     _ <- checkRelation (pos atom) d $ atomRelation atom
     exprValidate d [] ctx $ atomVal atom
     -- variable cannot be declared and used in the same atom
-    uniq' (Just d) (\_ -> pos atom) id (\v -> "Variable " ++ show v ++ " is both declared and used inside relational atom " ++ show atom)
+    uniqNames (Just d) (\v -> "Variable " ++ show v ++ " is both declared and used inside relational atom " ++ show atom)
         $ exprVarDecls d ctx $ atomVal atom
 
 ruleRHSValidate :: (MonadError String me) => DatalogProgram -> Rule -> RuleRHS -> Int -> me ()


### PR DESCRIPTION
Avoid constructing sets of `Var`, which can be very slow, since
`Var.compare` is an expensive operation.

