### PR TITLE
Add DDlogJooqProvider and a corresponding test

### DIFF
--- a/sql/src/main/java/com/vmware/ddlog/DDlogJooqProvider.java
+++ b/sql/src/main/java/com/vmware/ddlog/DDlogJooqProvider.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: BSD-2
+ */
+package com.vmware.ddlog;
+
+import ddlogapi.DDlogAPI;
+import ddlogapi.DDlogException;
+import ddlogapi.DDlogRecord;
+import org.jooq.DSLContext;
+import org.jooq.Field;
+import org.jooq.Record;
+import org.jooq.Result;
+import org.jooq.SQLDialect;
+import org.jooq.Table;
+import org.jooq.impl.DSL;
+import org.jooq.tools.jdbc.MockDataProvider;
+import org.jooq.tools.jdbc.MockExecuteContext;
+import org.jooq.tools.jdbc.MockResult;
+
+import javax.annotation.Nullable;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DDlogJooqProvider implements MockDataProvider {
+    private static final String INTEGER_TYPE = "java.lang.Integer";
+    private static final String STRING_TYPE = "java.lang.String";
+    private static final String BOOLEAN_TYPE = "java.lang.Boolean";
+    private static final String LONG_TYPE = "java.lang.Long";
+
+    private final DDlogAPI dDlogAPI;
+    private final Map<String, List<Field<?>>> tables = new HashMap<>();
+
+    public DDlogJooqProvider(final DDlogAPI dDlogAPI, final List<String> sqlStatements) {
+        this.dDlogAPI = dDlogAPI;
+        final DSLContext using = DSL.using("jdbc:h2:mem:");
+        for (final String sql : sqlStatements) {
+            using.execute(sql);
+        }
+        for (final Table<?> table: using.meta().getTables()) {
+            if (table.getSchema().getName().equals("PUBLIC")) {
+                tables.put(table.getName(), Arrays.asList(table.fields()));
+            }
+        }
+    }
+
+    @Override
+    public MockResult[] execute(final MockExecuteContext ctx) throws SQLException {
+        DSLContext create = DSL.using(SQLDialect.H2);
+        MockResult[] mock = new MockResult[1];
+        // The execute context contains SQL string(s), bind values, and other meta-data
+        String sql = ctx.sql();
+
+        // Exceptions are propagated through the JDBC and jOOQ APIs
+        if (sql.toUpperCase().startsWith("DROP")) {
+            throw new SQLException("Statement not supported: " + sql);
+        }
+        else if (sql.toUpperCase().startsWith("SELECT")) {
+            final String[] s = ctx.sql().toUpperCase().split(" ");
+            if (!s[s.length - 2].equals("FROM")) {
+                throw new SQLException("Statement not supported: " + sql);
+            }
+            final String tableName = s[s.length - 1];
+
+            final List<Field<?>> fields = tables.get(tableName);
+            Result<Record> result = create.newResult(fields);
+            try {
+                dDlogAPI.dumpTable("R" + tableName.toLowerCase(), (record, l) -> {
+                    final Record jooqRecord = create.newRecord(fields);
+                    final Object[] returnValue = new Object[fields.size()];
+                    for (int i = 0; i < fields.size(); i++) {
+                        returnValue[i] = structToValue(fields.get(i), record.getStructField(i));
+                    }
+                    jooqRecord.fromArray(returnValue);
+                    result.add(jooqRecord);
+                });
+            } catch (final DDlogException e) {
+                e.printStackTrace();
+            }
+            mock[0] = new MockResult(1, result);
+        }
+        return mock;
+    }
+
+    @Nullable
+    private Object structToValue(final Field<?> field, final DDlogRecord record) {
+        final Class<?> cls = field.getType();
+        if (record.isStruct() && record.getStructName().equals("std.None")) {
+            return null;
+        }
+        if (record.isStruct() && record.getStructName().equals("ddlog_std::Some")) {
+            return structToValue(field, record.getStructField(0));
+        }
+        switch (cls.getName()) {
+            case BOOLEAN_TYPE:
+                return record.getBoolean();
+            case INTEGER_TYPE:
+                return record.getInt().intValue();
+            case LONG_TYPE:
+                return record.getInt().longValue();
+            case STRING_TYPE:
+                return record.getString();
+            default:
+                throw new RuntimeException("Unknown datatype %s of field %s in table %s in update received");
+        }
+    }
+}

