### PR TITLE
D3log updated realization

### DIFF
--- a/rust/template/distributed_datalog/src/accumulate/accumulator.rs
+++ b/rust/template/distributed_datalog/src/accumulate/accumulator.rs
@@ -319,12 +319,12 @@ pub mod tests {
         assert_eq!(mock2.lock().unwrap().called_on_commit, 1);
 
         assert_eq!(accumulator.on_completed(), Ok(()));
-        assert_eq!(mock1.lock().unwrap().called_on_start, 2);
-        assert_eq!(mock2.lock().unwrap().called_on_start, 2);
-        assert_eq!(mock1.lock().unwrap().called_on_updates, 6);
-        assert_eq!(mock2.lock().unwrap().called_on_updates, 6);
-        assert_eq!(mock1.lock().unwrap().called_on_commit, 2);
-        assert_eq!(mock2.lock().unwrap().called_on_commit, 2);
+        assert_eq!(mock1.lock().unwrap().called_on_start, 1);
+        assert_eq!(mock2.lock().unwrap().called_on_start, 1);
+        assert_eq!(mock1.lock().unwrap().called_on_updates, 3);
+        assert_eq!(mock2.lock().unwrap().called_on_updates, 3);
+        assert_eq!(mock1.lock().unwrap().called_on_commit, 1);
+        assert_eq!(mock2.lock().unwrap().called_on_commit, 1);
         assert_eq!(mock1.lock().unwrap().called_on_completed, 1);
         assert_eq!(mock2.lock().unwrap().called_on_completed, 1);
     }
@@ -394,12 +394,12 @@ pub mod tests {
         assert_eq!(mock2.lock().unwrap().called_on_commit, 2);
 
         assert_eq!(accumulator.on_completed(), Ok(()));
-        assert_eq!(mock1.lock().unwrap().called_on_start, 3);
-        assert_eq!(mock2.lock().unwrap().called_on_start, 3);
-        assert_eq!(mock1.lock().unwrap().called_on_updates, 20);
-        assert_eq!(mock2.lock().unwrap().called_on_updates, 20);
-        assert_eq!(mock1.lock().unwrap().called_on_commit, 3);
-        assert_eq!(mock2.lock().unwrap().called_on_commit, 3);
+        assert_eq!(mock1.lock().unwrap().called_on_start, 2);
+        assert_eq!(mock2.lock().unwrap().called_on_start, 2);
+        assert_eq!(mock1.lock().unwrap().called_on_updates, 10);
+        assert_eq!(mock2.lock().unwrap().called_on_updates, 10);
+        assert_eq!(mock1.lock().unwrap().called_on_commit, 2);
+        assert_eq!(mock2.lock().unwrap().called_on_commit, 2);
         assert_eq!(mock1.lock().unwrap().called_on_completed, 1);
         assert_eq!(mock2.lock().unwrap().called_on_completed, 1);
     }
@@ -526,36 +526,12 @@ pub mod tests {
             .iter()
             .any(|u| eq_updates(u, &Update::Insert { relid: 4, v: 4 })));
 
-        assert_eq!(accumulator.on_completed(), Ok(()));
+        assert_eq!(accumulator.on_completed(), Ok(())); // no longer does the 4 automatic deletions
 
         let received_updates = mock1.lock().unwrap().received_updates.clone();
-        assert_eq!(received_updates.len(), 14); // 3 + 4 inserts, 3 manual deletions, 4 automatic deletions
-        assert!(received_updates
-            .iter()
-            .any(|u| eq_updates(u, &Update::DeleteValue { relid: 4, v: 1 })));
-        assert!(received_updates
-            .iter()
-            .any(|u| eq_updates(u, &Update::DeleteValue { relid: 4, v: 2 })));
-        assert!(received_updates
-            .iter()
-            .any(|u| eq_updates(u, &Update::DeleteValue { relid: 4, v: 3 })));
-        assert!(received_updates
-            .iter()
-            .any(|u| eq_updates(u, &Update::DeleteValue { relid: 4, v: 4 })));
+        assert_eq!(received_updates.len(), 10); // (3 + 4) inserts + 3 manual deletions = 10
 
         let received_updates = mock2.lock().unwrap().received_updates.clone();
