### PR TITLE
Minor debug hooks-related fixes

### DIFF
--- a/lib/debug.dl
+++ b/lib/debug.dl
@@ -2,9 +2,11 @@
  * an external debugger tool.
  */
 
-extern function debug_event(operator_id: (u32, u32, u32), w: DDWeight, ts: 'T1,
+typedef DDlogOpId = (u32, u32, u32)
+
+extern function debug_event(operator_id: DDlogOpId, w: DDWeight, ts: 'T1,
                             operator_type: string, input1: 'A1, out: 'A2): ()
-extern function debug_event_join(operator_id: (u32, u32, u32), w: DDWeight, ts: 'T1,
+extern function debug_event_join(operator_id: DDlogOpId, w: DDWeight, ts: 'T1,
                                  input1: 'A1, input2: 'A2, out: 'A3): ()
 
 extern function debug_split_group(g: Group<'K, ('I,'V)>): (Vec<'I>, Group<'K, 'V>)

--- a/src/Language/DifferentialDatalog/Debug.hs
+++ b/src/Language/DifferentialDatalog/Debug.hs
@@ -130,7 +130,7 @@ generateInspectDebug d ruleIdx rule index =
                      RHSInspect{} -> "Inspect"
                      RHSFlatMap{} -> "Flatmap"
                      RHSCondition{} -> "Condition"
-                     _ -> "Undefined" -- Should not reach this case
+                     rhs -> error $ "generateInspectDebug " ++ show rhs
     outputs = Compile.recordAfterPrefix d rule index
   in map (\i -> RHSInspect {rhsInspectExpr = eApply "debug.debug_event"
                                              [generateOperatorIdExpr ruleIdx index i,

--- a/test/datalog_tests/lib_test.debug.ast.expected
+++ b/test/datalog_tests/lib_test.debug.ast.expected
@@ -1,3 +1,4 @@
+typedef debug.DDlogOpId = (std.u32, std.u32, std.u32)
 typedef fp_test.BB = fp_test.BB{s: string, b: bool}
 typedef fp_test.D = fp_test.D{s: string, d: double}
 typedef fp_test.DoublesFromRecord = fp_test.DoublesFromRecord{s: string, d: double}
@@ -110,8 +111,8 @@ function __debug_287_1_tinyset.group2set (g: std.Group<string,('I, bit<32>)>): (
     ((var inputs, var original_group) = debug.debug_split_group(g);
      (inputs, tinyset.group2set(original_group)))
 }
-extern function debug.debug_event (operator_id: (std.u32, std.u32, std.u32), w: std.DDWeight, ts: 'T1, operator_type: string, input1: 'A1, out: 'A2): ()
-extern function debug.debug_event_join (operator_id: (std.u32, std.u32, std.u32), w: std.DDWeight, ts: 'T1, input1: 'A1, input2: 'A2, out: 'A3): ()
+extern function debug.debug_event (operator_id: debug.DDlogOpId, w: std.DDWeight, ts: 'T1, operator_type: string, input1: 'A1, out: 'A2): ()
+extern function debug.debug_event_join (operator_id: debug.DDlogOpId, w: std.DDWeight, ts: 'T1, input1: 'A1, input2: 'A2, out: 'A3): ()
 extern function debug.debug_split_group (g: std.Group<'K,('I, 'V)>): (std.Vec<'I>, std.Group<'K,'V>)
 extern function fp.abs_d (f: double): double
 extern function fp.abs_f (f: float): float

--- a/test/datalog_tests/simple.debug.ast.expected
+++ b/test/datalog_tests/simple.debug.ast.expected
@@ -151,6 +151,7 @@ typedef YX = YX{y: bigint, x: bigint}
 typedef YZX = YZX{y: bigint, z: bigint, x: bigint}
 typedef Z = Z{field: bigint}
 typedef ZZ = ZZ{x: bigint, y: R3}
+typedef debug.DDlogOpId = (std.u32, std.u32, std.u32)
 typedef entid_t = bit<32>
 #[size = 4]
 #[shared_ref = true]
@@ -458,8 +459,8 @@ function dbl (): double
 {
     (64'f0.0: double)
 }
-extern function debug.debug_event (operator_id: (std.u32, std.u32, std.u32), w: std.DDWeight, ts: 'T1, operator_type: string, input1: 'A1, out: 'A2): ()
-extern function debug.debug_event_join (operator_id: (std.u32, std.u32, std.u32), w: std.DDWeight, ts: 'T1, input1: 'A1, input2: 'A2, out: 'A3): ()
+extern function debug.debug_event (operator_id: debug.DDlogOpId, w: std.DDWeight, ts: 'T1, operator_type: string, input1: 'A1, out: 'A2): ()
+extern function debug.debug_event_join (operator_id: debug.DDlogOpId, w: std.DDWeight, ts: 'T1, input1: 'A1, input2: 'A2, out: 'A3): ()
 extern function debug.debug_split_group (g: std.Group<'K,('I, 'V)>): (std.Vec<'I>, std.Group<'K,'V>)
 function double_evens (xs: std.Vec<bigint>): std.Vec<bigint>
 {

--- a/test/datalog_tests/simple2.debug.ast.expected
+++ b/test/datalog_tests/simple2.debug.ast.expected
@@ -19,6 +19,7 @@ typedef TArrng1 = TArrng1{f1: bool, f2: bigint}
 typedef TArrng1Arrng2 = TArrng1Arrng2{x: bigint}
 typedef TArrng2 = TArrng2{f1: bool, f2: std.Ref<std.Ref<TArrng1>>}
 typedef TestRelation = TestRelation{x: bit<32>, y: bit<32>}
+typedef debug.DDlogOpId = (std.u32, std.u32, std.u32)
 #[size = 8]
 #[shared_ref = true]
 extern type internment.Intern<'A>
@@ -69,8 +70,8 @@ function agg_avg_double_N (aggregate: std.Option<(double, double)>, item: std.Op
         (std.Some{.x=(var sum, var ct)}, std.Some{.x=var y}) -> std.Some{.x=((sum + y), (ct + 64'f1.0))}
     }
 }
-extern function debug.debug_event (operator_id: (std.u32, std.u32, std.u32), w: std.DDWeight, ts: 'T1, operator_type: string, input1: 'A1, out: 'A2): ()
-extern function debug.debug_event_join (operator_id: (std.u32, std.u32, std.u32), w: std.DDWeight, ts: 'T1, input1: 'A1, input2: 'A2, out: 'A3): ()
+extern function debug.debug_event (operator_id: debug.DDlogOpId, w: std.DDWeight, ts: 'T1, operator_type: string, input1: 'A1, out: 'A2): ()
+extern function debug.debug_event_join (operator_id: debug.DDlogOpId, w: std.DDWeight, ts: 'T1, input1: 'A1, input2: 'A2, out: 'A3): ()
 extern function debug.debug_split_group (g: std.Group<'K,('I, 'V)>): (std.Vec<'I>, std.Group<'K,'V>)
 extern function fp.abs_d (f: double): double
 extern function fp.abs_f (f: float): float

--- a/test/datalog_tests/tutorial.debug.ast.expected
+++ b/test/datalog_tests/tutorial.debug.ast.expected
@@ -65,6 +65,7 @@ typedef Word1 = Word1{word: string, cat: Category}
 typedef Word2 = Word2{word: string, cat: Category}
 typedef WorstPrice = WorstPrice{item: string, price: bit<64>}
 typedef X = X{x: bit<16>}
+typedef debug.DDlogOpId = (std.u32, std.u32, std.u32)
 typedef eth_payload_t = EthIP4{ip4: ip4_pkt_t} |
                         EthIP6{ip6: ip6_pkt_t} |
                         EthOther{}
@@ -200,8 +201,8 @@ function best_vendor_string (g: std.Group<string,(string, bit<64>)>): string
        };
        ((((("Best deal for " ++ std.group_key(g)) ++ ": ") ++ min_vendor) ++ ", $") ++ std.__builtin_2string(min_price)))))
 }
-extern function debug.debug_event (operator_id: (std.u32, std.u32, std.u32), w: std.DDWeight, ts: 'T1, operator_type: string, input1: 'A1, out: 'A2): ()
-extern function debug.debug_event_join (operator_id: (std.u32, std.u32, std.u32), w: std.DDWeight, ts: 'T1, input1: 'A1, input2: 'A2, out: 'A3): ()
+extern function debug.debug_event (operator_id: debug.DDlogOpId, w: std.DDWeight, ts: 'T1, operator_type: string, input1: 'A1, out: 'A2): ()
+extern function debug.debug_event_join (operator_id: debug.DDlogOpId, w: std.DDWeight, ts: 'T1, input1: 'A1, input2: 'A2, out: 'A3): ()
 extern function debug.debug_split_group (g: std.Group<'K,('I, 'V)>): (std.Vec<'I>, std.Group<'K,'V>)
 function evens (vec: std.Vec<bigint>): std.Vec<bigint>
 {


### PR DESCRIPTION
1. Create a typedef for the operator id type in debug.dl
2. Throw an error if an unexpected operator type is used in generateInspectDebug function