--- a/sql/src/main/java/com/vmware/ddlog/DDlogJooqProvider.java
+++ b/sql/src/main/java/com/vmware/ddlog/DDlogJooqProvider.java
@@ -54,11 +54,7 @@ public class DDlogJooqProvider implements MockDataProvider {
         // The execute context contains SQL string(s), bind values, and other meta-data
         String sql = ctx.sql();
 
-        // Exceptions are propagated through the JDBC and jOOQ APIs
-        if (sql.toUpperCase().startsWith("DROP")) {
-            throw new SQLException("Statement not supported: " + sql);
-        }
-        else if (sql.toUpperCase().startsWith("SELECT")) {
+        if (sql.toUpperCase().startsWith("SELECT")) {
             final String[] s = ctx.sql().toUpperCase().split(" ");
             if (!s[s.length - 2].equals("FROM")) {
                 throw new SQLException("Statement not supported: " + sql);
@@ -81,6 +77,9 @@ public class DDlogJooqProvider implements MockDataProvider {
                 e.printStackTrace();
             }
             mock[0] = new MockResult(1, result);
+        } else {
+            // Exceptions are propagated through the JDBC and jOOQ APIs
+            throw new SQLException("Statement not supported: " + sql);
         }
         return mock;
     }

--- a/sql/src/main/java/com/vmware/ddlog/DDlogJooqProvider.java
+++ b/sql/src/main/java/com/vmware/ddlog/DDlogJooqProvider.java
@@ -64,7 +64,7 @@ public class DDlogJooqProvider implements MockDataProvider {
 
     private MockResult executeSelectStar(final String sql) throws SQLException {
         final String[] s = sql.toUpperCase().split(" ");
-        if (!(s[1].equals("*") && s[2].equals("FROM"))) {
+        if (!(s.length == 4 && s[1].equals("*") && s[2].equals("FROM"))) {
             throw new SQLException("Statement not supported: " + sql);
         }
         final String tableName = s[3];

--- a/sql/src/test/java/ddlog/JooqProviderTest.java
+++ b/sql/src/test/java/ddlog/JooqProviderTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: BSD-2
+ */
+package ddlog;
+
+import com.vmware.ddlog.DDlogJooqProvider;
+import com.vmware.ddlog.ir.DDlogProgram;
+import com.vmware.ddlog.translator.Translator;
+import ddlogapi.DDlogAPI;
+import ddlogapi.DDlogCommand;
+import ddlogapi.DDlogException;
+import ddlogapi.DDlogRecCommand;
+import ddlogapi.DDlogRecord;
+import org.jooq.DSLContext;
+import org.jooq.Record;
+import org.jooq.Result;
+import org.jooq.impl.DSL;
+import org.jooq.tools.jdbc.MockConnection;
+import org.jooq.tools.jdbc.MockDataProvider;
+import org.junit.Test;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public class JooqProviderTest {
+
+    @Test
+    public void testddlog() throws IOException, DDlogException {
+        final Translator t = new Translator(null);
+        final String s1 = "create table hosts (id integer, capacity integer)";
+        final String v2 = "create view hostsv as select distinct * from hosts";
+        final String v1 = "create view good_hosts as select distinct * from hosts where capacity < 50";
+        t.translateSqlStatement(s1);
+        t.translateSqlStatement(v2);
+        t.translateSqlStatement(v1);
+        final DDlogProgram dDlogProgram = t.getDDlogProgram();
+        writeProgramToFile(dDlogProgram.toString());
+        DDlogAPI.compileDDlogProgram("/tmp/program.dl", true, "../lib", "./lib");
+        DDlogAPI.loadDDlog();
+
+        final DDlogAPI dDlogAPI = new DDlogAPI(1, null, true);
+        final int numInserts = 5;
+        for (int i = 0; i < numInserts; i++) {
+            final DDlogRecord rec = new DDlogRecord(i);
+            final DDlogRecord cap = new DDlogRecord(20);
+            final DDlogRecord struct = DDlogRecord.makeStruct("Thosts", rec, cap);
+            final int id = dDlogAPI.getTableId("Rhosts");
+            final DDlogRecCommand command = new DDlogRecCommand(DDlogCommand.Kind.Insert, id, struct);
+            dDlogAPI.transactionStart();
+            dDlogAPI.applyUpdates(new DDlogRecCommand[]{command});
+            dDlogAPI.transactionCommit();
+        }
+
+        final List<String> ddl = new ArrayList<>();
+        ddl.add(s1);
+        ddl.add(v2);
+        ddl.add(v1);
+
+        // Initialise the data provider
+        MockDataProvider provider = new DDlogJooqProvider(dDlogAPI, ddl);
+        MockConnection connection = new MockConnection(provider);
+
+        // Pass the mock connection to a jOOQ DSLContext:
+        DSLContext create = DSL.using(connection);
+        final Result<Record> fetch = create.fetch("select * from hostsv");
+        assertEquals(numInserts, fetch.size());
+        assertArrayEquals(new int[]{0, 1, 2, 3, 4},
+                          fetch.stream().mapToInt(r -> r.get(0, Integer.class)).toArray());
+    }
+
+    public File writeProgramToFile(String programBody) throws IOException {
+        File tmp = new File("/tmp/program.dl");
+        BufferedWriter bw = new BufferedWriter(new FileWriter(tmp));
+        bw.write(programBody);
+        bw.close();
+        return tmp;
+    }
+}

--- a/sql/src/test/java/ddlog/JooqProviderTest.java
+++ b/sql/src/test/java/ddlog/JooqProviderTest.java
@@ -48,16 +48,16 @@ public class JooqProviderTest {
 
         final DDlogAPI dDlogAPI = new DDlogAPI(1, null, true);
         final int numInserts = 5;
+        dDlogAPI.transactionStart();
         for (int i = 0; i < numInserts; i++) {
             final DDlogRecord rec = new DDlogRecord(i);
             final DDlogRecord cap = new DDlogRecord(20);
             final DDlogRecord struct = DDlogRecord.makeStruct("Thosts", rec, cap);
             final int id = dDlogAPI.getTableId("Rhosts");
             final DDlogRecCommand command = new DDlogRecCommand(DDlogCommand.Kind.Insert, id, struct);
-            dDlogAPI.transactionStart();
             dDlogAPI.applyUpdates(new DDlogRecCommand[]{command});
-            dDlogAPI.transactionCommit();
         }
+        dDlogAPI.transactionCommit();
 
         final List<String> ddl = new ArrayList<>();
         ddl.add(s1);

--- a/sql/src/test/java/ddlog/JooqProviderTest.java
+++ b/sql/src/test/java/ddlog/JooqProviderTest.java
@@ -76,7 +76,7 @@ public class JooqProviderTest {
                           fetch.stream().mapToInt(r -> r.get(0, Integer.class)).toArray());
     }
 
-    public File writeProgramToFile(String programBody) throws IOException {
+    public static File writeProgramToFile(String programBody) throws IOException {
         File tmp = new File("/tmp/program.dl");
         BufferedWriter bw = new BufferedWriter(new FileWriter(tmp));
         bw.write(programBody);


### PR DESCRIPTION
The high-level idea here is to intercept a JOOQ connection and redirect calls to DDlog. You can see the test I added for usage.

Given that DDlog only supports standing queries and JDBC/JOOQ has no means of returning incremental changes, the only queries we can support via this API are of the form "select * from X". We should be able to support inserts/updates as well, which I'm exploring (parsing the SQL string like I'm doing now is one way, but in the worst case I can fall back to triggers to learn of changes made to base tables).