### PR TITLE
Vector and map literals.

### DIFF
--- a/doc/language_reference/language_reference.md
+++ b/doc/language_reference/language_reference.md
@@ -337,6 +337,8 @@ term ::= "_"                 (* wildcard *)
        | bool_literal        (* Boolean literal *)
        | fp_literal          (* floating point literal *)
        | string_literal      (* string literal *)
+       | vec_literal         (* vector literal *)
+       | map_literal         (* map literal *)
        | cons_term           (* type constructor invocation *)
        | apply_term          (* function application *)
        | var_term            (* variable reference *)
@@ -409,9 +411,11 @@ they produce results of type `string`, e.g.:
 Other terms:
 
 ```EBNF
+vec_literal  :: "[" expr ("," expr)* "]"
+map_literal  :: "[" expr "->" expr ("," expr "->" expr)* "]"
 bool_literal ::= "true" | "false"
 cons_term    ::= (* positional arguments *)
-                 cons_name ["{" [expr (,expr)*] "}"]
+                 cons_name ["{" [expr ("," expr)*] "}"]
                  (* named arguments *)
                | cons_name ["{" "." field_name "=" expr
                             ("," "." field_name "=" expr)* "}"]

--- a/src/Language/DifferentialDatalog/Validate.hs
+++ b/src/Language/DifferentialDatalog/Validate.hs
@@ -583,13 +583,13 @@ exprValidate1 d _ _   (ESlice p _ h l)    =
     check d (h >= l) p
           $ "Upper bound of the slice must be greater than lower bound"
 exprValidate1 _ _ _   EMatch{}            = return ()
-exprValidate1 d _ ctx (EVarDecl p v)      = do
+exprValidate1 d _ ctx (EVarDecl p _)      = do
     check d (ctxInSetL ctx || ctxInMatchPat ctx) p "Variable declaration is not allowed in this context"
-    checkNoVar p d ctx v
+    --checkNoVar p d ctx v
 
 exprValidate1 _ _ _   ESeq{}              = return ()
 exprValidate1 _ _ _   EITE{}              = return ()
-exprValidate1 d _ ctx EFor{..}            = checkNoVar exprPos d ctx exprLoopVar
+exprValidate1 _ _ _   EFor{..}            = return () -- checkNoVar exprPos d ctx exprLoopVar
 exprValidate1 _ _ _   ESet{}              = return ()
 exprValidate1 d _ ctx (EContinue p)       = check d (ctxInForLoopBody ctx) p "\"continue\" outside of a loop"
 exprValidate1 d _ ctx (EBreak p)          = check d (ctxInForLoopBody ctx) p "\"break\" outside of a loop"

--- a/test/datalog_tests/function.fail.ast.expected
+++ b/test/datalog_tests/function.fail.ast.expected
@@ -6,10 +6,6 @@ error: ./test/datalog_tests/function.fail.dl:13:13-14:1: Missing field 'f2' in c
     var z = C{.f1 = "foo"}
             ^
 
-error: ./test/datalog_tests/function.fail.dl:11:17-11:18: Variable v already defined in this scope
-        C0{.x = v} -> v,
-                ^
-
 error: ./test/datalog_tests/function.fail.dl:11:17-11:24: Type mismatch:
 expected type: bit<32>
 actual type: bool
@@ -17,10 +13,6 @@ in
 expression '(var w: bool)'
         C0{.x = w: bool} -> w,
                 ^^^^^^^
-
-error: ./test/datalog_tests/function.fail.dl:7:5-7:11: Variable v already defined in this scope
-    var v = "foo"
-    ^^^^^^
 
 error: ./test/datalog_tests/function.fail.dl:6:13-7:1: Access to guarded field 'x' (not all constructors of type 'std::Option' have this field).
     var b = a.x

--- a/test/datalog_tests/function.fail.dl
+++ b/test/datalog_tests/function.fail.dl
@@ -23,21 +23,6 @@ function vars(): () = {
 typedef Alt = C0{x: bit<32>}
             | C1{x: bit<32>}
 
-// shadow argument name
-function shadow(v: string): () = {
-    var a: Alt = C0{1};
-
-    var i: bit<32> = match (a) {
-        C0{.x = v} -> v,
-        C1{v} -> v
-    }
-}
-
-//---
-
-typedef Alt = C0{x: bit<32>}
-            | C1{x: bit<32>}
-
 // Invalid type annotation in pattern.
 function shadow(v: string): () = {
     var a: Alt = C0{1};
@@ -46,15 +31,6 @@ function shadow(v: string): () = {
         C0{.x = w: bool} -> w,
         C1{w} -> w
     }
-}
-
-//---
-
-// shadow local variable
-function shadow(): () = {
-    var v: string = "bar";
-
-    var v = "foo"
 }
 
 //---

--- a/test/datalog_tests/simple2.debug.ast.expected
+++ b/test/datalog_tests/simple2.debug.ast.expected
@@ -1,8 +1,12 @@
 typedef Ack = Ack{m: std::u64, n: std::u64, a: std::u64}
+typedef Alt = C0{x: bit<32>} |
+              C1{x: bit<32>}
 typedef Arrng1 = Arrng1{f1: std::Ref<std::Ref<std::Ref<TArrng2>>>, f2: bigint}
 typedef Arrng1Arrng2 = Arrng1Arrng2{x: bigint}
 typedef Arrng1Arrng2_2 = Arrng1Arrng2_2{x: bigint}
 typedef Arrng2 = Arrng2{f1: std::Ref<TArrng2>, f2: bigint, f3: bool}
+typedef BoolVecVec = BoolVecVec{v: std::Vec<std::Vec<bool>>}
+typedef BoolVectors = BoolVectors{v: std::Vec<bool>}
 typedef Chunk = Chunk{json: string}
 typedef ChunkParseError = ChunkParseError{err: string}
 typedef CompressedChunk = CompressedChunk{json: string}
@@ -15,6 +19,8 @@ typedef InputInspectNot2 = InputInspectNot2{x: bit<32>}
 typedef InputTuples = InputTuples{x: bit<32>, y: bit<32>}
 typedef InspectSimpleSum = InspectSimpleSum{x: bit<32>, total: bit<32>}
 typedef Ints = Ints{x: bigint}
+typedef MapOfMaps = MapOfMaps{m: std::Map<string,std::Map<double,(std::usize, bool)>>}
+typedef MapOfVecs = MapOfVecs{m: std::Map<(std::u32, bigint),std::Vec<double>>}
 typedef ModifyMe = ModifyMe{x: string, y: std::s128}
 typedef Object = Object{field: std::u128}
 typedef Objects = Objects{chunk: Object}
@@ -28,6 +34,7 @@ typedef Rseq = Rseq{_s: TSeq}
 typedef Rseqs = Rseqs{_s: TSeq}
 typedef SResult<'V> = std::Result<'V,string>
 typedef SomeInts = SomeInts{x: std::Option<bigint>}
+typedef StringMaps = StringMaps{m: std::Map<string,(std::usize, bool)>}
 typedef Strings = Strings{descr: string, str: string}
 typedef SumsOfDoubles = SumsOfDoubles{x: double, y: double, sum: double}
 typedef TArrng1 = TArrng1{f1: bool, f2: bigint}
@@ -40,6 +47,7 @@ typedef TestRelation = TestRelation{x: bit<32>, y: bit<32>}
 typedef Try1 = Try1{description: string, result: Opt<(string, string)>}
 typedef Try2 = Try2{description: string, result: SResult<(string, string)>}
 typedef Try3 = Try3{description: string, result: Opt<(string, string)>}
+typedef VecOfMaps = VecOfMaps{m: std::Vec<std::Map<(std::u32, bigint),double>>}
 typedef debug::DDlogOpId = (std::u32, std::u32, std::u32)
 #[size = 8]
 #[shared_ref = true]
@@ -377,6 +385,19 @@ extern function log::log (module: log::module_t, level: log::log_level_t, msg: s
 function myfunc (x: string): string
 {
     x
+}
+function shadow (v: string): ()
+{
+    ((var a: Alt) = (C0{.x=32'd1}: Alt);
+     (var i: bit<32>) = match (a) {
+                            (C0{.x=(var v: bit<32>)}: Alt) -> v,
+                            (C1{.x=(var v: bit<32>)}: Alt) -> v
+                        })
+}
+function shadow2 (): ()
+{
+    ((var v: string) = "bar";
+     (var v: string) = "foo")
 }
 extern function std::__builtin_2string (x: 'X): string
 function std::append (v: mut std::Vec<'X>, other: std::Vec<'X>): ()
@@ -916,6 +937,8 @@ input relation Arrng1 [Arrng1]
 output relation Arrng1Arrng2 [Arrng1Arrng2]
 output relation Arrng1Arrng2_2 [Arrng1Arrng2_2]
 input relation Arrng2 [Arrng2]
+output relation BoolVecVec [BoolVecVec]
+output relation BoolVectors [BoolVectors]
 input multiset Chunk [Chunk]
 output multiset ChunkParseError [ChunkParseError]
 output multiset CompressedChunk [CompressedChunk]
@@ -928,6 +951,8 @@ input relation InputInspectNot2 [InputInspectNot2]
 input relation InputTuples [InputTuples]
 output relation InspectSimpleSum [InspectSimpleSum]
 input relation Ints [Ints]
+output relation MapOfMaps [MapOfMaps]
+output relation MapOfVecs [MapOfVecs]
 relation Objects [Objects]
 output relation OutputInspectNot [OutputInspectNot]
 relation ParsedChunk [ParsedChunk]
@@ -937,6 +962,7 @@ input relation Rletter [Rletter]
 output relation Rseq [Rseq]
 input relation Rseqs [Rseqs]
 output relation SomeInts [SomeInts]
+output relation StringMaps [StringMaps]
 output relation Strings [Strings]
 output relation SumsOfDoubles [SumsOfDoubles]
 input relation TArrng1 [(std::Ref<std::Ref<std::Ref<TArrng2>>>, bigint)]
@@ -947,6 +973,7 @@ input relation TestRelation [TestRelation]
 output relation Try1 [Try1]
 output relation Try2 [Try2]
 output relation Try3 [Try3]
+output relation VecOfMaps [VecOfMaps]
 Arrng1Arrng2[(Arrng1Arrng2{.x=x.f2.f2}: Arrng1Arrng2)] :- Arrng1[(__arrng10@ (Arrng1{.f1=(f1: std::Ref<std::Ref<std::Ref<TArrng2>>>), .f2=(f2: bigint)}: Arrng1))], Arrng2[(__arrng21@ (Arrng2{.f1=(x: std::Ref<TArrng2>), .f2=f1.f2.f2, .f3=(_: bool)}: Arrng2))], Inspect debug::debug_event_join((32'd0, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, __arrng10, __arrng21, (Arrng1Arrng2{.x=x.f2.f2}: Arrng1Arrng2)).
 Arrng1Arrng2_2[(Arrng1Arrng2_2{.x=x.f2.f2}: Arrng1Arrng2_2)] :- Arrng1[(__arrng10@ (Arrng1{.f1=(f1: std::Ref<std::Ref<std::Ref<TArrng2>>>), .f2=(f2: bigint)}: Arrng1))], Arrng2[(__arrng21@ (Arrng2{.f1=(x: std::Ref<TArrng2>), .f2=f1.f2.f2, .f3=f1.f2.f1}: Arrng2))], Inspect debug::debug_event_join((32'd1, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, __arrng10, __arrng21, (Arrng1Arrng2_2{.x=x.f2.f2}: Arrng1Arrng2_2)).
 TArrng1Arrng2[(TArrng1Arrng2{.x=x.f2.f2}: TArrng1Arrng2)] :- TArrng1[(__tarrng10@ (t: (std::Ref<std::Ref<std::Ref<TArrng2>>>, bigint)))], TArrng2[(__tarrng21@ ((x: std::Ref<TArrng2>), t.0.f2.f2))], Inspect debug::debug_event_join((32'd2, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, __tarrng10, __tarrng21, (TArrng1Arrng2{.x=x.f2.f2}: TArrng1Arrng2)).
@@ -1001,4 +1028,67 @@ Try2[(Try2{.description="Albert_Einstein", .result=try2("Albert_Einstein")}: Try
 Try3[(Try3{.description="Isaac Newton", .result=try3("Isaac Newton")}: Try3)].
 Try3[(Try3{.description="", .result=try3("")}: Try3)].
 Try3[(Try3{.description="Albert_Einstein", .result=try3("Albert_Einstein")}: Try3)].
+BoolVectors[(BoolVectors{.v=((var __vec: std::Vec<bool>) = (std::vec_with_capacity(64'd3): std::Vec<bool>);
+                             (std::push(__vec, true);
+                              (std::push(__vec, false);
+                               (std::push(__vec, true);
+                                __vec))))}: BoolVectors)].
+BoolVecVec[(BoolVecVec{.v=((var __vec: std::Vec<std::Vec<bool>>) = (std::vec_with_capacity(64'd3): std::Vec<std::Vec<bool>>);
+                           (std::push(__vec, ((var __vec: std::Vec<bool>) = (std::vec_with_capacity(64'd3): std::Vec<bool>);
+                                              (std::push(__vec, true);
+                                               (std::push(__vec, false);
+                                                (std::push(__vec, true);
+                                                 __vec)))));
+                            (std::push(__vec, ((var __vec: std::Vec<bool>) = (std::vec_with_capacity(64'd1): std::Vec<bool>);
+                                               (std::push(__vec, true);
+                                                __vec)));
+                             (std::push(__vec, ((var __vec: std::Vec<bool>) = (std::vec_with_capacity(64'd1): std::Vec<bool>);
+                                                (std::push(__vec, false);
+                                                 __vec)));
+                              __vec))))}: BoolVecVec)].
+StringMaps[(StringMaps{.m=((var __map: std::Map<string,(std::usize, bool)>) = (std::map_empty(): std::Map<string,(std::usize, bool)>);
+                           (std::insert(__map, "foo", (64'd1, true));
+                            (std::insert(__map, "bar", (64'd2, false));
+                             (std::insert(__map, "foobar", (64'd3, false));
+                              __map))))}: StringMaps)].
+MapOfMaps[(MapOfMaps{.m=((var __map: std::Map<string,std::Map<double,(std::usize, bool)>>) = (std::map_empty(): std::Map<string,std::Map<double,(std::usize, bool)>>);
+                         (std::insert(__map, "foo", ((var __map: std::Map<double,(bit<64>, bool)>) = (std::map_empty(): std::Map<double,(bit<64>, bool)>);
+                                                     (std::insert(__map, 64'f1.0, (64'd1, true));
+                                                      (std::insert(__map, 64'f2.0, (64'd4, false));
+                                                       __map))));
+                          (std::insert(__map, "bar", ((var __map: std::Map<double,(bit<64>, bool)>) = (std::map_empty(): std::Map<double,(bit<64>, bool)>);
+                                                      (std::insert(__map, (- 64'f10.0), (64'd10000, true));
+                                                       (std::insert(__map, 64'f200.0, (64'd2, false));
+                                                        __map))));
+                           (std::insert(__map, "foobar", (std::map_empty(): std::Map<double,(std::usize, bool)>));
+                            __map))))}: MapOfMaps)].
+MapOfVecs[(MapOfVecs{.m=((var __map: std::Map<(std::u32, bigint),std::Vec<double>>) = (std::map_empty(): std::Map<(std::u32, bigint),std::Vec<double>>);
+                         (std::insert(__map, (32'd100, 100), ((var __vec: std::Vec<double>) = (std::vec_with_capacity(64'd4): std::Vec<double>);
+                                                              (std::push(__vec, 64'f0.1);
+                                                               (std::push(__vec, (- 64'f100.0));
+                                                                (std::push(__vec, 64'f0.0);
+                                                                 (std::push(__vec, 64'f1000000.0);
+                                                                  __vec))))));
+                          (std::insert(__map, (32'd100, (- 100)), (std::vec_empty(): std::Vec<double>));
+                           (std::insert(__map, (32'd0, (- 0)), ((var __vec: std::Vec<double>) = (std::vec_with_capacity(64'd4): std::Vec<double>);
+                                                                (std::push(__vec, 64'f0.1);
+                                                                 (std::push(__vec, (- 64'f100.0));
+                                                                  (std::push(__vec, 64'f0.0);
+                                                                   (std::push(__vec, 64'f1000000.0);
+                                                                    __vec))))));
+                            __map))))}: MapOfVecs)].
+VecOfMaps[(VecOfMaps{.m=((var __vec: std::Vec<std::Map<(std::u32, bigint),double>>) = (std::vec_with_capacity(64'd3): std::Vec<std::Map<(std::u32, bigint),double>>);
+                         (std::push(__vec, ((var __map: std::Map<(bit<32>, bigint),double>) = (std::map_empty(): std::Map<(bit<32>, bigint),double>);
+                                            (std::insert(__map, (32'd100, 100), 64'f0.1);
+                                             __map)));
+                          (std::push(__vec, ((var __map: std::Map<(bit<32>, bigint),double>) = (std::map_empty(): std::Map<(bit<32>, bigint),double>);
+                                             (std::insert(__map, (32'd100, 100), 64'f0.1);
+                                              (std::insert(__map, (32'd1000, (- 100)), (- 64'f0.1));
+                                               __map))));
+                           (std::push(__vec, ((var __map: std::Map<(bit<32>, bigint),double>) = (std::map_empty(): std::Map<(bit<32>, bigint),double>);
+                                              (std::insert(__map, (32'd100, 100), 64'f0.1);
+                                               (std::insert(__map, (32'd1000, (- 100)), (- 64'f0.1));
+                                                (std::insert(__map, (32'd1000, (- 10000000000000000000000000000000000000)), (- 64'f0.0));
+                                                 __map)))));
+                            __vec))))}: VecOfMaps)].
 

--- a/test/datalog_tests/simple2.dl
+++ b/test/datalog_tests/simple2.dl
@@ -322,3 +322,58 @@ output relation Try3(description: string, result: Opt<(string, string)>)
 Try3("Isaac Newton", try3("Isaac Newton")).
 Try3("", try3("")).
 Try3("Albert_Einstein", try3("Albert_Einstein")).
+
+/*
+ * Vector literals.
+ */
+
+output relation BoolVectors(v: Vec<bool>)
+BoolVectors([true, false, true]).
+
+output relation BoolVecVec(v: Vec<Vec<bool>>)
+BoolVecVec([[true, false, true], [true], [false]]).
+
+output relation StringMaps(m: Map<string, (usize, bool)>)
+StringMaps(["foo" -> (1, true), "bar" -> (2, false), "foobar" -> (3, false)]).
+
+output relation MapOfMaps(m: Map<string, Map<double, (usize, bool)>>)
+MapOfMaps(["foo" -> [1.0 -> (1, true), 2 -> (4, false)],
+           "bar" -> [-10 -> (10000, true), 200 -> (2, false)],
+           "foobar" -> map_empty()
+          ]).
+
+output relation MapOfVecs(m: Map<(u32, bigint), Vec<double>>)
+MapOfVecs([ (100, 100) -> [0.1, -100, 0, 1000000],
+            (100, -100) -> vec_empty(),
+            (0, -0) -> [0.1, -100, 0, 1000000]
+          ]).
+
+output relation VecOfMaps(m: Vec<Map<(u32, bigint), double>>)
+VecOfMaps([ [(100, 100) -> 0.1],
+            [(100, 100) -> 0.1, (1000, -100) -> -0.1],
+            [(100, 100) -> 0.1, (1000, -100) -> -0.1, (1000, -10000000000000000000000000000000000000) -> -0]
+          ]).
+
+/* Variable shadowing (now legal). */
+
+typedef Alt = C0{x: bit<32>}
+            | C1{x: bit<32>}
+
+// shadow argument name
+function shadow(v: string): () = {
+    var a: Alt = C0{1};
+
+    var i: bit<32> = match (a) {
+        C0{.x = v} -> v,
+        C1{v} -> v
+    }
+}
+
+// shadow local variable
+function shadow2(): () = {
+    var v: string = "bar";
+
+    var v = "foo"
+}
+
+

--- a/test/datalog_tests/simple2.dump.expected
+++ b/test/datalog_tests/simple2.dump.expected
@@ -1,5 +1,9 @@
 Ack:
 Ack{.m = 2, .n = 1, .a = 5}: +1
+BoolVecVec:
+BoolVecVec{.v = [[true, false, true], [true], [false]]}: +1
+BoolVectors:
+BoolVectors{.v = [true, false, true]}: +1
 Fib:
 Fib{.x = 0, .f = 0}: +1
 Fib{.x = 1, .f = 1}: +1
@@ -10,8 +14,14 @@ Fib{.x = 10, .f = 55}: +1
 Fib{.x = 20, .f = 6765}: +1
 FuncTest:
 FuncTest{.x = "foo"}: +1
+MapOfMaps:
+MapOfMaps{.m = [("bar", [(-10, (10000, true)), (200, (2, false))]), ("foo", [(1, (1, true)), (2, (4, false))]), ("foobar", [])]}: +1
+MapOfVecs:
+MapOfVecs{.m = [((0, 0), [0.1, -100, 0, 1000000]), ((100, -100), []), ((100, 100), [0.1, -100, 0, 1000000])]}: +1
 RFloatToInt:
 RFloatToInt{._x = -333}: +1
+StringMaps:
+StringMaps{.m = [("bar", (2, false)), ("foo", (1, true)), ("foobar", (3, false))]}: +1
 Strings:
 Strings{.descr = "x={10:bit<12>}, y={10:float}, z={-4:signed<125>}", .str = "x=10, y=10, z=-4"}: +1
 Try1:
@@ -26,6 +36,8 @@ Try3:
 Try3{.description = "", .result = std::None{}}: +1
 Try3{.description = "Albert_Einstein", .result = std::None{}}: +1
 Try3{.description = "Isaac Newton", .result = std::Some{.x = ("Isaac", "Newton")}}: +1
+VecOfMaps:
+VecOfMaps{.m = [[((100, 100), 0.1)], [((100, 100), 0.1), ((1000, -100), -0.1)], [((100, 100), 0.1), ((1000, -10000000000000000000000000000000000000), 0), ((1000, -100), -0.1)]]}: +1
 RFloatToInt{._x = -333}
 Arrng1Arrng2:
 Arrng1Arrng2{.x = 5}: +1


### PR DESCRIPTION
Introduced syntactic sugar for vector and map literals.

Vector literals:
===============

```
var v = [0, x, f(y)];
```

is equivalent to:

```
var v = vec_with_capacity(3);
v.push(0);
v.push(x);
v.push(f(y));
...
```

Map literals:
=============

Likewise, **map literals** can be used to create maps by listing their
key-value pairs:

```
var m = ["foo" -> 0,
         "bar" -> 1,
         "foobar" -> 2];
...
```

To keep the implementation simple, map and vector literals are expanded
inside the parser, so we don't need to introduce new kinds of
nodes for them in the AST.  This may lead to less clear error messages.
In addition, this means that empty vector and map literals are not
allowed, as the parser cannot tell a vector from a map.  One needs to
write `vec_empty()` or `map_empty()` for empty vectors and maps
respectively.

-----

This PR also allows variable shadowing, i.e., declaring a variable that shadows
existing variable name.  This simplifies the implementation of the new feature,
but also there is no good reason to disallow this.