### PR TITLE
?-operator

### DIFF
--- a/doc/language_reference/language_reference.md
+++ b/doc/language_reference/language_reference.md
@@ -276,44 +276,46 @@ primary key (r) r.f1
 
 ```EBNF
 expr ::= term
-       | expr "["decimal "," decimal"]"  (*bit slice (e[h:l])*)
-       | expr ":" simple_type_spec       (*explicit type signature*)
-       | expr "." identifier             (*struct field*)
-       | expr "." decimal                (*tuple field access*)
-       | "-" expr                        (*unary arithmetic negation*)
-       | "~" expr                        (*bitwise negation*)
-       | "not" expr                      (*boolean negation*)
-       | "(" expr ")"                    (*grouping*)
-       | "{" expr "}"                    (*grouping (alternative syntax)*)
-       | expr "*" expr                   (*multiplication*)
-       | expr "/" expr                   (*division*)
-       | expr "%" expr                   (*remainder*)
+       | expr "["decimal "," decimal"]"                 (*bit slice (e[h:l])*)
+       | expr ":" simple_type_spec                      (*explicit type signature*)
+       | expr "." identifier                            (*struct field*)
+       | expr "." func_name "(" [expr (,expr)*] ")"     (*dot function call notation*)
+       | expr "." decimal                               (*tuple field access*)
+       | "-" expr                                       (*unary arithmetic negation*)
+       | "~" expr                                       (*bitwise negation*)
+       | "not" expr                                     (*boolean negation*)
+       | "(" expr ")"                                   (*grouping*)
+       | "{" expr "}"                                   (*grouping (alternative syntax)*)
+       | expr "*" expr                                  (*multiplication*)
+       | expr "/" expr                                  (*division*)
+       | expr "%" expr                                  (*remainder*)
        | expr "+" expr
        | expr "-" expr
-       | expr ">>" expr                  (*right shift*)
-       | expr "<<" expr                  (*left shift*)
-       | expr "++" expr                  (*concatenation (applies to bitvectors or strings)*)
+       | expr ">>" expr                                 (*right shift*)
+       | expr "<<" expr                                 (*left shift*)
+       | expr "++" expr                                 (*concatenation (applies to bitvectors or strings)*)
        | expr "==" expr
        | expr "!=" expr
        | expr ">" expr
        | expr ">=" expr
        | expr "<" expr
        | expr "<=" expr
-       | expr "&" expr                   (*bitwise and*)
-       | expr "|" expr                   (*bitwise or*)
-       | expr "and" expr                 (*logical and*)
-       | expr "or" expr                  (*logical or*)
-       | expr "=>" expr                  (*implication*)
-       | expr "=" expr                   (*assignment*)
-       | expr ";" expr                   (*sequential composition*)
-       | expr "as" simple_type_spec      (*cast*)
+       | expr "&" expr                                  (*bitwise and*)
+       | expr "|" expr                                  (*bitwise or*)
+       | expr "and" expr                                (*logical and*)
+       | expr "or" expr                                 (*logical or*)
+       | expr "=>" expr                                 (*implication*)
+       | expr "=" expr                                  (*assignment*)
+       | expr ";" expr                                  (*sequential composition*)
+       | expr "as" simple_type_spec                     (*cast*)
+       | expr "?"                                       (*try*)
 ```
 
 The following table lists operators order by decreasing priority.
 
-|**priority** | **operators**       |
-| ------ |:-----------------------:|
-| Highest| e[h:l], x:t, x.f        |
+|**priority** | **operators**                     |
+| ------ |:--------------------------------------:|
+| Highest| e[h:l], x:t, x.f, x?, x as t, x.f()    |
 |        | ~                       |
 |        | not                     |
 |        | %  / *                  |

--- a/lib/std.dl
+++ b/lib/std.dl
@@ -100,6 +100,8 @@ function is_some(x: Option<'A>): bool = {
     }
 }
 
+/* Returns the contained `Some` value or a provided default.
+ */
 function unwrap_or(x: Option<'A>, def: 'A): 'A = {
     match (x) {
         Some{v} -> v,
@@ -153,6 +155,8 @@ function is_err(res: Result<'V,'E>): bool = {
     }
 }
 
