### PR TITLE
test.sh: A script to selectively run DDlog tests.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,7 @@
 default:
     image: ddlog/gitlab-ci:latest
+    before_script:
+        - export PATH="${PWD}/bin:${PATH}"
 
 variables:
     # Controls differential dataflow's eager compaction behavior
@@ -16,90 +18,117 @@ variables:
     # Tell ./test.sh script not to redirect test stdout and stderr to file.
     NO_STD_REDIRECT: 1
 
-# Template for tests that expect ddlog to be in the $PATH.
-.install-ddlog:
-    before_script:
-        - stack install
+build_ddlog:
+    stage: build
+    tags:
+        - ddlog-ci-1
+    script:
+        - stack install --local-bin-path ./bin
+    artifacts:
+        paths:
+            - ./bin/ddlog
+            - ./bin/ovsdb2ddlog
+            - ./bin/debugparser
 
 # Test Rust template only.
 test-rust:
+    stage: test
+    tags:
+        - ddlog-ci-1
     script:
         - ./test.sh crates
         - ./test.sh tcp_channel
 
+test-modules:
+    stage: test
+    script: ./test.sh modules
+
+test-ovn-ftl:
+    stage: test
+    tags:
+        - ddlog-ci-1
+    script: ./test.sh ovn_ftl
+
+test-ovn:
+    stage: test
+    tags:
+        - ddlog-ci-1
+    script: ./test.sh ovn_mockup
+
+test-path:
+    stage: test
+    tags:
+        - ddlog-ci-1
+    script:
+        - ./test.sh negative
+        - ./test.sh path
+
 # Run individual stack-based tests, when possible combining them with Java tests
 # that depend on the same DDlog program.
 test-tutorial:
+    stage: test
     script: ./test.sh tutorial
 
 test-rust-api:
+    stage: test
     script: ./test.sh rust_api
 
 # Test individual libraries
 
 test-libs:
-    extends: .install-ddlog
+    stage: test
+    tags:
+        - ddlog-ci-1
     script: ./test.sh libs
 
 test-server_api:
-    extends: .install-ddlog
+    stage: test
     script: ./test.sh server_api
 
 test-simple:
+    stage: test
     tags:
         - ddlog-ci-1
     script: ./test.sh simple
 
 test-simple2:
+    stage: test
     script: ./test.sh simple2
 
-test-modules:
-    script: ./test.sh modules
-
-test-ovn-ftl:
-    script: ./test.sh ovn_ftl
-
-test-ovn:
-    script: ./test.sh ovn_mockup
-
-test-path:
+test-span_string:
+    stage: test
     script:
-        - ./test.sh negative
-        - ./test.sh path
+        - ./test.sh span_string
+        - ./test.sh java3
 
 test-souffle0:
-    extends: .install-ddlog
+    stage: test
     tags:
         - ddlog-ci-1
     script: ./test.sh static_analysis 
 
 test-redist:
-    extends: .install-ddlog
+    stage: test
     tags:
         - ddlog-ci-1
     script:
-        - ./test.sh redist
+        #- ./test.sh redist
         - ./test.sh java1
         - ./test.sh flatbuf0
 
-test-span_string:
-    extends: .install-ddlog
-    script:
-        - ./test.sh span_string
-        - ./test.sh java3
-
 test-output-internal:
-    script: ./test.sh stream
+    stage: test
+    script: ./test.sh output_internal
 
 # All other Java tests.
 test-span_uuid:
-    extends: .install-ddlog
+    stage: test
     script:
         - ./test.sh span_uuid
         - ./test.sh java0
 
 test-java1:
-    extends: .install-ddlog
+    stage: test
     script:
         - ./test.sh java2
         - ./test.sh java4
@@ -112,14 +141,14 @@ test-java1:
 #        - (cd java/test6 && ./run.sh)
 
 test-flatbuf:
-    extends: .install-ddlog
+    stage: test
     tags:
         - ddlog-ci-1
     script: ./test.sh flatbuf1
 
 # Template for souffle tests
 .test-imported-souffle:
-    extends: .install-ddlog
+    stage: test
     tags:
         - ddlog-ci-1
 
@@ -154,21 +183,21 @@ test-imported-souffle-tests7:
 
 # Test DDlog code from the Declarative Cluster Management project
 test-dcm:
-    extends: .install-ddlog
+    stage: test
     tags:
         - ddlog-ci-1
     script: ./test.sh dcm
 
 # Torture-test optimized version of redist
 test-redist_opt:
-    extends: .install-ddlog
+    stage: test
     tags:
         - ddlog-ci-2
     script: ./test.sh redist_opt
 
 # Test ovn-northd-ddlog
 test-ovn-northd:
-    extends: .install-ddlog
+    stage: test
     # Don't use eager merging, as northd tends to perform many small
     # transactions, making things slow.
     variables: {}
@@ -178,22 +207,22 @@ test-ovn-northd:
 
 # Test antrea
 test-antrea:
-    extends: .install-ddlog
+    stage: test
     tags:
         - ddlog-ci-1
     script: ./test.sh antrea_check
 
 # Test the SQL-to-DDlog compiler.
 test-sql:
-    extends: .install-ddlog
+    stage: test
     script: ./test.sh sql
 
 # Test Go bindings
 test-golang:
-    extends: .install-ddlog
+    stage: test
     script: ./test.sh go
 
 # Test stream relations.
 test-stream:
