### PR TITLE
Switch from lazy_static to once_cell

### DIFF
--- a/lib/intern.rs
+++ b/lib/intern.rs
@@ -1,6 +1,6 @@
 use differential_datalog::record;
 use differential_datalog::record::*;
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use serde;
 use std::collections;
 use std::marker;
@@ -55,11 +55,11 @@ impl<T: Clone + Eq + Hash> Interner<T> {
 
 type StringInterner = Interner<String>;
 
-lazy_static! {
-    static ref global_string_interner: sync::Arc<sync::Mutex<StringInterner>> =
-        sync::Arc::new(sync::Mutex::new(StringInterner::new()));
-}
+// TODO: Arc is unneeded
+static global_string_interner: Lazy<sync::Arc<sync::Mutex<StringInterner>>> =
+    Lazy::new(|| sync::Arc::new(sync::Mutex::new(StringInterner::new())));
 
+// TODO: Arc can be replaced by an `&'static Mutex<_>`
 thread_local!(static STRING_INTERNER: sync::Arc<sync::Mutex<StringInterner>> = global_string_interner.clone());
 
 impl Default for intern_IString {

--- a/rust/template/Cargo.toml
+++ b/rust/template/Cargo.toml
@@ -39,7 +39,7 @@ ordered-float = { version = "2.0.0", features = ["serde"] }
 cpuprofiler = { version = "0.0", optional = true }
 differential-dataflow = "0.11.0"
 fnv = "1.0.2"
-lazy_static = "1.3"
+once_cell = "1.4.1"
 libc = "0.2"
 num-traits = "0.2"
 num = { version = "0.2", features = ["serde"] }

--- a/rust/template/types/Cargo.toml
+++ b/rust/template/types/Cargo.toml
@@ -22,7 +22,7 @@ ordered-float = { version = "2.0.0", features = ["serde"] }
 time = { version = "0.2", features = ["serde"] }
 differential-dataflow = "0.11.0"
 fnv = "1.0.2"
-lazy_static = "1.3"
+once_cell = "1.4.1"
 libc = "0.2"
 num-traits = "0.2"
 num = "0.2"

--- a/rust/template/types/lib.rs
+++ b/rust/template/types/lib.rs
@@ -30,7 +30,7 @@ use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde::Serialize;
 
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 
 use differential_datalog::ddval::*;
 use differential_datalog::decl_enum_into_record;

--- a/rust/template/types/log.rs
+++ b/rust/template/types/log.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::ptr_arg, clippy::trivially_copy_pass_by_ref)]
 
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use std::collections;
 use std::ffi;
 use std::os::raw;
@@ -24,14 +24,11 @@ impl LogConfig {
     }
 }
 
