### PR TITLE
Fix double semi-colon warnings in inspect generated rust code

### DIFF
--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -1636,7 +1636,7 @@ mkInspect d prefix rl idx e input_val = do
     let timestamp = if ruleIsRecursive d rl
         then "let ddlog_timestamp = &std_DDNestedTS{epoch:" <+> tIMESTAMP_VAR <> ".0 as std_DDEpoch, iter:" <+> tIMESTAMP_VAR <> ".1.x as std_DDIteration};"
         else "let ddlog_timestamp = &(" <> tIMESTAMP_VAR <> ".0 as std_DDEpoch);"
-    let inspected = mkExpr d (CtxRuleRInspect rl idx) e EVal <> ";"
+    let inspected = (braces $ mkExpr d (CtxRuleRInspect rl idx) e EVal) <> ";"
     let ifun = braces'
                 $ weight $$
                   timestamp $$


### PR DESCRIPTION
In some cases the expression in the inspect already contains
a semi-colon. Wrap the expression in a braces to fix
the warnings.