-    extends: .install-ddlog
+    stage: test
     script: ./test.sh stream

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,6 +13,8 @@ variables:
     # potentially changing GitLab behavior as well as to achieve some
     # form of independence of the underlying CI pipeline.
     IS_CI_RUN: 1
+    # Tell ./test.sh script not to redirect test stdout and stderr to file.
+    NO_STD_REDIRECT: 1
 
 # Template for tests that expect ddlog to be in the $PATH.
 .install-ddlog:
@@ -21,116 +23,86 @@ variables:
 
 # Test Rust template only.
 test-rust:
-    variables:
-      ZOOKEEPER_ENDPOINTS: "127.0.0.1:2181"
     script:
-    - /usr/share/zookeeper/bin/zkServer.sh start
-    - (cd rust/template/ && cargo fmt --all -- --check)
-    - (cd lib && rustfmt *.rs --check)
-    - (cd rust/template/ && cargo clippy --all --features command-line,ovsdb -- -D warnings)
-    - for i in $(seq 100); do
-        /usr/share/zookeeper/bin/zkServer.sh status && break;
-      done
-    - (cd rust/template/ && cargo test --all)
-    - (cd rust/template/distributed_datalog && (
-        i=0;
-        true;
-        while [ $? -eq 0 -a $i -lt 100 ]; do
-          i=$((i+1));
-          cargo test -- tcp_channel::;
-        done
-      ))
+        - ./test.sh crates
+        - ./test.sh tcp_channel
 
 # Run individual stack-based tests, when possible combining them with Java tests
 # that depend on the same DDlog program.
 test-tutorial:
-    script:
-        - (cd test/datalog_tests && DDLOGFLAGS="-g" ./run-test.sh tutorial release)
+    script: ./test.sh tutorial
 
 test-rust-api:
-    script:
-        - test/datalog_tests/rust_api_test/test.sh
+    script: ./test.sh rust_api
 
 # Test individual libraries
 
 test-libs:
     extends: .install-ddlog
-    script:
-        - (cd test/datalog_tests &&
-           ./test-libs.sh)
+    script: ./test.sh libs
 
 test-server_api:
     extends: .install-ddlog
-    script:
-        # It seems that stale files cause cargo to rebuild the project
-        # unnecessarily in CI.
-        - rm -rf test/datalog_tests/server_api_ddlog
-        - (export DDLOG_HOME=`pwd` && test/datalog_tests/test-server_api.sh)
+    script: ./test.sh server_api
 
 test-simple:
     tags:
         - ddlog-ci-1
-    script:
-    - (cd test/datalog_tests && DDLOGFLAGS="-g" CARGOFLAGS="--features nested_ts_32"  ./run-test.sh simple release)
-    - cd test/datalog_tests/simple_ddlog/ && LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/ cargo build --features='profile'
+    script: ./test.sh simple
 
 test-simple2:
-    script:
-    - (cd test/datalog_tests && DDLOGFLAGS="-g --nested-ts-32" ./run-test.sh simple2 release)
+    script: ./test.sh simple2
 
 test-modules:
-    script: stack --no-terminal test --ta "-p modules"
+    script: ./test.sh modules
 
 test-ovn-ftl:
-    script: stack --no-terminal test --ta "-p ovn_ftl"
+    script: ./test.sh ovn_ftl
 
 test-ovn:
-    script: stack test --ta '-p "$(NF) == \"generate ovn\" || ($(NF-1) == \"compiler tests\" && $(NF) == \"ovn\")"'
+    script: ./test.sh ovn_mockup
 
 test-path:
     script:
-        - stack --no-terminal test --ta "-p fail"
-        - stack --no-terminal test --ta "-p path"
+        - ./test.sh negative
+        - ./test.sh path
 
 test-souffle0:
     extends: .install-ddlog
     tags:
         - ddlog-ci-1
-    script:
-        - (cd test/souffle0 &&
-          ../../tools/souffle_converter.py test.dl souffle --convert-dnf &&
-          ../datalog_tests/run-test.sh souffle.dl release)
+    script: ./test.sh static_analysis 
 
 test-redist:
     extends: .install-ddlog
     tags:
         - ddlog-ci-1
     script:
-        - STACK_CARGO_FLAGS='--release' stack test --ta '-p "$(NF) == \"generate redist\" || ($(NF-1) == \"compiler tests\" && $(NF) == \"redist\")"'
-        - (cd java/test1 && ./run.sh)
-        - (cd java/test_flatbuf && ./run.sh)
+        - ./test.sh redist
+        - ./test.sh java1
+        - ./test.sh flatbuf0
 
 test-span_string:
     extends: .install-ddlog
     script:
-        - stack --no-terminal test --ta "-p span_string"
-        - (cd java/test3 && ./run.sh)
+        - ./test.sh span_string
+        - ./test.sh java3
 
 test-output-internal:
-    script: ./test/datalog_tests/run-tests.sh three
+    script: ./test.sh stream
 
 # All other Java tests.
 test-span_uuid:
     extends: .install-ddlog
     script:
-        - stack --no-terminal test --ta "-p span_uuid"
-        - (cd java/test && ./run.sh)
+        - ./test.sh span_uuid
+        - ./test.sh java0
 
 test-java1:
     extends: .install-ddlog
     script:
-        - (cd java/test2 && ./run.sh)
-        - (cd java/test4 && ./run.sh)
+        - ./test.sh java2
+        - ./test.sh java4
 
 # these tests are currently failing (#372)
 #test-java2:
@@ -143,8 +115,7 @@ test-flatbuf:
     extends: .install-ddlog
     tags:
         - ddlog-ci-1