-lazy_static! {
-    /* Logger configuration for each module consists of the maximal enabled
-     * log level (messages above this level are ignored) and callback.
-     */
-    static ref LOG_CONFIG: sync::RwLock<LogConfig> = {
-        sync::RwLock::new(LogConfig::new())
-    };
-}
+/* Logger configuration for each module consists of the maximal enabled
+ * log level (messages above this level are ignored) and callback.
+ */
+static LOG_CONFIG: Lazy<sync::RwLock<LogConfig>> =
+    Lazy::new(|| sync::RwLock::new(LogConfig::new()));
 
 /*
  * Logging API exposed to the DDlog program.

--- a/rust/template/value/Cargo.toml
+++ b/rust/template/value/Cargo.toml
@@ -19,7 +19,7 @@ path = "../types"
 abomonation = "0.7"
 differential-dataflow = "0.11.0"
 fnv = "1.0.2"
-lazy_static = "1.3"
+once_cell = "1.4.1"
 libc = "0.2"
 num-traits = "0.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/rust/template/value/lib.rs
+++ b/rust/template/value/lib.rs
@@ -137,9 +137,11 @@ pub fn relid2cname(_rid: RelId) -> Option<&'static ffi::CStr> {
     panic!("relid2cname not implemented")
 }
 
-pub static RELIDMAP: Lazy<FnvHashMap<Relations, &'static str>> = Lazy::new(|| FnvHashMap::default());
-pub static INPUT_RELIDMAP: Lazy<FnvHashMap<Relations, &'static str>> = Lazy::new(|| FnvHashMap::default());
-pub static OUTPUT_RELIDMAP: Lazy<FnvHashMap<Relations, &'static str>> = Lazy::new(|| FnvHashMap::default());
+pub static RELIDMAP: Lazy<FnvHashMap<Relations, &'static str>> = Lazy::new(FnvHashMap::default);
+pub static INPUT_RELIDMAP: Lazy<FnvHashMap<Relations, &'static str>> =
+    Lazy::new(FnvHashMap::default);
+pub static OUTPUT_RELIDMAP: Lazy<FnvHashMap<Relations, &'static str>> =
+    Lazy::new(FnvHashMap::default);
 
 pub fn indexid2name(_iid: IdxId) -> Option<&'static str> {
     panic!("indexid2name not implemented")
@@ -153,4 +155,4 @@ pub fn indexes2arrid(idx: Indexes) -> ArrId {
     panic!("indexes2arrid not implemented")
 }
 
-pub static IDXIDMAP: Lazy<FnvHashMap<Indexes, &'static str>> = Lazy::new(|| FnvHashMap::default());
+pub static IDXIDMAP: Lazy<FnvHashMap<Indexes, &'static str>> = Lazy::new(FnvHashMap::default);

--- a/rust/template/value/lib.rs
+++ b/rust/template/value/lib.rs
@@ -33,7 +33,7 @@ use differential_datalog::record::RelIdentifier;
 use differential_datalog::uint::*;
 
 use fnv::FnvHashMap;
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use ordered_float::OrderedFloat;
 
 use types::*;
@@ -137,17 +137,9 @@ pub fn relid2cname(_rid: RelId) -> Option<&'static ffi::CStr> {
     panic!("relid2cname not implemented")
 }
 
-lazy_static! {
-    pub static ref RELIDMAP: FnvHashMap<Relations, &'static str> = FnvHashMap::default();
-}
-
-lazy_static! {
-    pub static ref INPUT_RELIDMAP: FnvHashMap<Relations, &'static str> = FnvHashMap::default();
-}
-
-lazy_static! {
-    pub static ref OUTPUT_RELIDMAP: FnvHashMap<Relations, &'static str> = FnvHashMap::default();
-}
+pub static RELIDMAP: Lazy<FnvHashMap<Relations, &'static str>> = Lazy::new(|| FnvHashMap::default());
+pub static INPUT_RELIDMAP: Lazy<FnvHashMap<Relations, &'static str>> = Lazy::new(|| FnvHashMap::default());
+pub static OUTPUT_RELIDMAP: Lazy<FnvHashMap<Relations, &'static str>> = Lazy::new(|| FnvHashMap::default());
 
 pub fn indexid2name(_iid: IdxId) -> Option<&'static str> {
     panic!("indexid2name not implemented")
@@ -161,6 +153,4 @@ pub fn indexes2arrid(idx: Indexes) -> ArrId {
     panic!("indexes2arrid not implemented")
 }
 
-lazy_static! {
-    pub static ref IDXIDMAP: FnvHashMap<Indexes, &'static str> = FnvHashMap::default();
-}
+pub static IDXIDMAP: Lazy<FnvHashMap<Indexes, &'static str>> = Lazy::new(|| FnvHashMap::default());

--- a/test/datalog_tests/server_api/Cargo.toml
+++ b/test/datalog_tests/server_api/Cargo.toml
@@ -4,17 +4,17 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-differential_datalog = {path = "../server_api_ddlog/differential_datalog"}
-distributed_datalog = {path = "../server_api_ddlog/distributed_datalog", features=["test"]}
-env_logger = {version = "0.7", default_features = false, features = ["humantime"]}
-lazy_static = "1.3"
+differential_datalog = { path = "../server_api_ddlog/differential_datalog" }
+distributed_datalog = { path = "../server_api_ddlog/distributed_datalog", features = ["test"] }
+env_logger = { version = "0.7", default_features = false, features = ["humantime"] }
+once_cell = "1.4.1"
 log = "0.4"
 maplit = "1.0"
 serde_json = "1.0"
-server_api = {path = "../server_api_ddlog"}
+server_api = { path = "../server_api_ddlog" }
 structopt = "0.3"
 tempfile = "3.1"
-uuid = {version = "0.8", default-features = false, features = ["v4"]}
+uuid = { version = "0.8", default-features = false, features = ["v4"] }
 
 [dev-dependencies]
 test-env-log = "0.1"

--- a/test/datalog_tests/server_api/src/main.rs
+++ b/test/datalog_tests/server_api/src/main.rs
@@ -3,7 +3,7 @@ use std::sync::Mutex;
 use std::thread::park;
 
 use env_logger::init;
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use log::debug;
 use log::info;
 use log::log_enabled;
@@ -164,9 +164,7 @@ impl State {
 }
 
 fn zookeeper(member: Addr, nodes: Vec<String>) -> Result<(), String> {
-    lazy_static! {
-        static ref STATE: Mutex<State> = Mutex::new(State::new());
-    }
+    static STATE: Lazy<Mutex<State>> = Lazy::new(|| Mutex::new(State::new()));
 
     let watch = move |event: WatchedEvent| {
         debug!("Watch event: {:?}", event);


### PR DESCRIPTION
* Switches all generated static variables to use [`once_cell::sync::Lazy`](https://docs.rs/once_cell/1.4.1/once_cell/sync/struct.Lazy.html) instead of `lazy_static!`

#### Rationale:
`once_cell` is soon to be [part of the standard library](https://github.com/rust-lang/rfcs/pull/2788) (and is available now [on nightly](https://doc.rust-lang.org/nightly/std/lazy/struct.SyncLazy.html)). That allows a lighter dependency load, in addition to a lighter compile-time load now (due to less macros being expanded) and in the future (when it's in the std, that's one less dep to compile). `once_cell` allows greater flexibility due to having sync and unsync variants of the `Lazy` type and the `OnceCell` type. Usage of `OnceCell` can allow what would otherwise be circular dependencies within statics, which could be useful in the future. `once_cell` is also marginally faster at runtime, but I doubt we'd be able to see the effects of that.