-        assert_eq!(received_updates.len(), 8); // 4 inserts, 4 automatic deletions
-        assert!(received_updates
-            .iter()
-            .any(|u| eq_updates(u, &Update::DeleteValue { relid: 4, v: 1 })));
-        assert!(received_updates
-            .iter()
-            .any(|u| eq_updates(u, &Update::DeleteValue { relid: 4, v: 2 })));
-        assert!(received_updates
-            .iter()
-            .any(|u| eq_updates(u, &Update::DeleteValue { relid: 4, v: 3 })));
-        assert!(received_updates
-            .iter()
-            .any(|u| eq_updates(u, &Update::DeleteValue { relid: 4, v: 4 })));
+        assert_eq!(received_updates.len(), 4); // 4 inserts, 0 automatic deletions
     }
 }

--- a/rust/template/distributed_datalog/src/accumulate/observer.rs
+++ b/rust/template/distributed_datalog/src/accumulate/observer.rs
@@ -58,6 +58,15 @@ where
         trace!("AccumulatingObserver({})::get_current_state()", self.id);
         self.data.clone()
     }
+
+    pub fn clear_and_return_state(&mut self) -> HashMap<RelId, HashSet<V>> {
+        trace!(
+            "AccumulatingObserver({})::clear_and_return_state()",
+            self.id
+        );
+        let _ = self.buffer.take();
+        self.data.drain().collect()
+    }
 }
 
 impl<T, V, E> Observable<T, E> for AccumulatingObserver<T, V, E>

--- a/rust/template/distributed_datalog/src/accumulate/observer.rs
+++ b/rust/template/distributed_datalog/src/accumulate/observer.rs
@@ -59,6 +59,11 @@ where
         self.data.clone()
     }
 