-    script:
-        - (cd java/test_flatbuf1 && ./run.sh)
+    script: ./test.sh flatbuf1
 
 # Template for souffle tests
 .test-imported-souffle:
@@ -155,58 +126,45 @@ test-flatbuf:
 # Tests from the souffle github repo.
 test-imported-souffle-tests1:
     extends: .test-imported-souffle
-    script:
-        - (cd test && ./run-souffle-tests-in-batches.py 0 24)
+    script: ./test.sh souffle_tests1
 
 test-imported-souffle-tests2:
     extends: .test-imported-souffle
-    script:
-        - (cd test && ./run-souffle-tests-in-batches.py 25 49)
+    script: ./test.sh souffle_tests2
 
 test-imported-souffle-tests3:
     extends: .test-imported-souffle
-    script:
-        - (cd test && ./run-souffle-tests-in-batches.py 50 74)
+    script: ./test.sh souffle_tests3
 
 test-imported-souffle-tests4:
     extends: .test-imported-souffle
-    script:
-        - (cd test && ./run-souffle-tests-in-batches.py 75 99)
+    script: ./test.sh souffle_tests4
 
 test-imported-souffle-tests5:
     extends: .test-imported-souffle
-    script:
-        - (cd test && ./run-souffle-tests-in-batches.py 100 124)
+    script: ./test.sh souffle_tests5
 
 test-imported-souffle-tests6:
     extends: .test-imported-souffle
-    script:
-        - (cd test && ./run-souffle-tests-in-batches.py 125 149)
+    script: ./test.sh souffle_tests6
 
 test-imported-souffle-tests7:
     extends: .test-imported-souffle
-    script:
-        - (cd test && ./run-souffle-tests-in-batches.py 150 175)
+    script: ./test.sh souffle_tests7
 
 # Test DDlog code from the Declarative Cluster Management project
 test-dcm:
     extends: .install-ddlog
     tags:
         - ddlog-ci-1
-    script:
-        - (cd test/datalog_tests &&
-          git clone https://github.com/ddlog-dev/dcm-test-data.git &&
-          ./test-dcm.sh)
+    script: ./test.sh dcm
 
 # Torture-test optimized version of redist
 test-redist_opt:
     extends: .install-ddlog
     tags:
         - ddlog-ci-2
-    script:
-        - cd test/datalog_tests
-        - git clone -b v2 https://github.com/ddlog-dev/redist_opt-test-data.git
-        - ./test-redist_opt.sh
+    script: ./test.sh redist_opt
 
 # Test ovn-northd-ddlog
 test-ovn-northd:
@@ -216,40 +174,26 @@ test-ovn-northd:
     variables: {}
     tags:
         - ddlog-ci-2
-    script:
-        - cd test
-        - git clone https://github.com/ryzhyk/ovs.git
-        - git clone https://github.com/ryzhyk/ovn.git
-        - git clone https://github.com/ddlog-dev/ovn-test-data.git
-        - ./test-ovn.sh
+    script: ./test.sh ovn_check
 
 # Test antrea
 test-antrea:
     extends: .install-ddlog
     tags:
         - ddlog-ci-1
-    script:
-        - cd test/antrea
-        - git clone -b v3 https://github.com/ddlog-dev/antrea-test-data.git
-        - ./test-antrea.sh
+    script: ./test.sh antrea_check
 
 # Test the SQL-to-DDlog compiler.
 test-sql:
     extends: .install-ddlog
-    script:
-        - (cd java && make)
-        - (export DDLOG_HOME=`pwd` && cd sql && ./install-ddlog-jar.sh && mvn test)
+    script: ./test.sh sql
 
 # Test Go bindings
 test-golang:
     extends: .install-ddlog
-    script:
-        - (cd go && ./test.sh)
-        - (cd go && ./run-example.sh)
+    script: ./test.sh go
 
 # Test stream relations.
 test-stream:
     extends: .install-ddlog
-    script:
-        - cd test/datalog_tests
-        - ./test-stream.sh
+    script: ./test.sh stream

--- a/java/build_java.sh
+++ b/java/build_java.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 # Shell script which generates a Java program from a DDlog program and compiles it
 
-# Only run `stack install` if we are inside the DDlog source tree;
-# otherwise expect `ddlog` to already be in `$PATH`
-if test -f "../../stack.yaml"; then
+# When running in CI, the DDlog compiler should be prinstalled by the build stage.
+if [ -z "${IS_CI_RUN}" ]; then
     stack install
 fi
 

--- a/rust/template/distributed_datalog/src/instantiate.rs
+++ b/rust/template/distributed_datalog/src/instantiate.rs
@@ -39,8 +39,8 @@ use crate::tcp_channel::TcpSender;
 use crate::txnmux::TxnMux;
 use crate::DDlogServer;
 
-use serde::Serialize;
 use serde::de::DeserializeOwned;
+use serde::Serialize;
 
 /// A mapping from member address to relation IDs used for describing
 /// output relationships.
@@ -175,7 +175,7 @@ where
 enum SinkRealization<C, S>
 where
     C: DDlogConvert,
-    S: Serialize + Debug + Send + 'static
+    S: Serialize + Debug + Send + 'static,
 {
     File(SharedObserver<FileSink<C>>),
     Node(SharedObserver<TcpSender<S>>),

--- a/rust/template/distributed_datalog/src/tcp_channel/sender.rs
+++ b/rust/template/distributed_datalog/src/tcp_channel/sender.rs
@@ -108,7 +108,7 @@ where
 }
 
 /// `TcpSender` can be an observer for any type `V` that can be converted to `T`.
