### PR TITLE
Improved static variable generation

### DIFF
--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -624,19 +624,13 @@ collectStatics d = execState (progExprMapCtxM d (checkStaticExpr)) M.empty
 -- computed by 'collectStatics'.
 mkStatics :: DatalogProgram -> Statics -> Doc
 mkStatics d statics =
-    "lazy_static! {"
-    $$ (nest' $ vcat $ static_decls)
-    $$ "}"
-    where
-        static_decls =
-            map
-                ( \((e, t), i) ->
-                      let static_name = "__STATIC_" <> pp i
-                       in let ?statics = deleteStatic e t statics
-                           in let e' = mkExpr d CtxTop (eTyped e t) EVal
-                               in "pub static ref" <+> static_name <> ":" <+> mkType t <+> "=" <+> e' <+> ";"
-                )
-                $ M.toList statics
+    vcat $
+    map (\((e, t), i) ->
+            let static_name = "__STATIC_" <> pp i in
+            let ?statics = deleteStatic e t statics in
+            let e' = mkExpr d CtxTop (eTyped e t) EVal in
+            "lazy_static!{ pub static ref" <+> static_name <> ":" <+> mkType t <+> "=" <+> e' <+> "; }")
+        $ M.toList statics
 
 -- Add dummy relation to the spec if it does not contain any.
 -- Otherwise, we have to tediously handle this corner case in various


### PR DESCRIPTION
* ~~Collected program statics are now nested within a single `lazy_static!` invocation (theoretically reduces compile times)~~
* Relation statics were refactored into one core function
* Relation statics now have their hashmaps pre-allocated, should reduce memory usage/churn and make startups quicker (affects large programs more)
* C-Name maps now store `&'static CStr`s instead of `CStrings`. This brings a *huge* memory benefit since now names are only baked into the binary instead of being uselessly heap-allocated
* Changed the C-Name maps to panicking instead of silently returning a corrupted/dummy value, a panic only in the instance of something being *terribly* wrong is better than silent state corruption and un-huntable bugs
* Docs! Both the generated relation statics have (kinda bad) docs and (most) of the functions that create them have 'em as well