### PR TITLE
Allow running rustfmt and generating only Rust flatbuffers bindings

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -74,7 +74,7 @@ options = [ Option ['h'] ["help"]             (NoArg Help)                      
           , Option ['L'] []                   (ReqArg LibDir   "PATH")          "Extra DDlog library directory."
           , Option ['o'] ["output-dir"]       (ReqArg OutputDir "DIR")          "Output directory (default based on program name)."
           , Option []    ["dynlib"]           (NoArg DynLib)                    "Generate dynamic library."
-          , Option ['j'] ["java"]             (NoArg Java)                      "Generate Java bindings."
+          , Option ['j'] ["java"]             (NoArg Java)                      "Generate Java bindings. Implies '--rust-flatbuffers'."
           , Option []    ["output-internal-relations"]  (NoArg OutputInternal)  "All non-input relations are marked as output relations."
           , Option []    ["output-input-relations"]  (ReqArg OutputInput "PREFIX") "Mirror each input relation into an output relation named by prepending the prefix."
           , Option []    ["no-dynlib"]        (NoArg NoDynLib)                  "Do not generate dynamic library (default)."

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -476,7 +476,7 @@ mkConstructorName tname t c =
 --
 -- 'crate_types' - list of Cargo library crate types, e.g., [\"staticlib\"],
 --                  [\"cdylib\"], [\"staticlib\", \"cdylib\"]
-compile :: (?cfg::Config) => DatalogProgram -> String -> Doc -> Doc -> FilePath -> [String] -> IO ()
+compile :: (?cfg :: Config) => DatalogProgram -> String -> Doc -> Doc -> FilePath -> [String] -> IO ()
 compile d_unoptimized specname rs_code toml_code dir crate_types = do
     -- Create dir if it does not exist.
     createDirectoryIfMissing True (dir </> rustProjectDir specname)
@@ -488,8 +488,8 @@ compile d_unoptimized specname rs_code toml_code dir crate_types = do
     when (confDumpDebug ?cfg) $
         writeFile (replaceExtension (confDatalogFile ?cfg) ".opt.ast") (show d)
     let (types, value, main) = compileLib d specname rs_code
-    when (confJava ?cfg) $
-        compileFlatBufferBindings d specname (dir </> rustProjectDir specname)
+    -- Produce flatbuffer bindings if either the java or rust bindings are enabled
+    compileFlatBufferBindings d specname (dir </> rustProjectDir specname)
     -- Substitute specname template files; write files if changed.
     mapM_ (\(path, content) -> do
             let path' = dir </> path

--- a/src/Language/DifferentialDatalog/Config.hs
+++ b/src/Language/DifferentialDatalog/Config.hs
@@ -36,41 +36,45 @@ data DLAction = ActionCompile
               | ActionVersion
               deriving Eq
 
-data Config = Config { confDatalogFile   :: FilePath
-                     , confAction        :: DLAction
-                     , confLibDirs       :: [FilePath]
-                     , confOutputDir     :: FilePath
-                     , confOutputInput   :: String
-                     , confStaticLib     :: Bool
-                     , confDynamicLib    :: Bool
-                     , confJava          :: Bool
-                     , confOutputInternal:: Bool
-                     , confDebugHooks    :: Bool
-                     , confDumpFlat      :: Bool
-                     , confDumpValid     :: Bool
-                     , confDumpDebug     :: Bool
-                     , confDumpOpt       :: Bool
-                     , confReValidate    :: Bool
-                     , confOmitProfile   :: Bool
-                     , confOmitWorkspace :: Bool
+data Config = Config { confDatalogFile     :: FilePath
+                     , confAction          :: DLAction
+                     , confLibDirs         :: [FilePath]
+                     , confOutputDir       :: FilePath
+                     , confOutputInput     :: String
+                     , confStaticLib       :: Bool
+                     , confDynamicLib      :: Bool
+                     , confJava            :: Bool
+                     , confOutputInternal  :: Bool
+                     , confDebugHooks      :: Bool
+                     , confDumpFlat        :: Bool
+                     , confDumpValid       :: Bool
+                     , confDumpDebug       :: Bool
+                     , confDumpOpt         :: Bool
+                     , confReValidate      :: Bool
+                     , confOmitProfile     :: Bool
+                     , confOmitWorkspace   :: Bool
+                     , confRunRustfmt      :: Bool
+                     , confRustFlatBuffers :: Bool
                      }
 
 defaultConfig :: Config
-defaultConfig = Config { confDatalogFile    = ""
-                       , confAction         = ActionCompile
-                       , confLibDirs        = []
-                       , confOutputDir      = ""
-                       , confStaticLib      = True
-                       , confDynamicLib     = False
-                       , confOutputInternal = False
-                       , confOutputInput    = ""
-                       , confJava           = False
-                       , confDebugHooks     = False
-                       , confDumpFlat       = False
-                       , confDumpValid      = False
-                       , confDumpDebug      = False
-                       , confDumpOpt        = False
-                       , confReValidate     = False
-                       , confOmitProfile   = False
-                       , confOmitWorkspace = False
+defaultConfig = Config { confDatalogFile     = ""
+                       , confAction          = ActionCompile
+                       , confLibDirs         = []
+                       , confOutputDir       = ""
+                       , confStaticLib       = True
+                       , confDynamicLib      = False
+                       , confOutputInternal  = False
+                       , confOutputInput     = ""
+                       , confJava            = False
+                       , confDebugHooks      = False
+                       , confDumpFlat        = False
+                       , confDumpValid       = False
+                       , confDumpDebug       = False
+                       , confDumpOpt         = False
+                       , confReValidate      = False
+                       , confOmitProfile     = False
+                       , confOmitWorkspace   = False
+                       , confRunRustfmt      = False
+                       , confRustFlatBuffers = False
                        }

--- a/src/Language/DifferentialDatalog/FlatBuffer.hs
+++ b/src/Language/DifferentialDatalog/FlatBuffer.hs
@@ -61,10 +61,9 @@ TODO: Generated Java code structure:
 {-# LANGUAGE RecordWildCards, FlexibleContexts, LambdaCase, OverloadedStrings, ImplicitParams, TemplateHaskell #-}
 
 module Language.DifferentialDatalog.FlatBuffer
-  ( flatBufferValidate,
-    compileFlatBufferBindings,
-    compileFlatBufferRustBindings,
-  )
+    ( flatBufferValidate,
+      compileFlatBufferBindings,
+    )
 where
 
 -- FIXME: support `DeleteKey` and `Modify` commands.  The former require collecting


### PR DESCRIPTION
* Added the `--run-rustfmt` command line option to run rustfmt over the generated code
  * Previously the `types/flatbuf.rs`, `types/flatbuf_generated.rs` and `value/flatbuf.rs` files were not generated for non-flatbuffers builds, which broke tooling (namely rustfmt). This was fixed by adding the `generateDummyRustBindings` function which makes placeholder files when flatbuffers are disabled (In the future a more preferable solution would be removing the module declarations entirely)
* Added the `--rust-flatbuffers` command line option to only generate Rust flatbuffers bindings, previously passing the `--java` flag was required for this