+/* Returns the contained Ok value or a provided default.
+ */
 function unwrap_or(res: Result<'V,'E>, def: 'V): 'V = {
     match (res) {
         Ok{v} -> v,

--- a/src/Language/DifferentialDatalog/Expr.hs
+++ b/src/Language/DifferentialDatalog/Expr.hs
@@ -139,6 +139,8 @@ exprFoldCtxM' f ctx e@(EAs p x t)             = do x' <- exprFoldCtxM f (CtxAs e
                                                    f ctx $ EAs p x' t
 exprFoldCtxM' f ctx e@(ERef p x)              = do x' <- exprFoldCtxM f (CtxRef e ctx) x
                                                    f ctx $ ERef p x'
+exprFoldCtxM' f ctx e@(ETry p x)              = do x' <- exprFoldCtxM f (CtxTry e ctx) x
+                                                   f ctx $ ETry p x'
 
 exprMapM :: (Monad m) => (a -> m b) -> ExprNode a -> m (ExprNode b)
 exprMapM g e = case e of
@@ -172,6 +174,7 @@ exprMapM g e = case e of
                    ETyped p x t        -> (\x' -> ETyped p x' t) <$> g x
                    EAs p x t           -> (\x' -> EAs p x' t) <$> g x
                    ERef p x            -> ERef p <$> g x
+                   ETry p x            -> ETry p <$> g x
 
 
 exprMap :: (a -> b) -> ExprNode a -> ExprNode b
@@ -229,6 +232,7 @@ exprCollectCtxM f op ctx e = exprFoldCtxM g ctx e
                                      ETyped _ v _          -> x' `op` v
                                      EAs _ v _             -> x' `op` v
                                      ERef _ v              -> x' `op` v
+                                     ETry _ v              -> x' `op` v
 
 exprCollectM :: (Monad m) => (ExprNode b -> m b) -> (b -> b -> b) -> Expr -> m b
 exprCollectM f op e = exprCollectCtxM (\_ e' -> f e') op undefined e

--- a/src/Language/DifferentialDatalog/NS.hs
+++ b/src/Language/DifferentialDatalog/NS.hs
@@ -199,4 +199,5 @@ ctxVars d ctx =
          CtxTyped _ _             -> (plvars, prvars)
          CtxAs _ _                -> (plvars, prvars)
          CtxRef _ _               -> (plvars, prvars)
+         CtxTry _ _               -> (plvars, prvars)
     where (plvars, prvars) = ctxVars d $ ctxParent ctx

--- a/src/Language/DifferentialDatalog/Parse.hs
+++ b/src/Language/DifferentialDatalog/Parse.hs
@@ -115,7 +115,7 @@ ccnDef = emptyDef { T.commentStart      = "/*"
                   , T.identLetter       = alphaNum <|> char '_'
                   , T.reservedOpNames   = reservedOpNames
                   , T.reservedNames     = reservedNames
-                  , T.opLetter          = oneOf "!?:%*-+./=|<>"
+                  , T.opLetter          = oneOf "!:%*-+./=|<>"
                   , T.caseSensitive     = True}
 
 ccnLCDef = ccnDef{T.identStart = lower <|> char '_'}
@@ -689,7 +689,7 @@ mkNumberLit (Just w) (FloatNumber v) | w == 32 = return $ eFloat $ double2Float 
                                      | w == 64 = return $ eDouble v
                                      | otherwise = fail "Only 32- and 64-bit floating point values are supported"
 
-etable = [[postf $ choice [postSlice, postApply, postField, postType, postAs, postTupField]]
+etable = [[postf $ choice [postTry, postSlice, postApply, postField, postType, postAs, postTupField]]
          ,[pref  $ choice [preRef]]
          ,[pref  $ choice [prefixOp "-" UMinus]]
          ,[pref  $ choice [prefixOp "~" BNeg]]
@@ -726,6 +726,7 @@ postApply = (\(f, args) end e -> E $ EApply (fst $ pos e, end) [f] (e:args)) <$>
 postType = (\t end e -> E $ ETyped (fst $ pos e, end) e t) <$> etype <*> getPosition
 postAs = (\t end e -> E $ EAs (fst $ pos e, end) e t) <$> eAsType <*> getPosition
 postSlice  = try $ (\(h,l) end e -> E $ ESlice (fst $ pos e, end) e h l) <$> slice <*> getPosition
+postTry = (\end e -> E $ ETry (fst $ pos e, end) e) <$ symbol "?" <*> getPosition
 slice = brackets $ (\h l -> (fromInteger h, fromInteger l)) <$> natural <*> (colon *> natural)
 
 field = isfield *> dot *> varIdent

--- a/src/Language/DifferentialDatalog/Type.hs
+++ b/src/Language/DifferentialDatalog/Type.hs
@@ -46,7 +46,9 @@ module Language.DifferentialDatalog.Type(
     typ', typ'',
     typDeref',
     typDeref'',
-    isBool, isBit, isSigned, isBigInt, isInteger, isFP, isString, isStruct, isTuple, isGroup, isMap, isTinySet, isSharedRef, isDouble, isFloat,
+    isBool, isBit, isSigned, isBigInt, isInteger, isFP, isString, isStruct, isTuple, isGroup, isDouble, isFloat,
+    isMap, isTinySet, isSharedRef,
+    isOption, isResult,
     checkTypesMatch,
     typesMatch,
     typeNormalize,
@@ -65,6 +67,12 @@ module Language.DifferentialDatalog.Type(
     iTERATION_TYPE,
     nESTED_TS_TYPE,
     wEIGHT_TYPE,
+    oPTION_TYPE,
+    sOME_CONSTRUCTOR,
+    nONE_CONSTRUCTOR,
+    rESULT_TYPE,
+    eRR_CONSTRUCTOR,
+    oK_CONSTRUCTOR,
     checkIterable,
     typeIterType,
     varType
@@ -117,6 +125,24 @@ nESTED_TS_TYPE = "std::DDNestedTS"
 
 wEIGHT_TYPE :: String
 wEIGHT_TYPE = "std::DDWeight"
+
+oPTION_TYPE :: String
+oPTION_TYPE = "std::Option"
+
+sOME_CONSTRUCTOR :: String
+sOME_CONSTRUCTOR = "std::Some"
+
+nONE_CONSTRUCTOR :: String
+nONE_CONSTRUCTOR = "std::None"
+
+rESULT_TYPE :: String
+rESULT_TYPE = "std::Result"
+
+eRR_CONSTRUCTOR :: String
+eRR_CONSTRUCTOR = "std::Err"
+
+oK_CONSTRUCTOR :: String
+oK_CONSTRUCTOR = "std::Ok"
 
 -- | An object with type
 class WithType a where
@@ -276,6 +302,7 @@ exprNodeType' _ _   (EBinding _ _ e)       = e
 exprNodeType' _ _   (ETyped _ _ t)         = t
 exprNodeType' _ _   (EAs _ _ t)            = t
 exprNodeType' _ ctx (ERef _ _)             = ctxExpectType ctx
+exprNodeType' _ _   (ETry _ _)             = error "exprNodeType: ?-expressions should be eliminated during type inference."
 --exprNodeType' d ctx (ERef p _)             = eunknown d p ctx
 
 --exprTypes :: Refine -> ECtx -> Expr -> [Type]
@@ -425,6 +452,16 @@ isSharedRef d a =
     case typ' d a of
          TOpaque _ t _ -> tdefGetSharedRefAttr d $ getType d t
          _             -> False
+
+isOption :: (WithType a) => DatalogProgram -> a -> Bool
+isOption d a = case typ'' d a of
+                    TUser _ t _ | t == oPTION_TYPE -> True
+                    _                              -> False
+
+isResult :: (WithType a) => DatalogProgram -> a -> Bool
+isResult d a = case typ'' d a of
+                    TUser _ t _ | t == rESULT_TYPE -> True
+                    _                              -> False
 
 -- | Check if 'a' and 'b' have identical types up to type aliasing;
 -- throw exception if they don't.

--- a/src/Language/DifferentialDatalog/Validate.hs
+++ b/src/Language/DifferentialDatalog/Validate.hs
@@ -610,6 +610,12 @@ exprValidate1 d tvs _ (EAs _ _ t)         = typeValidate d tvs t
 exprValidate1 d _ ctx (ERef p _)          =
     -- Rust does not allow pattern matching inside 'Arc'
     check d (ctxInRuleRHSPattern ctx || ctxInIndex ctx) p "Dereference pattern not allowed in this context"
+exprValidate1 d _ ctx (ETry p _)          = do
+    check d (isJust $ ctxInFunc ctx) p "?-expressions are only allowed in the body of a function"
+    let Function{..} = fromJust $ ctxInFunc ctx
+    check d (isOption d funcType || isResult d funcType) p
+          $ "?-expressions are only allowed in functions that return 'Option<>' or 'Result<>', " ++
+            "but function '" ++ funcName ++ "' returns '" ++ show funcType ++ "'"
 
 -- True if a placeholder ("_") can appear in this context
 ctxPHolderAllowed :: ECtx -> Bool

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -178,7 +178,10 @@ parserTest fname = do
         when (not exists) $ writeFile expectedFile ast
         expected <- if exists then readFile expectedFile
                               else return ast
-        assertEqual "Expected output differs from compiler output" expected ast
+        when (expected /= ast)
+            $ errorWithoutStackTrace $ "Expected output differs from compiler output\n" ++
+                                       "expected:\n" ++ expected ++
+                                       "\nbut got:\n" ++ ast
       else do
         -- parse Datalog file and output its AST
         (prog, _, _) <- parseValidate fname False body

--- a/test/datalog_tests/function.fail.ast.expected
+++ b/test/datalog_tests/function.fail.ast.expected
@@ -111,7 +111,11 @@ expression 'bool_identity(any)'
                ^^^^^^^^^^^^^^^^^^
 
 error: ./test/datalog_tests/function.fail.dl:5:1-6:1: Extern function 'foo' clashes with function declaration(s) at
-  ./test/datalog_tests/function.fail.dl:6:1-7:1
+  ./test/datalog_tests/function.fail.dl:6:1-8:1
 Only non-extern functions can be overloaded.
 extern function foo(x: u32): ()
 ^
+
+error: ./test/datalog_tests/function.fail.dl:8:21-8:38: expression 'std::nth(components, 1)' must be of type 'Result<>', but its type is 'std::Option<'a>'
+    var last_name = components.nth(1)?;
+                    ^^^^^^^^^^^^^^^^^

--- a/test/datalog_tests/function.fail.dl
+++ b/test/datalog_tests/function.fail.dl
@@ -205,3 +205,14 @@ function agg():Tagg =
 
 extern function foo(x: u32): ()
 extern function foo(x: Vec<u32>): ()
+
+//---
+
+// Invalid use of ?-operator
+
+function try1(name: string): Result<(string, string), string> {
+    var components = name.split(" ");
+    var first_name = components.nth(0)?;
+    var last_name = components.nth(1)?;
+    Some{(first_name, last_name)}
+}

--- a/test/datalog_tests/rules.fail.ast.expected
+++ b/test/datalog_tests/rules.fail.ast.expected
@@ -33,3 +33,7 @@ expression '(x, z)'
 error: ./test/datalog_tests/rules.fail.dl:9:13-9:18: expression '(1 + 2)' of a numeric type appears in a context where type '()' is expected
     Inspect 1 + 2.
             ^^^^^
+
+error: ./test/datalog_tests/rules.fail.dl:10:19-10:28: ?-expressions are only allowed in the body of a function
+          var z = y.nth(5)?.
+                  ^^^^^^^^^

--- a/test/datalog_tests/rules.fail.dl
+++ b/test/datalog_tests/rules.fail.dl
@@ -72,3 +72,14 @@ output relation InspectFail(x: string)
 InspectFail(x) :-
     InspectInput(x),
     Inspect 1 + 2.
+
+//---
+
+// Use ?-operator in a rule
+
+input relation Input(x: string)
+output relation Try(x: string)
+
+Try(z) :- Input(x),
+          var y = x.split(" "),
+          var z = y.nth(5)?.

--- a/test/datalog_tests/simple2.debug.ast.expected
+++ b/test/datalog_tests/simple2.debug.ast.expected
@@ -18,6 +18,7 @@ typedef Ints = Ints{x: bigint}
 typedef ModifyMe = ModifyMe{x: string, y: std::s128}
 typedef Object = Object{field: std::u128}
 typedef Objects = Objects{chunk: Object}
+typedef Opt<'X> = std::Option<'X>
 typedef OutputInspectNot = OutputInspectNot{x: bit<32>, y: bit<32>}
 typedef ParsedChunk = ParsedChunk{data: std::Result<Object,string>}
 typedef RFloatToInt = RFloatToInt{_x: signed<32>}
@@ -25,6 +26,7 @@ typedef RFtoIDummy = RFtoIDummy{x: signed<32>}
 typedef Rletter = Rletter{_l: string}
 typedef Rseq = Rseq{_s: TSeq}
 typedef Rseqs = Rseqs{_s: TSeq}
+typedef SResult<'V> = std::Result<'V,string>
 typedef SomeInts = SomeInts{x: std::Option<bigint>}
 typedef Strings = Strings{descr: string, str: string}
 typedef SumsOfDoubles = SumsOfDoubles{x: double, y: double, sum: double}
@@ -35,6 +37,9 @@ typedef TI_R = TI_R{a: std::Set<string>}
 typedef TSeq = TSeq1{x: (string, std::Ref<TSeq>)} |
                TSeqNone{}
 typedef TestRelation = TestRelation{x: bit<32>, y: bit<32>}
+typedef Try1 = Try1{description: string, result: Opt<(string, string)>}
+typedef Try2 = Try2{description: string, result: SResult<(string, string)>}
+typedef Try3 = Try3{description: string, result: Opt<(string, string)>}
 typedef debug::DDlogOpId = (std::u32, std::u32, std::u32)
 #[size = 8]
 #[shared_ref = true]
@@ -832,6 +837,57 @@ function ti_f (value: std::Option<string>): std::Option<(string, string)>
          (_: (std::Option<string>, std::Option<string>)) -> (std::None{}: std::Option<(string, string)>)
      })
 }
+function try1 (name: string): std::Option<(string, string)>
+{
+    ((var components: std::Vec<string>) = std::split(name, " ");
+     ((var first_name: string) = match ((std::nth(components, 64'd0): std::Option<string>)) {
+                                     (std::None{}: std::Option<string>) -> ((return (std::None{}: std::Option<(string, string)>)): string),
+                                     (std::Some{.x=(var __x: string)}: std::Option<string>) -> __x
+                                 };
+      ((var last_name: string) = match ((std::nth(components, 64'd1): std::Option<string>)) {
+                                     (std::None{}: std::Option<string>) -> ((return (std::None{}: std::Option<(string, string)>)): string),
+                                     (std::Some{.x=(var __x: string)}: std::Option<string>) -> __x
+                                 };
+       (std::Some{.x=(first_name, last_name)}: std::Option<(string, string)>))))
+}
+function try2 (name: string): std::Result<(string, string),string>
+{
+    ((var components: std::Vec<string>) = std::split(name, " ");
+     ((var first_name: string) = match (match ((std::nth(components, 64'd0): std::Option<string>)) {
+                                            (std::None{}: std::Option<string>) -> (std::Err{.err="No first name"}: std::Result<string,string>),
+                                            (std::Some{.x=(var n: string)}: std::Option<string>) -> (std::Ok{.res=n}: std::Result<string,string>)
+                                        }) {
+                                     (std::Err{.err=(var __e: string)}: std::Result<string,string>) -> ((return (std::Err{.err=__e}: std::Result<(string, string),string>)): string),
+                                     (std::Ok{.res=(var __x: string)}: std::Result<string,string>) -> __x
+                                 };
+      ((var last_name: string) = match (match ((std::nth(components, 64'd1): std::Option<string>)) {
+                                            (std::None{}: std::Option<string>) -> (std::Err{.err="No last name"}: std::Result<string,string>),
+                                            (std::Some{.x=(var n: string)}: std::Option<string>) -> (std::Ok{.res=n}: std::Result<string,string>)
+                                        }) {
+                                     (std::Err{.err=(var __e: string)}: std::Result<string,string>) -> ((return (std::Err{.err=__e}: std::Result<(string, string),string>)): string),
+                                     (std::Ok{.res=(var __x: string)}: std::Result<string,string>) -> __x
+                                 };
+       (std::Ok{.res=(first_name, last_name)}: std::Result<(string, string),string>))))
+}
+function try3 (name: string): Opt<(string, string)>
+{
+    ((var components: std::Vec<string>) = std::split(name, " ");
+     ((var first_name: string) = match (match ((std::nth(components, 64'd0): std::Option<string>)) {
+                                            (std::None{}: std::Option<string>) -> (std::Err{.err="No first name"}: std::Result<string,string>),
+                                            (std::Some{.x=(var n: string)}: std::Option<string>) -> (std::Ok{.res=n}: std::Result<string,string>)
+                                        }) {
+                                     (std::Err{.err=(_: string)}: std::Result<string,string>) -> ((return (std::None{}: Opt<(string, string)>)): string),
+                                     (std::Ok{.res=(var __x: string)}: std::Result<string,string>) -> __x
+                                 };
+      ((var last_name: string) = match (match ((std::nth(components, 64'd1): std::Option<string>)) {
+                                            (std::None{}: std::Option<string>) -> (std::Err{.err="No last name"}: std::Result<string,string>),
+                                            (std::Some{.x=(var n: string)}: std::Option<string>) -> (std::Ok{.res=n}: std::Result<string,string>)
+                                        }) {
+                                     (std::Err{.err=(_: string)}: std::Result<string,string>) -> ((return (std::None{}: Opt<(string, string)>)): string),
+                                     (std::Ok{.res=(var __x: string)}: std::Result<string,string>) -> __x
+                                 };
+       (std::Some{.x=(first_name, last_name)}: std::Option<(string, string)>))))
+}
 function weird_zero (x: 'A): std::usize
 {
     ((var empty_vec: std::Vec<'A>) = (std::vec_empty(): std::Vec<'A>);
@@ -888,6 +944,9 @@ output relation TArrng1Arrng2 [TArrng1Arrng2]
 input relation TArrng2 [(std::Ref<TArrng2>, bigint)]
 relation TI_R [TI_R]
 input relation TestRelation [TestRelation]
+output relation Try1 [Try1]
+output relation Try2 [Try2]
+output relation Try3 [Try3]
 Arrng1Arrng2[(Arrng1Arrng2{.x=x.f2.f2}: Arrng1Arrng2)] :- Arrng1[(__arrng10@ (Arrng1{.f1=(f1: std::Ref<std::Ref<std::Ref<TArrng2>>>), .f2=(f2: bigint)}: Arrng1))], Arrng2[(__arrng21@ (Arrng2{.f1=(x: std::Ref<TArrng2>), .f2=f1.f2.f2, .f3=(_: bool)}: Arrng2))], Inspect debug::debug_event_join((32'd0, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, __arrng10, __arrng21, (Arrng1Arrng2{.x=x.f2.f2}: Arrng1Arrng2)).
 Arrng1Arrng2_2[(Arrng1Arrng2_2{.x=x.f2.f2}: Arrng1Arrng2_2)] :- Arrng1[(__arrng10@ (Arrng1{.f1=(f1: std::Ref<std::Ref<std::Ref<TArrng2>>>), .f2=(f2: bigint)}: Arrng1))], Arrng2[(__arrng21@ (Arrng2{.f1=(x: std::Ref<TArrng2>), .f2=f1.f2.f2, .f3=f1.f2.f1}: Arrng2))], Inspect debug::debug_event_join((32'd1, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, __arrng10, __arrng21, (Arrng1Arrng2_2{.x=x.f2.f2}: Arrng1Arrng2_2)).
 TArrng1Arrng2[(TArrng1Arrng2{.x=x.f2.f2}: TArrng1Arrng2)] :- TArrng1[(__tarrng10@ (t: (std::Ref<std::Ref<std::Ref<TArrng2>>>, bigint)))], TArrng2[(__tarrng21@ ((x: std::Ref<TArrng2>), t.0.f2.f2))], Inspect debug::debug_event_join((32'd2, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, __tarrng10, __tarrng21, (TArrng1Arrng2{.x=x.f2.f2}: TArrng1Arrng2)).
@@ -933,4 +992,13 @@ Fib[(Fib{.x=64'd20, .f=fib(64'd20)}: Fib)].
 Ack[(Ack{.m=64'd2, .n=64'd1, .a=ack(64'd2, 64'd1)}: Ack)].
 Strings[(Strings{.descr="x={10:bit<12>}, y={10:float}, z={-4:signed<125>}", .str=((((("x=" ++ (std::__builtin_2string((12'd10: bit<12>)): string)) ++ ", y=") ++ (std::__builtin_2string((32'f10.0: float)): string)) ++ ", z=") ++ (std::__builtin_2string((- (128'sd4: signed<128>))): string))}: Strings)].
 Rseq[(Rseq{._s=(TSeq1{.x=(_l, (std::ref_new(_s): std::Ref<TSeq>))}: TSeq)}: Rseq)] :- Rletter[(__rletter0@ (Rletter{._l=(_l: string)}: Rletter))], Rseqs[(__rseqs1@ (Rseqs{._s=(_s: TSeq)}: Rseqs))], Inspect debug::debug_event_join((32'd25, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, __rletter0, __rseqs1, (Rseq{._s=(TSeq1{.x=(_l, (std::ref_new(_s): std::Ref<TSeq>))}: TSeq)}: Rseq)).
+Try1[(Try1{.description="Isaac Newton", .result=try1("Isaac Newton")}: Try1)].
+Try1[(Try1{.description="", .result=try1("")}: Try1)].
+Try1[(Try1{.description="Albert_Einstein", .result=try1("Albert_Einstein")}: Try1)].
+Try2[(Try2{.description="Isaac Newton", .result=try2("Isaac Newton")}: Try2)].
+Try2[(Try2{.description="", .result=try2("")}: Try2)].
+Try2[(Try2{.description="Albert_Einstein", .result=try2("Albert_Einstein")}: Try2)].
+Try3[(Try3{.description="Isaac Newton", .result=try3("Isaac Newton")}: Try3)].
+Try3[(Try3{.description="", .result=try3("")}: Try3)].
+Try3[(Try3{.description="Albert_Einstein", .result=try3("Albert_Einstein")}: Try3)].
 

--- a/test/datalog_tests/simple2.dl
+++ b/test/datalog_tests/simple2.dl
@@ -263,3 +263,62 @@ input relation Rletter(_l:string)
 input relation Rseqs(_s:TSeq)
 output relation Rseq(_s:TSeq)
 Rseq(TSeq1{(_l, ref_new(_s))}) :- Rletter(_l), Rseqs(_s).
+
+/*
+ * ?-operator
+ */
+
+function try1(name: string): Option<(string, string)> {
+    var components = name.split(" ");
+    var first_name = components.nth(0)?;
+    var last_name = components.nth(1)?;
+    Some{(first_name, last_name)}
+}
+
+// makes sure it works with type aliases.
+typedef Opt<'X> = Option<'X>
+typedef SResult<'V> = Result<'V, string>
+
+output relation Try1(description: string, result: Opt<(string, string)>)
+
+Try1("Isaac Newton", try1("Isaac Newton")).
+Try1("", try1("")).
+Try1("Albert_Einstein", try1("Albert_Einstein")).
+
+function try2(name: string): Result<(string, string), string> {
+    var components = name.split(" ");
+    var first_name = match (components.nth(0)) {
+        None -> Err{"No first name"},
+        Some{n} -> Ok{n}
+    }?;
+    var last_name = match (components.nth(1)) {
+        None -> Err{"No last name"},
+        Some{n} -> Ok{n}
+    }?;
+    Ok{(first_name, last_name)}
+}
+
+output relation Try2(description: string, result: SResult<(string, string)>)
+
+Try2("Isaac Newton", try2("Isaac Newton")).
+Try2("", try2("")).
+Try2("Albert_Einstein", try2("Albert_Einstein")).
+
+function try3(name: string): Opt<(string, string)> {
+    var components = name.split(" ");
+    var first_name = match (components.nth(0)) {
+        None -> Err{"No first name"},
+        Some{n} -> Ok{n}
+    }?;
+    var last_name = match (components.nth(1)) {
+        None -> Err{"No last name"},
+        Some{n} -> Ok{n}
+    }?;
+    Some{(first_name, last_name)}
+}
+
+output relation Try3(description: string, result: Opt<(string, string)>)
+
+Try3("Isaac Newton", try3("Isaac Newton")).
+Try3("", try3("")).
+Try3("Albert_Einstein", try3("Albert_Einstein")).

--- a/test/datalog_tests/simple2.dump.expected
+++ b/test/datalog_tests/simple2.dump.expected
@@ -14,6 +14,18 @@ RFloatToInt:
 RFloatToInt{._x = -333}: +1
 Strings:
 Strings{.descr = "x={10:bit<12>}, y={10:float}, z={-4:signed<125>}", .str = "x=10, y=10, z=-4"}: +1
+Try1:
+Try1{.description = "", .result = std::None{}}: +1
+Try1{.description = "Albert_Einstein", .result = std::None{}}: +1
+Try1{.description = "Isaac Newton", .result = std::Some{.x = ("Isaac", "Newton")}}: +1
+Try2:
+Try2{.description = "", .result = std::Err{.err = "No last name"}}: +1
+Try2{.description = "Albert_Einstein", .result = std::Err{.err = "No last name"}}: +1
+Try2{.description = "Isaac Newton", .result = std::Ok{.res = ("Isaac", "Newton")}}: +1
+Try3:
+Try3{.description = "", .result = std::None{}}: +1
+Try3{.description = "Albert_Einstein", .result = std::None{}}: +1
+Try3{.description = "Isaac Newton", .result = std::Some{.x = ("Isaac", "Newton")}}: +1
 RFloatToInt{._x = -333}
 Arrng1Arrng2:
 Arrng1Arrng2{.x = 5}: +1

--- a/test/datalog_tests/tutorial.debug.ast.expected
+++ b/test/datalog_tests/tutorial.debug.ast.expected
@@ -48,6 +48,7 @@ typedef Phrases = Phrases{phrase: string}
 typedef Pow2 = Pow2{p: string}
 typedef Prefix = Prefix{vec: std::Vec<string>}
 typedef Price = Price{item: string, vendor: string, price: bit<64>}
+typedef PriceInCents = PriceInCents{item: string, price1: std::Option<std::u64>, price2: std::u64, price3: std::Option<std::u64>}
 typedef Product = Product{x: bit<16>, y: bit<16>, prod: bit<16>}
 typedef SanitizedEndpoint = SanitizedEndpoint{ep: string}
 typedef School = School{name: string, address: string}
@@ -143,17 +144,17 @@ function __debug_20_2_best_vendor_string (g: std::Group<string,('I, (string, bit
     (((var inputs: std::Vec<'I>), (var original_group: std::Group<string,(string, bit<64>)>)) = debug::debug_split_group(g);
      (inputs, best_vendor_string(original_group)))
 }
-function __debug_31_1_std::group_max (g: std::Group<string,('I, bit<16>)>): (std::Vec<'I>, bit<16>)
+function __debug_33_1_std::group_max (g: std::Group<string,('I, bit<16>)>): (std::Vec<'I>, bit<16>)
 {
     (((var inputs: std::Vec<'I>), (var original_group: std::Group<string,bit<16>>)) = debug::debug_split_group(g);
      (inputs, std::group_max(original_group)))
 }
-function __debug_32_1_std::group_max (g: std::Group<string,('I, bit<16>)>): (std::Vec<'I>, bit<16>)
+function __debug_34_1_std::group_max (g: std::Group<string,('I, bit<16>)>): (std::Vec<'I>, bit<16>)
 {
     (((var inputs: std::Vec<'I>), (var original_group: std::Group<string,bit<16>>)) = debug::debug_split_group(g);
      (inputs, std::group_max(original_group)))
 }
-function __debug_33_1_std::group_to_vec (g: std::Group<internment::Intern<string>,('I, bit<64>)>): (std::Vec<'I>, std::Vec<bit<64>>)
+function __debug_35_1_std::group_to_vec (g: std::Group<internment::Intern<string>,('I, bit<64>)>): (std::Vec<'I>, std::Vec<bit<64>>)
 {
     (((var inputs: std::Vec<'I>), (var original_group: std::Group<internment::Intern<string>,bit<64>>)) = debug::debug_split_group(g);
      (inputs, std::group_to_vec(original_group)))
@@ -218,6 +219,30 @@ function evens (vec: std::Vec<bigint>): std::Vec<bigint>
            std::vec_push(res, x))
       };
       res))
+}
+function get_price_in_cents (inventory: std::Map<string,string>, item: string): std::Option<std::u64>
+{
+    match ((std::get(inventory, item): std::Option<string>)) {
+        (std::None{}: std::Option<string>) -> (std::None{}: std::Option<bit<64>>),
+        (std::Some{.x=(var price: string)}: std::Option<string>) -> match (std::parse_dec_u64(price)) {
+                                                                        (std::None{}: std::Option<bit<64>>) -> (std::None{}: std::Option<bit<64>>),
+                                                                        (std::Some{.x=(var p: bit<64>)}: std::Option<bit<64>>) -> (std::Some{.x=(64'd100 * p)}: std::Option<bit<64>>)
+                                                                    }
+    }
+}
+function get_price_in_cents_ (inventory: std::Map<string,string>, item: string): std::Option<std::u64>
+{
+    (std::Some{.x=(match (std::parse_dec_u64(match ((std::get(inventory, item): std::Option<string>)) {
+                                                 (std::None{}: std::Option<string>) -> ((return (std::None{}: std::Option<std::u64>)): string),
+                                                 (std::Some{.x=(var __x: string)}: std::Option<string>) -> __x
+                                             })) {
+                       (std::None{}: std::Option<bit<64>>) -> ((return (std::None{}: std::Option<std::u64>)): bit<64>),
+                       (std::Some{.x=(var __x: bit<64>)}: std::Option<bit<64>>) -> __x
+                   } * 64'd100)}: std::Option<bit<64>>)
+}
+function get_price_in_cents_unwrap (inventory: std::Map<string,string>, item: string): std::u64
+{
+    ((std::unwrap_or(std::parse_dec_u64((std::unwrap_or_default((std::get(inventory, item): std::Option<string>)): string)), 64'd0): bit<64>) * 64'd100)
 }
 #[has_side_effects = true]
 extern function inspect_log::log (filename: string, msg: string): ()
@@ -288,6 +313,10 @@ function internment::to_uppercase (s: internment::istring): string
 function internment::trim (s: internment::istring): string
 {
     internment::istring_trim(s)
+}
+function inventory (): std::Map<string,string>
+{
+    (std::insert_imm((std::map_singleton("Falcon 9", "62000000"): std::Map<string,string>), "Soyuz", "180000000"): std::Map<string,string>)
 }
 function ip_from_bytes (b3: bit<8>, b2: bit<8>, b1: bit<8>, b0: bit<8>): ip_addr_t
 {
@@ -867,6 +896,7 @@ output relation Phrases [Phrases]
 output relation Pow2 [Pow2]
 output relation Prefix [Prefix]
 input relation Price [Price]
+output relation PriceInCents [PriceInCents]
 output relation Product [Product]
 output relation SanitizedEndpoint [SanitizedEndpoint]
 input relation School [std::Ref<School>]
@@ -915,19 +945,21 @@ UDPDstPort2[(UDPDstPort2{.port=port}: UDPDstPort2)] :- Packet[(__packet0@ (Packe
 IntranetHost[(IntranetHost{.addr=addr}: IntranetHost)] :- KnownHost[(__knownhost0@ (KnownHost{.addr=(addr: bit<32>)}: KnownHost))], ((var b3: bit<8>), (var b2: bit<8>), (_: bit<8>), (_: bit<8>)) = addr_to_tuple(addr), (b3 == 8'd192), (b2 == 8'd168), Inspect debug::debug_event((32'd26, 32'd3, 32'd0), ddlog_weight, ddlog_timestamp, "Condition", (addr, b2), (IntranetHost{.addr=addr}: IntranetHost)).
 IntranetHost2[(IntranetHost2{.addr=addr}: IntranetHost2)] :- KnownHost[(__knownhost0@ (KnownHost{.addr=(addr: bit<32>)}: KnownHost))], (8'd192, 8'd168, (_: bit<8>), (_: bit<8>)) = addr_to_tuple(addr), Inspect debug::debug_event((32'd27, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, "Condition", __knownhost0, (IntranetHost2{.addr=addr}: IntranetHost2)).
 IntranetHost3[(IntranetHost3{.addr=addr}: IntranetHost3)] :- KnownHost[(__knownhost0@ (KnownHost{.addr=(addr: bit<32>)}: KnownHost))], (var t: (bit<8>, bit<8>, bit<8>, bit<8>)) = addr_to_tuple(addr), (t.0 == 8'd192), (t.1 == 8'd168), Inspect debug::debug_event((32'd28, 32'd3, 32'd0), ddlog_weight, ddlog_timestamp, "Condition", (addr, t), (IntranetHost3{.addr=addr}: IntranetHost3)).
-TargetAudience[person] :- Person[(__person0@ (person: Person))], is_target_audience(person), Inspect debug::debug_event((32'd29, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, "Condition", __person0, person).
-StudentInfo[(StudentInfo{.student=student, .school=school}: StudentInfo)] :- Student[(student@ ((&(Student{.id=(_: bit<64>), .name=(_: string), .school=(school_name: string), .sat_score=(_: bit<16>)}: Student)): std::Ref<Student>))], School[(school@ ((&(School{.name=(school_name: string), .address=(_: string)}: School)): std::Ref<School>))], Inspect debug::debug_event_join((32'd30, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, student, school, (StudentInfo{.student=student, .school=school}: StudentInfo)).
-TopScore[(TopScore{.school=school, .top_score=top_score}: TopScore)] :- StudentInfo[(__studentinfo0@ (StudentInfo{.student=((&(Student{.id=(_: bit<64>), .name=(_: string), .school=(_: string), .sat_score=(sat: bit<16>)}: Student)): std::Ref<Student>), .school=((&(School{.name=(school: string), .address=(_: string)}: School)): std::Ref<School>)}: StudentInfo))], var __inputs_top_score = Aggregate(school, __debug_31_1_std::group_max((__studentinfo0, sat))), Inspect debug::debug_event((32'd31, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, "Aggregate", __inputs_top_score.0, (__inputs_top_score, school)), (var top_score: bit<16>) = __inputs_top_score.1, Inspect debug::debug_event((32'd31, 32'd2, 32'd0), ddlog_weight, ddlog_timestamp, "Condition", (__inputs_top_score, school), (TopScore{.school=school, .top_score=top_score}: TopScore)).
-TopScore[(TopScore{.school=school, .top_score=top_score}: TopScore)] :- StudentInfo[(__studentinfo0@ (StudentInfo{.student=(student: std::Ref<Student>), .school=((&(School{.name=(school: string), .address=(_: string)}: School)): std::Ref<School>)}: StudentInfo))], var __inputs_top_score = Aggregate(school, __debug_32_1_std::group_max((__studentinfo0, student.sat_score))), Inspect debug::debug_event((32'd32, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, "Aggregate", __inputs_top_score.0, (__inputs_top_score, school)), (var top_score: bit<16>) = __inputs_top_score.1, Inspect debug::debug_event((32'd32, 32'd2, 32'd0), ddlog_weight, ddlog_timestamp, "Condition", (__inputs_top_score, school), (TopScore{.school=school, .top_score=top_score}: TopScore)).
-ItemInOrders[(ItemInOrders{.item=(internment::ival(item): string), .orders=orders}: ItemInOrders)] :- OnlineOrder[(__onlineorder0@ (OnlineOrder{.order_id=(order: bit<64>), .item=(item: internment::Intern<string>)}: OnlineOrder))], var __inputs_orders = Aggregate(item, __debug_33_1_std::group_to_vec((__onlineorder0, order))), Inspect debug::debug_event((32'd33, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, "Aggregate", __inputs_orders.0, (__inputs_orders, item)), (var orders: std::Vec<bit<64>>) = __inputs_orders.1, Inspect debug::debug_event((32'd33, 32'd2, 32'd0), ddlog_weight, ddlog_timestamp, "Condition", (__inputs_orders, item), (ItemInOrders{.item=(internment::ival(item): string), .orders=orders}: ItemInOrders)).
-OrderFormatted[(OrderFormatted{.order=formatted}: OrderFormatted)] :- OnlineOrder[(__onlineorder0@ (OnlineOrder{.order_id=(order: bit<64>), .item=(item: internment::Intern<string>)}: OnlineOrder))], (var formatted: string) = ((("order: " ++ (std::__builtin_2string(order): string)) ++ ", item: ") ++ (internment::ival(item): string)), Inspect debug::debug_event((32'd34, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, "Condition", __onlineorder0, (OrderFormatted{.order=formatted}: OrderFormatted)).
-MilkOrders[(MilkOrders{.order=order}: MilkOrders)] :- OnlineOrder[(__onlineorder0@ (OnlineOrder{.order_id=(order: bit<64>), .item=(internment::intern("milk"): internment::Intern<string>)}: OnlineOrder))], Inspect debug::debug_event((32'd35, 32'd0, 32'd0), ddlog_weight, ddlog_timestamp, "Map", __onlineorder0, (MilkOrders{.order=order}: MilkOrders)).
-InventoryItemName[(InventoryItemName{.name=name}: InventoryItemName)] :- StoreInventory[(__storeinventory0@ (StoreInventory{.item=(item: internment::Intern<StoreItem>)}: StoreInventory))], (var name: string) = (internment::ival(item): StoreItem).name, Inspect debug::debug_event((32'd36, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, "Condition", __storeinventory0, (InventoryItemName{.name=name}: InventoryItemName)).
-Flow[(Flow{.lr=ls, .stage=(LS_IN_PRE_LB{}: stage), .prio=100, .matchStr=("ip4.dst == " ++ addresses), .actionStr="{ reg0[0] = 1; next; }"}: Flow)] :- Load_Balancer[(__load_balancer0@ (Load_Balancer{.lb=(_: bigint), .ls=(ls: bigint), .ip_addresses=(addresses: string), .protocol=(std::Some{.x=(_: string)}: std::Option<string>), .name=(_: string)}: Load_Balancer))], Inspect debug::debug_event((32'd37, 32'd0, 32'd0), ddlog_weight, ddlog_timestamp, "Map", __load_balancer0, (Flow{.lr=ls, .stage=(LS_IN_PRE_LB{}: stage), .prio=100, .matchStr=("ip4.dst == " ++ addresses), .actionStr="{ reg0[0] = 1; next; }"}: Flow)).
-Flow[(Flow{.lr=ls, .stage=(LS_OUT_PRE_LB{}: stage), .prio=100, .matchStr="ip4", .actionStr="{ reg0[0] = 1; next; }"}: Flow)] :- Logical_Switch[(__logical_switch0@ (Logical_Switch{.ls=(ls: bigint)}: Logical_Switch))], Load_Balancer[(__load_balancer1@ (Load_Balancer{.lb=(_: bigint), .ls=(ls: bigint), .ip_addresses=(_: string), .protocol=(_: std::Option<string>), .name=(_: string)}: Load_Balancer))], Inspect debug::debug_event_join((32'd38, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, __logical_switch0, __load_balancer1, (Flow{.lr=ls, .stage=(LS_OUT_PRE_LB{}: stage), .prio=100, .matchStr="ip4", .actionStr="{ reg0[0] = 1; next; }"}: Flow)).
+PriceInCents[(PriceInCents{.item="Falcon 9", .price1=get_price_in_cents(inventory(), "Falcon 9"), .price2=get_price_in_cents_unwrap(inventory(), "Falcon 9"), .price3=get_price_in_cents_(inventory(), "Falcon 9")}: PriceInCents)].
+PriceInCents[(PriceInCents{.item="Atlantis", .price1=get_price_in_cents(inventory(), "Atlantis"), .price2=get_price_in_cents_unwrap(inventory(), "Atlantis"), .price3=get_price_in_cents_(inventory(), "Atlantis")}: PriceInCents)].
+TargetAudience[person] :- Person[(__person0@ (person: Person))], is_target_audience(person), Inspect debug::debug_event((32'd31, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, "Condition", __person0, person).
+StudentInfo[(StudentInfo{.student=student, .school=school}: StudentInfo)] :- Student[(student@ ((&(Student{.id=(_: bit<64>), .name=(_: string), .school=(school_name: string), .sat_score=(_: bit<16>)}: Student)): std::Ref<Student>))], School[(school@ ((&(School{.name=(school_name: string), .address=(_: string)}: School)): std::Ref<School>))], Inspect debug::debug_event_join((32'd32, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, student, school, (StudentInfo{.student=student, .school=school}: StudentInfo)).
+TopScore[(TopScore{.school=school, .top_score=top_score}: TopScore)] :- StudentInfo[(__studentinfo0@ (StudentInfo{.student=((&(Student{.id=(_: bit<64>), .name=(_: string), .school=(_: string), .sat_score=(sat: bit<16>)}: Student)): std::Ref<Student>), .school=((&(School{.name=(school: string), .address=(_: string)}: School)): std::Ref<School>)}: StudentInfo))], var __inputs_top_score = Aggregate(school, __debug_33_1_std::group_max((__studentinfo0, sat))), Inspect debug::debug_event((32'd33, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, "Aggregate", __inputs_top_score.0, (__inputs_top_score, school)), (var top_score: bit<16>) = __inputs_top_score.1, Inspect debug::debug_event((32'd33, 32'd2, 32'd0), ddlog_weight, ddlog_timestamp, "Condition", (__inputs_top_score, school), (TopScore{.school=school, .top_score=top_score}: TopScore)).
+TopScore[(TopScore{.school=school, .top_score=top_score}: TopScore)] :- StudentInfo[(__studentinfo0@ (StudentInfo{.student=(student: std::Ref<Student>), .school=((&(School{.name=(school: string), .address=(_: string)}: School)): std::Ref<School>)}: StudentInfo))], var __inputs_top_score = Aggregate(school, __debug_34_1_std::group_max((__studentinfo0, student.sat_score))), Inspect debug::debug_event((32'd34, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, "Aggregate", __inputs_top_score.0, (__inputs_top_score, school)), (var top_score: bit<16>) = __inputs_top_score.1, Inspect debug::debug_event((32'd34, 32'd2, 32'd0), ddlog_weight, ddlog_timestamp, "Condition", (__inputs_top_score, school), (TopScore{.school=school, .top_score=top_score}: TopScore)).
+ItemInOrders[(ItemInOrders{.item=(internment::ival(item): string), .orders=orders}: ItemInOrders)] :- OnlineOrder[(__onlineorder0@ (OnlineOrder{.order_id=(order: bit<64>), .item=(item: internment::Intern<string>)}: OnlineOrder))], var __inputs_orders = Aggregate(item, __debug_35_1_std::group_to_vec((__onlineorder0, order))), Inspect debug::debug_event((32'd35, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, "Aggregate", __inputs_orders.0, (__inputs_orders, item)), (var orders: std::Vec<bit<64>>) = __inputs_orders.1, Inspect debug::debug_event((32'd35, 32'd2, 32'd0), ddlog_weight, ddlog_timestamp, "Condition", (__inputs_orders, item), (ItemInOrders{.item=(internment::ival(item): string), .orders=orders}: ItemInOrders)).
+OrderFormatted[(OrderFormatted{.order=formatted}: OrderFormatted)] :- OnlineOrder[(__onlineorder0@ (OnlineOrder{.order_id=(order: bit<64>), .item=(item: internment::Intern<string>)}: OnlineOrder))], (var formatted: string) = ((("order: " ++ (std::__builtin_2string(order): string)) ++ ", item: ") ++ (internment::ival(item): string)), Inspect debug::debug_event((32'd36, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, "Condition", __onlineorder0, (OrderFormatted{.order=formatted}: OrderFormatted)).
+MilkOrders[(MilkOrders{.order=order}: MilkOrders)] :- OnlineOrder[(__onlineorder0@ (OnlineOrder{.order_id=(order: bit<64>), .item=(internment::intern("milk"): internment::Intern<string>)}: OnlineOrder))], Inspect debug::debug_event((32'd37, 32'd0, 32'd0), ddlog_weight, ddlog_timestamp, "Map", __onlineorder0, (MilkOrders{.order=order}: MilkOrders)).
+InventoryItemName[(InventoryItemName{.name=name}: InventoryItemName)] :- StoreInventory[(__storeinventory0@ (StoreInventory{.item=(item: internment::Intern<StoreItem>)}: StoreInventory))], (var name: string) = (internment::ival(item): StoreItem).name, Inspect debug::debug_event((32'd38, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, "Condition", __storeinventory0, (InventoryItemName{.name=name}: InventoryItemName)).
+Flow[(Flow{.lr=ls, .stage=(LS_IN_PRE_LB{}: stage), .prio=100, .matchStr=("ip4.dst == " ++ addresses), .actionStr="{ reg0[0] = 1; next; }"}: Flow)] :- Load_Balancer[(__load_balancer0@ (Load_Balancer{.lb=(_: bigint), .ls=(ls: bigint), .ip_addresses=(addresses: string), .protocol=(std::Some{.x=(_: string)}: std::Option<string>), .name=(_: string)}: Load_Balancer))], Inspect debug::debug_event((32'd39, 32'd0, 32'd0), ddlog_weight, ddlog_timestamp, "Map", __load_balancer0, (Flow{.lr=ls, .stage=(LS_IN_PRE_LB{}: stage), .prio=100, .matchStr=("ip4.dst == " ++ addresses), .actionStr="{ reg0[0] = 1; next; }"}: Flow)).
+Flow[(Flow{.lr=ls, .stage=(LS_OUT_PRE_LB{}: stage), .prio=100, .matchStr="ip4", .actionStr="{ reg0[0] = 1; next; }"}: Flow)] :- Logical_Switch[(__logical_switch0@ (Logical_Switch{.ls=(ls: bigint)}: Logical_Switch))], Load_Balancer[(__load_balancer1@ (Load_Balancer{.lb=(_: bigint), .ls=(ls: bigint), .ip_addresses=(_: string), .protocol=(_: std::Option<string>), .name=(_: string)}: Load_Balancer))], Inspect debug::debug_event_join((32'd40, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, __logical_switch0, __load_balancer1, (Flow{.lr=ls, .stage=(LS_OUT_PRE_LB{}: stage), .prio=100, .matchStr="ip4", .actionStr="{ reg0[0] = 1; next; }"}: Flow)).
 Flow1[(Flow1{.lr=lb.ls, .stage=(LS_IN_PRE_LB{}: stage), .prio=100, .matchStr=("ip4.dst == " ++ a), .actionStr="{ reg0[0] = 1; next; }"}: Flow1)] :- Load_Balancer[(lb@ (Load_Balancer{.lb=(_: bigint), .ls=(_: bigint), .ip_addresses=(_: string), .protocol=(_: std::Option<string>), .name=(_: string)}: Load_Balancer))], (var a: string) = lb.ip_addresses, match (lb.protocol) {
                                                                                                                                                                                                                                                                                                                                                                     (std::Some{.x=(_: string)}: std::Option<string>) -> true,
                                                                                                                                                                                                                                                                                                                                                                     (std::None{}: std::Option<string>) -> false
-                                                                                                                                                                                                                                                                                                                                                                }, Inspect debug::debug_event((32'd39, 32'd2, 32'd0), ddlog_weight, ddlog_timestamp, "Condition", (lb, a), (Flow1{.lr=lb.ls, .stage=(LS_IN_PRE_LB{}: stage), .prio=100, .matchStr=("ip4.dst == " ++ a), .actionStr="{ reg0[0] = 1; next; }"}: Flow1)).
-Flow1[(Flow1{.lr=ls.ls, .stage=(LS_OUT_PRE_LB{}: stage), .prio=100, .matchStr="ip4", .actionStr="{ reg0[0] = 1; next; }"}: Flow1)] :- Logical_Switch[(ls@ (Logical_Switch{.ls=(_: bigint)}: Logical_Switch))], Load_Balancer[(lb@ (Load_Balancer{.lb=(_: bigint), .ls=(_: bigint), .ip_addresses=(_: string), .protocol=(_: std::Option<string>), .name=(_: string)}: Load_Balancer))], Inspect debug::debug_event_join((32'd40, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, ls, lb, (ls, lb)), (lb.ls == ls.ls), Inspect debug::debug_event((32'd40, 32'd2, 32'd0), ddlog_weight, ddlog_timestamp, "Condition", (ls, lb), (Flow1{.lr=ls.ls, .stage=(LS_OUT_PRE_LB{}: stage), .prio=100, .matchStr="ip4", .actionStr="{ reg0[0] = 1; next; }"}: Flow1)).
+                                                                                                                                                                                                                                                                                                                                                                }, Inspect debug::debug_event((32'd41, 32'd2, 32'd0), ddlog_weight, ddlog_timestamp, "Condition", (lb, a), (Flow1{.lr=lb.ls, .stage=(LS_IN_PRE_LB{}: stage), .prio=100, .matchStr=("ip4.dst == " ++ a), .actionStr="{ reg0[0] = 1; next; }"}: Flow1)).
+Flow1[(Flow1{.lr=ls.ls, .stage=(LS_OUT_PRE_LB{}: stage), .prio=100, .matchStr="ip4", .actionStr="{ reg0[0] = 1; next; }"}: Flow1)] :- Logical_Switch[(ls@ (Logical_Switch{.ls=(_: bigint)}: Logical_Switch))], Load_Balancer[(lb@ (Load_Balancer{.lb=(_: bigint), .ls=(_: bigint), .ip_addresses=(_: string), .protocol=(_: std::Option<string>), .name=(_: string)}: Load_Balancer))], Inspect debug::debug_event_join((32'd42, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, ls, lb, (ls, lb)), (lb.ls == ls.ls), Inspect debug::debug_event((32'd42, 32'd2, 32'd0), ddlog_weight, ddlog_timestamp, "Condition", (ls, lb), (Flow1{.lr=ls.ls, .stage=(LS_OUT_PRE_LB{}: stage), .prio=100, .matchStr="ip4", .actionStr="{ reg0[0] = 1; next; }"}: Flow1)).
 

--- a/test/datalog_tests/tutorial.dl
+++ b/test/datalog_tests/tutorial.dl
@@ -465,6 +465,48 @@ IntranetHost3(addr) :- KnownHost(addr),
                        t.0 == 192, t.1 == 168.
 
 /*
+ * Example: error handling.
+ */
+
+/* Lookup item in the inventory and return its price in cents. */
+function get_price_in_cents(inventory: Map<string, string>, item: string): Option<u64> {
+    match (inventory.get(item)) {
+        None -> None,
+        Some{price} -> match (parse_dec_u64(price)) {
+                           None    -> None,
+                           Some{p} -> Some{100 * p}
+                       }
+    }
+}
+
+/* As above, but returns 0 if the item is missing from the inventory or the price
+ * string is invalid. */
+function get_price_in_cents_unwrap(inventory: Map<string, string>, item: string): u64 {
+    inventory.get(item).unwrap_or_default().parse_dec_u64().unwrap_or(0) * 100
+}
+
+/* get_price_in_cents written more concisely with the help of the `?` operator. */
+function get_price_in_cents_(inventory: Map<string, string>, item: string): Option<u64> {
+    Some{ inventory.get(item)?.parse_dec_u64()? * 100 }
+}
+
+function inventory(): Map<string, string> {
+    map_singleton("Falcon 9", "62000000")
+    .insert_imm("Soyuz", "180000000")
+}
+
+output relation PriceInCents(item: string, price1: Option<u64>, price2: u64, price3: Option<u64>)
+
+PriceInCents("Falcon 9",
+             inventory().get_price_in_cents("Falcon 9"),
+             inventory().get_price_in_cents_unwrap("Falcon 9"),
+             inventory().get_price_in_cents_("Falcon 9")).
+PriceInCents("Atlantis",
+             inventory().get_price_in_cents("Atlantis"),
+             inventory().get_price_in_cents_unwrap("Atlantis"),
+             inventory().get_price_in_cents_("Atlantis")).
+
+/*
  * Example: explicit relation type
  */
 

--- a/test/datalog_tests/tutorial.dump.expected
+++ b/test/datalog_tests/tutorial.dump.expected
@@ -2,6 +2,9 @@ First5:
 First5{.str = "Hello"}: +1
 Phrases:
 Phrases{.phrase = "Hello, World!"}: +1
+PriceInCents:
+PriceInCents{.item = "Atlantis", .price1 = std::None{}, .price2 = 0, .price3 = std::None{}}: +1
+PriceInCents{.item = "Falcon 9", .price1 = std::Some{.x = 6200000000}, .price2 = 6200000000, .price3 = std::Some{.x = 6200000000}}: +1
 Phrases:
 Phrases{.phrase = "Goodbye, Ruby Tuesday"}
 Phrases{.phrase = "Goodbye, World"}

--- a/test/run-souffle-tests.py
+++ b/test/run-souffle-tests.py
@@ -29,6 +29,7 @@ xfail = [
     "aggregates2", # aggregation used in head
     "aggregates4", # Implicit cast from signed to unsigned
     "aggregates5", # Cannot convert constant to float implicitly
+    "aggregates7", # Cannot convert constant to float implicitly
     "aggregates_complex", # cannot be evaluated bottom-up; issue 293
     "aggregates",  # issue 227 - count of empty group
     "magic_aggregates",  # 227


### PR DESCRIPTION


See RFC #707.

We introduce Rust-style error handling operator `?`.

The `?` operator can placed after an expression that returns `Option<>` or
`Result<>` inside a function scope.  Similar to `unwrap_` functions, it
extracts the inner value on success.  On error, it returns the error value
(or `None`) from the function, e.g.:

```
/* Lookup item in the inventory and return its price in cents. */
function get_price_in_cents_(inventory: Map<string, string>, item: string): Option<u64> {
    Some{ inventory.get(item)?.parse_dec_u64()? * 100 }
}
```

is equivalent to

```
function get_price_in_cents(inventory: Map<string, string>, item: string): Option<u64> {
    match (inventory.get(item)) {
        None -> None,
        Some{price} -> match (parse_dec_u64(price)) {
                           None    -> None,
                           Some{p} -> Some{100 * p}
                       }
    }
}

```

The `?` operator can only be used inside a function whose return type is
`Option` or `Result`.  The following table summarizes the behvaior of `?`
for various combinations of expression type and function return type.

| Function return type |     Expression type    | Expression value |  ? behaves as  |
|:--------------------:|:----------------------:|------------------|:--------------:|
| Option<T1>           | Option<T2>             | None             |   return None  |
| Option<T1>           | Option<T2>             | Some{x}          |        x       |
| Option<T1>           | Result<V,E>            | Err{e}           |   return None  |
| Option<T1>           | Result<V,E>            | Ok{v}            |        v       |
| Result<X,E>          | Result<Y,E>            | Err{e}           | return Err{e}  |
| Result<X,E>          | Result<Y,E>            | Ok{v}            |        v       |
| Result<V,E>          | Option<T>              |                  |     invalid    |
| Result<X,E1>         | Result<Y,E2>, E2 != E1 |                  |     invalid    |