### PR TITLE
Ignored more clippy lints, conditionally compile IDXIDMAPC and RELIDMAPC

### DIFF
--- a/rust/template/src/api/mod.rs
+++ b/rust/template/src/api/mod.rs
@@ -75,6 +75,7 @@ impl HDDlog {
         relid2name(tid).ok_or_else(|| format!("unknown relation {}", tid))
     }
 
+    #[cfg(feature = "c_api")]
     pub fn get_table_cname(tid: RelId) -> Result<&'static ffi::CStr, String> {
         relid2cname(tid).ok_or_else(|| format!("unknown relation {}", tid))
     }
@@ -87,6 +88,7 @@ impl HDDlog {
         indexid2name(iid).ok_or_else(|| format!("unknown index {}", iid))
     }
 
+    #[cfg(feature = "c_api")]
     pub fn get_index_cname(iid: IdxId) -> Result<&'static ffi::CStr, String> {
         indexid2cname(iid).ok_or_else(|| format!("unknown index {}", iid))
     }

--- a/rust/template/src/lib.rs
+++ b/rust/template/src/lib.rs
@@ -11,7 +11,14 @@
     unused_variables,
     clippy::unknown_clippy_lints,
     clippy::missing_safety_doc,
-    clippy::toplevel_ref_arg
+    clippy::toplevel_ref_arg,
+    clippy::double_parens,
+    clippy::clone_on_copy,
+    clippy::just_underscores_and_digits,
+    clippy::match_single_binding,
+    clippy::op_ref,
+    clippy::nonminimal_bool,
+    clippy::redundant_clone
 )]
 
 use num::bigint::BigInt;

--- a/rust/template/types/lib.rs
+++ b/rust/template/types/lib.rs
@@ -12,7 +12,25 @@
     unused_variables,
     clippy::unknown_clippy_lints,
     clippy::missing_safety_doc,
-    clippy::match_single_binding
+    clippy::match_single_binding,
+    clippy::ptr_arg,
+    clippy::redundant_closure,
+    clippy::needless_lifetimes,
+    clippy::borrowed_box,
+    clippy::map_clone,
+    clippy::toplevel_ref_arg,
+    clippy::double_parens,
+    clippy::collapsible_if,
+    clippy::clone_on_copy,
+    clippy::unused_unit,
+    clippy::deref_addrof,
+    clippy::clone_on_copy,
+    clippy::needless_return,
+    clippy::op_ref,
+    clippy::match_like_matches_macro,
+    clippy::comparison_chain,
+    clippy::len_zero,
+    clippy::extra_unused_lifetimes
 )]
 
 //use ::serde::de::DeserializeOwned;


### PR DESCRIPTION
- Added a bunch of clippy lint ignores on generated code
- Gated `IDXIDMAPC`, `RELIDMAPC`, `relid2cname()`, `indexid2cname()`, `HDDlog::get_table_cname()` and `HDDlog::get_index_cname()` under the `c_api` feature gate (Missed in #802)
  - Same goal as in #802, non-consumers of the C api don't have to keep extra code they don't need around