+    pub fn buffer_is_empty(&self) -> bool {
+        trace!("AccumulatingObserver({})::buffer_is_empty()", self.id);
+        self.buffer.is_none()
+    }
+
     pub fn clear_and_return_state(&mut self) -> HashMap<RelId, HashSet<V>> {
         trace!(
             "AccumulatingObserver({})::clear_and_return_state()",

--- a/rust/template/distributed_datalog/src/instantiate.rs
+++ b/rust/template/distributed_datalog/src/instantiate.rs
@@ -266,7 +266,7 @@ where
         Addr::Ip(addr) => realization.add_tcp_receiver(addr)?,
     }
     realization.add_file_sources(node_cfg)?;
-    
+
     println!(
         "realized node configuration locally in {} ms",
         now.elapsed().as_millis()
@@ -330,10 +330,9 @@ where
     P: Send + DDlog + 'static,
     P::Convert: Send + DDlogConvert,
 {
-    /// Subscribe the `TxnMux` of the existing realization to the given server. 
+    /// Subscribe the `TxnMux` of the existing realization to the given server.
     pub fn subscribe_txnmux(&mut self, server: DDlogServer<P>) -> Result<(), &str> {
-        self
-            ._txnmux
+        self._txnmux
             .subscribe(Box::new(server))
             .map_err(|_| "failed to subscribe DDlogServer to TxnMux")
     }
@@ -341,7 +340,7 @@ where
     /// Remove a source from the existing realization.
     /// Also clear the accumulator and disconnect
     /// from the TxnMux.
-    pub fn remove_source(&mut self, src: &Source) -> Result<(), &str>{
+    pub fn remove_source(&mut self, src: &Source) -> Result<(), &str> {
         // Remove entry.
         let (_, accumulator, id) = self._sources.remove(src).unwrap();
         let mut accum_observ = accumulator.lock().unwrap();
@@ -356,7 +355,7 @@ where
         }
     }
 
-    /// Add a `TcpReceiver` to the existing realization feeding the given server 
+    /// Add a `TcpReceiver` to the existing realization feeding the given server
     /// if one is needed given the provided node configuration.
     pub fn add_tcp_receiver(&mut self, addr: &SocketAddr) -> Result<(), String> {
         let receiver =

--- a/rust/template/distributed_datalog/src/instantiate.rs
+++ b/rust/template/distributed_datalog/src/instantiate.rs
@@ -209,12 +209,11 @@ fn deduce_sinks_or_sources(node_cfg: &NodeCfg, sinks: bool) -> BTreeMap<&Path, B
                             let _ = map.entry(path).or_default().insert(*relid);
                         }
                     },
-                    RelCfg::Source(source) if !sinks => match source {
-                        Source::File(path) => {
+                    RelCfg::Source(source) if !sinks => {
+                        if let Source::File(path) = source {
                             let _ = map.entry(path).or_default().insert(*relid);
                         }
-                        _ => (),
-                    },
+                    }
                     _ => (),
                 };
                 map
@@ -305,7 +304,7 @@ where
     match addr {
         Addr::Ip(addr) => add_tcp_receiver::<P>(&mut txnmux, addr, &mut sources)?,
     }
-    
+
     let mut realization = Realization {
         _sources: sources,
         _txnmux: txnmux,
@@ -423,16 +422,10 @@ where
 
     /// Add file sources as per the node configuration to the TxnMux for this
     /// Realization.
-    fn add_file_sources(
-        &mut self,
-        node_cfg: &NodeCfg,
-    ) -> Result<(), String>
-    {
+    fn add_file_sources(&mut self, node_cfg: &NodeCfg) -> Result<(), String> {
         deduce_sinks_or_sources(node_cfg, false)
             .iter()
-            .try_for_each(|(path, _rel_ids)| {
-                self.add_source(path)
-            })
+            .try_for_each(|(path, _rel_ids)| self.add_source(path))
     }
 }
 

--- a/rust/template/distributed_datalog/src/instantiate.rs
+++ b/rust/template/distributed_datalog/src/instantiate.rs
@@ -341,16 +341,19 @@ where
     /// Remove a source from the existing realization.
     /// Also clear the accumulator and disconnect
     /// from the TxnMux.
-    pub fn remove_source(&mut self, src: &Source) {
+    pub fn remove_source(&mut self, src: &Source) -> Result<(), &str>{
         // Remove entry.
         let (_, accumulator, id) = self._sources.remove(src).unwrap();
         let mut accum_observ = accumulator.lock().unwrap();
 
         // Clear accumulator.
-        accum_observ.clear();
-
-        // Disconnect from TxnMux.
-        self._txnmux.remove_observable(id);
+        if accum_observ.clear().is_ok() {
+            // Disconnect from TxnMux.
+            self._txnmux.remove_observable(id);
+            Ok(())
+        } else {
+            Err("Cannot remove source, transaction in progress")
+        }
     }
 
     /// Add a `TcpReceiver` to the existing realization feeding the given server 

--- a/rust/template/distributed_datalog/src/schema.rs
+++ b/rust/template/distributed_datalog/src/schema.rs
@@ -125,10 +125,14 @@ impl Member {
 pub type Members = BTreeSet<Member>;
 
 /// All the input sources we support.
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Deserialize, Serialize, Hash)]
 pub enum Source {
     /// Input is coming from a file.
     File(PathBuf),
+    /// Input is coming from a TcpReceiver.
+    /// Right now there is at most one TcpReceiver at a given time, so it does
+    /// not require an identifier.
+    TcpReceiver,
 }
 
 /// All the output sinks we support.

--- a/rust/template/distributed_datalog/src/txnmux.rs
+++ b/rust/template/distributed_datalog/src/txnmux.rs
@@ -159,13 +159,9 @@ where
     }
 
     /// Removes an `Observable` from the multiplexer.
-    pub fn remove_observable(&mut self, id: usize) -> Result<(), usize> {
+    pub fn remove_observable(&mut self, id: usize) {
         trace!("TxnMux({})::remove_observable", id);
-
-        match self.subscriptions.remove(&id) {
-            Some(_) => Ok(()),
-            None => Err(id),
-        }
+        let _ = self.subscriptions.remove(&id);
     }
 
     /// Creates and adds an `Observer` to which the multiplexer is subscribed.


### PR DESCRIPTION
This pull request refactors the Realization interface, specifically the input side. The old interface did not allow for changes; to change a realization, the existing one had to be torn down and an entirely new one created. The new interface allows one to add a source to an existing realization or remove a source from the existing realization. The following is a brief list of changes made to allow for the new functionality:

- Changes the type of _sources for a Realization struct to be keyed by Source and contain the Source's accumulator.
- Rewrites accumulator on_completed() to no longer automatically clear the accumulator.
- Moves accumulator clearing logic to clear().
- For TxnMux: add_observable() now returns a handle, and remove_observable() function was added.
- Implements remove_source() and add_source() for Realization and refactors add_file_sources() to use add_source().