-/// This way we can support scenarios where `T` is a wrapper that implements the 
+/// This way we can support scenarios where `T` is a wrapper that implements the
 /// `Serialize` trait for another type without having to insert an additional
 /// transformer in the chain.
 impl<T, V> Observer<V, String> for TcpSender<T>
@@ -125,7 +125,10 @@ where
     /// Send a series of items over the TCP channel.
     fn on_updates<'a>(&mut self, updates: Box<dyn Iterator<Item = V> + 'a>) -> Result<(), String> {
         trace!("TcpSender({})::on_updates", self.id);
-        self.buffer.lock().unwrap().on_updates(Box::new(updates.map(|u| T::from(u))))
+        self.buffer
+            .lock()
+            .unwrap()
+            .on_updates(Box::new(updates.map(T::from)))
     }
 
     /// Flush the TCP stream and signal the commit.
@@ -169,7 +172,7 @@ mod tests {
     /// Connect a `TcpSender` to a `TcpReceiver`.
     #[test]
     fn connect() {
-        let recv = TcpReceiver::<(),()>::new("127.0.0.1:0").unwrap();
+        let recv = TcpReceiver::<(), ()>::new("127.0.0.1:0").unwrap();
         {
             let _send = TcpSender::<()>::new(*recv.addr());
         }
@@ -194,7 +197,7 @@ mod tests {
     #[test]
     fn delayed_connect() {
         let mut send = TcpSender::<u64>::new("127.0.0.1:5006".parse().unwrap()).unwrap();
-        let mut recv = TcpReceiver::<u64,u64>::new("127.0.0.1:5006").unwrap();
+        let mut recv = TcpReceiver::<u64, u64>::new("127.0.0.1:5006").unwrap();
         let observer = SharedObserver::new(Mutex::new(MockObserver::new()));
         let _ = recv.subscribe(Box::new(observer.clone())).unwrap();
 

--- a/rust/template/ovsdb/lib.rs
+++ b/rust/template/ovsdb/lib.rs
@@ -395,10 +395,12 @@ fn record_into_field(rec: Record) -> Result<Value, String> {
             Value::String("set".to_owned()),
             Value::Array(vec![]),
         ])),
-        Record::NamedStruct(name, mut fields) if name == "ddlog_std::Some" => Ok(Value::Array(vec![
-            Value::String("set".to_owned()),
-            Value::Array(vec![record_into_field(fields.remove(0).1)?]),
-        ])),
+        Record::NamedStruct(name, mut fields) if name == "ddlog_std::Some" => {
+            Ok(Value::Array(vec![
+                Value::String("set".to_owned()),
+                Value::Array(vec![record_into_field(fields.remove(0).1)?]),
+            ]))
+        }
         Record::Array(CollectionKind::Set, v) => {
             let elems: Result<Vec<Value>, String> = v.into_iter().map(record_into_field).collect();
             Ok(Value::Array(vec![

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,453 @@
+#!/bin/bash
+
+set -e
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+LOG_DIR="${THIS_DIR}/testsuite.log"
+
+fail() {
+    printf "${RED}FAIL${NC}"
+}
+
+ok() {
+    printf "${GREEN}OK${NC}"
+}
+
+testsuite_setup() {
+    mkdir -p "${LOG_DIR}"
+}
+
+gen_log_file_name() {
+    log_file_name="${LOG_DIR}/${1}.log"
+}
+
+# Execute specified test function, redirecting outputs to a log file.
+run_test() {
+    gen_log_file_name ${1}
+    if [ -z "${NO_STD_REDIRECT}" ]; then
+        $1 &> "${log_file_name}"
+    else
+        $1
+    fi
+}
+
+# List of test groups
+test_groups=("crates:Test DDlog runtime crates."
+             "basic:Test basic DDlog functionality."
+             "perf:Performance tests."
+             "go:Test Go bindings."
+             "java:Test Java bindings."
+             "ovn:Test OVN virtual network controller implemented in DDlog."
+             "sql:Test SQL-to-DDlog compiler."
+             "antrea:Test Antrea controller implemented in DDlog"
+             "souffle:Tests imported from Souffle Datalog."
+             "d3log:Distributed DDlog (D3log) tests."
+             "stack:Tests using Haskell stack infrastructure.")
+
+# List of tests in each group.  Test name must match the name of a function below.
+
+crates=("rust_fmt:Rust formatting"
+        "rust_lint:Rust lints"
+        "differential_datalog:Test 'differential_datalog' crate"
+        "cmd_parser:Test 'cmd_parser' crate"
+        "ovsdb:Test OVSDB bindings crate"
+        "main_crate:Test main crate")
+
+basic=("rust_api:Test Rust API to a DDlog program"
+       "tutorial:Examples from the DDlog tutorial"
+       "simple:Unit tests for various DDlog constructs"
+       "simple2:Unit tests for various DDlog constructs, part 2"
+       "libs:Tests for libraries in the 'lib' directory"
+       "output_internal:Test '--output-internal-relations' switch"
+       "stream:Test stream relations")
+
+
+perf=("dcm:Declarative Cluster Management benchmark"
+      "redist_opt:'redist_opt' benchmark")
+
+go=("go_test:Go API test")
+
+java=("java0:Java API test 0"
+      "java1:Java API test 1"
+      "java2:Java API test 2"
+      "java3:Java API test 3"
+      "java4:Java API test 4"
+      "flatbuf0:Java Flatbuf API test 0"
+      "flatbuf1:Java Flatbuf API test 1")
+
+sql=("sql_test:Test SQL-to-DDlog compiler")
+
+ovn=("ovn_check:OVN controller test suite")
+
+antrea=("antrea_check:Antrea tests")
+
+souffle=("static_analysis:Souffle static analysis test."
+         "souffle_tests1:Souffle tests part1"
+         "souffle_tests2:Souffle tests part2"
+         "souffle_tests3:Souffle tests part3"
+         "souffle_tests4:Souffle tests part4"
+         "souffle_tests5:Souffle tests part5"
+         "souffle_tests6:Souffle tests part6"
+         "souffle_tests7:Souffle tests part7")
+
+d3log=("tcp_channel:TCP channel test"
+       "server_api:Test D3log server API")
+
+stack=("modules:Test modules and imports"
+       "ovn_ftl:Test FTL syntax"
+       "ovn_mockup:OVN-inspired example"
+       "path:Trivial graph reachability test"
+       "redist:'redist' example"
+       "span_string:'span_string' example"
+       "span_uuid:'span_uuid' example"
+       "negative:Negative tests that validate compiler error handling")
+
+# 'crates' test group.
+
+rust_fmt() {
+    (cd "${THIS_DIR}/rust/template/" && cargo fmt -- --check) &&
+    (cd "${THIS_DIR}/rust/template/cmd_parser" && cargo fmt -- --check) &&
+    (cd "${THIS_DIR}/rust/template/ovsdb" && cargo fmt -- --check) &&
+    (cd "${THIS_DIR}/rust/template/differential_datalog" && cargo fmt -- --check) &&
+    (cd "${THIS_DIR}/lib" && rustfmt *.rs --check)
+}
+
+rust_lint() {
+    (cd "${THIS_DIR}/rust/template/" && cargo clippy --features command-line,ovsdb -- -D warnings) &&
+    (cd "${THIS_DIR}/rust/template/cmd_parser" && cargo clippy -- -D warnings) &&
+    (cd "${THIS_DIR}/rust/template/ovsdb" && cargo clippy -- -D warnings) &&
+    (cd "${THIS_DIR}/rust/template/differential_datalog" && cargo clippy -- -D warnings)
+}
+differential_datalog() {
+    (cd "${THIS_DIR}/rust/template/differential_datalog" && cargo test)
+}
+
+cmd_parser() {
+    (cd "${THIS_DIR}/rust/template/cmd_parser" && cargo test)
+}
+ 
+ovsdb() {
+    (cd "${THIS_DIR}/rust/template/ovsdb" && cargo test)
+}
+
+main_crate() {
+    (cd "${THIS_DIR}/rust/template" && cargo test --features command-line,ovsdb)
+}
+
+# 'basic' test group.
+
+tutorial() {
+    (cd "${THIS_DIR}/test/datalog_tests" && DDLOGFLAGS="-g" ./run-test.sh tutorial release)
+}
+
+rust_api() {
+    ${THIS_DIR}/test/datalog_tests/rust_api_test/test.sh
+}
+
+libs() {
+    (cd "${THIS_DIR}/test/datalog_tests" && ./test-libs.sh)
+}
+
+simple() {
+    (cd "${THIS_DIR}/test/datalog_tests" && DDLOGFLAGS="-g" CARGOFLAGS="--features nested_ts_32,profile" ./run-test.sh simple release)
+}
+
+simple2() {
+    (cd "${THIS_DIR}/test/datalog_tests" && DDLOGFLAGS="-g --nested-ts-32" ./run-test.sh simple2 release)
+}
+
+negative() {
+    (cd "${THIS_DIR}" && stack --no-terminal test --ta "-p fail")
+}
+
+output_internal() {
+    (cd "${THIS_DIR}" && ./test/datalog_tests/run-tests.sh three)
+}
+
+stream() {
+    (cd "${THIS_DIR}/test/datalog_tests" && ./test-stream.sh)
+}
+
+# 'perf' test group.
+
+dcm() {
+    (cd "${THIS_DIR}/test/datalog_tests" && ./test-dcm.sh)
+}
+
+redist_opt() {
+    (cd "${THIS_DIR}/test/datalog_tests" && ./test-redist_opt.sh)
+}
+
+# 'go' test group
+
+go_test() {
+    (cd "${THIS_DIR}/go" && ./test.sh && ./run-example.sh)
+}
+
+# 'java' test group.
+
+java0() {
+    (cd "${THIS_DIR}/java/test" && ./run.sh)
+}
+
+java1() {
+    (cd "${THIS_DIR}/java/test1" && ./run.sh)
+}
+
+java2() {
+    (cd "${THIS_DIR}/java/test2" && ./run.sh)
+}
+
+java3() {
+    (cd "${THIS_DIR}/java/test3" && ./run.sh)
+}
+
+java4() {
+    (cd "${THIS_DIR}/java/test4" && ./run.sh)
+}
+
+flatbuf0() {
+    (cd "${THIS_DIR}/java/test_flatbuf" && ./run.sh)
+}
+
+flatbuf1() {
+    (cd "${THIS_DIR}/java/test_flatbuf1" && ./run.sh)
+}
+
+# 'sql' test group
+
+sql_test() {
+    (cd "${THIS_DIR}/java" && make) &&
+    (export DDLOG_HOME="${THIS_DIR}" && cd "${THIS_DIR}/sql" && ./install-ddlog-jar.sh && mvn test)
+}
+
+# 'ovn' test group.
+
+ovn_check() {
+    (cd "${THIS_DIR}/test" && ./test-ovn.sh)
+}
+
+# 'antrea' test group.
+
+antrea_check() {
+    (cd "${THIS_DIR}/test/antrea" && ./test-antrea.sh)
+}
+
+# 'souffle' test group.
+
+static_analysis() {
+    (cd "${THIS_DIR}/test/souffle0" &&
+     ../../tools/souffle_converter.py test.dl souffle --convert-dnf &&
+     ../datalog_tests/run-test.sh souffle.dl release)
+}
+
+souffle_tests1() {
+    (cd "${THIS_DIR}/test" && ./run-souffle-tests-in-batches.py 0 24)
+}
+
+souffle_tests2() {
+    (cd "${THIS_DIR}/test" && ./run-souffle-tests-in-batches.py 25 49)
+}
+
+souffle_tests3() {
+    (cd "${THIS_DIR}/test" && ./run-souffle-tests-in-batches.py 50 74)
+}
+
+souffle_tests4() {
+    (cd "${THIS_DIR}/test" && ./run-souffle-tests-in-batches.py 75 99)
+}
+
+souffle_tests5() {
+    (cd "${THIS_DIR}/test" && ./run-souffle-tests-in-batches.py 100 124)
+}
+
+souffle_tests6() {
+    (cd "${THIS_DIR}/test" && ./run-souffle-tests-in-batches.py 125 149)
+}
+
+souffle_tests7() {
+    (cd "${THIS_DIR}/test" && ./run-souffle-tests-in-batches.py 150 175)
+}
+
+# 'd3log' test group.
+
+tcp_channel() {
+    #ZOOKEEPER_ENDPOINTS="127.0.0.1:2181"
+    #/usr/share/zookeeper/bin/zkServer.sh start &&
+    (cd "${THIS_DIR}/rust/template/distributed_datalog" && cargo fmt -- --check) &&
+    (cd "${THIS_DIR}/rust/template/distributed_datalog" && cargo clippy -- -D warnings) &&
+    #for i in $(seq 100); do
+    #    /usr/share/zookeeper/bin/zkServer.sh status && break;
+    #    sleep 1
+    #done &&
+    (cd "${THIS_DIR}/rust/template/distributed_datalog" && (
+        i=0;
+        true;
+        while [ $? -eq 0 -a $i -lt 100 ]; do
+          i=$((i+1));
+          cargo test -- tcp_channel::;
+        done
+        )
+    )
+}
+
+server_api() {
+    # It seems that stale files cause cargo to rebuild the project
+    # unnecessarily in CI.
+    #rm -rf test/datalog_tests/server_api_ddlog
+    (export DDLOG_HOME="${THIS_DIR}" && "${THIS_DIR}/test/datalog_tests/test-server_api.sh")
+}
+
+# 'stack' test group.
+
+modules() {
+    (cd "${THIS_DIR}" && stack --no-terminal test --ta "-p modules")
+}
+
+ovn_ftl() {
+    (cd "${THIS_DIR}" && stack --no-terminal test --ta "-p ovn_ftl")
+}
+
+ovn_mockup() {
+    (cd "${THIS_DIR}" && stack test --ta '-p "$(NF) == \"generate ovn\" || ($(NF-1) == \"compiler tests\" && $(NF) == \"ovn\")"')
+}
+
+path() {
+    (cd "${THIS_DIR}" && stack --no-terminal test --ta "-p path")
+}
+
+redist() {
+    (cd "${THIS_DIR}" && STACK_CARGO_FLAGS='--release' stack test --ta '-p "$(NF) == \"generate redist\" || ($(NF-1) == \"compiler tests\" && $(NF) == \"redist\")"')
+}
+
+span_string() {
+    (cd "${THIS_DIR}" && stack --no-terminal test --ta "-p span_string")
+}
+
+span_uuid() {
+    (cd "${THIS_DIR}" && stack --no-terminal test --ta "-p span_uuid")
+}
+
+
+
+#==========================================
+# Main test script.
+#==========================================
+
+printf "DDlog test suite\n\n"
+testsuite_setup
+
+if ( [ "$#" -eq 0 ] || [ "x$1" == "xhelp" ] || [ "x$1" == "x--help" ] ); then
+    printf "Usage: ${0} test_or_test_group1 test_or_test_group2 ...\n"
+    printf "   or: ${0} all\n\n"
+    printf "Available test groups:\n"
+    for group_with_descr in "${test_groups[@]}"
+    do
+        IFS=":" read -ra tokens <<< "$group_with_descr"
+        group=${tokens[0]}
+        description=${tokens[1]}
+
+        printf "\n    ${group}: ${description}\n"
+
+        eval "tests=(\"\${${group}[@]}\")"
+        for tst_with_descr in "${tests[@]}"
+        do
+            IFS=":" read -ra tokens <<< "$tst_with_descr"
+            tst=${tokens[0]}
+            description=${tokens[1]}
+            printf "        %-25s %s\n" "${tst}" "${description}"
+        done
+    done
+else
+    if [ "x$1" == "xall" ]; then
+        test_list=()
+        for group_with_descr in "${test_groups[@]}"
+        do
+            IFS=":" read -ra tokens <<< "$group_with_descr"
+            group=${tokens[0]}
+            test_list+=(${group})
+        done
+    else
+        test_list="$@"
+    fi
+
+    # Make a list of tests to run.
+    all_tests=()
+
+    for tst in "${test_list[@]}"
+    do
+        if [[ "${test_groups[@]}" =~ "${tst}" ]]; then
+            #echo "test group '${tst}'"
+            eval "tests=(\"\${${tst}[@]}\")"
+            for tst_with_descr in "${tests[@]}"
+            do
+                IFS=":" read -ra tokens <<< "$tst_with_descr"
+                tst_func=${tokens[0]}
+
+                # Only add test if not already in the list.
+                if ! [[ " ${all_tests[@]} " =~ " ${tst_func} " ]]; then
+                    all_tests+=(${tst_func})
+                fi
+            done
+
+        else
+            # Only add test if not already in the list.
+            if ! [[ " ${all_tests[@]} " =~ " ${tst} " ]]; then
+                all_tests+=(${tst})
+            fi
+        fi
+    done
+
+    echo "Running the following tests: ${all_tests[@]}"
+    echo ""
+
+    # Validate the resulting list of tests.
+    for tst in "${all_tests[@]}"; do
+        if ! ([ -n "$(type -t ${tst})" ] && [ "$(type -t ${tst})" = function ]); then
+            echo "Unknown test '${tst}'"
+            fail=1
+        fi
+    done
+
+    if [ " ${fail} " == " 1 " ]; then
+        printf "${RED}FAIL${NC}\n"
+        exit 1
+    fi
+
+    # Run the tests.
+    passed=0
+    failed=0
+    for tst in "${all_tests[@]}"; do
+        printf "%-25s %s" "${tst}"
+        start=`date +%s`
+        if run_test "${tst}"; then
+            ok
+            passed=$((passed+1))
+        else
+            fail
+            if [ -z "${NO_STD_REDIRECT}" ]; then
+                printf " [output saved in '${log_file_name}']"
+            fi
+            failed=$((failed+1))
+        fi
+        end=`date +%s`
+        runtime=$((end-start))
+        printf " (${runtime}s)\n"
+    done
+
+    if [ ${passed} -gt 0 ]; then
+        echo "========================================="
+        printf "${GREEN}PASSED: ${passed}${NC}\n"
+        echo "========================================="
+    fi
+
+    if [ ${failed} -gt 0 ]; then
+        echo "========================================="
+        printf "${RED}FAILED: ${failed}${NC}\n"
+        echo "========================================="
+        exit 1
+    fi
+fi

--- a/test.sh
+++ b/test.sh
@@ -45,6 +45,7 @@ test_groups=("crates:Test DDlog runtime crates."
              "antrea:Test Antrea controller implemented in DDlog"
              "souffle:Tests imported from Souffle Datalog."
              "d3log:Distributed DDlog (D3log) tests."
+             "misc:Miscellaneous other tests."
              "stack:Tests using Haskell stack infrastructure.")
 
 # List of tests in each group.  Test name must match the name of a function below.
@@ -96,13 +97,14 @@ souffle=("static_analysis:Souffle static analysis test."
 d3log=("tcp_channel:TCP channel test"
        "server_api:Test D3log server API")
 
+misc=("span_string"
+      "span_uuid"
+      "path:Trivial graph reachability test")
+
 stack=("modules:Test modules and imports"
        "ovn_ftl:Test FTL syntax"
        "ovn_mockup:OVN-inspired example"
-       "path:Trivial graph reachability test"
        "redist:'redist' example"
-       "span_string:'span_string' example"
-       "span_uuid:'span_uuid' example"
        "negative:Negative tests that validate compiler error handling")
 
 # 'crates' test group.
@@ -315,23 +317,23 @@ ovn_mockup() {
     (cd "${THIS_DIR}" && stack test --ta '-p "$(NF) == \"generate ovn\" || ($(NF-1) == \"compiler tests\" && $(NF) == \"ovn\")"')
 }
 
-path() {
-    (cd "${THIS_DIR}" && stack --no-terminal test --ta "-p path")
-}
-
 redist() {
     (cd "${THIS_DIR}" && STACK_CARGO_FLAGS='--release' stack test --ta '-p "$(NF) == \"generate redist\" || ($(NF-1) == \"compiler tests\" && $(NF) == \"redist\")"')
 }
 
+# 'misc' test group.
+
 span_string() {
-    (cd "${THIS_DIR}" && stack --no-terminal test --ta "-p span_string")
+    (cd "${THIS_DIR}/test/datalog_tests" && ./run-test.sh span_string release)
 }
 
 span_uuid() {
-    (cd "${THIS_DIR}" && stack --no-terminal test --ta "-p span_uuid")
+    (cd "${THIS_DIR}/test/datalog_tests" && ./run-test.sh span_uuid release)
 }
 
-
+path() {
+    (cd "${THIS_DIR}/test/datalog_tests" && ./run-test.sh path release)
+}
 
 #==========================================
 # Main test script.

--- a/test/antrea/test-antrea.sh
+++ b/test/antrea/test-antrea.sh
@@ -6,6 +6,18 @@ set -e
 
 stack install
 
+# Clone or refresh the repo.
+DATA_REPO_NAME="antrea-test-data"
+DATA_REPO=https://github.com/ddlog-dev/${DATA_REPO_NAME}.git
+DATA_REPO_BRANCH=v3
+
+if [ ! -d "${DATA_REPO_NAME}/.git" ]
+then
+    git clone -b ${DATA_REPO_BRANCH} ${DATA_REPO}
+else
+    (cd "${DATA_REPO_NAME}" && git fetch "${DATA_REPO}" && git checkout "${DATA_REPO_BRANCH}")
+fi
+
 #export DDLOGFLAGS="--output-input-relations=O --output-internal-relations"
 #../datalog_tests/run-test.sh networkpolicy_controller.dl release
 ddlog -i networkpolicy_controller.dl -j -L../../lib

--- a/test/datalog_tests/run-test.sh
+++ b/test/datalog_tests/run-test.sh
@@ -56,11 +56,14 @@ else
     usage
 fi
 
-if [ "x${PROFILE}" == "x1" ]; then
-    stack install --profile
-    export GHCRTS="-xc"
-else
-    stack install
+# When running in CI, the DDlog compiler should be prinstalled by the build stage.
+if [ -z "${IS_CI_RUN}" ]; then
+    if [ "x${PROFILE}" == "x1" ]; then
+        stack install --profile
+        export GHCRTS="-xc"
+    else
+        stack install
+    fi
 fi
 
 CLASSPATH=$(pwd)/${base}_ddlog/flatbuf/java:$(pwd)/../../java/ddlogapi.jar:$CLASSPATH

--- a/test/datalog_tests/rust_api_test/test.sh
+++ b/test/datalog_tests/rust_api_test/test.sh
@@ -2,7 +2,10 @@
 
 set -ex
 
-stack install
+# When running in CI, the DDlog compiler should be prinstalled by the build stage.
+if [ -z "${IS_CI_RUN}" ]; then
+    stack install
+fi
 
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 DATALOG_TEST_DIR="${THIS_DIR}/../"

--- a/test/datalog_tests/test-dcm.sh
+++ b/test/datalog_tests/test-dcm.sh
@@ -2,6 +2,17 @@
 
 set -e
 
+# Clone or refresh the repo.
+DCM_DATA_REPO=https://github.com/ddlog-dev/dcm-test-data.git
+LOCAL_DCM_DATA_REPO=dcm-test-data
+
+if [ ! -d "${LOCAL_DCM_DATA_REPO}/.git" ]
+then
+    git clone $DCM_DATA_REPO
+else
+    (cd $LOCAL_DCM_DATA_REPO && git pull $DCM_DATA_REPO)
+fi
+
 ./run-test.sh dcm1 release
 
 # $1 - number of workers
@@ -17,7 +28,6 @@ run_test() {
     fi
     /usr/bin/time ./dcm1_ddlog/target/release/dcm1_cli -w $1 --no-print --no-store < $2 > dcm1.dump
 
-    # The output should be $1 copies of redist_opt.dump.expected
     diff -q $3 dcm1.dump
 }
 

--- a/test/datalog_tests/test-redist_opt.sh
+++ b/test/datalog_tests/test-redist_opt.sh
@@ -2,6 +2,18 @@
 
 set -e
 
+# Clone or refresh the repo.
+DATA_REPO_NAME=redist_opt-test-data
+DATA_REPO=https://github.com/ddlog-dev/${DATA_REPO_NAME}.git
+DATA_REPO_BRANCH=v2
+
+if [ ! -d "${DATA_REPO_NAME}/.git" ]
+then
+    git clone -b ${DATA_REPO_BRANCH} ${DATA_REPO}
+else
+    (cd "${DATA_REPO_NAME}" && git fetch "${DATA_REPO}" && git checkout "${DATA_REPO_BRANCH}")
+fi
+
 ./run-test.sh redist_opt release
 
 # $1 - number of iterations

--- a/test/test-ovn.sh
+++ b/test/test-ovn.sh
@@ -2,11 +2,29 @@
 
 set -e
 
-(cd ovn-test-data && git checkout v5)
+clone_repo() {
+    REPO_URL=$1
+    REPO_DIR=$2
+    if [ -z "$3" ]; then
+        REPO_BRANCH="master"
+    else
+        REPO_BRANCH=$3
+    fi
+
+    if [ ! -d "${REPO_DIR}/.git" ]
+    then
+        git clone -b "${REPO_BRANCH}" "${REPO_URL}" "${REPO_DIR}" 
+    else
+        (cd "${REPO_DIR}" && git fetch "${REPO_URL}" && git checkout "${REPO_BRANCH}")
+    fi
+}
+
+clone_repo https://github.com/ryzhyk/ovs.git ovs ovs-for-ddlog
+clone_repo https://github.com/ryzhyk/ovn.git ovn
+clone_repo https://github.com/ddlog-dev/ovn-test-data.git ovn-test-data v5
 
 # TODO: use OVS master once these changes are there.
 (cd ovs &&
- git checkout ovs-for-ddlog &&
  ./boot.sh &&
  ./configure  &&
  make -j6)


### PR DESCRIPTION
The DDlog test suite consists of many individual scripts all over the
repo.  Until now the only place that "knew" how to run all these scripts
correctly was the `.gitlab-ci.yml` file.  This was kind of acceptable
because the test suite is too slow to run in its entirety on a single
machine.  Still, running individual test scripts and having to check
`.gitlab-ci.yml` for correct arguments is cumbersome and creates an
extra barrier for external contributions.

So here is finally a script to run all DDlog tests from one place.  In
order to make it easier to pick and choose tests to run, we break them
into groups.  The script takes a list of test names, group names, or a
mix of both as arguments and runs all requested tests.  It can also be
invoked as `./test.sh all` to run all available tests.

Other features:
- Measure the runtime of each test
- Redirect stdout and stderr to file

The `.gitlab-ci.yml` file now uses `test.sh` to run all tests.

I also refactored some test scripts to either clone or pull external git
repos (ovs, ovn, test data repos), which was previously done in
`.gitlab-ci.yml`.

@Kixiron