### PR TITLE
New C APIs for ovn-northd-ddlog

### DIFF
--- a/rust/template/ddlog.h
+++ b/rust/template/ddlog.h
@@ -700,6 +700,33 @@ extern int ddlog_dump_ovsdb_output_table(
     char **json);
 
 /*
+ * Serializes table record 'rec' into a JSON object for an OVSDB insert,
+ * update, or delete operation, respectively, to apply to OVSDB table 'table'.
+ *
+ * On success, returns `0` and stores a pointer to JSON string in
+ * `json`.  This pointer must be later deallocated by calling
+ * `ddlog_free_json()`
+ *
+ * On error, returns a negative number and writes error message
+ * (see `print_err_msg` parameter to `ddlog_run()`).
+ */
+extern int ddlog_into_ovsdb_insert_str(
+    ddlog_prog prog,
+    const char *table,
+    const ddlog_record *rec,
+    char **json);
+extern int ddlog_into_ovsdb_update_str(
+    ddlog_prog prog,
+    const char *table,
+    const ddlog_record *rec,
+    char **json);
+extern int ddlog_into_ovsdb_delete_str(
+    ddlog_prog prog,
+    const char *table,
+    const ddlog_record *rec,
+    char **json);
+
+/*
  * Deallocates strings returned by other functions in this API.
  */
 extern void ddlog_free_json(char *json);

--- a/rust/template/ddlog.h
+++ b/rust/template/ddlog.h
@@ -141,7 +141,7 @@ extern const char* ddlog_get_table_name(table_id id);
  *
  * On error, returns -1.
  */
-extern table_id ddlog_get_index_id(const char* iname);
+extern index_id ddlog_get_index_id(const char* iname);
 
 /*
  * Get DDlog index name from id.
@@ -447,7 +447,7 @@ extern int ddlog_apply_updates_from_flatbuf(ddlog_prog prog,
  */
 extern int
 ddlog_query_index(ddlog_prog prog,
-                  size_t idxid,
+                  index_id idxid,
                   ddlog_record *key,
                   void (*cb)(uintptr_t arg, const ddlog_record *rec),
                   uintptr_t cb_arg);
@@ -491,7 +491,7 @@ extern int ddlog_query_index_from_flatbuf(ddlog_prog prog,
  */
 extern int
 ddlog_dump_index(ddlog_prog prog,
-                 size_t idxid,
+                 index_id idxid,
                  void (*cb)(uintptr_t arg, const ddlog_record *rec),
                  uintptr_t cb_arg);
 
@@ -517,7 +517,7 @@ ddlog_dump_index(ddlog_prog prog,
  *
  */
 extern int ddlog_dump_index_to_flatbuf(ddlog_prog prog,
-                                       size_t idxid,
+                                       index_id idxid,
                                        unsigned char ** resbuf,
                                        size_t* resbuf_size,
                                        size_t* resbuf_capacity,

--- a/rust/template/ddlog.h
+++ b/rust/template/ddlog.h
@@ -1336,6 +1336,22 @@ extern const char * ddlog_get_constructor_with_length(const ddlog_record *rec,
 extern const ddlog_record* ddlog_get_struct_field(const ddlog_record* rec,
                                                   size_t i);
 
+/*
+ * Retrieves field 'name' of struct 'rec'.
+ *
+ * Returns NULL if `rec` is not a struct with named fields or if the struct
+ * does not have a field with the given name.
+ *
+ * The pointer returned by this function is owned by DDlog. The caller
+ * may inspect the returned record, but must not modify it, attach to
+ * other records (e.g., using `ddlog_vector_push()`) or write to the
+ * database.  The lifetime of the pointer coincides with the lifetime of
+ * the record it was obtained from, e.g., the pointer is invalidated
+ * when the value is written to the database.
+ */
+extern const ddlog_record* ddlog_get_named_struct_field(const ddlog_record* rec,
+                                                        const char* name);
+
 /***********************************************************************
  * Command API
  ***********************************************************************/

--- a/rust/template/differential_datalog/record.rs
+++ b/rust/template/differential_datalog/record.rs
@@ -740,6 +740,27 @@ pub unsafe extern "C" fn ddlog_get_struct_field(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn ddlog_get_named_struct_field(
+    rec: *const Record,
+    name: *const raw::c_char,
+) -> *const Record {
+    let name = match CStr::from_ptr(name).to_str() {
+        Ok(s) => s,
+        Err(_) => {
+            return null_mut();
+        }
+    };
+    match rec.as_ref() {
+        Some(Record::NamedStruct(_, fields)) => fields
+            .iter()
+            .find(|(f, _)| f == name)
+            .map(|(_, r)| r as *const Record)
+            .unwrap_or(null_mut()),
+        _ => null_mut(),
+    }
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn ddlog_get_constructor_with_length(
     rec: *const Record,
     len: *mut libc::size_t,

--- a/rust/template/ovsdb/lib.rs
+++ b/rust/template/ovsdb/lib.rs
@@ -315,7 +315,7 @@ pub fn record_into_update_str(rec: Record, table: &str) -> Result<String, String
             .clone(),
         _ => {
             return Err(format!(
-                "Cannot convert record to insert command: {:?}",
+                "Cannot convert record to update command: {:?}",
                 rec
             ))
         }


### PR DESCRIPTION
This adds the C APIs I needed to make reconnection work with output-only tables in OVN in commit https://github.com/blp/ovs-reviews/commit/a0cda0ec5b93276f657c9aa88658c14a1300236d
