### PR TITLE
Allow a semicolon after a sequence of expressions.

### DIFF
--- a/doc/tutorial/tutorial.md
+++ b/doc/tutorial/tutorial.md
@@ -734,7 +734,15 @@ function addr_port(ip: ip_addr_t, proto: string, preferred_port: bit<16>): strin
 
 The result computed by a function is the value of the last expression evaluated
 or the value produced by the first `return` statement encountered when
-evaluating the function.  If the `else` is missing the value `()` (empty tuple)
+evaluating the function.  A semicolon at the end of a sequence of expressions
+discards the value of the last expressions and produces an empty tuple.  For
+instance, expressions `{ var x: u32 = y + 1; x }` and
+`{ var x: u32 = y + 1; x; }` have different meaning.  The former returns the
+32-bit value of variable `x`, whereas the latter is equivalent to
+`{ var x: u32 = y + 1; x; () }`, which produces an empty tuple `()`,
+described [below](#tuples).
+
+If the `else` clause of an `if-else` expression is missing the value `()`
 is used for the `else` branch.  In `match` expressions the patterns must cover
 all possible cases (for instance, the match expression above would not be
 correct without the last "catch-all" (`_`) case).
@@ -745,8 +753,7 @@ expression.  A variable can be assigned multiple times, overwriting
 previous values.
 
 DDlog assignments cannot be chained like in C; although an assignment
-is an expression, it produces the value `()` (an empty tuple,
-described [below](#tuples)).
+is an expression, it produces an empty tuple.
 
 `match` matches the value of its argument against a series of
 *patterns*.  The simplest pattern is a constant value, e.g., `"FTP"`.

--- a/src/Language/DifferentialDatalog/Syntax.hs
+++ b/src/Language/DifferentialDatalog/Syntax.hs
@@ -799,7 +799,7 @@ instance PP e => PP (ExprNode e) where
                                $$
                                "}"
     pp (EVarDecl _ v)        = "var" <+> pp v
-    pp (ESeq _ l r)          = parens $ (pp l <> semi) $$ pp r
+    pp (ESeq _ l r)          = braces $ (pp l <> semi) $$ pp r
     pp (EITE _ c t e)        = ("if" <+> pp c <+> lbrace)
                                $$
                                (nest' $ pp t)

--- a/test/datalog_tests/function.fail.dl
+++ b/test/datalog_tests/function.fail.dl
@@ -171,9 +171,10 @@ function bool_identity(b: Option<bool>): Option<bool> = b
 
 typedef Tagg = Tagg{col:bool}
 
-function agg():Tagg =
+function agg():Tagg {
   (var any = Some{false}: Option<bool>);
   (Tagg{.col = bool_identity(any)})
+}
 
 //---
 

--- a/test/datalog_tests/lib_test.debug.ast.expected
+++ b/test/datalog_tests/lib_test.debug.ast.expected
@@ -120,8 +120,8 @@ extern type uuid::Uuid
 typedef uuid_test::UUID = uuid_test::UUID{description: string, result: string}
 function __debug_306_1_tinyset::group_to_set (g: std::Group<string,('I, bit<32>)>): (std::Vec<'I>, tinyset::Set64<bit<32>>)
 {
-    (((var inputs: std::Vec<'I>), (var original_group: std::Group<string,bit<32>>)) = debug::debug_split_group(g);
-     (inputs, tinyset::group_to_set(original_group)))
+    {((var inputs: std::Vec<'I>), (var original_group: std::Group<string,bit<32>>)) = debug::debug_split_group(g);
+     (inputs, tinyset::group_to_set(original_group))}
 }
 extern function debug::debug_event (operator_id: debug::DDlogOpId, w: std::DDWeight, ts: 'T1, operator_type: string, input1: 'A1, out: 'A2): ()
 extern function debug::debug_event_join (operator_id: debug::DDlogOpId, w: std::DDWeight, ts: 'T1, input1: 'A1, input2: 'A2, out: 'A3): ()
@@ -396,34 +396,34 @@ function json::set_by_ptr (jval: mut json::JsonValue, ptr: json::JsonPtr, v: jso
 function json::set_by_ptr_ (jval: mut json::JsonValue, ptr: json::JsonPtr, v: json::JsonValue, idx: std::usize): std::Result<(),string>
 {
     match ((std::nth(ptr, idx): std::Option<json::JsonPtrItem>)) {
-        (std::None{}: std::Option<json::JsonPtrItem>) -> (jval = v;
-                                                          (std::Ok{.res=()}: std::Result<(),string>)),
-        (std::Some{.x=(json::JKeyPtr{.key=(var key: internment::Intern<string>)}: json::JsonPtrItem)}: std::Option<json::JsonPtrItem>) -> (if (jval == (json::JsonNull{}: json::JsonValue)) {
+        (std::None{}: std::Option<json::JsonPtrItem>) -> {jval = v;
+                                                          (std::Ok{.res=()}: std::Result<(),string>)},
+        (std::Some{.x=(json::JKeyPtr{.key=(var key: internment::Intern<string>)}: json::JsonPtrItem)}: std::Option<json::JsonPtrItem>) -> {if (jval == (json::JsonNull{}: json::JsonValue)) {
                                                                                                                                                jval = (json::JsonObject{.o=(std::map_empty(): std::Map<internment::istring,json::JsonValue>)}: json::JsonValue)
                                                                                                                                            } else {
                                                                                                                                                  ()
                                                                                                                                              };
                                                                                                                                            match (jval) {
-                                                                                                                                               (json::JsonObject{.o=(var m: std::Map<internment::istring,json::JsonValue>)}: json::JsonValue) -> ((var old: json::JsonValue) = (std::unwrap_or((std::remove(m, key): std::Option<json::JsonValue>), (json::JsonNull{}: json::JsonValue)): json::JsonValue);
-                                                                                                                                                                                                                                                  (json::set_by_ptr_(old, ptr, v, (idx + 64'd1));
-                                                                                                                                                                                                                                                   (std::insert(m, key, old);
-                                                                                                                                                                                                                                                    (std::Ok{.res=()}: std::Result<(),string>)))),
+                                                                                                                                               (json::JsonObject{.o=(var m: std::Map<internment::istring,json::JsonValue>)}: json::JsonValue) -> {(var old: json::JsonValue) = (std::unwrap_or((std::remove(m, key): std::Option<json::JsonValue>), (json::JsonNull{}: json::JsonValue)): json::JsonValue);
+                                                                                                                                                                                                                                                  {json::set_by_ptr_(old, ptr, v, (idx + 64'd1));
+                                                                                                                                                                                                                                                   {std::insert(m, key, old);
+                                                                                                                                                                                                                                                    (std::Ok{.res=()}: std::Result<(),string>)}}},
                                                                                                                                                (_: json::JsonValue) -> (std::Err{.err="Not a JSON map"}: std::Result<(),string>)
-                                                                                                                                           }),
-        (std::Some{.x=(json::JIdxPtr{.idx=(var n: bit<64>)}: json::JsonPtrItem)}: std::Option<json::JsonPtrItem>) -> (if (jval == (json::JsonNull{}: json::JsonValue)) {
+                                                                                                                                           }},
+        (std::Some{.x=(json::JIdxPtr{.idx=(var n: bit<64>)}: json::JsonPtrItem)}: std::Option<json::JsonPtrItem>) -> {if (jval == (json::JsonNull{}: json::JsonValue)) {
                                                                                                                           jval = (json::JsonArray{.a=(std::vec_empty(): std::Vec<json::JsonValue>)}: json::JsonValue)
                                                                                                                       } else {
                                                                                                                             ()
                                                                                                                         };
                                                                                                                       match (jval) {
-                                                                                                                          (json::JsonArray{.a=(var xs: std::Vec<json::JsonValue>)}: json::JsonValue) -> (std::resize(xs, (std::max((n + 64'd1), std::len(xs)): bit<64>), (json::JsonNull{}: json::JsonValue));
-                                                                                                                                                                                                         ((var old: json::JsonValue) = (json::JsonNull{}: json::JsonValue);
-                                                                                                                                                                                                          (std::swap_nth(xs, n, old);
-                                                                                                                                                                                                           (json::set_by_ptr_(old, ptr, v, (idx + 64'd1));
-                                                                                                                                                                                                            (std::swap_nth(xs, n, old);
-                                                                                                                                                                                                             (std::Ok{.res=()}: std::Result<(),string>)))))),
+                                                                                                                          (json::JsonArray{.a=(var xs: std::Vec<json::JsonValue>)}: json::JsonValue) -> {std::resize(xs, (std::max((n + 64'd1), std::len(xs)): bit<64>), (json::JsonNull{}: json::JsonValue));
+                                                                                                                                                                                                         {(var old: json::JsonValue) = (json::JsonNull{}: json::JsonValue);
+                                                                                                                                                                                                          {std::swap_nth(xs, n, old);
+                                                                                                                                                                                                           {json::set_by_ptr_(old, ptr, v, (idx + 64'd1));
+                                                                                                                                                                                                            {std::swap_nth(xs, n, old);
+                                                                                                                                                                                                             (std::Ok{.res=()}: std::Result<(),string>)}}}}},
                                                                                                                           (_: json::JsonValue) -> (std::Err{.err="Not a JSON array"}: std::Result<(),string>)
-                                                                                                                      })
+                                                                                                                      }}
     }
 }
 extern function json::to_json_string (x: 'T): std::Result<string,string>
@@ -466,50 +466,50 @@ function json_test::map1 (): string
 }
 function json_test::mutilate_jval (): json::JsonValue
 {
-    ((var jval: json::JsonValue) = (std::unwrap_or_default((json::from_json_string(json_test::nestedStruct1()): std::Result<json::JsonValue,string>)): json::JsonValue);
-     (json::set_by_ptr(jval, ((var __vec: std::Vec<json::JsonPtrItem>) = (std::vec_with_capacity(64'd2): std::Vec<json::JsonPtrItem>);
-                              (std::push(__vec, (json::JKeyPtr{.key=(internment::intern("nested"): internment::Intern<string>)}: json::JsonPtrItem));
-                               (std::push(__vec, (json::JKeyPtr{.key=(internment::intern("x"): internment::Intern<string>)}: json::JsonPtrItem));
-                                __vec))), (std::unwrap_or_default((json::from_json_string(json_test::boolStruct2()): std::Result<json::JsonValue,string>)): json::JsonValue));
-      (json::set_by_ptr(jval, ((var __vec: std::Vec<json::JsonPtrItem>) = (std::vec_with_capacity(64'd2): std::Vec<json::JsonPtrItem>);
-                               (std::push(__vec, (json::JKeyPtr{.key=(internment::intern("nested"): internment::Intern<string>)}: json::JsonPtrItem));
-                                (std::push(__vec, (json::JKeyPtr{.key=(internment::intern("y"): internment::Intern<string>)}: json::JsonPtrItem));
-                                 __vec))), (std::unwrap_or_default((json::from_json_string(json_test::boolStruct2()): std::Result<json::JsonValue,string>)): json::JsonValue));
-       (json::set_by_ptr(jval, ((var __vec: std::Vec<json::JsonPtrItem>) = (std::vec_with_capacity(64'd2): std::Vec<json::JsonPtrItem>);
-                                (std::push(__vec, (json::JKeyPtr{.key=(internment::intern("nested"): internment::Intern<string>)}: json::JsonPtrItem));
-                                 (std::push(__vec, (json::JKeyPtr{.key=(internment::intern("z"): internment::Intern<string>)}: json::JsonPtrItem));
-                                  __vec))), (json::JsonArray{.a=((var __vec: std::Vec<json::JsonValue>) = (std::vec_with_capacity(64'd2): std::Vec<json::JsonValue>);
-                                                                 (std::push(__vec, (std::unwrap_or_default((json::from_json_string(json_test::wenum1()): std::Result<json::JsonValue,string>)): json::JsonValue));
-                                                                  (std::push(__vec, (std::unwrap_or_default((json::from_json_string(json_test::wenum2()): std::Result<json::JsonValue,string>)): json::JsonValue));
-                                                                   __vec)))}: json::JsonValue));
-        (json::set_by_ptr(jval, ((var __vec: std::Vec<json::JsonPtrItem>) = (std::vec_with_capacity(64'd3): std::Vec<json::JsonPtrItem>);
-                                 (std::push(__vec, (json::JKeyPtr{.key=(internment::intern("nested"): internment::Intern<string>)}: json::JsonPtrItem));
-                                  (std::push(__vec, (json::JKeyPtr{.key=(internment::intern("z"): internment::Intern<string>)}: json::JsonPtrItem));
-                                   (std::push(__vec, (json::JIdxPtr{.idx=64'd1}: json::JsonPtrItem));
-                                    __vec)))), (std::unwrap_or_default((json::from_json_string(json_test::wenum3()): std::Result<json::JsonValue,string>)): json::JsonValue));
-         (json::set_by_ptr(jval, ((var __vec: std::Vec<json::JsonPtrItem>) = (std::vec_with_capacity(64'd4): std::Vec<json::JsonPtrItem>);
-                                  (std::push(__vec, (json::JKeyPtr{.key=(internment::intern("nested"): internment::Intern<string>)}: json::JsonPtrItem));
-                                   (std::push(__vec, (json::JKeyPtr{.key=(internment::intern("z"): internment::Intern<string>)}: json::JsonPtrItem));
-                                    (std::push(__vec, (json::JIdxPtr{.idx=64'd1}: json::JsonPtrItem));
-                                     (std::push(__vec, (json::JKeyPtr{.key=(internment::intern("b"): internment::Intern<string>)}: json::JsonPtrItem));
-                                      __vec))))), (std::unwrap_or_default((json::from_json_string(json_test::struct_with_map1()): std::Result<json::JsonValue,string>)): json::JsonValue));
-          (json::set_by_ptr(jval, ((var __vec: std::Vec<json::JsonPtrItem>) = (std::vec_with_capacity(64'd4): std::Vec<json::JsonPtrItem>);
-                                   (std::push(__vec, (json::JKeyPtr{.key=(internment::intern("nested"): internment::Intern<string>)}: json::JsonPtrItem));
-                                    (std::push(__vec, (json::JKeyPtr{.key=(internment::intern("z"): internment::Intern<string>)}: json::JsonPtrItem));
-                                     (std::push(__vec, (json::JIdxPtr{.idx=64'd10}: json::JsonPtrItem));
-                                      (std::push(__vec, (json::JKeyPtr{.key=(internment::intern("b"): internment::Intern<string>)}: json::JsonPtrItem));
-                                       __vec))))), (std::unwrap_or_default((json::from_json_string(json_test::struct_with_map1()): std::Result<json::JsonValue,string>)): json::JsonValue));
-           (json::set_by_ptr(jval, ((var __vec: std::Vec<json::JsonPtrItem>) = (std::vec_with_capacity(64'd4): std::Vec<json::JsonPtrItem>);
-                                    (std::push(__vec, (json::JKeyPtr{.key=(internment::intern("nested"): internment::Intern<string>)}: json::JsonPtrItem));
-                                     (std::push(__vec, (json::JKeyPtr{.key=(internment::intern("z"): internment::Intern<string>)}: json::JsonPtrItem));
-                                      (std::push(__vec, (json::JIdxPtr{.idx=64'd9}: json::JsonPtrItem));
-                                       (std::push(__vec, (json::JKeyPtr{.key=(internment::intern("q"): internment::Intern<string>)}: json::JsonPtrItem));
-                                        __vec))))), (std::unwrap_or_default((json::from_json_string(json_test::struct_with_map1()): std::Result<json::JsonValue,string>)): json::JsonValue));
-            (json::set_by_ptr(jval, ((var __vec: std::Vec<json::JsonPtrItem>) = (std::vec_with_capacity(64'd2): std::Vec<json::JsonPtrItem>);
-                                     (std::push(__vec, (json::JKeyPtr{.key=(internment::intern("t"): internment::Intern<string>)}: json::JsonPtrItem));
-                                      (std::push(__vec, (json::JKeyPtr{.key=(internment::intern("z"): internment::Intern<string>)}: json::JsonPtrItem));
-                                       __vec))), (std::unwrap_or_default((json::from_json_string(json_test::struct_with_map1()): std::Result<json::JsonValue,string>)): json::JsonValue));
-             jval)))))))))
+    {(var jval: json::JsonValue) = (std::unwrap_or_default((json::from_json_string(json_test::nestedStruct1()): std::Result<json::JsonValue,string>)): json::JsonValue);
+     {json::set_by_ptr(jval, {(var __vec: std::Vec<json::JsonPtrItem>) = (std::vec_with_capacity(64'd2): std::Vec<json::JsonPtrItem>);
+                              {std::push(__vec, (json::JKeyPtr{.key=(internment::intern("nested"): internment::Intern<string>)}: json::JsonPtrItem));
+                               {std::push(__vec, (json::JKeyPtr{.key=(internment::intern("x"): internment::Intern<string>)}: json::JsonPtrItem));
+                                __vec}}}, (std::unwrap_or_default((json::from_json_string(json_test::boolStruct2()): std::Result<json::JsonValue,string>)): json::JsonValue));
+      {json::set_by_ptr(jval, {(var __vec: std::Vec<json::JsonPtrItem>) = (std::vec_with_capacity(64'd2): std::Vec<json::JsonPtrItem>);
+                               {std::push(__vec, (json::JKeyPtr{.key=(internment::intern("nested"): internment::Intern<string>)}: json::JsonPtrItem));
+                                {std::push(__vec, (json::JKeyPtr{.key=(internment::intern("y"): internment::Intern<string>)}: json::JsonPtrItem));
+                                 __vec}}}, (std::unwrap_or_default((json::from_json_string(json_test::boolStruct2()): std::Result<json::JsonValue,string>)): json::JsonValue));
+       {json::set_by_ptr(jval, {(var __vec: std::Vec<json::JsonPtrItem>) = (std::vec_with_capacity(64'd2): std::Vec<json::JsonPtrItem>);
+                                {std::push(__vec, (json::JKeyPtr{.key=(internment::intern("nested"): internment::Intern<string>)}: json::JsonPtrItem));
+                                 {std::push(__vec, (json::JKeyPtr{.key=(internment::intern("z"): internment::Intern<string>)}: json::JsonPtrItem));
+                                  __vec}}}, (json::JsonArray{.a={(var __vec: std::Vec<json::JsonValue>) = (std::vec_with_capacity(64'd2): std::Vec<json::JsonValue>);
+                                                                 {std::push(__vec, (std::unwrap_or_default((json::from_json_string(json_test::wenum1()): std::Result<json::JsonValue,string>)): json::JsonValue));
+                                                                  {std::push(__vec, (std::unwrap_or_default((json::from_json_string(json_test::wenum2()): std::Result<json::JsonValue,string>)): json::JsonValue));
+                                                                   __vec}}}}: json::JsonValue));
+        {json::set_by_ptr(jval, {(var __vec: std::Vec<json::JsonPtrItem>) = (std::vec_with_capacity(64'd3): std::Vec<json::JsonPtrItem>);
+                                 {std::push(__vec, (json::JKeyPtr{.key=(internment::intern("nested"): internment::Intern<string>)}: json::JsonPtrItem));
+                                  {std::push(__vec, (json::JKeyPtr{.key=(internment::intern("z"): internment::Intern<string>)}: json::JsonPtrItem));
+                                   {std::push(__vec, (json::JIdxPtr{.idx=64'd1}: json::JsonPtrItem));
+                                    __vec}}}}, (std::unwrap_or_default((json::from_json_string(json_test::wenum3()): std::Result<json::JsonValue,string>)): json::JsonValue));
+         {json::set_by_ptr(jval, {(var __vec: std::Vec<json::JsonPtrItem>) = (std::vec_with_capacity(64'd4): std::Vec<json::JsonPtrItem>);
+                                  {std::push(__vec, (json::JKeyPtr{.key=(internment::intern("nested"): internment::Intern<string>)}: json::JsonPtrItem));
+                                   {std::push(__vec, (json::JKeyPtr{.key=(internment::intern("z"): internment::Intern<string>)}: json::JsonPtrItem));
+                                    {std::push(__vec, (json::JIdxPtr{.idx=64'd1}: json::JsonPtrItem));
+                                     {std::push(__vec, (json::JKeyPtr{.key=(internment::intern("b"): internment::Intern<string>)}: json::JsonPtrItem));
+                                      __vec}}}}}, (std::unwrap_or_default((json::from_json_string(json_test::struct_with_map1()): std::Result<json::JsonValue,string>)): json::JsonValue));
+          {json::set_by_ptr(jval, {(var __vec: std::Vec<json::JsonPtrItem>) = (std::vec_with_capacity(64'd4): std::Vec<json::JsonPtrItem>);
+                                   {std::push(__vec, (json::JKeyPtr{.key=(internment::intern("nested"): internment::Intern<string>)}: json::JsonPtrItem));
+                                    {std::push(__vec, (json::JKeyPtr{.key=(internment::intern("z"): internment::Intern<string>)}: json::JsonPtrItem));
+                                     {std::push(__vec, (json::JIdxPtr{.idx=64'd10}: json::JsonPtrItem));
+                                      {std::push(__vec, (json::JKeyPtr{.key=(internment::intern("b"): internment::Intern<string>)}: json::JsonPtrItem));
+                                       __vec}}}}}, (std::unwrap_or_default((json::from_json_string(json_test::struct_with_map1()): std::Result<json::JsonValue,string>)): json::JsonValue));
+           {json::set_by_ptr(jval, {(var __vec: std::Vec<json::JsonPtrItem>) = (std::vec_with_capacity(64'd4): std::Vec<json::JsonPtrItem>);
+                                    {std::push(__vec, (json::JKeyPtr{.key=(internment::intern("nested"): internment::Intern<string>)}: json::JsonPtrItem));
+                                     {std::push(__vec, (json::JKeyPtr{.key=(internment::intern("z"): internment::Intern<string>)}: json::JsonPtrItem));
+                                      {std::push(__vec, (json::JIdxPtr{.idx=64'd9}: json::JsonPtrItem));
+                                       {std::push(__vec, (json::JKeyPtr{.key=(internment::intern("q"): internment::Intern<string>)}: json::JsonPtrItem));
+                                        __vec}}}}}, (std::unwrap_or_default((json::from_json_string(json_test::struct_with_map1()): std::Result<json::JsonValue,string>)): json::JsonValue));
+            {json::set_by_ptr(jval, {(var __vec: std::Vec<json::JsonPtrItem>) = (std::vec_with_capacity(64'd2): std::Vec<json::JsonPtrItem>);
+                                     {std::push(__vec, (json::JKeyPtr{.key=(internment::intern("t"): internment::Intern<string>)}: json::JsonPtrItem));
+                                      {std::push(__vec, (json::JKeyPtr{.key=(internment::intern("z"): internment::Intern<string>)}: json::JsonPtrItem));
+                                       __vec}}}, (std::unwrap_or_default((json::from_json_string(json_test::struct_with_map1()): std::Result<json::JsonValue,string>)): json::JsonValue));
+             jval}}}}}}}}}
 }
 function json_test::nestedStruct1 (): string
 {
@@ -762,14 +762,14 @@ extern function std::group_to_setmap (g: std::Group<'K1,('K2, 'V)>): std::Map<'K
 extern function std::group_to_vec (g: std::Group<'K,'V>): std::Vec<'V>
 function std::group_unzip (g: std::Group<'K,('X, 'Y)>): (std::Vec<'X>, std::Vec<'Y>)
 {
-    ((var xs: std::Vec<'X>) = (std::vec_empty(): std::Vec<'X>);
-     ((var ys: std::Vec<'Y>) = (std::vec_empty(): std::Vec<'Y>);
-      (for (v in g) {
-           (((var x: 'X), (var y: 'Y)) = v;
-            (std::vec_push(xs, x);
-             std::vec_push(ys, y)))
+    {(var xs: std::Vec<'X>) = (std::vec_empty(): std::Vec<'X>);
+     {(var ys: std::Vec<'Y>) = (std::vec_empty(): std::Vec<'Y>);
+      {for (v in g) {
+           {((var x: 'X), (var y: 'Y)) = v;
+            {std::vec_push(xs, x);
+             std::vec_push(ys, y)}}
        };
-       (xs, ys))))
+       (xs, ys)}}}
 }
 extern function std::hash128 (x: 'X): bit<128>
 extern function std::hash64 (x: 'X): bit<64>
@@ -1228,13 +1228,13 @@ extern function std::vec_with_capacity (len: std::usize): std::Vec<'A>
 extern function std::vec_with_length (len: std::usize, x: 'A): std::Vec<'A>
 function std_test::alphabet_map (): std::Map<std::usize,string>
 {
-    ((var __map: std::Map<bit<64>,string>) = (std::map_empty(): std::Map<bit<64>,string>);
-     (std::insert(__map, 64'd0, "a");
-      (std::insert(__map, 64'd1, "b");
-       (std::insert(__map, 64'd2, "c");
-        (std::insert(__map, 64'd3, "d");
-         (std::insert(__map, 64'd4, "e");
-          __map))))))
+    {(var __map: std::Map<bit<64>,string>) = (std::map_empty(): std::Map<bit<64>,string>);
+     {std::insert(__map, 64'd0, "a");
+      {std::insert(__map, 64'd1, "b");
+       {std::insert(__map, 64'd2, "c");
+        {std::insert(__map, 64'd3, "d");
+         {std::insert(__map, 64'd4, "e");
+          __map}}}}}}
 }
 function std_test::to_string (e: std_test::DefaultEnum): string
 {
@@ -1245,14 +1245,14 @@ function std_test::to_string (e: std_test::DefaultEnum): string
 }
 function std_test::vec0 (): std::Vec<std::s64>
 {
-    ((var __vec: std::Vec<signed<64>>) = (std::vec_with_capacity(64'd6): std::Vec<signed<64>>);
-     (std::push(__vec, 64'sd0);
-      (std::push(__vec, 64'sd1);
-       (std::push(__vec, 64'sd2);
-        (std::push(__vec, 64'sd3);
-         (std::push(__vec, 64'sd4);
-          (std::push(__vec, 64'sd5);
-           __vec)))))))
+    {(var __vec: std::Vec<signed<64>>) = (std::vec_with_capacity(64'd6): std::Vec<signed<64>>);
+     {std::push(__vec, 64'sd0);
+      {std::push(__vec, 64'sd1);
+       {std::push(__vec, 64'sd2);
+        {std::push(__vec, 64'sd3);
+         {std::push(__vec, 64'sd4);
+          {std::push(__vec, 64'sd5);
+           __vec}}}}}}}
 }
 extern function tinyset::contains (s: tinyset::Set64<'X>, v: 'X): bool
 extern function tinyset::difference (s1: tinyset::Set64<'X>, s2: tinyset::Set64<'X>): tinyset::Set64<'X>
@@ -1310,11 +1310,11 @@ extern function uuid::to_urn_lower (uuid: uuid::Uuid): string
 extern function uuid::to_urn_upper (uuid: uuid::Uuid): string
 function uuid_test::test_uuid_from_bytes (): uuid::Uuid
 {
-    ((var bytes: std::Vec<bit<8>>) = (std::vec_empty(): std::Vec<bit<8>>);
-     (for (i in (std::range((8'd0: bit<8>), (8'd15: bit<8>), (8'd1: bit<8>)): std::Vec<bit<8>>)) {
+    {(var bytes: std::Vec<bit<8>>) = (std::vec_empty(): std::Vec<bit<8>>);
+     {for (i in (std::range((8'd0: bit<8>), (8'd15: bit<8>), (8'd1: bit<8>)): std::Vec<bit<8>>)) {
           std::vec_push(bytes, (i as bit<8>))
       };
-      (std::unwrap_or(uuid::from_bytes(bytes), uuid::nil()): uuid::Uuid)))
+      (std::unwrap_or(uuid::from_bytes(bytes), uuid::nil()): uuid::Uuid)}}
 }
 function uuid_test::uuid_parse_or_nil (str: string): uuid::Uuid
 {
@@ -1359,29 +1359,29 @@ output relation tinyset_test::Sets [tinyset_test::Sets]
 output relation url_test::URLTest [url_test::URLTest]
 output relation uuid_test::UUID [uuid_test::UUID]
 std_test::SortedVector[(std_test::SortedVector{.v=sorted}: std_test::SortedVector)] :- std_test::Vector[(__std_test_vector0@ (std_test::Vector{.v=(v: std::Vec<bigint>)}: std_test::Vector))], (var sorted: std::Vec<bigint>) = (std::sort_imm(v): std::Vec<bigint>), Inspect debug::debug_event((32'd0, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, "Condition", __std_test_vector0, (std_test::SortedVector{.v=sorted}: std_test::SortedVector)).
-std_test::SortedVectorInPlace[(std_test::SortedVectorInPlace{.v=sorted}: std_test::SortedVectorInPlace)] :- std_test::Vector[(__std_test_vector0@ (std_test::Vector{.v=(v: std::Vec<bigint>)}: std_test::Vector))], (var sorted: std::Vec<bigint>) = ((var v2: std::Vec<bigint>) = v;
-                                                                                                                                                                                                                                                      (std::sort(v2);
-                                                                                                                                                                                                                                                       v2)), Inspect debug::debug_event((32'd1, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, "Condition", __std_test_vector0, (std_test::SortedVectorInPlace{.v=sorted}: std_test::SortedVectorInPlace)).
+std_test::SortedVectorInPlace[(std_test::SortedVectorInPlace{.v=sorted}: std_test::SortedVectorInPlace)] :- std_test::Vector[(__std_test_vector0@ (std_test::Vector{.v=(v: std::Vec<bigint>)}: std_test::Vector))], (var sorted: std::Vec<bigint>) = {(var v2: std::Vec<bigint>) = v;
+                                                                                                                                                                                                                                                      {std::sort(v2);
+                                                                                                                                                                                                                                                       v2}}, Inspect debug::debug_event((32'd1, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, "Condition", __std_test_vector0, (std_test::SortedVectorInPlace{.v=sorted}: std_test::SortedVectorInPlace)).
 std_test::IntVecTest[(std_test::IntVecTest{.descr="vec0", .vec=std_test::vec0()}: std_test::IntVecTest)].
-std_test::IntVecTest[(std_test::IntVecTest{.descr="vec0.resize(10,-100)", .vec=((var v: std::Vec<std::s64>) = std_test::vec0();
-                                                                                (std::resize(v, 64'd10, (- 64'sd100));
-                                                                                 v))}: std_test::IntVecTest)].
-std_test::IntVecTest[(std_test::IntVecTest{.descr="vec0.update_nth(10, -1)", .vec=((var v: std::Vec<std::s64>) = std_test::vec0();
-                                                                                   (std::update_nth(v, 64'd10, (- 64'sd1));
-                                                                                    v))}: std_test::IntVecTest)].
-std_test::IntVecTest[(std_test::IntVecTest{.descr="vec0.update_nth(1, -1)", .vec=((var v: std::Vec<std::s64>) = std_test::vec0();
-                                                                                  (std::update_nth(v, 64'd1, (- 64'sd1));
-                                                                                   v))}: std_test::IntVecTest)].
-std_test::IntVecTest[(std_test::IntVecTest{.descr="vec0.swap_nth(10, -1)", .vec=((var v: std::Vec<std::s64>) = std_test::vec0();
-                                                                                 ((var val: signed<64>) = (- 64'sd1);
-                                                                                  (std::swap_nth(v, 64'd10, val);
-                                                                                   (std::push(v, val);
-                                                                                    v))))}: std_test::IntVecTest)].
-std_test::IntVecTest[(std_test::IntVecTest{.descr="vec0.swap_nth(5, -1)", .vec=((var v: std::Vec<std::s64>) = std_test::vec0();
-                                                                                ((var val: signed<64>) = (- 64'sd1);
-                                                                                 (std::swap_nth(v, 64'd5, val);
-                                                                                  (std::push(v, val);
-                                                                                   v))))}: std_test::IntVecTest)].
+std_test::IntVecTest[(std_test::IntVecTest{.descr="vec0.resize(10,-100)", .vec={(var v: std::Vec<std::s64>) = std_test::vec0();
+                                                                                {std::resize(v, 64'd10, (- 64'sd100));
+                                                                                 v}}}: std_test::IntVecTest)].
+std_test::IntVecTest[(std_test::IntVecTest{.descr="vec0.update_nth(10, -1)", .vec={(var v: std::Vec<std::s64>) = std_test::vec0();
+                                                                                   {std::update_nth(v, 64'd10, (- 64'sd1));
+                                                                                    v}}}: std_test::IntVecTest)].
+std_test::IntVecTest[(std_test::IntVecTest{.descr="vec0.update_nth(1, -1)", .vec={(var v: std::Vec<std::s64>) = std_test::vec0();
+                                                                                  {std::update_nth(v, 64'd1, (- 64'sd1));
+                                                                                   v}}}: std_test::IntVecTest)].
+std_test::IntVecTest[(std_test::IntVecTest{.descr="vec0.swap_nth(10, -1)", .vec={(var v: std::Vec<std::s64>) = std_test::vec0();
+                                                                                 {(var val: signed<64>) = (- 64'sd1);
+                                                                                  {std::swap_nth(v, 64'd10, val);
+                                                                                   {std::push(v, val);
+                                                                                    v}}}}}: std_test::IntVecTest)].
+std_test::IntVecTest[(std_test::IntVecTest{.descr="vec0.swap_nth(5, -1)", .vec={(var v: std::Vec<std::s64>) = std_test::vec0();
+                                                                                {(var val: signed<64>) = (- 64'sd1);
+                                                                                 {std::swap_nth(v, 64'd5, val);
+                                                                                  {std::push(v, val);
+                                                                                   v}}}}}: std_test::IntVecTest)].
 std_test::SetDifference[(std_test::SetDifference{.s1=s1, .s2=s2, .diff=(std::set_difference(s1, s2): std::Set<std::u64>)}: std_test::SetDifference)] :- std_test::SetPairs[(__std_test_setpairs0@ (std_test::SetPairs{.s1=(s1: std::Set<std::u64>), .s2=(s2: std::Set<std::u64>)}: std_test::SetPairs))], Inspect debug::debug_event((32'd8, 32'd0, 32'd0), ddlog_weight, ddlog_timestamp, "Map", __std_test_setpairs0, (std_test::SetDifference{.s1=s1, .s2=s2, .diff=(std::set_difference(s1, s2): std::Set<std::u64>)}: std_test::SetDifference)).
 std_test::SetDifference[(std_test::SetDifference{.s1=s2, .s2=s1, .diff=(std::set_difference(s2, s1): std::Set<std::u64>)}: std_test::SetDifference)] :- std_test::SetPairs[(__std_test_setpairs0@ (std_test::SetPairs{.s1=(s1: std::Set<std::u64>), .s2=(s2: std::Set<std::u64>)}: std_test::SetPairs))], Inspect debug::debug_event((32'd9, 32'd0, 32'd0), ddlog_weight, ddlog_timestamp, "Map", __std_test_setpairs0, (std_test::SetDifference{.s1=s2, .s2=s1, .diff=(std::set_difference(s2, s1): std::Set<std::u64>)}: std_test::SetDifference)).
 std_test::MapSizes[(std_test::MapSizes{.m=m, .size=std::size(m)}: std_test::MapSizes)] :- std_test::Maps[(__std_test_maps0@ (std_test::Maps{.m=(m: std::Map<std::u64,string>)}: std_test::Maps))], Inspect debug::debug_event((32'd10, 32'd0, 32'd0), ddlog_weight, ddlog_timestamp, "Map", __std_test_maps0, (std_test::MapSizes{.m=m, .size=std::size(m)}: std_test::MapSizes)).
@@ -1390,9 +1390,9 @@ std_test::Pow[(std_test::Pow{.descr="$pow32(2: u64, 32)", .val=("" ++ (std::__bu
 std_test::Default[(std_test::Default{.descr="u32", .val=("" ++ (std::__builtin_2string((std::default(): std::u32)): string))}: std_test::Default)].
 std_test::Default[(std_test::Default{.descr="DefaultEnum", .val=("" ++ (std_test::to_string((std::default(): std_test::DefaultEnum)): string))}: std_test::Default)].
 std_test::MapDelete[(std_test::MapDelete{.descr="alphabet", .m=std_test::alphabet_map(), .s=(std::None{}: std::Option<string>)}: std_test::MapDelete)].
-std_test::MapDelete[(std_test::MapDelete{.descr=((("" ++ d) ++ "\\") ++ (std::__builtin_2string((std::size(m) - 64'd1)): string)), .m=m2, .s=s}: std_test::MapDelete)] :- std_test::MapDelete[(__std_test_mapdelete0@ (std_test::MapDelete{.descr=(d: string), .m=(m: std::Map<std::usize,string>), .s=(_: std::Option<string>)}: std_test::MapDelete))], (std::size(m) > 64'd0), ((var m2: std::Map<std::usize,string>), (var s: std::Option<string>)) = ((var m2: std::Map<bit<64>,string>) = m;
-                                                                                                                                                                                                                                                                                                                                                                                                                                                           ((var s: std::Option<string>) = (std::remove(m2, (std::size(m) - 64'd1)): std::Option<string>);
-                                                                                                                                                                                                                                                                                                                                                                                                                                                            (m2, s))), Inspect debug::debug_event((32'd16, 32'd2, 32'd0), ddlog_weight, ddlog_timestamp, "Condition", (d, m), (std_test::MapDelete{.descr=((("" ++ d) ++ "\\") ++ (std::__builtin_2string((std::size(m) - 64'd1)): string)), .m=m2, .s=s}: std_test::MapDelete)).
+std_test::MapDelete[(std_test::MapDelete{.descr=((("" ++ d) ++ "\\") ++ (std::__builtin_2string((std::size(m) - 64'd1)): string)), .m=m2, .s=s}: std_test::MapDelete)] :- std_test::MapDelete[(__std_test_mapdelete0@ (std_test::MapDelete{.descr=(d: string), .m=(m: std::Map<std::usize,string>), .s=(_: std::Option<string>)}: std_test::MapDelete))], (std::size(m) > 64'd0), ((var m2: std::Map<std::usize,string>), (var s: std::Option<string>)) = {(var m2: std::Map<bit<64>,string>) = m;
+                                                                                                                                                                                                                                                                                                                                                                                                                                                           {(var s: std::Option<string>) = (std::remove(m2, (std::size(m) - 64'd1)): std::Option<string>);
+                                                                                                                                                                                                                                                                                                                                                                                                                                                            (m2, s)}}, Inspect debug::debug_event((32'd16, 32'd2, 32'd0), ddlog_weight, ddlog_timestamp, "Condition", (d, m), (std_test::MapDelete{.descr=((("" ++ d) ++ "\\") ++ (std::__builtin_2string((std::size(m) - 64'd1)): string)), .m=m2, .s=s}: std_test::MapDelete)).
 uuid_test::UUID[(uuid_test::UUID{.description="uuid::to_hyphenated_lower(uuid::nil())", .result=uuid::to_hyphenated_lower(uuid::nil())}: uuid_test::UUID)].
 uuid_test::UUID[(uuid_test::UUID{.description="uuid::to_hyphenated_upper(uuid::nil())", .result=uuid::to_hyphenated_upper(uuid::nil())}: uuid_test::UUID)].
 uuid_test::UUID[(uuid_test::UUID{.description="uuid::to_simple_lower(uuid::nil())", .result=uuid::to_simple_lower(uuid::nil())}: uuid_test::UUID)].
@@ -1439,8 +1439,8 @@ net_test::NetChecks[(net_test::NetChecks{.description="ipv4_from_octet_vec(ipv4_
 net_test::NetChecks[(net_test::NetChecks{.description="iPV4_LOCALHOST()", .value=("" ++ (net::ipv4::to_string(net::ipv4::iPV4_LOCALHOST()): string))}: net_test::NetChecks)].
 net_test::NetChecks[(net_test::NetChecks{.description="iPV4_UNSPECIFIED()", .value=("" ++ (net::ipv4::to_string(net::ipv4::iPV4_UNSPECIFIED()): string))}: net_test::NetChecks)].
 net_test::NetChecks[(net_test::NetChecks{.description="iPV4_BROADCAST()", .value=("" ++ (net::ipv4::to_string(net::ipv4::iPV4_BROADCAST()): string))}: net_test::NetChecks)].
-net_test::NetChecks[(net_test::NetChecks{.description="ipv4_octets(ipv4_new(192,168,0,1))", .value=(((var a: bit<8>), (var b: bit<8>), (var c: bit<8>), (var d: bit<8>)) = net::ipv4::ipv4_octets(net::ipv4::ipv4_new(8'd192, 8'd168, 8'd0, 8'd1));
-                                                                                                    (((((((("(" ++ (std::__builtin_2string(a): string)) ++ ",") ++ (std::__builtin_2string(b): string)) ++ ",") ++ (std::__builtin_2string(c): string)) ++ ",") ++ (std::__builtin_2string(d): string)) ++ ")"))}: net_test::NetChecks)].
+net_test::NetChecks[(net_test::NetChecks{.description="ipv4_octets(ipv4_new(192,168,0,1))", .value={((var a: bit<8>), (var b: bit<8>), (var c: bit<8>), (var d: bit<8>)) = net::ipv4::ipv4_octets(net::ipv4::ipv4_new(8'd192, 8'd168, 8'd0, 8'd1));
+                                                                                                    (((((((("(" ++ (std::__builtin_2string(a): string)) ++ ",") ++ (std::__builtin_2string(b): string)) ++ ",") ++ (std::__builtin_2string(c): string)) ++ ",") ++ (std::__builtin_2string(d): string)) ++ ")")}}: net_test::NetChecks)].
 net_test::NetChecks[(net_test::NetChecks{.description="ipv4_is_unspecified(iPV4_UNSPECIFIED())", .value=("" ++ (std::__builtin_2string(net::ipv4::ipv4_is_unspecified(net::ipv4::iPV4_UNSPECIFIED())): string))}: net_test::NetChecks)].
 net_test::NetChecks[(net_test::NetChecks{.description="ipv4_is_unspecified(ipv4_new(10,0,0,0))", .value=("" ++ (std::__builtin_2string(net::ipv4::ipv4_is_unspecified(net::ipv4::ipv4_new(8'd10, 8'd0, 8'd0, 8'd0))): string))}: net_test::NetChecks)].
 net_test::NetChecks[(net_test::NetChecks{.description="ipv4_is_loopback(ipv4_new(127,0,0,5))", .value=("" ++ (std::__builtin_2string(net::ipv4::ipv4_is_loopback(net::ipv4::ipv4_new(8'd127, 8'd0, 8'd0, 8'd5))): string))}: net_test::NetChecks)].
@@ -1491,10 +1491,10 @@ net_test::NetChecks[(net_test::NetChecks{.description="ipv6_from_str(::175.16.1.
 net_test::NetChecks[(net_test::NetChecks{.description="ipv6_from_str(ffff:192.10.2.255)", .value=("" ++ (net::ipv6::to_string((std::unwrap_or(net::ipv6::ipv6_from_str("ffff:192.10.2.255"), net::ipv6::iPV6_UNSPECIFIED()): net::ipv6::Ipv6Addr)): string))}: net_test::NetChecks)].
 net_test::NetChecks[(net_test::NetChecks{.description="ipv6_from_str(::)", .value=("" ++ (net::ipv6::to_string((std::unwrap_or(net::ipv6::ipv6_from_str("::"), net::ipv6::iPV6_LOCALHOST()): net::ipv6::Ipv6Addr)): string))}: net_test::NetChecks)].
 net_test::NetChecks[(net_test::NetChecks{.description="ipv6_to_u128(ipv6_from_str(::ffff:192.10.2.255))", .value=("" ++ std::hex(net::ipv6::ipv6_to_u128((std::unwrap_or(net::ipv6::ipv6_from_str("::ffff:192.10.2.255"), net::ipv6::iPV6_UNSPECIFIED()): net::ipv6::Ipv6Addr))))}: net_test::NetChecks)].
-net_test::NetChecks[(net_test::NetChecks{.description="ipv6_segments(ipv6_from_str(::ffff:192.10.2.255))", .value=(((var a: bit<16>), (var b: bit<16>), (var c: bit<16>), (var d: bit<16>), (var e: bit<16>), (var f: bit<16>), (var g: bit<16>), (var h: bit<16>)) = net::ipv6::ipv6_segments((std::unwrap_or(net::ipv6::ipv6_from_str("::ffff:192.10.2.255"), net::ipv6::iPV6_UNSPECIFIED()): net::ipv6::Ipv6Addr));
-                                                                                                                   (((((((((((((((("(" ++ (std::__builtin_2string(a): string)) ++ ",") ++ (std::__builtin_2string(b): string)) ++ ",") ++ (std::__builtin_2string(c): string)) ++ ",") ++ (std::__builtin_2string(d): string)) ++ ",") ++ (std::__builtin_2string(e): string)) ++ ",") ++ (std::__builtin_2string(f): string)) ++ ",") ++ (std::__builtin_2string(g): string)) ++ ",") ++ (std::__builtin_2string(h): string)) ++ ")"))}: net_test::NetChecks)].
-net_test::NetChecks[(net_test::NetChecks{.description="ipv6_octets(ipv6_from_str(::ffff:192.10.2.255))", .value=(((var a: bit<8>), (var b: bit<8>), (var c: bit<8>), (var d: bit<8>), (var e: bit<8>), (var f: bit<8>), (var g: bit<8>), (var h: bit<8>), (var i: bit<8>), (var j: bit<8>), (var k: bit<8>), (var l: bit<8>), (var m: bit<8>), (var n: bit<8>), (var o: bit<8>), (var p: bit<8>)) = net::ipv6::ipv6_octets((std::unwrap_or(net::ipv6::ipv6_from_str("::ffff:192.10.2.255"), net::ipv6::iPV6_UNSPECIFIED()): net::ipv6::Ipv6Addr));
-                                                                                                                 (((((((((((((((((((((((((((((((("(" ++ (std::__builtin_2string(a): string)) ++ ",") ++ (std::__builtin_2string(b): string)) ++ ",") ++ (std::__builtin_2string(c): string)) ++ ",") ++ (std::__builtin_2string(d): string)) ++ ",") ++ (std::__builtin_2string(e): string)) ++ ",") ++ (std::__builtin_2string(f): string)) ++ ",") ++ (std::__builtin_2string(g): string)) ++ ",") ++ (std::__builtin_2string(h): string)) ++ ",") ++ (std::__builtin_2string(i): string)) ++ ",") ++ (std::__builtin_2string(j): string)) ++ ",") ++ (std::__builtin_2string(k): string)) ++ ",") ++ (std::__builtin_2string(l): string)) ++ ",") ++ (std::__builtin_2string(m): string)) ++ ",") ++ (std::__builtin_2string(n): string)) ++ ",") ++ (std::__builtin_2string(o): string)) ++ ",") ++ (std::__builtin_2string(p): string)) ++ ")"))}: net_test::NetChecks)].
+net_test::NetChecks[(net_test::NetChecks{.description="ipv6_segments(ipv6_from_str(::ffff:192.10.2.255))", .value={((var a: bit<16>), (var b: bit<16>), (var c: bit<16>), (var d: bit<16>), (var e: bit<16>), (var f: bit<16>), (var g: bit<16>), (var h: bit<16>)) = net::ipv6::ipv6_segments((std::unwrap_or(net::ipv6::ipv6_from_str("::ffff:192.10.2.255"), net::ipv6::iPV6_UNSPECIFIED()): net::ipv6::Ipv6Addr));
+                                                                                                                   (((((((((((((((("(" ++ (std::__builtin_2string(a): string)) ++ ",") ++ (std::__builtin_2string(b): string)) ++ ",") ++ (std::__builtin_2string(c): string)) ++ ",") ++ (std::__builtin_2string(d): string)) ++ ",") ++ (std::__builtin_2string(e): string)) ++ ",") ++ (std::__builtin_2string(f): string)) ++ ",") ++ (std::__builtin_2string(g): string)) ++ ",") ++ (std::__builtin_2string(h): string)) ++ ")")}}: net_test::NetChecks)].
+net_test::NetChecks[(net_test::NetChecks{.description="ipv6_octets(ipv6_from_str(::ffff:192.10.2.255))", .value={((var a: bit<8>), (var b: bit<8>), (var c: bit<8>), (var d: bit<8>), (var e: bit<8>), (var f: bit<8>), (var g: bit<8>), (var h: bit<8>), (var i: bit<8>), (var j: bit<8>), (var k: bit<8>), (var l: bit<8>), (var m: bit<8>), (var n: bit<8>), (var o: bit<8>), (var p: bit<8>)) = net::ipv6::ipv6_octets((std::unwrap_or(net::ipv6::ipv6_from_str("::ffff:192.10.2.255"), net::ipv6::iPV6_UNSPECIFIED()): net::ipv6::Ipv6Addr));
+                                                                                                                 (((((((((((((((((((((((((((((((("(" ++ (std::__builtin_2string(a): string)) ++ ",") ++ (std::__builtin_2string(b): string)) ++ ",") ++ (std::__builtin_2string(c): string)) ++ ",") ++ (std::__builtin_2string(d): string)) ++ ",") ++ (std::__builtin_2string(e): string)) ++ ",") ++ (std::__builtin_2string(f): string)) ++ ",") ++ (std::__builtin_2string(g): string)) ++ ",") ++ (std::__builtin_2string(h): string)) ++ ",") ++ (std::__builtin_2string(i): string)) ++ ",") ++ (std::__builtin_2string(j): string)) ++ ",") ++ (std::__builtin_2string(k): string)) ++ ",") ++ (std::__builtin_2string(l): string)) ++ ",") ++ (std::__builtin_2string(m): string)) ++ ",") ++ (std::__builtin_2string(n): string)) ++ ",") ++ (std::__builtin_2string(o): string)) ++ ",") ++ (std::__builtin_2string(p): string)) ++ ")")}}: net_test::NetChecks)].
 net_test::NetChecks[(net_test::NetChecks{.description="ipv6_from_segment_vec(ipv6_segment_vec(ipv6_from_str(::ffff:192.10.2.255)))", .value=("" ++ (net::ipv6::to_string((std::unwrap_or(net::ipv6::ipv6_from_segment_vec(net::ipv6::ipv6_segment_vec((std::unwrap_or(net::ipv6::ipv6_from_str("::ffff:192.10.2.255"), net::ipv6::iPV6_UNSPECIFIED()): net::ipv6::Ipv6Addr))), net::ipv6::iPV6_UNSPECIFIED()): net::ipv6::Ipv6Addr)): string))}: net_test::NetChecks)].
 net_test::NetChecks[(net_test::NetChecks{.description="ipv6_from_octet_vec(ipv6_octet_vec(ipv6_from_str(::ffff:192.10.2.255)))", .value=("" ++ (net::ipv6::to_string((std::unwrap_or(net::ipv6::ipv6_from_octet_vec(net::ipv6::ipv6_octet_vec((std::unwrap_or(net::ipv6::ipv6_from_str("::ffff:192.10.2.255"), net::ipv6::iPV6_UNSPECIFIED()): net::ipv6::Ipv6Addr))), net::ipv6::iPV6_UNSPECIFIED()): net::ipv6::Ipv6Addr)): string))}: net_test::NetChecks)].
 net_test::NetChecks[(net_test::NetChecks{.description="ipv6_is_unspecified(iPV6_UNSPECIFIED())", .value=("" ++ (std::__builtin_2string(net::ipv6::ipv6_is_unspecified(net::ipv6::iPV6_UNSPECIFIED())): string))}: net_test::NetChecks)].
@@ -1569,18 +1569,18 @@ json_test::JsonTestValue[(json_test::JsonTestValue{.description=("wrapped " ++ j
 json_test::JsonTestValue[(json_test::JsonTestValue{.description=("wrapped " ++ json_test::wenum2()), .value=json_test::to_json_string_or_default((std::unwrap_or_default(json::to_json_value((json::from_json_string(json_test::wenum2()): std::Result<json_test::WrappedEnum,string>))): json::JsonValue))}: json_test::JsonTestValue)].
 json_test::JsonTestValue[(json_test::JsonTestValue{.description=("wrapped " ++ json_test::wenum3()), .value=json_test::to_json_string_or_default((std::unwrap_or_default(json::to_json_value((json::from_json_string(json_test::wenum3()): std::Result<json_test::WrappedEnum,string>))): json::JsonValue))}: json_test::JsonTestValue)].
 json_test::JsonTest[(json_test::JsonTest{.description="set_by_ptr test", .value=json_test::to_json_string_or_default(json_test::mutilate_jval())}: json_test::JsonTest)].
-json_test::JsonTest[(json_test::JsonTest{.description="get_by_ptr(nested/z/10/b)", .value=(std::unwrap_or_default(json::to_json_string(json::get_by_ptr(json_test::mutilate_jval(), ((var __vec: std::Vec<json::JsonPtrItem>) = (std::vec_with_capacity(64'd4): std::Vec<json::JsonPtrItem>);
-                                                                                                                                                                                     (std::push(__vec, (json::JKeyPtr{.key=(internment::intern("nested"): internment::Intern<string>)}: json::JsonPtrItem));
-                                                                                                                                                                                      (std::push(__vec, (json::JKeyPtr{.key=(internment::intern("z"): internment::Intern<string>)}: json::JsonPtrItem));
-                                                                                                                                                                                       (std::push(__vec, (json::JIdxPtr{.idx=64'd10}: json::JsonPtrItem));
-                                                                                                                                                                                        (std::push(__vec, (json::JKeyPtr{.key=(internment::intern("b"): internment::Intern<string>)}: json::JsonPtrItem));
-                                                                                                                                                                                         __vec)))))))): string)}: json_test::JsonTest)].
-json_test::JsonTest[(json_test::JsonTest{.description="get_by_ptr(nested/z/10/c)", .value=(std::unwrap_or_default(json::to_json_string(json::get_by_ptr(json_test::mutilate_jval(), ((var __vec: std::Vec<json::JsonPtrItem>) = (std::vec_with_capacity(64'd4): std::Vec<json::JsonPtrItem>);
-                                                                                                                                                                                     (std::push(__vec, (json::JKeyPtr{.key=(internment::intern("nested"): internment::Intern<string>)}: json::JsonPtrItem));
-                                                                                                                                                                                      (std::push(__vec, (json::JKeyPtr{.key=(internment::intern("z"): internment::Intern<string>)}: json::JsonPtrItem));
-                                                                                                                                                                                       (std::push(__vec, (json::JIdxPtr{.idx=64'd10}: json::JsonPtrItem));
-                                                                                                                                                                                        (std::push(__vec, (json::JKeyPtr{.key=(internment::intern("c"): internment::Intern<string>)}: json::JsonPtrItem));
-                                                                                                                                                                                         __vec)))))))): string)}: json_test::JsonTest)].
+json_test::JsonTest[(json_test::JsonTest{.description="get_by_ptr(nested/z/10/b)", .value=(std::unwrap_or_default(json::to_json_string(json::get_by_ptr(json_test::mutilate_jval(), {(var __vec: std::Vec<json::JsonPtrItem>) = (std::vec_with_capacity(64'd4): std::Vec<json::JsonPtrItem>);
+                                                                                                                                                                                     {std::push(__vec, (json::JKeyPtr{.key=(internment::intern("nested"): internment::Intern<string>)}: json::JsonPtrItem));
+                                                                                                                                                                                      {std::push(__vec, (json::JKeyPtr{.key=(internment::intern("z"): internment::Intern<string>)}: json::JsonPtrItem));
+                                                                                                                                                                                       {std::push(__vec, (json::JIdxPtr{.idx=64'd10}: json::JsonPtrItem));
+                                                                                                                                                                                        {std::push(__vec, (json::JKeyPtr{.key=(internment::intern("b"): internment::Intern<string>)}: json::JsonPtrItem));
+                                                                                                                                                                                         __vec}}}}}))): string)}: json_test::JsonTest)].
+json_test::JsonTest[(json_test::JsonTest{.description="get_by_ptr(nested/z/10/c)", .value=(std::unwrap_or_default(json::to_json_string(json::get_by_ptr(json_test::mutilate_jval(), {(var __vec: std::Vec<json::JsonPtrItem>) = (std::vec_with_capacity(64'd4): std::Vec<json::JsonPtrItem>);
+                                                                                                                                                                                     {std::push(__vec, (json::JKeyPtr{.key=(internment::intern("nested"): internment::Intern<string>)}: json::JsonPtrItem));
+                                                                                                                                                                                      {std::push(__vec, (json::JKeyPtr{.key=(internment::intern("z"): internment::Intern<string>)}: json::JsonPtrItem));
+                                                                                                                                                                                       {std::push(__vec, (json::JIdxPtr{.idx=64'd10}: json::JsonPtrItem));
+                                                                                                                                                                                        {std::push(__vec, (json::JKeyPtr{.key=(internment::intern("c"): internment::Intern<string>)}: json::JsonPtrItem));
+                                                                                                                                                                                         __vec}}}}}))): string)}: json_test::JsonTest)].
 json_test::JsonTest[(json_test::JsonTest{.description="get_by_ptr([])", .value=(std::unwrap_or_default(json::to_json_string(json::get_by_ptr(json_test::mutilate_jval(), (std::vec_empty(): std::Vec<json::JsonPtrItem>)))): string)}: json_test::JsonTest)].
 fp_test::F[(fp_test::F{.s="nan_f()", .d=fp::nan_f()}: fp_test::F)].
 fp_test::F[(fp_test::F{.s="floor_f(32'f0.5)", .d=fp::floor_f(32'f0.5)}: fp_test::F)].
@@ -1696,15 +1696,15 @@ internment_test::Projections[(internment_test::Projections{.inp=internment_test:
 internment_test::Projections[(internment_test::Projections{.inp=internment_test::istruct2struct((internment::ival(i): internment_test::IStruct)), .p=("f2=" ++ (std::__builtin_2string(f2): string))}: internment_test::Projections)] :- internment_test::IStruct[(i@ ((&(internment_test::IStruct{.u=((&(t@ (internment_test::Tag2{.f2=(f2: bit<32>), .f3=(_: string)}: internment_test::IUnion))): internment::Intern<internment_test::IUnion>), .t=(_: internment::Intern<(std::s32, double)>), .x=(_: bigint)}: internment_test::IStruct)): internment::Intern<internment_test::IStruct>))], Inspect debug::debug_event((32'd304, 32'd0, 32'd0), ddlog_weight, ddlog_timestamp, "Map", i, (internment_test::Projections{.inp=internment_test::istruct2struct((internment::ival(i): internment_test::IStruct)), .p=("f2=" ++ (std::__builtin_2string(f2): string))}: internment_test::Projections)).
 internment_test::Projections[(internment_test::Projections{.inp=internment_test::istruct2struct((internment::ival(i): internment_test::IStruct)), .p=("f3=" ++ f3)}: internment_test::Projections)] :- internment_test::IStruct[(i@ ((&(internment_test::IStruct{.u=(t@ ((&(internment_test::Tag2{.f2=(_: bit<32>), .f3=(f3: string)}: internment_test::IUnion)): internment::Intern<internment_test::IUnion>)), .t=(_: internment::Intern<(std::s32, double)>), .x=(_: bigint)}: internment_test::IStruct)): internment::Intern<internment_test::IStruct>))], Inspect debug::debug_event((32'd305, 32'd0, 32'd0), ddlog_weight, ddlog_timestamp, "Map", i, (internment_test::Projections{.inp=internment_test::istruct2struct((internment::ival(i): internment_test::IStruct)), .p=("f3=" ++ f3)}: internment_test::Projections)).
 tinyset_test::Sets[(tinyset_test::Sets{.setid=setid, .set=set}: tinyset_test::Sets)] :- tinyset_test::SetElement[(__tinyset_test_setelement0@ (tinyset_test::SetElement{.setid=(setid: string), .element=(v: bit<32>)}: tinyset_test::SetElement))], var __inputs_set = Aggregate(setid, __debug_306_1_tinyset::group_to_set((__tinyset_test_setelement0, v))), Inspect debug::debug_event((32'd306, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, "Aggregate", __inputs_set.0, (__inputs_set, setid)), (var set: tinyset::Set64<bit<32>>) = __inputs_set.1, Inspect debug::debug_event((32'd306, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, "Condition", (__inputs_set, setid), (tinyset_test::Sets{.setid=setid, .set=set}: tinyset_test::Sets)).
-tinyset_test::Intersects[(tinyset_test::Intersects{.setid1=setid1, .setid2=setid2, .set=set}: tinyset_test::Intersects)] :- tinyset_test::Sets[(__tinyset_test_sets0@ (tinyset_test::Sets{.setid=(setid1: string), .set=(set1: tinyset::Set64<std::u32>)}: tinyset_test::Sets))], tinyset_test::Sets[(__tinyset_test_sets1@ (tinyset_test::Sets{.setid=(setid2: string), .set=(set2: tinyset::Set64<std::u32>)}: tinyset_test::Sets))], Inspect debug::debug_event_join((32'd307, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, __tinyset_test_sets0, __tinyset_test_sets1, (setid1, set1, setid2, set2)), (var set: tinyset::Set64<std::u32>) = ((var set: tinyset::Set64<std::u32>) = (tinyset::empty(): tinyset::Set64<std::u32>);
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  (for (x in set1) {
+tinyset_test::Intersects[(tinyset_test::Intersects{.setid1=setid1, .setid2=setid2, .set=set}: tinyset_test::Intersects)] :- tinyset_test::Sets[(__tinyset_test_sets0@ (tinyset_test::Sets{.setid=(setid1: string), .set=(set1: tinyset::Set64<std::u32>)}: tinyset_test::Sets))], tinyset_test::Sets[(__tinyset_test_sets1@ (tinyset_test::Sets{.setid=(setid2: string), .set=(set2: tinyset::Set64<std::u32>)}: tinyset_test::Sets))], Inspect debug::debug_event_join((32'd307, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, __tinyset_test_sets0, __tinyset_test_sets1, (setid1, set1, setid2, set2)), (var set: tinyset::Set64<std::u32>) = {(var set: tinyset::Set64<std::u32>) = (tinyset::empty(): tinyset::Set64<std::u32>);
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  {for (x in set1) {
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        if tinyset::contains(set2, x) {
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            tinyset::insert(set, x)
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        } else {
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              ()
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          }
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    };
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   set)), Inspect debug::debug_event((32'd307, 32'd2, 32'd0), ddlog_weight, ddlog_timestamp, "Condition", (setid1, set1, setid2, set2), (tinyset_test::Intersects{.setid1=setid1, .setid2=setid2, .set=set}: tinyset_test::Intersects)).
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   set}}, Inspect debug::debug_event((32'd307, 32'd2, 32'd0), ddlog_weight, ddlog_timestamp, "Condition", (setid1, set1, setid2, set2), (tinyset_test::Intersects{.setid1=setid1, .setid2=setid2, .set=set}: tinyset_test::Intersects)).
 tinyset_test::Intersects2[(tinyset_test::Intersects2{.setid1=setid1, .setid2=setid2, .set=(tinyset::intersection(set1, set2): tinyset::Set64<std::u32>)}: tinyset_test::Intersects2)] :- tinyset_test::Sets[(__tinyset_test_sets0@ (tinyset_test::Sets{.setid=(setid1: string), .set=(set1: tinyset::Set64<std::u32>)}: tinyset_test::Sets))], tinyset_test::Sets[(__tinyset_test_sets1@ (tinyset_test::Sets{.setid=(setid2: string), .set=(set2: tinyset::Set64<std::u32>)}: tinyset_test::Sets))], Inspect debug::debug_event_join((32'd308, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, __tinyset_test_sets0, __tinyset_test_sets1, (tinyset_test::Intersects2{.setid1=setid1, .setid2=setid2, .set=(tinyset::intersection(set1, set2): tinyset::Set64<std::u32>)}: tinyset_test::Intersects2)).
 tinyset_test::Diffs[(tinyset_test::Diffs{.setid1=setid1, .setid2=setid2, .set=(tinyset::difference(set1, set2): tinyset::Set64<std::u32>)}: tinyset_test::Diffs)] :- tinyset_test::Sets[(__tinyset_test_sets0@ (tinyset_test::Sets{.setid=(setid1: string), .set=(set1: tinyset::Set64<std::u32>)}: tinyset_test::Sets))], tinyset_test::Sets[(__tinyset_test_sets1@ (tinyset_test::Sets{.setid=(setid2: string), .set=(set2: tinyset::Set64<std::u32>)}: tinyset_test::Sets))], Inspect debug::debug_event_join((32'd309, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, __tinyset_test_sets0, __tinyset_test_sets1, (tinyset_test::Diffs{.setid1=setid1, .setid2=setid2, .set=(tinyset::difference(set1, set2): tinyset::Set64<std::u32>)}: tinyset_test::Diffs)).
 url_test::URLTest[(url_test::URLTest{.description="https://example.net", .val=url::to_string((std::unwrap_or_default(url::url_parse("https://example.net")): url::Url))}: url_test::URLTest)].

--- a/test/datalog_tests/simple.debug.ast.expected
+++ b/test/datalog_tests/simple.debug.ast.expected
@@ -235,88 +235,88 @@ typedef t22 = float
 typedef tnid_t = bit<16>
 function __debug_100_1_std::group_to_vec (g: std::Group<string,('I, string)>): (std::Vec<'I>, std::Vec<string>)
 {
-    (((var inputs: std::Vec<'I>), (var original_group: std::Group<string,string>)) = debug::debug_split_group(g);
-     (inputs, std::group_to_vec(original_group)))
+    {((var inputs: std::Vec<'I>), (var original_group: std::Group<string,string>)) = debug::debug_split_group(g);
+     (inputs, std::group_to_vec(original_group))}
 }
 function __debug_101_1_std::group_to_map (g: std::Group<string,('I, (string, string))>): (std::Vec<'I>, std::Map<string,string>)
 {
-    (((var inputs: std::Vec<'I>), (var original_group: std::Group<string,(string, string)>)) = debug::debug_split_group(g);
-     (inputs, std::group_to_map(original_group)))
+    {((var inputs: std::Vec<'I>), (var original_group: std::Group<string,(string, string)>)) = debug::debug_split_group(g);
+     (inputs, std::group_to_map(original_group))}
 }
 function __debug_102_1_std::group_to_set (g: std::Group<string,('I, string)>): (std::Vec<'I>, std::Set<string>)
 {
-    (((var inputs: std::Vec<'I>), (var original_group: std::Group<string,string>)) = debug::debug_split_group(g);
-     (inputs, std::group_to_set(original_group)))
+    {((var inputs: std::Vec<'I>), (var original_group: std::Group<string,string>)) = debug::debug_split_group(g);
+     (inputs, std::group_to_set(original_group))}
 }
 function __debug_103_1_std::group_sum (g: std::Group<string,('I, bit<32>)>): (std::Vec<'I>, bit<32>)
 {
-    (((var inputs: std::Vec<'I>), (var original_group: std::Group<string,bit<32>>)) = debug::debug_split_group(g);
-     (inputs, std::group_sum(original_group)))
+    {((var inputs: std::Vec<'I>), (var original_group: std::Group<string,bit<32>>)) = debug::debug_split_group(g);
+     (inputs, std::group_sum(original_group))}
 }
 function __debug_104_2_std::group_count (g: std::Group<string,('I, ())>): (std::Vec<'I>, std::usize)
 {
-    (((var inputs: std::Vec<'I>), (var original_group: std::Group<string,()>)) = debug::debug_split_group(g);
-     (inputs, std::group_count(original_group)))
+    {((var inputs: std::Vec<'I>), (var original_group: std::Group<string,()>)) = debug::debug_split_group(g);
+     (inputs, std::group_count(original_group))}
 }
 function __debug_105_1_concat_ys (g: std::Group<(string, string),('I, string)>): (std::Vec<'I>, string)
 {
-    (((var inputs: std::Vec<'I>), (var original_group: std::Group<(string, string),string>)) = debug::debug_split_group(g);
-     (inputs, concat_ys(original_group)))
+    {((var inputs: std::Vec<'I>), (var original_group: std::Group<(string, string),string>)) = debug::debug_split_group(g);
+     (inputs, concat_ys(original_group))}
 }
 function __debug_112_2_std::group_to_vec (g: std::Group<string,('I, string)>): (std::Vec<'I>, std::Vec<string>)
 {
-    (((var inputs: std::Vec<'I>), (var original_group: std::Group<string,string>)) = debug::debug_split_group(g);
-     (inputs, std::group_to_vec(original_group)))
+    {((var inputs: std::Vec<'I>), (var original_group: std::Group<string,string>)) = debug::debug_split_group(g);
+     (inputs, std::group_to_vec(original_group))}
 }
 function __debug_113_1_std::group_to_set (g: std::Group<string,('I, bit<32>)>): (std::Vec<'I>, std::Set<bit<32>>)
 {
-    (((var inputs: std::Vec<'I>), (var original_group: std::Group<string,bit<32>>)) = debug::debug_split_group(g);
-     (inputs, std::group_to_set(original_group)))
+    {((var inputs: std::Vec<'I>), (var original_group: std::Group<string,bit<32>>)) = debug::debug_split_group(g);
+     (inputs, std::group_to_set(original_group))}
 }
 function __debug_248_2_std::group_to_set (g: std::Group<bit<32>,('I, bit<16>)>): (std::Vec<'I>, std::Set<bit<16>>)
 {
-    (((var inputs: std::Vec<'I>), (var original_group: std::Group<bit<32>,bit<16>>)) = debug::debug_split_group(g);
-     (inputs, std::group_to_set(original_group)))
+    {((var inputs: std::Vec<'I>), (var original_group: std::Group<bit<32>,bit<16>>)) = debug::debug_split_group(g);
+     (inputs, std::group_to_set(original_group))}
 }
 function __debug_249_3_std::group_set_unions (g: std::Group<bit<32>,('I, std::Set<tnid_t>)>): (std::Vec<'I>, std::Set<bit<16>>)
 {
-    (((var inputs: std::Vec<'I>), (var original_group: std::Group<bit<32>,std::Set<tnid_t>>)) = debug::debug_split_group(g);
-     (inputs, std::group_set_unions(original_group)))
+    {((var inputs: std::Vec<'I>), (var original_group: std::Group<bit<32>,std::Set<tnid_t>>)) = debug::debug_split_group(g);
+     (inputs, std::group_set_unions(original_group))}
 }
 function __debug_93_1_count_xs (g: std::Group<string,('I, string)>): (std::Vec<'I>, std::u64)
 {
-    (((var inputs: std::Vec<'I>), (var original_group: std::Group<string,string>)) = debug::debug_split_group(g);
-     (inputs, count_xs(original_group)))
+    {((var inputs: std::Vec<'I>), (var original_group: std::Group<string,string>)) = debug::debug_split_group(g);
+     (inputs, count_xs(original_group))}
 }
 function __debug_94_1_find_x_in_group (g: std::Group<string,('I, string)>): (std::Vec<'I>, bool)
 {
-    (((var inputs: std::Vec<'I>), (var original_group: std::Group<string,string>)) = debug::debug_split_group(g);
-     (inputs, find_x_in_group(original_group)))
+    {((var inputs: std::Vec<'I>), (var original_group: std::Group<string,string>)) = debug::debug_split_group(g);
+     (inputs, find_x_in_group(original_group))}
 }
 function __debug_95_1_std::group_count (g: std::Group<string,('I, string)>): (std::Vec<'I>, std::usize)
 {
-    (((var inputs: std::Vec<'I>), (var original_group: std::Group<string,string>)) = debug::debug_split_group(g);
-     (inputs, std::group_count(original_group)))
+    {((var inputs: std::Vec<'I>), (var original_group: std::Group<string,string>)) = debug::debug_split_group(g);
+     (inputs, std::group_count(original_group))}
 }
 function __debug_96_1_std::group_count (g: std::Group<(),('I, ())>): (std::Vec<'I>, std::usize)
 {
-    (((var inputs: std::Vec<'I>), (var original_group: std::Group<(),()>)) = debug::debug_split_group(g);
-     (inputs, std::group_count(original_group)))
+    {((var inputs: std::Vec<'I>), (var original_group: std::Group<(),()>)) = debug::debug_split_group(g);
+     (inputs, std::group_count(original_group))}
 }
 function __debug_97_1_std::group_sum (g: std::Group<(),('I, bit<64>)>): (std::Vec<'I>, bit<64>)
 {
-    (((var inputs: std::Vec<'I>), (var original_group: std::Group<(),bit<64>>)) = debug::debug_split_group(g);
-     (inputs, std::group_sum(original_group)))
+    {((var inputs: std::Vec<'I>), (var original_group: std::Group<(),bit<64>>)) = debug::debug_split_group(g);
+     (inputs, std::group_sum(original_group))}
 }
 function __debug_98_2_std::group_sum (g: std::Group<(),('I, bit<64>)>): (std::Vec<'I>, bit<64>)
 {
-    (((var inputs: std::Vec<'I>), (var original_group: std::Group<(),bit<64>>)) = debug::debug_split_group(g);
-     (inputs, std::group_sum(original_group)))
+    {((var inputs: std::Vec<'I>), (var original_group: std::Group<(),bit<64>>)) = debug::debug_split_group(g);
+     (inputs, std::group_sum(original_group))}
 }
 function __debug_99_1_std::group_to_set (g: std::Group<string,('I, string)>): (std::Vec<'I>, std::Set<string>)
 {
-    (((var inputs: std::Vec<'I>), (var original_group: std::Group<string,string>)) = debug::debug_split_group(g);
-     (inputs, std::group_to_set(original_group)))
+    {((var inputs: std::Vec<'I>), (var original_group: std::Group<string,string>)) = debug::debug_split_group(g);
+     (inputs, std::group_to_set(original_group))}
 }
 function a0 (): bigint
 {
@@ -380,29 +380,29 @@ function a9 (): bit<32>
 }
 function agg1 (g1: std::Group<'K,Tt1>): Ttmp0
 {
-    ((var first3: bool) = true;
-     ((var max5: signed<64>) = 64'sd0;
-      (for (i2 in g1) {
-           ((var v0: Tt1) = i2;
+    {(var first3: bool) = true;
+     {(var max5: signed<64>) = 64'sd0;
+      {for (i2 in g1) {
+           {(var v0: Tt1) = i2;
             max5 = if first3 {
                        v0.column1
                    } else {
-                         (first3 = false;
-                          64'sd0)
-                     })
+                         {first3 = false;
+                          64'sd0}
+                     }}
        };
-       (Ttmp0{.col4=max5}: Ttmp0))))
+       (Ttmp0{.col4=max5}: Ttmp0)}}}
 }
 function all (xs: std::Vec<bool>): bool
 {
-    (for (x in xs) {
+    {for (x in xs) {
          if (not x) {
              ((return false): ())
          } else {
                ()
            }
      };
-     ((return true): bool))
+     ((return true): bool)}
 }
 extern function allocate::adjust_allocation (allocated: std::Map<'A,'N>, toallocate: std::Vec<'A>, min_val: 'N, max_val: 'N): std::Vec<('A, 'N)>
 extern function allocate::allocate (allocated: std::Set<'N>, toallocate: std::Vec<'B>, min_val: 'N, max_val: 'N): std::Vec<('B, 'N)>
@@ -410,16 +410,16 @@ extern function allocate::allocate_opt (allocated: std::Set<'N>, toallocate: std
 extern function allocate::allocate_with_hint (allocated: std::Set<'N>, toallocate: std::Vec<('B, std::Option<'N>)>, min_val: 'N, max_val: 'N): std::Vec<('B, 'N)>
 function any (xs: std::Vec<bool>): bool
 {
-    ((var res: bool) = false;
-     (for (x in xs) {
+    {(var res: bool) = false;
+     {for (x in xs) {
           if x {
-              (res = true;
-               (break: ()))
+              {res = true;
+               (break: ())}
           } else {
                 ()
             }
       };
-      ((return res): bool)))
+      ((return res): bool)}}
 }
 function b0 (): bool
 {
@@ -431,29 +431,31 @@ function b1 (a: bool): bool
 }
 function c0 (a: bit<32>, b: bit<16>): bit<16>
 {
-    (a;
-     b)
+    {a;
+     b}
 }
 function concat_ys (ys: std::Group<(string, string),string>): string
 {
-    (((var x: string), (var z: string)) = (std::group_key(ys): (string, string));
-     ((var res: string) = (((x ++ "-") ++ z) ++ ":");
-      (for (y in ys) {
-           res = (res ++ y)
+    {((var x: string), (var z: string)) = (std::group_key(ys): (string, string));
+     {(var res: string) = (((x ++ "-") ++ z) ++ ":");
+      {for (y in ys) {
+           {res = (res ++ y);
+            ()}
        };
-       res)))
+       res}}}
 }
 function count_xs (ys: std::Group<string,string>): std::u64
 {
-    ((var res: std::u64) = 64'd0;
-     (for (y in ys) {
+    {(var res: std::u64) = 64'd0;
+     {for (y in ys) {
           if (y == (std::group_key(ys): string)) {
-              res = (res + 64'd1)
+              {res = (res + 64'd1);
+               ()}
           } else {
                 ()
             }
       };
-      res))
+      res}}
 }
 function dbl (): double
 {
@@ -464,8 +466,8 @@ extern function debug::debug_event_join (operator_id: debug::DDlogOpId, w: std::
 extern function debug::debug_split_group (g: std::Group<'K,('I, 'V)>): (std::Vec<'I>, std::Group<'K,'V>)
 function double_evens (xs: std::Vec<bigint>): std::Vec<bigint>
 {
-    ((var res: std::Vec<bigint>) = (std::vec_empty(): std::Vec<bigint>);
-     (for (x in xs) {
+    {(var res: std::Vec<bigint>) = (std::vec_empty(): std::Vec<bigint>);
+     {for (x in xs) {
           std::vec_push(res, mult2(if (x == 0) {
                                        (break: bigint)
                                    } else {
@@ -480,7 +482,7 @@ function double_evens (xs: std::Vec<bigint>): std::Vec<bigint>
                                            }
                                      }))
       };
-      res))
+      res}}
 }
 function dummy (x: string): string
 {
@@ -497,42 +499,42 @@ function edge_to (e: Edge): bigint
 extern function f (): bigint
 function f1 (x: T1, y: T2, q: T3): bool
 {
-    (match (x) {
+    {match (x) {
          (C11{.f1=(_: bigint), .f2=(_: (bigint, string))}: T1) -> true,
          (_: T1) -> false
      };
-     (match (x) {
+     {match (x) {
           (C11{.f1=(_: bigint), .f2=(_: (bigint, string))}: T1) -> true,
           (C12{.f3=(_: bit<32>), .f4=(_: (bool, bool, bool))}: T1) -> false
       };
-      (match (y) {
+      {match (y) {
            (C21{.f1=(_: T1), .f2=(_: bigint)}: T2) -> true,
            (C22{.f3=((_: bool), (C11{.f1=(_: bigint), .f2=(_: (bigint, string))}: T1))}: T2) -> true,
            (_: T2) -> false
        };
-       (match (y) {
+       {match (y) {
             (C21{.f1=(_: T1), .f2=(_: bigint)}: T2) -> true,
             (C22{.f3=(true, (C11{.f1=(_: bigint), .f2=(_: (bigint, string))}: T1))}: T2) -> true,
             (C22{.f3=(true, (C12{.f3=(_: bit<32>), .f4=(_: (bool, bool, bool))}: T1))}: T2) -> true,
             (C22{.f3=(false, (C11{.f1=(_: bigint), .f2=(_: (bigint, string))}: T1))}: T2) -> true,
             (C22{.f3=(false, (C12{.f3=(_: bit<32>), .f4=(_: (bool, bool, bool))}: T1))}: T2) -> true
         };
-        ((var z: (bool, (bool, (bool, bool)))) = (true, (false, (true, false)));
-         (match (z) {
+        {(var z: (bool, (bool, (bool, bool)))) = (true, (false, (true, false)));
+         {match (z) {
               (true, (_: (bool, (bool, bool)))) -> true,
               (false, ((_: bool), (true, true))) -> true,
               (false, ((_: bool), (true, false))) -> true,
               (false, ((_: bool), (false, true))) -> true,
               (false, ((_: bool), (false, false))) -> true
           };
-          (match (z) {
+          {match (z) {
                ((_: bool), ((_: bool), (true, true))) -> true,
                ((_: bool), ((_: bool), (true, false))) -> true,
                ((_: bool), ((_: bool), (false, true))) -> true,
                (false, ((_: bool), (false, false))) -> true,
                (true, ((_: bool), (false, false))) -> true
            };
-           (match (q) {
+           {match (q) {
                 (C31{.f1=(_: T1), .f2=(_: bigint), .s=(_: string), .b=(_: bit<32>)}: T3) -> true,
                 (C32{.f3=((true, ((_: bool), (_: bool), false)), (_: T1))}: T3) -> true,
                 (C32{.f3=((false, ((_: bool), (_: bool), false)), (_: T1))}: T3) -> true,
@@ -542,7 +544,7 @@ function f1 (x: T1, y: T2, q: T3): bool
                 (C32{.f3=(((_: bool), ((_: bool), (_: bool), true)), (C12{.f3=(_: bit<32>), .f4=((_: bool), (_: bool), false)}: T1))}: T3) -> false,
                 (C32{.f3=(((_: bool), ((_: bool), (_: bool), true)), (C12{.f3=(_: bit<32>), .f4=((_: bool), (_: bool), true)}: T1))}: T3) -> false
             };
-            (match (q) {
+            {match (q) {
                  (C31{.f1=(_: T1), .f2=0, .s="foo", .b=32'd15}: T3) -> true,
                  (C31{.f1=(_: T1), .f2=(_: bigint), .s=(_: string), .b=32'd15}: T3) -> true,
                  (C31{.f1=(_: T1), .f2=0, .s=(_: string), .b=(_: bit<32>)}: T3) -> true,
@@ -550,18 +552,18 @@ function f1 (x: T1, y: T2, q: T3): bool
                  (C32{.f3=(_: ((bool, (bool, bool, bool)), T1))}: T3) -> true,
                  (C31{.f1=(_: T1), .f2=(_: bigint), .s=(_: string), .b=(_: bit<32>)}: T3) -> true
              };
-             ((var s: string) = "bar";
+             {(var s: string) = "bar";
               match (s) {
                   "foo" -> true,
                   "bar" -> true,
                   (_: string) -> false
-              }))))))))))
+              }}}}}}}}}}}
 }
 function filter_C0 (xs: std::Vec<Alt>): std::Vec<bigint>
 {
-    ((var res: std::Vec<bigint>) = (std::vec_empty(): std::Vec<bigint>);
-     (for (x in xs) {
-          ((var val: bigint) = match (x) {
+    {(var res: std::Vec<bigint>) = (std::vec_empty(): std::Vec<bigint>);
+     {for (x in xs) {
+          {(var val: bigint) = match (x) {
                                    (C0{.x=(var v: bit<32>)}: Alt) -> (continue: bigint),
                                    (C1{.x=(var v: bit<32>)}: Alt) -> if (v > 32'd0) {
                                                                          (v as bigint)
@@ -569,33 +571,35 @@ function filter_C0 (xs: std::Vec<Alt>): std::Vec<bigint>
                                                                            (break: bigint)
                                                                        }
                                };
-           std::vec_push(res, val))
+           {std::vec_push(res, val);
+            ()}}
       };
-      res))
+      res}}
 }
 function filter_gt (xs: std::Vec<bigint>, threshold: bigint): std::Vec<bigint>
 {
-    ((var res: std::Vec<bigint>) = (std::vec_empty(): std::Vec<bigint>);
-     (for (x in xs) {
-          (if (x <= threshold) {
+    {(var res: std::Vec<bigint>) = (std::vec_empty(): std::Vec<bigint>);
+     {for (x in xs) {
+          {if (x <= threshold) {
                (continue: ())
            } else {
                  ()
              };
-           std::vec_push(res, x))
+           std::vec_push(res, x)}
       };
-      ((return res): std::Vec<bigint>)))
+      ((return res): std::Vec<bigint>)}}
 }
 function find_x_in_group (ys: std::Group<'A,'A>): bool
 {
-    (for (y in ys) {
+    {for (y in ys) {
          if (y == (std::group_key(ys): 'A)) {
-             ((return true): ())
+             {((return true): ());
+              ()}
          } else {
                ()
            }
      };
-     false)
+     false}
 }
 function flt (): float
 {
@@ -603,27 +607,27 @@ function flt (): float
 }
 function fnested (x: nested_t): string
 {
-    ((N{.field=(C{.f1=(var res: string), .f2=(_: string)}: C)}: nested_t) = x;
-     res)
+    {(N{.field=(C{.f1=(var res: string), .f2=(_: string)}: C)}: nested_t) = x;
+     res}
 }
 function foo (): bool
 {
-    ((var v1: bigint) = 0;
-     ((var v2: bit<32>) = 32'd1;
-      ((var v3: bit<129>) = 129'd0;
-       ((var v4: bool) = true;
-        ((var v5: (bigint, string)) = (0, "test_string");
-         ((var v6: IPAddr) = (IP4{.ip4=32'd2864434397}: IPAddr);
-          ((var v7: FooStruct) = (Option1{.f1=0, .f2=(IP4{.ip4=32'd0}: IPAddr), .f3=(true, "bar")}: FooStruct);
-           (v3 = (v3 + 129'd703710);
-            (match (v6) {
+    {(var v1: bigint) = 0;
+     {(var v2: bit<32>) = 32'd1;
+      {(var v3: bit<129>) = 129'd0;
+       {(var v4: bool) = true;
+        {(var v5: (bigint, string)) = (0, "test_string");
+         {(var v6: IPAddr) = (IP4{.ip4=32'd2864434397}: IPAddr);
+          {(var v7: FooStruct) = (Option1{.f1=0, .f2=(IP4{.ip4=32'd0}: IPAddr), .f3=(true, "bar")}: FooStruct);
+           {v3 = (v3 + 129'd703710);
+            {match (v6) {
                  (IP4{.ip4=(_: bit<32>)}: IPAddr) -> true,
                  (_: IPAddr) -> false
              };
              match (v7) {
                  (Option1{.f1=(_: bigint), .f2=(IP6{.ip6=(_: bit<128>)}: IPAddr), .f3=((_: bool), "bar")}: FooStruct) -> true,
                  (_: FooStruct) -> false
-             })))))))))
+             }}}}}}}}}}
 }
 extern function fp::abs_d (f: double): double
 extern function fp::abs_f (f: float): float
@@ -790,8 +794,8 @@ function mult2 (x: bigint): bigint
 }
 function p (): string
 {
-    ((var notable: string) = "hi";
-     notable)
+    {(var notable: string) = "hi";
+     notable}
 }
 extern function parameterized (x: 'A, y: 'A): 'A
 function parameterized2 (x: 'A, y: 'A): bool
@@ -800,15 +804,16 @@ function parameterized2 (x: 'A, y: 'A): bool
 }
 function patterns (): ()
 {
-    ((var a: Alt) = (C0{.x=32'd1}: Alt);
-     ((var b: bool) = match (a) {
+    {(var a: Alt) = (C0{.x=32'd1}: Alt);
+     {(var b: bool) = match (a) {
                           (C0{.x=(_: bit<32>)}: Alt) -> true,
                           (C1{.x=(_: bit<32>)}: Alt) -> false
                       };
-      (var i: bit<32>) = match (a) {
-                             (C0{.x=(var v: bit<32>)}: Alt) -> v,
-                             (C1{.x=(var v: bit<32>)}: Alt) -> v
-                         }))
+      {(var i: bit<32>) = match (a) {
+                              (C0{.x=(var v: bit<32>)}: Alt) -> v,
+                              (C1{.x=(var v: bit<32>)}: Alt) -> v
+                          };
+       ()}}}
 }
 extern function regex::regex (pattern: string): regex::Regex
 extern function regex::regex_all_matches (regex: regex::Regex, text: string): std::Vec<string>
@@ -825,12 +830,12 @@ function s1 (): string
 }
 function shadow (): string
 {
-    ((var b: std::Option<string>) = (std::None{}: std::Option<string>);
-     ((var a: std::Option<string>) = (std::Some{.x="foo"}: std::Option<string>);
+    {(var b: std::Option<string>) = (std::None{}: std::Option<string>);
+     {(var a: std::Option<string>) = (std::Some{.x="foo"}: std::Option<string>);
       match (a) {
           (std::Some{.x=(var v: string)}: std::Option<string>) -> v,
           (std::None{}: std::Option<string>) -> ""
-      }))
+      }}}
 }
 function souffle_lib::acos (l: signed<32>): signed<32>
 {
@@ -904,15 +909,15 @@ function souffle_lib::group_count32 (g: std::Group<'K,'V>): souffle_types::Tnumb
 }
 function souffle_lib::group_mean (g: std::Group<'K,signed<32>>): signed<32>
 {
-    ((var sum: signed<32>) = (std::group_sum(g): signed<32>);
-     ((var count: bit<64>) = std::group_count(g);
-      (sum / ((count as signed<64>) as signed<32>))))
+    {(var sum: signed<32>) = (std::group_sum(g): signed<32>);
+     {(var count: bit<64>) = std::group_count(g);
+      (sum / ((count as signed<64>) as signed<32>))}}
 }
 function souffle_lib::group_mean_d (g: std::Group<'K,double>): double
 {
-    ((var sum: double) = (std::group_sum(g): double);
-     ((var count: bit<64>) = std::group_count(g);
-      (sum / (count as double))))
+    {(var sum: double) = (std::group_sum(g): double);
+     {(var count: bit<64>) = std::group_count(g);
+      (sum / (count as double))}}
 }
 function souffle_lib::itof (l: signed<32>): double
 {
@@ -1072,14 +1077,14 @@ extern function std::group_to_setmap (g: std::Group<'K1,('K2, 'V)>): std::Map<'K
 extern function std::group_to_vec (g: std::Group<'K,'V>): std::Vec<'V>
 function std::group_unzip (g: std::Group<'K,('X, 'Y)>): (std::Vec<'X>, std::Vec<'Y>)
 {
-    ((var xs: std::Vec<'X>) = (std::vec_empty(): std::Vec<'X>);
-     ((var ys: std::Vec<'Y>) = (std::vec_empty(): std::Vec<'Y>);
-      (for (v in g) {
-           (((var x: 'X), (var y: 'Y)) = v;
-            (std::vec_push(xs, x);
-             std::vec_push(ys, y)))
+    {(var xs: std::Vec<'X>) = (std::vec_empty(): std::Vec<'X>);
+     {(var ys: std::Vec<'Y>) = (std::vec_empty(): std::Vec<'Y>);
+      {for (v in g) {
+           {((var x: 'X), (var y: 'Y)) = v;
+            {std::vec_push(xs, x);
+             std::vec_push(ys, y)}}
        };
-       (xs, ys))))
+       (xs, ys)}}}
 }
 extern function std::hash128 (x: 'X): bit<128>
 extern function std::hash64 (x: 'X): bit<64>
@@ -1538,23 +1543,23 @@ extern function std::vec_with_capacity (len: std::usize): std::Vec<'A>
 extern function std::vec_with_length (len: std::usize, x: 'A): std::Vec<'A>
 function strings (): ()
 {
-    ((var str1: string) = ("foo" ++ "bar");
-     ((var str2: string) = ((("foobar" ++ "buzz") ++ "\nraw string ") ++ "quoted string");
-      ((var str3: string) = ("str1: " ++ str1);
-       ((var str4: string) = (((((("str1: " ++ str1) ++ ", str2: ") ++ str2) ++ ", str3: ") ++ str3) ++ ".");
-        ((var str5: string) = [|str1: ${str1},
+    {(var str1: string) = ("foo" ++ "bar");
+     {(var str2: string) = ((("foobar" ++ "buzz") ++ "\nraw string ") ++ "quoted string");
+      {(var str3: string) = ("str1: " ++ str1);
+       {(var str4: string) = (((((("str1: " ++ str1) ++ ", str2: ") ++ str2) ++ ", str3: ") ++ str3) ++ ".");
+        {(var str5: string) = [|str1: ${str1},
 str2: ${str2},
 str3: ${str3}.|];
-         ((var str6: string) = ("" ++ (str1 ++ str2));
-          ((var str7: string) = ("" ++ ((var x: string) = (str1 ++ str2);
-                                        x));
-           ((var str8: string) = ("" ++ ((var x: string) = (str1 ++ str2);
-                                         dummy(x)));
-            ((var b: bool) = (str1 < str2);
-             ((var b1: bool) = ("" < str1);
-              ((var b2: bool) = ([|${}|] < "");
-               ((var b3: bool) = ((str1 != str2) and (str1 >= str2));
-                ()))))))))))))
+         {(var str6: string) = ("" ++ (str1 ++ str2));
+          {(var str7: string) = ("" ++ {(var x: string) = (str1 ++ str2);
+                                        x});
+           {(var str8: string) = ("" ++ {(var x: string) = (str1 ++ str2);
+                                         dummy(x)});
+            {(var b: bool) = (str1 < str2);
+             {(var b1: bool) = ("" < str1);
+              {(var b2: bool) = ([|${}|] < "");
+               {(var b3: bool) = ((str1 != str2) and (str1 >= str2));
+                ()}}}}}}}}}}}}
 }
 function to_string (x: serializable_t): string
 {
@@ -1568,22 +1573,22 @@ function to_string (x: serializable_t): string
 }
 function tostring1 (): ()
 {
-    ((var a: bigint) = 5;
-     ((var b: bit<32>) = 32'd5;
-      ((var c: bool) = true;
-       ((var d: string) = "foo";
-        ((var err: string) = ((((((("a=" ++ (std::__builtin_2string(a): string)) ++ ", b=") ++ (std::__builtin_2string(b): string)) ++ ", c=") ++ (std::__builtin_2string(c): string)) ++ ", d=") ++ d);
-         ())))))
+    {(var a: bigint) = 5;
+     {(var b: bit<32>) = 32'd5;
+      {(var c: bool) = true;
+       {(var d: string) = "foo";
+        {(var err: string) = ((((((("a=" ++ (std::__builtin_2string(a): string)) ++ ", b=") ++ (std::__builtin_2string(b): string)) ++ ", c=") ++ (std::__builtin_2string(c): string)) ++ ", d=") ++ d);
+         ()}}}}}
 }
 function tostring2 (): ()
 {
-    ((var a: bigint) = 5;
-     ((var b: bit<32>) = 32'd5;
-      ((var c: bool) = true;
-       ((var d: string) = "foo";
-        ((var e: serializable_t) = (ConsInt{.x=0}: serializable_t);
-         ((var err: string) = ((((((((("a=" ++ (std::__builtin_2string(a): string)) ++ ", b=") ++ (std::__builtin_2string(b): string)) ++ ", c=") ++ (std::__builtin_2string(c): string)) ++ ", d=") ++ d) ++ ", e:") ++ (to_string(e): string));
-          ()))))))
+    {(var a: bigint) = 5;
+     {(var b: bit<32>) = 32'd5;
+      {(var c: bool) = true;
+       {(var d: string) = "foo";
+        {(var e: serializable_t) = (ConsInt{.x=0}: serializable_t);
+         {(var err: string) = ((((((((("a=" ++ (std::__builtin_2string(a): string)) ++ ", b=") ++ (std::__builtin_2string(b): string)) ++ ", c=") ++ (std::__builtin_2string(c): string)) ++ ", d=") ++ d) ++ ", e:") ++ (to_string(e): string));
+          ()}}}}}}
 }
 function use_parameterized (x: string, y: string_syn): string
 {
@@ -1591,9 +1596,9 @@ function use_parameterized (x: string, y: string_syn): string
 }
 function v (): string
 {
-    ((var v1: string) = "hello";
-     ((var v2: string) = "there";
-      v2))
+    {(var v1: string) = "hello";
+     {(var v2: string) = "there";
+      v2}}
 }
 function v2 (): bool
 {
@@ -1601,25 +1606,26 @@ function v2 (): bool
 }
 function vars (): ()
 {
-    ((var x: bigint) = 0;
-     (x = 10;
-      ((var y: C) = (C{.f1="foo", .f2="bar"}: C);
-       ((var z: C) = (C{.f1="bar", .f2="foo"}: C);
-        (((var a: bigint), (var b: bigint)) = ((x + 5), (x - 5));
-         ((C{.f1=(var e: string), .f2=(_: string)}: C) = y;
-          (C{.f1=(var c: string), .f2=(var d: string)}: C) = y))))))
+    {(var x: bigint) = 0;
+     {x = 10;
+      {(var y: C) = (C{.f1="foo", .f2="bar"}: C);
+       {(var z: C) = (C{.f1="bar", .f2="foo"}: C);
+        {((var a: bigint), (var b: bigint)) = ((x + 5), (x - 5));
+         {(C{.f1=(var e: string), .f2=(_: string)}: C) = y;
+          {(C{.f1=(var c: string), .f2=(var d: string)}: C) = y;
+           ()}}}}}}}
 }
 function weird_any (xs: std::Vec<bool>): bool
 {
-    ((var res: bool) = false;
-     (for (x in xs) {
+    {(var res: bool) = false;
+     {for (x in xs) {
           ((return if (x == true) {
                        true
                    } else {
                          (continue: bool)
                      }): ())
       };
-      false))
+      false}}
 }
 function x (): Alt
 {
@@ -1775,9 +1781,9 @@ Compare[(Compare{.label="C0{32'd3} < C1{32'd4}", .value=((C0{.x=32'd3}: Alt) < (
 Compare[(Compare{.label="None < Some{1}", .value=((std::None{}: std::Option<signed<32>>) < (std::Some{.x=32'sd1}: std::Option<signed<32>>))}: Compare)].
 Compare[(Compare{.label="Some{0} < Some{1}", .value=((std::Some{.x=(32'd0: std::u32)}: std::Option<bit<32>>) < (std::Some{.x=32'd1}: std::Option<bit<32>>))}: Compare)].
 VecTest[(VecTest{.x=(std::vec_empty(): std::Vec<string>)}: VecTest)].
-VecTest[(VecTest{.x=((var v: std::Vec<string>) = (std::vec_empty(): std::Vec<string>);
-                     (std::vec_push(v, "Hello,");
-                      v))}: VecTest)].
+VecTest[(VecTest{.x={(var v: std::Vec<string>) = (std::vec_empty(): std::Vec<string>);
+                     {std::vec_push(v, "Hello,");
+                      v}}}: VecTest)].
 VecTest[(VecTest{.x=(std::vec_push_imm((std::vec_push_imm((std::vec_empty(): std::Vec<string>), "Hello, "): std::Vec<string>), "world!"): std::Vec<string>)}: VecTest)].
 Reach[(Reach{.s1=x, .s2=y}: Reach)] :- Links[(__links0@ (Links{.l=(l: bigint), .s1=(x: string), .s2=(y: string)}: Links))], Inspect debug::debug_event((32'd20, 32'd0, 32'd0), ddlog_weight, ddlog_timestamp, "Map", __links0, (Reach{.s1=x, .s2=y}: Reach)).
 Reach[(Reach{.s1=x, .s2=y}: Reach)] :- Links[(__links0@ (Links{.l=(l: bigint), .s1=(y: string), .s2=(x: string)}: Links))], Inspect debug::debug_event((32'd21, 32'd0, 32'd0), ddlog_weight, ddlog_timestamp, "Map", __links0, (Reach{.s1=x, .s2=y}: Reach)).
@@ -1916,18 +1922,18 @@ Filtered[(Filtered{.r=r.r}: Filtered)] :- Referee[(r@ (Referee{.r=((&(Referenced
 Referee2[(std::ref_new((Referee2{.r=r}: Referee2)): std::Ref<Referee2>)] :- Referenced[(__referenced0@ (r: Referenced))], Inspect debug::debug_event((32'd117, 32'd0, 32'd0), ddlog_weight, ddlog_timestamp, "Map", __referenced0, (std::ref_new((Referee2{.r=r}: Referee2)): std::Ref<Referee2>)).
 Filtered2[(Filtered2{.r=r}: Filtered2)] :- Referee2[(r@ ((&(Referee2{.r=(Referenced{.x=true, .y=(_: std::Option<string>)}: Referenced)}: Referee2)): std::Ref<Referee2>))], Inspect debug::debug_event((32'd118, 32'd0, 32'd0), ddlog_weight, ddlog_timestamp, "Map", r, (Filtered2{.r=r}: Filtered2)).
 Filtered3[(Filtered3{.r=r.r}: Filtered3)] :- Referee[(r@ (Referee{.r=(_: std::Ref<Referenced>)}: Referee))], (r.r.x == true), Inspect debug::debug_event((32'd119, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, "Condition", r, (Filtered3{.r=r.r}: Filtered3)).
-NewAllocation[(NewAllocation{.id=id, .alloc=alloc}: NewAllocation)] :- Alloc[(__alloc0@ (Alloc{.id=(id: bigint), .allocated=(allocated: std::Map<string,bit<32>>), .toallocate=(toallocate: std::Vec<string>), .min_val=(min_val: bit<32>), .max_val=(max_val: bit<32>)}: Alloc))], (var allocated_nums: std::Set<bit<32>>) = ((var allocated_nums: std::Set<bit<32>>) = (std::set_empty(): std::Set<bit<32>>);
-                                                                                                                                                                                                                                                                                                                               (for (a in allocated) {
-                                                                                                                                                                                                                                                                                                                                    (((_: string), (var num: bit<32>)) = a;
-                                                                                                                                                                                                                                                                                                                                     std::set_insert(allocated_nums, num))
+NewAllocation[(NewAllocation{.id=id, .alloc=alloc}: NewAllocation)] :- Alloc[(__alloc0@ (Alloc{.id=(id: bigint), .allocated=(allocated: std::Map<string,bit<32>>), .toallocate=(toallocate: std::Vec<string>), .min_val=(min_val: bit<32>), .max_val=(max_val: bit<32>)}: Alloc))], (var allocated_nums: std::Set<bit<32>>) = {(var allocated_nums: std::Set<bit<32>>) = (std::set_empty(): std::Set<bit<32>>);
+                                                                                                                                                                                                                                                                                                                               {for (a in allocated) {
+                                                                                                                                                                                                                                                                                                                                    {((_: string), (var num: bit<32>)) = a;
+                                                                                                                                                                                                                                                                                                                                     std::set_insert(allocated_nums, num)}
                                                                                                                                                                                                                                                                                                                                 };
-                                                                                                                                                                                                                                                                                                                                allocated_nums)), (var alloc: std::Vec<(string, bit<32>)>) = (allocate::allocate(allocated_nums, toallocate, min_val, max_val): std::Vec<(string, bit<32>)>), Inspect debug::debug_event((32'd120, 32'd2, 32'd0), ddlog_weight, ddlog_timestamp, "Condition", (id, toallocate, min_val, max_val, allocated_nums), (NewAllocation{.id=id, .alloc=alloc}: NewAllocation)).
-NewAllocationOpt[(NewAllocationOpt{.id=id, .alloc=alloc}: NewAllocationOpt)] :- Alloc[(__alloc0@ (Alloc{.id=(id: bigint), .allocated=(allocated: std::Map<string,bit<32>>), .toallocate=(toallocate: std::Vec<string>), .min_val=(min_val: bit<32>), .max_val=(max_val: bit<32>)}: Alloc))], (var allocated_nums: std::Set<bit<32>>) = ((var allocated_nums: std::Set<bit<32>>) = (std::set_empty(): std::Set<bit<32>>);
-                                                                                                                                                                                                                                                                                                                                        (for (a in allocated) {
-                                                                                                                                                                                                                                                                                                                                             (((_: string), (var num: bit<32>)) = a;
-                                                                                                                                                                                                                                                                                                                                              std::set_insert(allocated_nums, num))
+                                                                                                                                                                                                                                                                                                                                allocated_nums}}, (var alloc: std::Vec<(string, bit<32>)>) = (allocate::allocate(allocated_nums, toallocate, min_val, max_val): std::Vec<(string, bit<32>)>), Inspect debug::debug_event((32'd120, 32'd2, 32'd0), ddlog_weight, ddlog_timestamp, "Condition", (id, toallocate, min_val, max_val, allocated_nums), (NewAllocation{.id=id, .alloc=alloc}: NewAllocation)).
+NewAllocationOpt[(NewAllocationOpt{.id=id, .alloc=alloc}: NewAllocationOpt)] :- Alloc[(__alloc0@ (Alloc{.id=(id: bigint), .allocated=(allocated: std::Map<string,bit<32>>), .toallocate=(toallocate: std::Vec<string>), .min_val=(min_val: bit<32>), .max_val=(max_val: bit<32>)}: Alloc))], (var allocated_nums: std::Set<bit<32>>) = {(var allocated_nums: std::Set<bit<32>>) = (std::set_empty(): std::Set<bit<32>>);
+                                                                                                                                                                                                                                                                                                                                        {for (a in allocated) {
+                                                                                                                                                                                                                                                                                                                                             {((_: string), (var num: bit<32>)) = a;
+                                                                                                                                                                                                                                                                                                                                              std::set_insert(allocated_nums, num)}
                                                                                                                                                                                                                                                                                                                                          };
-                                                                                                                                                                                                                                                                                                                                         allocated_nums)), (var alloc: std::Vec<(string, std::Option<bit<32>>)>) = (allocate::allocate_opt(allocated_nums, toallocate, min_val, max_val): std::Vec<(string, std::Option<bit<32>>)>), Inspect debug::debug_event((32'd121, 32'd2, 32'd0), ddlog_weight, ddlog_timestamp, "Condition", (id, toallocate, min_val, max_val, allocated_nums), (NewAllocationOpt{.id=id, .alloc=alloc}: NewAllocationOpt)).
+                                                                                                                                                                                                                                                                                                                                         allocated_nums}}, (var alloc: std::Vec<(string, std::Option<bit<32>>)>) = (allocate::allocate_opt(allocated_nums, toallocate, min_val, max_val): std::Vec<(string, std::Option<bit<32>>)>), Inspect debug::debug_event((32'd121, 32'd2, 32'd0), ddlog_weight, ddlog_timestamp, "Condition", (id, toallocate, min_val, max_val, allocated_nums), (NewAllocationOpt{.id=id, .alloc=alloc}: NewAllocationOpt)).
 Adjusted[(Adjusted{.id=id, .alloc=alloc}: Adjusted)] :- Alloc[(__alloc0@ (Alloc{.id=(id: bigint), .allocated=(allocated: std::Map<string,bit<32>>), .toallocate=(toallocate: std::Vec<string>), .min_val=(min_val: bit<32>), .max_val=(max_val: bit<32>)}: Alloc))], (var alloc: std::Vec<(string, bit<32>)>) = (allocate::adjust_allocation(allocated, toallocate, min_val, max_val): std::Vec<(string, bit<32>)>), Inspect debug::debug_event((32'd122, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, "Condition", __alloc0, (Adjusted{.id=id, .alloc=alloc}: Adjusted)).
 YX[(YX{.y=y, .x=x}: YX)] :- XY[(__xy0@ (XY{.x=(x: bigint), .y=(y: bigint)}: XY))], YZX[(__yzx1@ (YZX{.y=(y: bigint), .z=(z: bigint), .x=(x: bigint)}: YZX))], Inspect debug::debug_event_join((32'd123, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, __xy0, __yzx1, (YX{.y=y, .x=x}: YX)).
 IConcatString[(IConcatString{.s=intern::string_intern((intern::istring_str(s1) ++ s2))}: IConcatString)] :- IString1[(__istring10@ (IString1{.s=(s1: intern::IObj<string>)}: IString1))], String2[(__string21@ (String2{.s=(s2: string)}: String2))], Inspect debug::debug_event_join((32'd124, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, __istring10, __string21, (IConcatString{.s=intern::string_intern((intern::istring_str(s1) ++ s2))}: IConcatString)).
@@ -2077,11 +2083,11 @@ BigintVectors[(BigintVectors{.expr="filter_gt((10, 20, 30), 15)", .vec=filter_gt
 BigintVectors[(BigintVectors{.expr="filter_C0(C0{1}, C1{2}, C1{0}, C1{3})", .vec=filter_C0((std::vec_push_imm((std::vec_push_imm((std::vec_push_imm((std::vec_push_imm((std::vec_empty(): std::Vec<Alt>), (C0{.x=32'd1}: Alt)): std::Vec<Alt>), (C1{.x=32'd2}: Alt)): std::Vec<Alt>), (C1{.x=32'd0}: Alt)): std::Vec<Alt>), (C1{.x=32'd3}: Alt)): std::Vec<Alt>))}: BigintVectors)].
 BigintVectors[(BigintVectors{.expr="double_evens(1,2,-1,4)", .vec=double_evens((std::vec_push_imm((std::vec_push_imm((std::vec_push_imm((std::vec_push_imm((std::vec_empty(): std::Vec<bigint>), 1): std::Vec<bigint>), 2): std::Vec<bigint>), (- 1)): std::Vec<bigint>), 4): std::Vec<bigint>))}: BigintVectors)].
 BigintVectors[(BigintVectors{.expr="double_evens(1,2,0,4)", .vec=double_evens((std::vec_push_imm((std::vec_push_imm((std::vec_push_imm((std::vec_push_imm((std::vec_empty(): std::Vec<bigint>), 1): std::Vec<bigint>), 2): std::Vec<bigint>), 0): std::Vec<bigint>), 4): std::Vec<bigint>))}: BigintVectors)].
-Trees[(Trees{.tree=((var leaf1: Tree<bit<64>>) = (LeafNode{.v=64'd100}: Tree<bit<64>>);
-                    ((var leaf2: Tree<bit<64>>) = (LeafNode{.v=64'd200}: Tree<bit<64>>);
-                     ((var leaf3: Tree<bit<64>>) = (LeafNode{.v=64'd300}: Tree<bit<64>>);
-                      ((var nonleaf: Tree<bit<64>>) = (NonLeafNode{.branches=(std::vec_push_imm((std::vec_push_imm((std::vec_empty(): std::Vec<Tree<std::u64>>), leaf1): std::Vec<Tree<bit<64>>>), leaf2): std::Vec<Tree<bit<64>>>)}: Tree<bit<64>>);
-                       (NonLeafNode{.branches=(std::vec_push_imm((std::vec_push_imm((std::vec_empty(): std::Vec<Tree<std::u64>>), leaf3): std::Vec<Tree<bit<64>>>), nonleaf): std::Vec<Tree<bit<64>>>)}: Tree<std::u64>)))))}: Trees)].
+Trees[(Trees{.tree={(var leaf1: Tree<bit<64>>) = (LeafNode{.v=64'd100}: Tree<bit<64>>);
+                    {(var leaf2: Tree<bit<64>>) = (LeafNode{.v=64'd200}: Tree<bit<64>>);
+                     {(var leaf3: Tree<bit<64>>) = (LeafNode{.v=64'd300}: Tree<bit<64>>);
+                      {(var nonleaf: Tree<bit<64>>) = (NonLeafNode{.branches=(std::vec_push_imm((std::vec_push_imm((std::vec_empty(): std::Vec<Tree<std::u64>>), leaf1): std::Vec<Tree<bit<64>>>), leaf2): std::Vec<Tree<bit<64>>>)}: Tree<bit<64>>);
+                       (NonLeafNode{.branches=(std::vec_push_imm((std::vec_push_imm((std::vec_empty(): std::Vec<Tree<std::u64>>), leaf3): std::Vec<Tree<bit<64>>>), nonleaf): std::Vec<Tree<bit<64>>>)}: Tree<std::u64>)}}}}}: Trees)].
 Doubles[(Doubles{.s="64'f5.0", .d=64'f5.0}: Doubles)].
 Doubles[(Doubles{.s="64'f5e2", .d=64'f500.0}: Doubles)].
 Doubles[(Doubles{.s="-5", .d=(- 64'f5.0)}: Doubles)].

--- a/test/datalog_tests/simple.dl
+++ b/test/datalog_tests/simple.dl
@@ -178,7 +178,7 @@ function vars(): () {
 
     C{.f1 = var e} = y;
 
-    C{var c, var d} = y
+    C{var c, var d} = y;
 }
 
 function dbl(): double { 0: double }
@@ -200,7 +200,7 @@ Compare("C0{32'd3} < C1{32'd4}", C0{32'd3} < C1{32'd4}).
 Compare("None < Some{1}", None < Some{32'sd1}).
 Compare("Some{0} < Some{1}", Some{0: u32} < Some{32'd1}).
 
-function patterns(): () {
+function patterns() {
     var a: Alt = C0{1};
 
     var b = match (a) {
@@ -211,7 +211,7 @@ function patterns(): () {
     var i: bit<32> = match (a) {
         C0{.x = var v: bit<32>} -> v,
         C1{v} -> v
-    }
+    };
 }
 
 function shadow(): string {
@@ -580,7 +580,7 @@ Strings("foo\\" ++ [|bar|]).
 
 function dummy(x: string): string { x ++ " dummy" }
 
-function strings(): () {
+function strings() {
     var str1 = "foo" ++ "bar";
     var str2 = "foo" "bar" ++ "buzz" ++ [|
 raw string |] ++ "quoted string";
@@ -596,7 +596,6 @@ str3: ${str3}.|];
     var b1 = "" < str1;
     var b2 = [|${}|] < "";
     var b3 = str1 != str2 and str1 >= str2;
-    ()
 }
 
 Strings("word1\
@@ -611,7 +610,6 @@ function tostring1(): () {
     var c: bool    = true;
     var d: string  = "foo";
     var err = "a=${a}, b=${b}, c=${c}, d=${d}";
-    ()
 }
 
 typedef serializable_t = ConsInt {x: bigint}
@@ -629,14 +627,13 @@ function to_string(x: serializable_t): string {
     }
 }
 
-function tostring2(): () {
+function tostring2() {
     var a: bigint     = 5;
     var b: bit<32> = 5;
     var c: bool    = true;
     var d: string  = "foo";
     var e: serializable_t = ConsInt{0};
     var err = "a=${a}, b=${b}, c=${c}, d=${d}, e:${e}";
-    ()
 }
 
 /* More random examples */
@@ -704,7 +701,7 @@ function count_xs(ys: Group<string, string>): u64 {
     var res: u64 = 0;
     for (y in ys) {
         if (y == group_key(ys)) {
-            res = res + 1
+            res = res + 1;
         }
     };
     res
@@ -719,7 +716,7 @@ Symmetric1(x, sym) :-
 function find_x_in_group(ys: Group<'A, 'A>): bool {
     for (y in ys) {
         if (y == group_key(ys)) {
-            return true
+            return true;
         }
     };
     false
@@ -771,7 +768,7 @@ function concat_ys(ys: Group<(string, string),string>): string {
     (var x, var z) = group_key(ys);
     var res = x ++ "-" ++ z ++ ":";
     for (y in ys) {
-        res = res ++ y
+        res = res ++ y;
     };
     res
 }
@@ -1345,7 +1342,7 @@ function filter_C0(xs: Vec<Alt>): Vec<bigint> {
                 break
             }
         };
-        vec_push(res, val)
+        vec_push(res, val);
     };
     res
 }

--- a/test/datalog_tests/simple2.debug.ast.expected
+++ b/test/datalog_tests/simple2.debug.ast.expected
@@ -103,8 +103,8 @@ typedef std::u8 = bit<8>
 typedef std::usize = std::u64
 function __debug_8_1_std::group_sum (g: std::Group<bit<32>,('I, bit<32>)>): (std::Vec<'I>, bit<32>)
 {
-    (((var inputs: std::Vec<'I>), (var original_group: std::Group<bit<32>,bit<32>>)) = debug::debug_split_group(g);
-     (inputs, std::group_sum(original_group)))
+    {((var inputs: std::Vec<'I>), (var original_group: std::Group<bit<32>,bit<32>>)) = debug::debug_split_group(g);
+     (inputs, std::group_sum(original_group))}
 }
 function ack (m: std::u64, n: std::u64): std::u64
 {
@@ -130,6 +130,10 @@ function agg_avg_double_N (aggregate: std::Option<(double, double)>, item: std::
 extern function debug::debug_event (operator_id: debug::DDlogOpId, w: std::DDWeight, ts: 'T1, operator_type: string, input1: 'A1, out: 'A2): ()
 extern function debug::debug_event_join (operator_id: debug::DDlogOpId, w: std::DDWeight, ts: 'T1, input1: 'A1, input2: 'A2, out: 'A3): ()
 extern function debug::debug_split_group (g: std::Group<'K,('I, 'V)>): (std::Vec<'I>, std::Group<'K,'V>)
+function do_nothing (): ()
+{
+    ()
+}
 function fib (x: std::u64): std::u64
 {
     if (x == 64'd0) {
@@ -417,34 +421,34 @@ function json::set_by_ptr (jval: mut json::JsonValue, ptr: json::JsonPtr, v: jso
 function json::set_by_ptr_ (jval: mut json::JsonValue, ptr: json::JsonPtr, v: json::JsonValue, idx: std::usize): std::Result<(),string>
 {
     match ((std::nth(ptr, idx): std::Option<json::JsonPtrItem>)) {
-        (std::None{}: std::Option<json::JsonPtrItem>) -> (jval = v;
-                                                          (std::Ok{.res=()}: std::Result<(),string>)),
-        (std::Some{.x=(json::JKeyPtr{.key=(var key: internment::Intern<string>)}: json::JsonPtrItem)}: std::Option<json::JsonPtrItem>) -> (if (jval == (json::JsonNull{}: json::JsonValue)) {
+        (std::None{}: std::Option<json::JsonPtrItem>) -> {jval = v;
+                                                          (std::Ok{.res=()}: std::Result<(),string>)},
+        (std::Some{.x=(json::JKeyPtr{.key=(var key: internment::Intern<string>)}: json::JsonPtrItem)}: std::Option<json::JsonPtrItem>) -> {if (jval == (json::JsonNull{}: json::JsonValue)) {
                                                                                                                                                jval = (json::JsonObject{.o=(std::map_empty(): std::Map<internment::istring,json::JsonValue>)}: json::JsonValue)
                                                                                                                                            } else {
                                                                                                                                                  ()
                                                                                                                                              };
                                                                                                                                            match (jval) {
-                                                                                                                                               (json::JsonObject{.o=(var m: std::Map<internment::istring,json::JsonValue>)}: json::JsonValue) -> ((var old: json::JsonValue) = (std::unwrap_or((std::remove(m, key): std::Option<json::JsonValue>), (json::JsonNull{}: json::JsonValue)): json::JsonValue);
-                                                                                                                                                                                                                                                  (json::set_by_ptr_(old, ptr, v, (idx + 64'd1));
-                                                                                                                                                                                                                                                   (std::insert(m, key, old);
-                                                                                                                                                                                                                                                    (std::Ok{.res=()}: std::Result<(),string>)))),
+                                                                                                                                               (json::JsonObject{.o=(var m: std::Map<internment::istring,json::JsonValue>)}: json::JsonValue) -> {(var old: json::JsonValue) = (std::unwrap_or((std::remove(m, key): std::Option<json::JsonValue>), (json::JsonNull{}: json::JsonValue)): json::JsonValue);
+                                                                                                                                                                                                                                                  {json::set_by_ptr_(old, ptr, v, (idx + 64'd1));
+                                                                                                                                                                                                                                                   {std::insert(m, key, old);
+                                                                                                                                                                                                                                                    (std::Ok{.res=()}: std::Result<(),string>)}}},
                                                                                                                                                (_: json::JsonValue) -> (std::Err{.err="Not a JSON map"}: std::Result<(),string>)
-                                                                                                                                           }),
-        (std::Some{.x=(json::JIdxPtr{.idx=(var n: bit<64>)}: json::JsonPtrItem)}: std::Option<json::JsonPtrItem>) -> (if (jval == (json::JsonNull{}: json::JsonValue)) {
+                                                                                                                                           }},
+        (std::Some{.x=(json::JIdxPtr{.idx=(var n: bit<64>)}: json::JsonPtrItem)}: std::Option<json::JsonPtrItem>) -> {if (jval == (json::JsonNull{}: json::JsonValue)) {
                                                                                                                           jval = (json::JsonArray{.a=(std::vec_empty(): std::Vec<json::JsonValue>)}: json::JsonValue)
                                                                                                                       } else {
                                                                                                                             ()
                                                                                                                         };
                                                                                                                       match (jval) {
-                                                                                                                          (json::JsonArray{.a=(var xs: std::Vec<json::JsonValue>)}: json::JsonValue) -> (std::resize(xs, (std::max((n + 64'd1), std::len(xs)): bit<64>), (json::JsonNull{}: json::JsonValue));
-                                                                                                                                                                                                         ((var old: json::JsonValue) = (json::JsonNull{}: json::JsonValue);
-                                                                                                                                                                                                          (std::swap_nth(xs, n, old);
-                                                                                                                                                                                                           (json::set_by_ptr_(old, ptr, v, (idx + 64'd1));
-                                                                                                                                                                                                            (std::swap_nth(xs, n, old);
-                                                                                                                                                                                                             (std::Ok{.res=()}: std::Result<(),string>)))))),
+                                                                                                                          (json::JsonArray{.a=(var xs: std::Vec<json::JsonValue>)}: json::JsonValue) -> {std::resize(xs, (std::max((n + 64'd1), std::len(xs)): bit<64>), (json::JsonNull{}: json::JsonValue));
+                                                                                                                                                                                                         {(var old: json::JsonValue) = (json::JsonNull{}: json::JsonValue);
+                                                                                                                                                                                                          {std::swap_nth(xs, n, old);
+                                                                                                                                                                                                           {json::set_by_ptr_(old, ptr, v, (idx + 64'd1));
+                                                                                                                                                                                                            {std::swap_nth(xs, n, old);
+                                                                                                                                                                                                             (std::Ok{.res=()}: std::Result<(),string>)}}}}},
                                                                                                                           (_: json::JsonValue) -> (std::Err{.err="Not a JSON array"}: std::Result<(),string>)
-                                                                                                                      })
+                                                                                                                      }}
     }
 }
 extern function json::to_json_string (x: 'T): std::Result<string,string>
@@ -453,11 +457,11 @@ extern function json::to_json_value (x: 'T): std::Result<json::JsonValue,string>
 extern function log::log (module: log::module_t, level: log::log_level_t, msg: string): ()
 function mutable_match (): ()
 {
-    ((var m: ModifyMe) = (ModifyMe{.x="foo", .y=128'sd123456789}: ModifyMe);
+    {(var m: ModifyMe) = (ModifyMe{.x="foo", .y=128'sd123456789}: ModifyMe);
      match (m) {
          (ModifyMe{.x=(var x: string), .y=128'sd123456789}: ModifyMe) -> x = "bar",
          (_: ModifyMe) -> ()
-     })
+     }}
 }
 function mutable_match_field (n: mut NestedStruct): ()
 {
@@ -473,16 +477,16 @@ function myfunc (x: string): string
 }
 function shadow (v: string): ()
 {
-    ((var a: Alt) = (C0{.x=32'd1}: Alt);
+    {(var a: Alt) = (C0{.x=32'd1}: Alt);
      (var i: bit<32>) = match (a) {
                             (C0{.x=(var v: bit<32>)}: Alt) -> v,
                             (C1{.x=(var v: bit<32>)}: Alt) -> v
-                        })
+                        }}
 }
 function shadow2 (): ()
 {
-    ((var v: string) = "bar";
-     (var v: string) = "foo")
+    {(var v: string) = "bar";
+     (var v: string) = "foo"}
 }
 extern function std::__builtin_2string (x: 'X): string
 function std::append (v: mut std::Vec<'X>, other: std::Vec<'X>): ()
@@ -544,14 +548,14 @@ extern function std::group_to_setmap (g: std::Group<'K1,('K2, 'V)>): std::Map<'K
 extern function std::group_to_vec (g: std::Group<'K,'V>): std::Vec<'V>
 function std::group_unzip (g: std::Group<'K,('X, 'Y)>): (std::Vec<'X>, std::Vec<'Y>)
 {
-    ((var xs: std::Vec<'X>) = (std::vec_empty(): std::Vec<'X>);
-     ((var ys: std::Vec<'Y>) = (std::vec_empty(): std::Vec<'Y>);
-      (for (v in g) {
-           (((var x: 'X), (var y: 'Y)) = v;
-            (std::vec_push(xs, x);
-             std::vec_push(ys, y)))
+    {(var xs: std::Vec<'X>) = (std::vec_empty(): std::Vec<'X>);
+     {(var ys: std::Vec<'Y>) = (std::vec_empty(): std::Vec<'Y>);
+      {for (v in g) {
+           {((var x: 'X), (var y: 'Y)) = v;
+            {std::vec_push(xs, x);
+             std::vec_push(ys, y)}}
        };
-       (xs, ys))))
+       (xs, ys)}}}
 }
 extern function std::hash128 (x: 'X): bit<128>
 extern function std::hash64 (x: 'X): bit<64>
@@ -1010,84 +1014,84 @@ extern function std::vec_with_capacity (len: std::usize): std::Vec<'A>
 extern function std::vec_with_length (len: std::usize, x: 'A): std::Vec<'A>
 function ti_f (value: std::Option<string>): std::Option<(string, string)>
 {
-    ((var strs: std::Vec<string>) = match (value) {
+    {(var strs: std::Vec<string>) = match (value) {
                                         (std::Some{.x=(var s: string)}: std::Option<string>) -> std::string_split(s, ":"),
                                         (std::None{}: std::Option<string>) -> ((return (std::None{}: std::Option<(string, string)>)): std::Vec<string>)
                                     };
      match (((std::vec_nth(strs, 64'd0): std::Option<string>), (std::vec_nth(strs, 64'd1): std::Option<string>))) {
          ((std::Some{.x=(var port_name: string)}: std::Option<string>), (std::Some{.x=(var src_ip: string)}: std::Option<string>)) -> (std::Some{.x=(port_name, src_ip)}: std::Option<(string, string)>),
          (_: (std::Option<string>, std::Option<string>)) -> (std::None{}: std::Option<(string, string)>)
-     })
+     }}
 }
 function try1 (name: string): std::Option<(string, string)>
 {
-    ((var components: std::Vec<string>) = std::split(name, " ");
-     ((var first_name: string) = match ((std::nth(components, 64'd0): std::Option<string>)) {
+    {(var components: std::Vec<string>) = std::split(name, " ");
+     {(var first_name: string) = match ((std::nth(components, 64'd0): std::Option<string>)) {
                                      (std::None{}: std::Option<string>) -> ((return (std::None{}: std::Option<(string, string)>)): string),
                                      (std::Some{.x=(var __x: string)}: std::Option<string>) -> __x
                                  };
-      ((var last_name: string) = match ((std::nth(components, 64'd1): std::Option<string>)) {
+      {(var last_name: string) = match ((std::nth(components, 64'd1): std::Option<string>)) {
                                      (std::None{}: std::Option<string>) -> ((return (std::None{}: std::Option<(string, string)>)): string),
                                      (std::Some{.x=(var __x: string)}: std::Option<string>) -> __x
                                  };
-       (std::Some{.x=(first_name, last_name)}: std::Option<(string, string)>))))
+       (std::Some{.x=(first_name, last_name)}: std::Option<(string, string)>)}}}
 }
 function try2 (name: string): std::Result<(string, string),string>
 {
-    ((var components: std::Vec<string>) = std::split(name, " ");
-     ((var first_name: string) = match (match ((std::nth(components, 64'd0): std::Option<string>)) {
+    {(var components: std::Vec<string>) = std::split(name, " ");
+     {(var first_name: string) = match (match ((std::nth(components, 64'd0): std::Option<string>)) {
                                             (std::None{}: std::Option<string>) -> (std::Err{.err="No first name"}: std::Result<string,string>),
                                             (std::Some{.x=(var n: string)}: std::Option<string>) -> (std::Ok{.res=n}: std::Result<string,string>)
                                         }) {
                                      (std::Err{.err=(var __e: string)}: std::Result<string,string>) -> ((return (std::Err{.err=__e}: std::Result<(string, string),string>)): string),
                                      (std::Ok{.res=(var __x: string)}: std::Result<string,string>) -> __x
                                  };
-      ((var last_name: string) = match (match ((std::nth(components, 64'd1): std::Option<string>)) {
+      {(var last_name: string) = match (match ((std::nth(components, 64'd1): std::Option<string>)) {
                                             (std::None{}: std::Option<string>) -> (std::Err{.err="No last name"}: std::Result<string,string>),
                                             (std::Some{.x=(var n: string)}: std::Option<string>) -> (std::Ok{.res=n}: std::Result<string,string>)
                                         }) {
                                      (std::Err{.err=(var __e: string)}: std::Result<string,string>) -> ((return (std::Err{.err=__e}: std::Result<(string, string),string>)): string),
                                      (std::Ok{.res=(var __x: string)}: std::Result<string,string>) -> __x
                                  };
-       (std::Ok{.res=(first_name, last_name)}: std::Result<(string, string),string>))))
+       (std::Ok{.res=(first_name, last_name)}: std::Result<(string, string),string>)}}}
 }
 function try3 (name: string): Opt<(string, string)>
 {
-    ((var components: std::Vec<string>) = std::split(name, " ");
-     ((var first_name: string) = match (match ((std::nth(components, 64'd0): std::Option<string>)) {
+    {(var components: std::Vec<string>) = std::split(name, " ");
+     {(var first_name: string) = match (match ((std::nth(components, 64'd0): std::Option<string>)) {
                                             (std::None{}: std::Option<string>) -> (std::Err{.err="No first name"}: std::Result<string,string>),
                                             (std::Some{.x=(var n: string)}: std::Option<string>) -> (std::Ok{.res=n}: std::Result<string,string>)
                                         }) {
                                      (std::Err{.err=(_: string)}: std::Result<string,string>) -> ((return (std::None{}: Opt<(string, string)>)): string),
                                      (std::Ok{.res=(var __x: string)}: std::Result<string,string>) -> __x
                                  };
-      ((var last_name: string) = match (match ((std::nth(components, 64'd1): std::Option<string>)) {
+      {(var last_name: string) = match (match ((std::nth(components, 64'd1): std::Option<string>)) {
                                             (std::None{}: std::Option<string>) -> (std::Err{.err="No last name"}: std::Result<string,string>),
                                             (std::Some{.x=(var n: string)}: std::Option<string>) -> (std::Ok{.res=n}: std::Result<string,string>)
                                         }) {
                                      (std::Err{.err=(_: string)}: std::Result<string,string>) -> ((return (std::None{}: Opt<(string, string)>)): string),
                                      (std::Ok{.res=(var __x: string)}: std::Result<string,string>) -> __x
                                  };
-       (std::Some{.x=(first_name, last_name)}: std::Option<(string, string)>))))
+       (std::Some{.x=(first_name, last_name)}: std::Option<(string, string)>)}}}
 }
 function weird_zero (x: 'A): std::usize
 {
-    ((var empty_vec: std::Vec<'A>) = (std::vec_empty(): std::Vec<'A>);
-     std::vec_len(empty_vec))
+    {(var empty_vec: std::Vec<'A>) = (std::vec_empty(): std::Vec<'A>);
+     std::vec_len(empty_vec)}
 }
 function write_to_struct_field (): ModifyMe
 {
-    ((var m: ModifyMe) = (ModifyMe{.x="foo", .y=128'sd123456789}: ModifyMe);
-     (m.x = "bar";
-      (m.y = (- m.y);
-       m)))
+    {(var m: ModifyMe) = (ModifyMe{.x="foo", .y=128'sd123456789}: ModifyMe);
+     {m.x = "bar";
+      {m.y = (- m.y);
+       m}}}
 }
 function write_to_tuple_field (): (string, std::u64)
 {
-    ((var m: (string, bit<64>)) = ("foo", 64'd123456789);
-     (m.0 = "bar";
-      (m.1 = (- m.1);
-       m)))
+    {(var m: (string, bit<64>)) = ("foo", 64'd123456789);
+     {m.0 = "bar";
+      {m.1 = (- m.1);
+       m}}}
 }
 function zero_test (): std::usize
 {
@@ -1148,14 +1152,14 @@ SumsOfDoubles[(SumsOfDoubles{.x=x, .y=y, .sum=z}: SumsOfDoubles)] :- Doubles[(__
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              } else {
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    "delete"
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                }) ++ ": (") ++ (std::__builtin_2string(x): string)) ++ ", ") ++ (std::__builtin_2string(y): string)) ++ ", ") ++ (std::__builtin_2string(z): string)) ++ ")")), Inspect debug::debug_event((32'd7, 32'd5, 32'd0), ddlog_weight, ddlog_timestamp, "Inspect", (y, x, z), (SumsOfDoubles{.x=x, .y=y, .sum=z}: SumsOfDoubles)).
-InspectSimpleSum[(InspectSimpleSum{.x=x, .total=total}: InspectSimpleSum)] :- InputTuples[(__inputtuples0@ (InputTuples{.x=(x: bit<32>), .y=(y: bit<32>)}: InputTuples))], var __inputs_total = Aggregate(x, __debug_8_1_std::group_sum((__inputtuples0, y))), Inspect debug::debug_event((32'd8, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, "Aggregate", __inputs_total.0, (__inputs_total, x)), (var total: bit<32>) = __inputs_total.1, Inspect debug::debug_event((32'd8, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, "Condition", (__inputs_total, x), (x, total)), Inspect ((var z: bit<64>) = (64'd1 + 64'd2);
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       ((var w: signed<64>) = ddlog_weight;
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        ((var t: bit<64>) = ddlog_timestamp;
+InspectSimpleSum[(InspectSimpleSum{.x=x, .total=total}: InspectSimpleSum)] :- InputTuples[(__inputtuples0@ (InputTuples{.x=(x: bit<32>), .y=(y: bit<32>)}: InputTuples))], var __inputs_total = Aggregate(x, __debug_8_1_std::group_sum((__inputtuples0, y))), Inspect debug::debug_event((32'd8, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, "Aggregate", __inputs_total.0, (__inputs_total, x)), (var total: bit<32>) = __inputs_total.1, Inspect debug::debug_event((32'd8, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, "Condition", (__inputs_total, x), (x, total)), Inspect {(var z: bit<64>) = (64'd1 + 64'd2);
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       {(var w: signed<64>) = ddlog_weight;
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        {(var t: bit<64>) = ddlog_timestamp;
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          inspect_log::log("../simple2.log", ((((((("" ++ (std::__builtin_2string(t): string)) ++ ": ") ++ if (w > 64'sd0) {
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               "insert"
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           } else {
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 "delete"
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            }) ++ ": x=") ++ (std::__builtin_2string(x): string)) ++ ", total=") ++ (std::__builtin_2string(total): string)))))), Inspect debug::debug_event((32'd8, 32'd2, 32'd0), ddlog_weight, ddlog_timestamp, "Inspect", (x, total), (InspectSimpleSum{.x=x, .total=total}: InspectSimpleSum)).
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            }) ++ ": x=") ++ (std::__builtin_2string(x): string)) ++ ", total=") ++ (std::__builtin_2string(total): string)))}}}, Inspect debug::debug_event((32'd8, 32'd2, 32'd0), ddlog_weight, ddlog_timestamp, "Inspect", (x, total), (InspectSimpleSum{.x=x, .total=total}: InspectSimpleSum)).
 FilteredRelation[(FilteredRelation{.y=y}: FilteredRelation)] :- TestRelation[(__testrelation0@ (TestRelation{.x=32'd6, .y=(y: bit<32>)}: TestRelation))], Inspect inspect_log::log("../simple2.log", ((((("" ++ (std::__builtin_2string(ddlog_timestamp): string)) ++ ": ") ++ if (ddlog_weight > 64'sd0) {
                                                                                                                                                                                                                                                                                    "insert"
                                                                                                                                                                                                                                                                                } else {
@@ -1167,15 +1171,15 @@ OutputInspectNot[(OutputInspectNot{.x=x, .y=y}: OutputInspectNot)] :- InputInspe
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              "delete"
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          }) ++ ": x=") ++ (std::__builtin_2string(y): string)) ++ " y=") ++ (std::__builtin_2string(y): string))), Inspect debug::debug_event((32'd10, 32'd2, 32'd0), ddlog_weight, ddlog_timestamp, "Inspect", (x, y), (OutputInspectNot{.x=x, .y=y}: OutputInspectNot)).
 TI_R[(TI_R{.a=a}: TI_R)] :- TI_R[(__ti_r0@ (TI_R{.a=(a: std::Set<string>)}: TI_R))], (std::set_size(a) > 64'd1), Inspect debug::debug_event((32'd11, 32'd1, 32'd0), ddlog_weight, ddlog_timestamp, "Condition", __ti_r0, (TI_R{.a=a}: TI_R)).
-Nested[(Nested{.descr="1", .n=((var n: NestedStruct) = (NestedStruct{.x=(std::Some{.x=(ModifyMe{.x="foo", .y=128'sd123456789}: ModifyMe)}: std::Option<ModifyMe>)}: NestedStruct);
-                               (mutable_match_field(n);
-                                n))}: Nested)].
-Nested[(Nested{.descr="2", .n=((var n: NestedStruct) = (NestedStruct{.x=(std::Some{.x=(ModifyMe{.x="", .y=128'sd0}: ModifyMe)}: std::Option<ModifyMe>)}: NestedStruct);
-                               (mutable_match_field(n);
-                                n))}: Nested)].
-Nested[(Nested{.descr="3", .n=((var n: NestedStruct) = (NestedStruct{.x=(std::None{}: std::Option<ModifyMe>)}: NestedStruct);
-                               (mutable_match_field(n);
-                                n))}: Nested)].
+Nested[(Nested{.descr="1", .n={(var n: NestedStruct) = (NestedStruct{.x=(std::Some{.x=(ModifyMe{.x="foo", .y=128'sd123456789}: ModifyMe)}: std::Option<ModifyMe>)}: NestedStruct);
+                               {mutable_match_field(n);
+                                n}}}: Nested)].
+Nested[(Nested{.descr="2", .n={(var n: NestedStruct) = (NestedStruct{.x=(std::Some{.x=(ModifyMe{.x="", .y=128'sd0}: ModifyMe)}: std::Option<ModifyMe>)}: NestedStruct);
+                               {mutable_match_field(n);
+                                n}}}: Nested)].
+Nested[(Nested{.descr="3", .n={(var n: NestedStruct) = (NestedStruct{.x=(std::None{}: std::Option<ModifyMe>)}: NestedStruct);
+                               {mutable_match_field(n);
+                                n}}}: Nested)].
 ChunkParseError[(ChunkParseError{.err=err}: ChunkParseError)] :- ParsedChunk[(__parsedchunk0@ (ParsedChunk{.data=(std::Err{.err=(err: string)}: std::Result<Object,string>)}: ParsedChunk))], Inspect debug::debug_event((32'd15, 32'd0, 32'd0), ddlog_weight, ddlog_timestamp, "Map", __parsedchunk0, (ChunkParseError{.err=err}: ChunkParseError)).
 ParsedChunk[(ParsedChunk{.data=(json::from_json_string(json): std::Result<Object,string>)}: ParsedChunk)] :- Chunk[(__chunk0@ (Chunk{.json=(json: string)}: Chunk))], Inspect debug::debug_event((32'd16, 32'd0, 32'd0), ddlog_weight, ddlog_timestamp, "Map", __chunk0, (ParsedChunk{.data=(json::from_json_string(json): std::Result<Object,string>)}: ParsedChunk)).
 Objects[(Objects{.chunk=objs}: Objects)] :- ParsedChunk[(__parsedchunk0@ (ParsedChunk{.data=(std::Ok{.res=(objs: Object)}: std::Result<Object,string>)}: ParsedChunk))], Inspect debug::debug_event((32'd17, 32'd0, 32'd0), ddlog_weight, ddlog_timestamp, "Map", __parsedchunk0, (Objects{.chunk=objs}: Objects)).
@@ -1199,67 +1203,67 @@ Try2[(Try2{.description="Albert_Einstein", .result=try2("Albert_Einstein")}: Try
 Try3[(Try3{.description="Isaac Newton", .result=try3("Isaac Newton")}: Try3)].
 Try3[(Try3{.description="", .result=try3("")}: Try3)].
 Try3[(Try3{.description="Albert_Einstein", .result=try3("Albert_Einstein")}: Try3)].
-BoolVectors[(BoolVectors{.v=((var __vec: std::Vec<bool>) = (std::vec_with_capacity(64'd3): std::Vec<bool>);
-                             (std::push(__vec, true);
-                              (std::push(__vec, false);
-                               (std::push(__vec, true);
-                                __vec))))}: BoolVectors)].
-BoolVecVec[(BoolVecVec{.v=((var __vec: std::Vec<std::Vec<bool>>) = (std::vec_with_capacity(64'd3): std::Vec<std::Vec<bool>>);
-                           (std::push(__vec, ((var __vec: std::Vec<bool>) = (std::vec_with_capacity(64'd3): std::Vec<bool>);
-                                              (std::push(__vec, true);
-                                               (std::push(__vec, false);
-                                                (std::push(__vec, true);
-                                                 __vec)))));
-                            (std::push(__vec, ((var __vec: std::Vec<bool>) = (std::vec_with_capacity(64'd1): std::Vec<bool>);
-                                               (std::push(__vec, true);
-                                                __vec)));
-                             (std::push(__vec, ((var __vec: std::Vec<bool>) = (std::vec_with_capacity(64'd1): std::Vec<bool>);
-                                                (std::push(__vec, false);
-                                                 __vec)));
-                              __vec))))}: BoolVecVec)].
-StringMaps[(StringMaps{.m=((var __map: std::Map<string,(std::usize, bool)>) = (std::map_empty(): std::Map<string,(std::usize, bool)>);
-                           (std::insert(__map, "foo", (64'd1, true));
-                            (std::insert(__map, "bar", (64'd2, false));
-                             (std::insert(__map, "foobar", (64'd3, false));
-                              __map))))}: StringMaps)].
-MapOfMaps[(MapOfMaps{.m=((var __map: std::Map<string,std::Map<double,(std::usize, bool)>>) = (std::map_empty(): std::Map<string,std::Map<double,(std::usize, bool)>>);
-                         (std::insert(__map, "foo", ((var __map: std::Map<double,(bit<64>, bool)>) = (std::map_empty(): std::Map<double,(bit<64>, bool)>);
-                                                     (std::insert(__map, 64'f1.0, (64'd1, true));
-                                                      (std::insert(__map, 64'f2.0, (64'd4, false));
-                                                       __map))));
-                          (std::insert(__map, "bar", ((var __map: std::Map<double,(bit<64>, bool)>) = (std::map_empty(): std::Map<double,(bit<64>, bool)>);
-                                                      (std::insert(__map, (- 64'f10.0), (64'd10000, true));
-                                                       (std::insert(__map, 64'f200.0, (64'd2, false));
-                                                        __map))));
-                           (std::insert(__map, "foobar", (std::map_empty(): std::Map<double,(std::usize, bool)>));
-                            __map))))}: MapOfMaps)].
-MapOfVecs[(MapOfVecs{.m=((var __map: std::Map<(std::u32, bigint),std::Vec<double>>) = (std::map_empty(): std::Map<(std::u32, bigint),std::Vec<double>>);
-                         (std::insert(__map, (32'd100, 100), ((var __vec: std::Vec<double>) = (std::vec_with_capacity(64'd4): std::Vec<double>);
-                                                              (std::push(__vec, 64'f0.1);
-                                                               (std::push(__vec, (- 64'f100.0));
-                                                                (std::push(__vec, 64'f0.0);
-                                                                 (std::push(__vec, 64'f1000000.0);
-                                                                  __vec))))));
-                          (std::insert(__map, (32'd100, (- 100)), (std::vec_empty(): std::Vec<double>));
-                           (std::insert(__map, (32'd0, (- 0)), ((var __vec: std::Vec<double>) = (std::vec_with_capacity(64'd4): std::Vec<double>);
-                                                                (std::push(__vec, 64'f0.1);
-                                                                 (std::push(__vec, (- 64'f100.0));
-                                                                  (std::push(__vec, 64'f0.0);
-                                                                   (std::push(__vec, 64'f1000000.0);
-                                                                    __vec))))));
-                            __map))))}: MapOfVecs)].
-VecOfMaps[(VecOfMaps{.m=((var __vec: std::Vec<std::Map<(std::u32, bigint),double>>) = (std::vec_with_capacity(64'd3): std::Vec<std::Map<(std::u32, bigint),double>>);
-                         (std::push(__vec, ((var __map: std::Map<(bit<32>, bigint),double>) = (std::map_empty(): std::Map<(bit<32>, bigint),double>);
-                                            (std::insert(__map, (32'd100, 100), 64'f0.1);
-                                             __map)));
-                          (std::push(__vec, ((var __map: std::Map<(bit<32>, bigint),double>) = (std::map_empty(): std::Map<(bit<32>, bigint),double>);
-                                             (std::insert(__map, (32'd100, 100), 64'f0.1);
-                                              (std::insert(__map, (32'd1000, (- 100)), (- 64'f0.1));
-                                               __map))));
-                           (std::push(__vec, ((var __map: std::Map<(bit<32>, bigint),double>) = (std::map_empty(): std::Map<(bit<32>, bigint),double>);
-                                              (std::insert(__map, (32'd100, 100), 64'f0.1);
-                                               (std::insert(__map, (32'd1000, (- 100)), (- 64'f0.1));
-                                                (std::insert(__map, (32'd1000, (- 10000000000000000000000000000000000000)), (- 64'f0.0));
-                                                 __map)))));
-                            __vec))))}: VecOfMaps)].
+BoolVectors[(BoolVectors{.v={(var __vec: std::Vec<bool>) = (std::vec_with_capacity(64'd3): std::Vec<bool>);
+                             {std::push(__vec, true);
+                              {std::push(__vec, false);
+                               {std::push(__vec, true);
+                                __vec}}}}}: BoolVectors)].
+BoolVecVec[(BoolVecVec{.v={(var __vec: std::Vec<std::Vec<bool>>) = (std::vec_with_capacity(64'd3): std::Vec<std::Vec<bool>>);
+                           {std::push(__vec, {(var __vec: std::Vec<bool>) = (std::vec_with_capacity(64'd3): std::Vec<bool>);
+                                              {std::push(__vec, true);
+                                               {std::push(__vec, false);
+                                                {std::push(__vec, true);
+                                                 __vec}}}});
+                            {std::push(__vec, {(var __vec: std::Vec<bool>) = (std::vec_with_capacity(64'd1): std::Vec<bool>);
+                                               {std::push(__vec, true);
+                                                __vec}});
+                             {std::push(__vec, {(var __vec: std::Vec<bool>) = (std::vec_with_capacity(64'd1): std::Vec<bool>);
+                                                {std::push(__vec, false);
+                                                 __vec}});
+                              __vec}}}}}: BoolVecVec)].
+StringMaps[(StringMaps{.m={(var __map: std::Map<string,(std::usize, bool)>) = (std::map_empty(): std::Map<string,(std::usize, bool)>);
+                           {std::insert(__map, "foo", (64'd1, true));
+                            {std::insert(__map, "bar", (64'd2, false));
+                             {std::insert(__map, "foobar", (64'd3, false));
+                              __map}}}}}: StringMaps)].
+MapOfMaps[(MapOfMaps{.m={(var __map: std::Map<string,std::Map<double,(std::usize, bool)>>) = (std::map_empty(): std::Map<string,std::Map<double,(std::usize, bool)>>);
+                         {std::insert(__map, "foo", {(var __map: std::Map<double,(bit<64>, bool)>) = (std::map_empty(): std::Map<double,(bit<64>, bool)>);
+                                                     {std::insert(__map, 64'f1.0, (64'd1, true));
+                                                      {std::insert(__map, 64'f2.0, (64'd4, false));
+                                                       __map}}});
+                          {std::insert(__map, "bar", {(var __map: std::Map<double,(bit<64>, bool)>) = (std::map_empty(): std::Map<double,(bit<64>, bool)>);
+                                                      {std::insert(__map, (- 64'f10.0), (64'd10000, true));
+                                                       {std::insert(__map, 64'f200.0, (64'd2, false));
+                                                        __map}}});
+                           {std::insert(__map, "foobar", (std::map_empty(): std::Map<double,(std::usize, bool)>));
+                            __map}}}}}: MapOfMaps)].
+MapOfVecs[(MapOfVecs{.m={(var __map: std::Map<(std::u32, bigint),std::Vec<double>>) = (std::map_empty(): std::Map<(std::u32, bigint),std::Vec<double>>);
+                         {std::insert(__map, (32'd100, 100), {(var __vec: std::Vec<double>) = (std::vec_with_capacity(64'd4): std::Vec<double>);
+                                                              {std::push(__vec, 64'f0.1);
+                                                               {std::push(__vec, (- 64'f100.0));
+                                                                {std::push(__vec, 64'f0.0);
+                                                                 {std::push(__vec, 64'f1000000.0);
+                                                                  __vec}}}}});
+                          {std::insert(__map, (32'd100, (- 100)), (std::vec_empty(): std::Vec<double>));
+                           {std::insert(__map, (32'd0, (- 0)), {(var __vec: std::Vec<double>) = (std::vec_with_capacity(64'd4): std::Vec<double>);
+                                                                {std::push(__vec, 64'f0.1);
+                                                                 {std::push(__vec, (- 64'f100.0));
+                                                                  {std::push(__vec, 64'f0.0);
+                                                                   {std::push(__vec, 64'f1000000.0);
+                                                                    __vec}}}}});
+                            __map}}}}}: MapOfVecs)].
+VecOfMaps[(VecOfMaps{.m={(var __vec: std::Vec<std::Map<(std::u32, bigint),double>>) = (std::vec_with_capacity(64'd3): std::Vec<std::Map<(std::u32, bigint),double>>);
+                         {std::push(__vec, {(var __map: std::Map<(bit<32>, bigint),double>) = (std::map_empty(): std::Map<(bit<32>, bigint),double>);
+                                            {std::insert(__map, (32'd100, 100), 64'f0.1);
+                                             __map}});
+                          {std::push(__vec, {(var __map: std::Map<(bit<32>, bigint),double>) = (std::map_empty(): std::Map<(bit<32>, bigint),double>);
+                                             {std::insert(__map, (32'd100, 100), 64'f0.1);
+                                              {std::insert(__map, (32'd1000, (- 100)), (- 64'f0.1));
+                                               __map}}});
+                           {std::push(__vec, {(var __map: std::Map<(bit<32>, bigint),double>) = (std::map_empty(): std::Map<(bit<32>, bigint),double>);
+                                              {std::insert(__map, (32'd100, 100), 64'f0.1);
+                                               {std::insert(__map, (32'd1000, (- 100)), (- 64'f0.1));
+                                                {std::insert(__map, (32'd1000, (- 10000000000000000000000000000000000000)), (- 64'f0.0));
+                                                 __map}}}});
+                            __vec}}}}}: VecOfMaps)].
 

--- a/test/datalog_tests/simple2.dl
+++ b/test/datalog_tests/simple2.dl
@@ -398,7 +398,7 @@ typedef Alt = C0{x: bit<32>}
             | C1{x: bit<32>}
 
 // shadow argument name
-function shadow(v: string): () = {
+function shadow(v: string) {
     var a: Alt = C0{1};
 
     var i: bit<32> = match (a) {
@@ -408,8 +408,10 @@ function shadow(v: string): () = {
 }
 
 // shadow local variable
-function shadow2(): () = {
+function shadow2() {
     var v: string = "bar";
 
     var v = "foo"
 }
+
+function do_nothing() {}

--- a/test/datalog_tests/tutorial.debug.ast.expected
+++ b/test/datalog_tests/tutorial.debug.ast.expected
@@ -126,42 +126,42 @@ typedef tcp_pkt_t = TCPPkt{src: bit<16>, dst: bit<16>, flags: bit<9>}
 typedef udp_pkt_t = UDPPkt{src: bit<16>, dst: bit<16>, len: bit<16>}
 function __debug_17_1_std::group_min (g: std::Group<string,('I, bit<64>)>): (std::Vec<'I>, bit<64>)
 {
-    (((var inputs: std::Vec<'I>), (var original_group: std::Group<string,bit<64>>)) = debug::debug_split_group(g);
-     (inputs, std::group_min(original_group)))
+    {((var inputs: std::Vec<'I>), (var original_group: std::Group<string,bit<64>>)) = debug::debug_split_group(g);
+     (inputs, std::group_min(original_group))}
 }
 function __debug_18_1_std::group_max (g: std::Group<string,('I, bit<64>)>): (std::Vec<'I>, bit<64>)
 {
-    (((var inputs: std::Vec<'I>), (var original_group: std::Group<string,bit<64>>)) = debug::debug_split_group(g);
-     (inputs, std::group_max(original_group)))
+    {((var inputs: std::Vec<'I>), (var original_group: std::Group<string,bit<64>>)) = debug::debug_split_group(g);
+     (inputs, std::group_max(original_group))}
 }
 function __debug_19_1_best_vendor (g: std::Group<string,('I, (string, bit<64>))>): (std::Vec<'I>, (string, bit<64>))
 {
-    (((var inputs: std::Vec<'I>), (var original_group: std::Group<string,(string, bit<64>)>)) = debug::debug_split_group(g);
-     (inputs, best_vendor(original_group)))
+    {((var inputs: std::Vec<'I>), (var original_group: std::Group<string,(string, bit<64>)>)) = debug::debug_split_group(g);
+     (inputs, best_vendor(original_group))}
 }
 function __debug_20_2_best_vendor_string (g: std::Group<string,('I, (string, bit<64>))>): (std::Vec<'I>, string)
 {
-    (((var inputs: std::Vec<'I>), (var original_group: std::Group<string,(string, bit<64>)>)) = debug::debug_split_group(g);
-     (inputs, best_vendor_string(original_group)))
+    {((var inputs: std::Vec<'I>), (var original_group: std::Group<string,(string, bit<64>)>)) = debug::debug_split_group(g);
+     (inputs, best_vendor_string(original_group))}
 }
 function __debug_33_1_std::group_max (g: std::Group<string,('I, bit<16>)>): (std::Vec<'I>, bit<16>)
 {
-    (((var inputs: std::Vec<'I>), (var original_group: std::Group<string,bit<16>>)) = debug::debug_split_group(g);
-     (inputs, std::group_max(original_group)))
+    {((var inputs: std::Vec<'I>), (var original_group: std::Group<string,bit<16>>)) = debug::debug_split_group(g);
+     (inputs, std::group_max(original_group))}
 }
 function __debug_34_1_std::group_max (g: std::Group<string,('I, bit<16>)>): (std::Vec<'I>, bit<16>)
 {
-    (((var inputs: std::Vec<'I>), (var original_group: std::Group<string,bit<16>>)) = debug::debug_split_group(g);
-     (inputs, std::group_max(original_group)))
+    {((var inputs: std::Vec<'I>), (var original_group: std::Group<string,bit<16>>)) = debug::debug_split_group(g);
+     (inputs, std::group_max(original_group))}
 }
 function __debug_35_1_std::group_to_vec (g: std::Group<internment::Intern<string>,('I, bit<64>)>): (std::Vec<'I>, std::Vec<bit<64>>)
 {
-    (((var inputs: std::Vec<'I>), (var original_group: std::Group<internment::Intern<string>,bit<64>>)) = debug::debug_split_group(g);
-     (inputs, std::group_to_vec(original_group)))
+    {((var inputs: std::Vec<'I>), (var original_group: std::Group<internment::Intern<string>,bit<64>>)) = debug::debug_split_group(g);
+     (inputs, std::group_to_vec(original_group))}
 }
 function addr_port (ip: ip_addr_t, proto: string, preferred_port: bit<16>): string
 {
-    ((var port: bit<16>) = match (proto) {
+    {(var port: bit<16>) = match (proto) {
                                "FTP" -> 16'd20,
                                "HTTPS" -> 16'd443,
                                (_: string) -> if (preferred_port != 16'd0) {
@@ -170,7 +170,7 @@ function addr_port (ip: ip_addr_t, proto: string, preferred_port: bit<16>): stri
                                                     ((return (("" ++ (to_string(ip): string)) ++ ":80")): bit<16>)
                                                 }
                            };
-     ((("" ++ (to_string(ip): string)) ++ ":") ++ (std::__builtin_2string(port): string)))
+     ((("" ++ (to_string(ip): string)) ++ ":") ++ (std::__builtin_2string(port): string))}
 }
 function addr_to_tuple (addr: ip4_addr_t): (bit<8>, bit<8>, bit<8>, bit<8>)
 {
@@ -178,47 +178,50 @@ function addr_to_tuple (addr: ip4_addr_t): (bit<8>, bit<8>, bit<8>, bit<8>)
 }
 function best_vendor (g: std::Group<'K,(string, bit<64>)>): (string, bit<64>)
 {
-    ((var min_vendor: string) = "";
-     ((var min_price: bit<64>) = 64'd18446744073709551615;
-      (for (vendor_price in g) {
+    {(var min_vendor: string) = "";
+     {(var min_price: bit<64>) = 64'd18446744073709551615;
+      {for (vendor_price in g) {
            if (vendor_price.1 < min_price) {
-               (min_vendor = vendor_price.0;
-                min_price = vendor_price.1)
+               {min_vendor = vendor_price.0;
+                {min_price = vendor_price.1;
+                 ()}}
            } else {
                  ()
              }
        };
-       (min_vendor, min_price))))
+       (min_vendor, min_price)}}}
 }
 function best_vendor_string (g: std::Group<string,(string, bit<64>)>): string
 {
-    ((var min_vendor: string) = "";
-     ((var min_price: bit<64>) = 64'd18446744073709551615;
-      (for (vendor_price in g) {
+    {(var min_vendor: string) = "";
+     {(var min_price: bit<64>) = 64'd18446744073709551615;
+      {for (vendor_price in g) {
            if (vendor_price.1 < min_price) {
-               (min_vendor = vendor_price.0;
-                min_price = vendor_price.1)
+               {min_vendor = vendor_price.0;
+                {min_price = vendor_price.1;
+                 ()}}
            } else {
                  ()
              }
        };
-       ((((("Best deal for " ++ (std::group_key(g): string)) ++ ": ") ++ min_vendor) ++ ", $") ++ (std::__builtin_2string(min_price): string)))))
+       ((((("Best deal for " ++ (std::group_key(g): string)) ++ ": ") ++ min_vendor) ++ ", $") ++ (std::__builtin_2string(min_price): string))}}}
 }
 extern function debug::debug_event (operator_id: debug::DDlogOpId, w: std::DDWeight, ts: 'T1, operator_type: string, input1: 'A1, out: 'A2): ()
 extern function debug::debug_event_join (operator_id: debug::DDlogOpId, w: std::DDWeight, ts: 'T1, input1: 'A1, input2: 'A2, out: 'A3): ()
 extern function debug::debug_split_group (g: std::Group<'K,('I, 'V)>): (std::Vec<'I>, std::Group<'K,'V>)
 function evens (vec: std::Vec<bigint>): std::Vec<bigint>
 {
-    ((var res: std::Vec<bigint>) = (std::vec_empty(): std::Vec<bigint>);
-     (for (x in vec) {
-          (if ((x % 2) != 0) {
+    {(var res: std::Vec<bigint>) = (std::vec_empty(): std::Vec<bigint>);
+     {for (x in vec) {
+          {if ((x % 2) != 0) {
                (continue: ())
            } else {
                  ()
              };
-           std::vec_push(res, x))
+           {std::vec_push(res, x);
+            ()}}
       };
-      res))
+      res}}
 }
 function get_price_in_cents (inventory: std::Map<string,string>, item: string): std::Option<std::u64>
 {
@@ -368,16 +371,17 @@ function pkt_udp_port2 (pkt: eth_pkt_t): std::Option<bit<16>>
 }
 function prefixBefore (vec: std::Vec<'A>, v: 'A): std::Vec<'A>
 {
-    ((var res: std::Vec<'A>) = (std::vec_empty(): std::Vec<'A>);
-     (for (x in vec) {
-          (if (x == v) {
+    {(var res: std::Vec<'A>) = (std::vec_empty(): std::Vec<'A>);
+     {for (x in vec) {
+          {if (x == v) {
                (break: ())
            } else {
                  ()
              };
-           std::vec_push(res, x))
+           {std::vec_push(res, x);
+            ()}}
       };
-      res))
+      res}}
 }
 function split_ip_list (x: string): std::Vec<string>
 {
@@ -443,14 +447,14 @@ extern function std::group_to_setmap (g: std::Group<'K1,('K2, 'V)>): std::Map<'K
 extern function std::group_to_vec (g: std::Group<'K,'V>): std::Vec<'V>
 function std::group_unzip (g: std::Group<'K,('X, 'Y)>): (std::Vec<'X>, std::Vec<'Y>)
 {
-    ((var xs: std::Vec<'X>) = (std::vec_empty(): std::Vec<'X>);
-     ((var ys: std::Vec<'Y>) = (std::vec_empty(): std::Vec<'Y>);
-      (for (v in g) {
-           (((var x: 'X), (var y: 'Y)) = v;
-            (std::vec_push(xs, x);
-             std::vec_push(ys, y)))
+    {(var xs: std::Vec<'X>) = (std::vec_empty(): std::Vec<'X>);
+     {(var ys: std::Vec<'Y>) = (std::vec_empty(): std::Vec<'Y>);
+      {for (v in g) {
+           {((var x: 'X), (var y: 'Y)) = v;
+            {std::vec_push(xs, x);
+             std::vec_push(ys, y)}}
        };
-       (xs, ys))))
+       (xs, ys)}}}
 }
 extern function std::hash128 (x: 'X): bit<128>
 extern function std::hash64 (x: 'X): bit<64>
@@ -926,11 +930,12 @@ function to_string (h: nethost_t): string
 }
 function vsep (strs: std::Vec<string>): string
 {
-    ((var res: string) = "";
-     (for (s in strs) {
-          res = ((res ++ s) ++ "\n")
+    {(var res: string) = "";
+     {for (s in strs) {
+          {res = ((res ++ s) ++ "\n");
+           ()}
       };
-      res))
+      res}}
 }
 output relation Address [Address]
 input relation Author [Author]

--- a/test/datalog_tests/tutorial.dl
+++ b/test/datalog_tests/tutorial.dl
@@ -205,7 +205,7 @@ HostIP(host, addr) :- HostAddress(host, addrs),
 function vsep(strs: Vec<string>): string {
     var res = "";
     for (s in strs) {
-        res = res ++ s ++ "\n"
+        res = res ++ s ++ "\n";
     };
     res
 }
@@ -224,7 +224,7 @@ function evens(vec: Vec<bigint>): Vec<bigint> {
     var res: Vec<bigint> = vec_empty();
     for (x in vec) {
         if (x % 2 != 0) { continue };
-        vec_push(res, x)
+        vec_push(res, x);
     };
     res
 }
@@ -239,7 +239,7 @@ function prefixBefore(vec: Vec<'A>, v: 'A): Vec<'A> {
     var res: Vec<'A> = vec_empty();
     for (x in vec) {
         if (x == v) { break };
-        vec_push(res, x)
+        vec_push(res, x);
     };
     res
 }
@@ -286,7 +286,7 @@ function best_vendor(g: Group<'K, (string, bit<64>)>): (string, bit<64>)
     for (vendor_price in g) {
         if (vendor_price.1 < min_price) {
             min_vendor = vendor_price.0;
-            min_price = vendor_price.1
+            min_price = vendor_price.1;
         }
     };
     (min_vendor, min_price)
@@ -304,7 +304,7 @@ function best_vendor_string(g: Group<string, (string, bit<64>)>): string
     for (vendor_price in g) {
         if (vendor_price.1 < min_price) {
             min_vendor = vendor_price.0;
-            min_price = vendor_price.1
+            min_price = vendor_price.1;
         }
     };
     "Best deal for ${group_key(g)}: ${min_vendor}, $${min_price}"


### PR DESCRIPTION
We used to disallow a semicolon after a sequence of expressions, e.g.,
`{ e1; e2; }` was illegal and had to be written as either
`{ e1; e2 }` (to return the value of `e2`) or `{ e1; e2; ()}`
to discard the result of `e2` and return an empty tuple.

This annoyed most users, including yours truly.  So we now allow
`{ e1; e2; }`, which gets desugared into `{ e1; e2; () }`.

Along the way, I fixed a bug in type inference when the type of
`continue`, `break`, or `return` is not constrained by the environment.
Instead of crashing, we now assign unit type to them.