### PR TITLE
Allowed trailing commas in relation definitions

### DIFF
--- a/src/Language/DifferentialDatalog/Parse.hs
+++ b/src/Language/DifferentialDatalog/Parse.hs
@@ -285,11 +285,11 @@ imprt = Import nopos <$ reserved "import" <*> modname <*> (option (ModuleName []
 modname = ModuleName <$> modIdent `sepBy1` reservedOp "::"
 
 typeDef = (TypeDef nopos []) <$ reserved "typedef" <*> typeIdent <*>
-                                (option [] (symbol "<" *> (commaSep $ symbol "'" *> typevarIdent) <* symbol ">")) <*>
+                                (option [] (symbol "<" *> (commaSepEnd $ symbol "'" *> typevarIdent) <* symbol ">")) <*>
                                 (Just <$ reservedOp "=" <*> typeSpec)
        <|>
           (TypeDef nopos []) <$ (try $ reserved "extern" *> reserved "type") <*> typeIdent <*>
-                                (option [] (symbol "<" *> (commaSep $ symbol "'" *> typevarIdent) <* symbol ">")) <*>
+                                (option [] (symbol "<" *> (commaSepEnd $ symbol "'" *> typevarIdent) <* symbol ">")) <*>
                                 (return Nothing)
 
 func = (Function nopos [] <$  (try $ reserved "extern" *> reserved "function")
@@ -318,7 +318,7 @@ targ = withPos $ HOField nopos <$> targIdent <*> (colon *> hotypeSpec)
 
 hotypeSpec = withPos $ (HOTypeRelation nopos <$ reserved "relation" <*> (brackets typeSpecSimple))
                        <|>
-                       (HOTypeFunction nopos <$ reserved "function" <*> (parens $ commaSep farg) <*> (colon *> typeSpecSimple))
+                       (HOTypeFunction nopos <$ reserved "function" <*> (parens $ commaSepEnd farg) <*> (colon *> typeSpecSimple))
 
 index = withPos $ Index nopos <$ symbol "index" <*> indexIdent <*> parens (commaSep arg) <*>
                   (symbol "on" *> atom False)
@@ -521,16 +521,16 @@ doubleType = TDouble nopos <$ reserved "double"
 floatType  = TFloat  nopos <$ reserved "float"
 stringType = TString nopos <$ reserved "string"
 boolType   = TBool   nopos <$ reserved "bool"
-userType   = TUser   nopos <$> typeIdent <*> (option [] $ symbol "<" *> commaSep typeSpec <* symbol ">")
+userType   = TUser   nopos <$> typeIdent <*> (option [] $ symbol "<" *> commaSepEnd typeSpec <* symbol ">")
 typeVar    = TVar    nopos <$ symbol "'" <*> typevarIdent
 structType = TStruct nopos <$ isstruct <*> sepBy1 constructor (reservedOp "|")
     where isstruct = try $ lookAhead $ attributes *> consIdent *> (symbol "{" <|> symbol "|")
 tupleType  = (\fs -> case fs of
                           [f] -> f
                           _   -> TTuple nopos fs)
-             <$> (parens $ commaSep typeSpecSimple)
-functionType =  (TFunction nopos <$ reserved "function" <*> (parens $ commaSep atype) <*> (option (TTuple nopos []) $ colon *> typeSpecSimple))
-            <|> (TFunction nopos <$> (symbol "|" *> commaSep atype <* symbol "|") <*> (option (TTuple nopos []) $ colon *> typeSpecSimple))
+             <$> (parens $ commaSepEnd typeSpecSimple)
+functionType =  (TFunction nopos <$ reserved "function" <*> (parens $ commaSepEnd atype) <*> (option (TTuple nopos []) $ colon *> typeSpecSimple))
+            <|> (TFunction nopos <$> (symbol "|" *> commaSepEnd atype <* symbol "|") <*> (option (TTuple nopos []) $ colon *> typeSpecSimple))
 
 
 constructor = withPos $ Constructor nopos <$> attributes

--- a/src/Language/DifferentialDatalog/Parse.hs
+++ b/src/Language/DifferentialDatalog/Parse.hs
@@ -139,6 +139,8 @@ dot          = T.dot lexer
 stringLit    = T.stringLiteral lexer
 --charLit    = T.charLiteral lexer
 
+commaSepEnd p = p `sepEndBy` comma
+
 varIdent     = lcIdentifier <?> "variable name"
 targIdent    = identifier   <?> "transformer argument name"
 typevarIdent = ucIdentifier <?> "type variable name"
@@ -333,7 +335,7 @@ relation = do
     isref <- option False $ (\_ -> True) <$> reservedOp "&"
     relName <- relIdent
     ((do start <- getPosition
-         fields <- parens $ commaSep arg
+         fields <- parens $ commaSepEnd arg
          pkey <- optionMaybe $ symbol "primary" *> symbol "key" *> key_expr
          end <- getPosition
          let p = (start, end)

--- a/test/datalog_tests/simple.dl
+++ b/test/datalog_tests/simple.dl
@@ -1417,3 +1417,59 @@ Floats("5/3", 32'f5.0 / 32'f3.0).
 Floats("5*3", 32'f5.0 * 32'f3.0).
 Floats("0: float", 0: float).
 Floats("floor_f(32'f0.1)", floor_f(32'f0.1)).
+
+// Trailing commas in relations
+input relation TrailingInputRelation(
+    a: u32,
+    b: u32,
+)
+relation TrailingInternalRelation(
+    a: u32,
+    b: u32,
+)
+output relation TrailingOutputRelation(
+    a: u32,
+    b: u32,
+)
+
+// Trailing commas in match arms
+function trailing_commas_in_matches(maybe: Option<u32>): u32 {
+    match (maybe) {
+        Some { int } -> int,
+        None -> 500,
+    }
+}
+
+// Trailing commas in facts
+relation TrailingCommasInFacts(name: string, act: u32, fact2: u32)
+TrailingCommasInFacts(
+    "foo",
+    10,
+    20,
+).
+
+// Trailing commas in structs
+typedef TrailingCommasInStructs = TrailingCommasInStructs {
+    foo: string,
+    bar: string,
+    baz: string,
+}
+
+// Trailing commas in function calls
+function trailing_commas_in_function_calls() {
+    trailing_commas_in_matches(
+        None,
+    );
+    trailing_commas_in_matches(
+        Some { 10 },
+    );
+}
+
+// Trailing commas in indexes
+index TrailingCommasInIndexes(
+    name: string,
+) on TrailingCommasInFacts(
+    name,
+    _,
+    _,
+)


### PR DESCRIPTION
Allows trailing commas in relations, so now this code is valid

```prolog
input relation A(
    field: Value,
    field1: Value1,
    field2: Value2,
    field3: Value3,
)
```