### PR TITLE
Fixed issue with rustfmt incorrectly removing carets

### DIFF
--- a/rust/template/differential_datalog/record.rs
+++ b/rust/template/differential_datalog/record.rs
@@ -1755,7 +1755,7 @@ macro_rules! decl_record_mutator_struct {
 #[macro_export]
 macro_rules! decl_record_mutator_enum {
     ( $n:ident<$( $targ:ident),*>, $($cons:ident {$( $arg:ident : $type:ty),*}),* ) => {
-        impl<$($targ: $crate::record::FromRecord+serde::de::DeserializeOwned+Default),*> $crate::record::Mutator<$n<$($targ),*>> for $crate::record::Record
+        impl<$($targ: $crate::record::FromRecord+serde::de::DeserializeOwned+::std::default::Default),*> $crate::record::Mutator<$n<$($targ),*>> for $crate::record::Record
             where $($crate::record::Record: $crate::record::Mutator<$targ>),*
         {
             fn mutate(&self, x: &mut $n<$($targ),*>) -> ::std::result::Result<(), String> {

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -926,7 +926,8 @@ mkStructIntoRecord t@TypeDef{..} =
 
 mkStructMutator :: DatalogProgram -> TypeDef -> Doc
 mkStructMutator d t@TypeDef{..} =
-    "::differential_datalog::decl_record_mutator_struct!(" <> nameLocal t <> "," <+> targs <> "," <+> args <> ");"
+    -- Rustfmt tries to remove the empty `<>` on enums, even though it's within a macro invocation
+    "#[rustfmt::skip] ::differential_datalog::decl_record_mutator_struct!(" <> nameLocal t <> "," <+> targs <> "," <+> args <> ");"
     where
     targs = "<" <> (hcat $ punctuate comma $ map pp tdefArgs) <> ">"
     args = commaSep $ map (\arg -> pp (name arg) <> ":" <+> mkType d True arg) $ consArgs $ head $ typeCons $ fromJust tdefType
@@ -941,7 +942,8 @@ mkEnumIntoRecord t@TypeDef{..} =
 
 mkEnumMutator :: DatalogProgram -> TypeDef -> Doc
 mkEnumMutator d t@TypeDef{..} =
-    "::differential_datalog::decl_record_mutator_enum!(" <> nameLocal t <> targs <> "," <+> cons <> ");"
+    -- Rustfmt tries to remove the empty `<>` on enums, even though it's within a macro invocation
+    "#[rustfmt::skip] ::differential_datalog::decl_record_mutator_enum!(" <> nameLocal t <> targs <> "," <+> cons <> ");"
     where
     targs = "<" <> (hcat $ punctuate comma $ map pp tdefArgs) <> ">"
     cons = commaSep $ map (\c -> nameLocal c <> "{" <> (commaSep $ map (\arg -> pp (name arg) <> ":" <+> mkType d True arg) $ consArgs c) <> "}")


### PR DESCRIPTION
I found out that in some generated code, rustfmt will remove `<>` from the macro invocation, even though that's incorrect

```prolog
// Ddlog source
typedef ExprKind = Var { v: Ident } | App | Decl | Lit
```

```rust
// Correct generated code
::differential_datalog::decl_record_mutator_enum!(
    ExprKind<>,
    Var { v: crate::Ident },
    App {},
    Decl {},
    Lit {}
);

// Incorrect rustfmt fix
::differential_datalog::decl_record_mutator_enum!(
    ExprKind,
    Var { v: crate::Ident },
    App {},
    Decl {},
    Lit {}
);
```