### PR TITLE
ddlog-jooq: support inserts and batch queries

### DIFF
--- a/sql/src/main/java/com/vmware/ddlog/DDlogJooqProvider.java
+++ b/sql/src/main/java/com/vmware/ddlog/DDlogJooqProvider.java
@@ -73,8 +73,8 @@ public class DDlogJooqProvider implements MockDataProvider {
     private static final String STRING_TYPE = "java.lang.String";
     private static final String BOOLEAN_TYPE = "java.lang.Boolean";
     private static final String LONG_TYPE = "java.lang.Long";
-    private static final String DDLOG_SOME_TYPE = "ddlog_std::Some";
-    private static final String DDLOG_NONE_TYPE = "ddlog_std::None";
+    private static final String DDLOG_SOME = "ddlog_std::Some";
+    private static final String DDLOG_NONE = "ddlog_std::None";
     private final DDlogAPI dDlogAPI;
     private final DSLContext dslContext;
     private final Field<Integer> updateCountField;
@@ -246,7 +246,7 @@ public class DDlogJooqProvider implements MockDataProvider {
             try {
                 final DDlogRecord[] arr = new DDlogRecord[1];
                 arr[0] = record;
-                return DDlogRecord.makeStruct(DDLOG_SOME_TYPE, arr);
+                return DDlogRecord.makeStruct(DDLOG_SOME, arr);
             } catch (final DDlogException e) {
                 throw new RuntimeException(e);
             }
@@ -258,10 +258,10 @@ public class DDlogJooqProvider implements MockDataProvider {
     @Nullable
     private static Object structToValue(final Field<?> field, final DDlogRecord record) {
         final Class<?> cls = field.getType();
-        if (record.isStruct() && record.getStructName().equals(DDLOG_NONE_TYPE)) {
+        if (record.isStruct() && record.getStructName().equals(DDLOG_NONE)) {
             return null;
         }
-        if (record.isStruct() && record.getStructName().equals(DDLOG_SOME_TYPE)) {
+        if (record.isStruct() && record.getStructName().equals(DDLOG_SOME)) {
             return structToValue(field, record.getStructField(0));
         }
         switch (cls.getName()) {

--- a/sql/src/main/java/com/vmware/ddlog/DDlogJooqProvider.java
+++ b/sql/src/main/java/com/vmware/ddlog/DDlogJooqProvider.java
@@ -5,7 +5,9 @@
 package com.vmware.ddlog;
 
 import ddlogapi.DDlogAPI;
+import ddlogapi.DDlogCommand;
 import ddlogapi.DDlogException;
+import ddlogapi.DDlogRecCommand;
 import ddlogapi.DDlogRecord;
 import org.jooq.DSLContext;
 import org.jooq.Field;
@@ -22,6 +24,7 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 public class DDlogJooqProvider implements MockDataProvider {
@@ -29,7 +32,8 @@ public class DDlogJooqProvider implements MockDataProvider {
     private static final String STRING_TYPE = "java.lang.String";
     private static final String BOOLEAN_TYPE = "java.lang.Boolean";
     private static final String LONG_TYPE = "java.lang.Long";
-
+    private static final String DDLOG_SOME_TYPE = "ddlog_std::Some";
+    private static final String DDLOG_NONE_TYPE = "ddlog_std::None";
     private final DDlogAPI dDlogAPI;
     private final DSLContext dslContext;
     private final Map<String, List<Field<?>>> tables = new HashMap<>();
@@ -52,9 +56,10 @@ public class DDlogJooqProvider implements MockDataProvider {
         final MockResult[] mock = new MockResult[1];
         // The execute context contains SQL string(s), bind values, and other meta-data
         final String sql = ctx.sql();
-
         if (sql.toUpperCase().startsWith("SELECT")) {
             mock[0] = executeSelectStar(sql);
+        } else if (sql.toUpperCase().startsWith("INSERT INTO")) {
+            mock[0] = executeInsert(sql);
         } else {
             // Exceptions are propagated through the JDBC and jOOQ APIs
             throw new SQLException("Statement not supported: " + sql);
@@ -63,12 +68,12 @@ public class DDlogJooqProvider implements MockDataProvider {
     }
 
     private MockResult executeSelectStar(final String sql) throws SQLException {
-        final String[] s = sql.toUpperCase().split(" ");
-        if (!(s.length == 4 && s[1].equals("*") && s[2].equals("FROM"))) {
+        final String[] s = sql.split("[ ]+");
+        if (!(s.length == 4 && s[1].equalsIgnoreCase("*") && s[2].equalsIgnoreCase("FROM"))) {
             throw new SQLException("Statement not supported: " + sql);
         }
         final String tableName = s[3];
-        final List<Field<?>> fields = tables.get(tableName);
+        final List<Field<?>> fields = tables.get(tableName.toUpperCase());
         if (fields == null) {
             throw new SQLException("Unknown table: " + tableName);
         }
@@ -89,13 +94,40 @@ public class DDlogJooqProvider implements MockDataProvider {
         return new MockResult(1, result);
     }
 
+    private MockResult executeInsert(final String sql) throws SQLException {
+        final String[] s = sql.replaceAll("[(),]", "")
+                              .split("[ ]+");
+        if (!(s.length >= 4 && s[1].equalsIgnoreCase("INTO")
+                && s[3].equalsIgnoreCase("VALUES"))) {
+            throw new SQLException("Statement not supported: " + sql);
+        }
+        final String tableName = s[2];
+        final int valuesIndex = 4; // the index representing the 1st field of the value being inserted
+        final List<Field<?>> fields = tables.get(tableName.toUpperCase());
+        if (fields == null) {
+            throw new SQLException("Table cannot be queried: " + tableName);
+        }
+        String[] valuesTuple = Arrays.copyOfRange(s, valuesIndex, s.length);
+        final DDlogRecord dDlogRecord = toDDlogRecord(tableName, valuesTuple);
+        final int tableId = dDlogAPI.getTableId("R" + tableName.toLowerCase());
+        final DDlogRecCommand command = new DDlogRecCommand(DDlogCommand.Kind.Insert, tableId, dDlogRecord);
+        try {
+            dDlogAPI.transactionStart();
+            dDlogAPI.applyUpdates(new DDlogRecCommand[]{command});
+            dDlogAPI.transactionCommit();
+        } catch (final DDlogException e) {
+            e.printStackTrace();
+        }
+        return new MockResult(1, null);
+    }
+
     @Nullable
     private Object structToValue(final Field<?> field, final DDlogRecord record) {
         final Class<?> cls = field.getType();
-        if (record.isStruct() && record.getStructName().equals("ddlog_std::None")) {
+        if (record.isStruct() && record.getStructName().equals(DDLOG_NONE_TYPE)) {
             return null;
         }
-        if (record.isStruct() && record.getStructName().equals("ddlog_std::Some")) {
+        if (record.isStruct() && record.getStructName().equals(DDLOG_SOME_TYPE)) {
             return structToValue(field, record.getStructField(0));
         }
         switch (cls.getName()) {
@@ -109,6 +141,74 @@ public class DDlogJooqProvider implements MockDataProvider {
                 return record.getString();
             default:
                 throw new RuntimeException("Unknown datatype %s of field %s in table %s in update received");
+        }
+    }
+
+    private DDlogRecord toDDlogRecord(final String tableName, final String[] args) {
+        final DDlogRecord[] recordsArray = new DDlogRecord[args.length];
+        final List<Field<?>> fields = tables.get(tableName.toUpperCase());
+
+        int fieldIndex = 0;
+        for (final Field<?> field : fields) {
+            final Class<?> cls = field.getType();
+            try {
+                // Handle nullable columns here
+                if (args[fieldIndex] == null) {
+                    recordsArray[fieldIndex] = DDlogRecord.makeStruct(DDLOG_NONE_TYPE, new DDlogRecord[0]);
+                }
+                else {
+                    switch (cls.getName()) {
+                        case BOOLEAN_TYPE:
+                            recordsArray[fieldIndex] = maybeOption(field,
+                                    new DDlogRecord(Boolean.parseBoolean(args[fieldIndex])));
+                            break;
+                        case INTEGER_TYPE:
+                            recordsArray[fieldIndex] = maybeOption(field,
+                                    new DDlogRecord(Integer.parseInt(args[fieldIndex])));
+                            break;
+                        case LONG_TYPE:
+                            recordsArray[fieldIndex] = maybeOption(field,
+                                    new DDlogRecord(Long.parseLong(args[fieldIndex])));
+                            break;
+                        case STRING_TYPE:
+                            // Strings have to be escaped by single quotes
+                            if (args[fieldIndex].startsWith("'") && args[fieldIndex].endsWith("'")) {
+                                recordsArray[fieldIndex] = maybeOption(field,
+                                        new DDlogRecord(args[fieldIndex].substring(1, args[fieldIndex].length() - 1)));
+                            } else {
+                                throw new RuntimeException("Unexpected string");
+                            }
+                            break;
+                        default:
+                            throw new RuntimeException(String.format("Unknown datatype %s of field %s in table %s" +
+                                            " while sending DB data to DDLog", args[fieldIndex].getClass().getName(),
+                                    field.getName(), tableName));
+                    }
+                }
+            } catch (final DDlogException e) {
+                throw new RuntimeException(e);
+            }
+            fieldIndex = fieldIndex + 1;
+        }
+
+        try {
+            return DDlogRecord.makeStruct("T" + tableName.toLowerCase(Locale.US), recordsArray);
+        } catch (final DDlogException | NullPointerException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public DDlogRecord maybeOption(final Field<?> field, final DDlogRecord record) {
+        if (field.getDataType().nullable()) {
+            try {
+                final DDlogRecord[] arr = new DDlogRecord[1];
+                arr[0] = record;
+                return DDlogRecord.makeStruct(DDLOG_SOME_TYPE, arr);
+            } catch (final DDlogException e) {
+                throw new RuntimeException(e);
+            }
+        } else {
+            return record;
         }
     }
 }

--- a/sql/src/main/java/com/vmware/ddlog/DDlogJooqProvider.java
+++ b/sql/src/main/java/com/vmware/ddlog/DDlogJooqProvider.java
@@ -4,6 +4,21 @@
  */
 package com.vmware.ddlog;
 
+import com.facebook.presto.sql.parser.ParsingOptions;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.tree.AllColumns;
+import com.facebook.presto.sql.tree.AstVisitor;
+import com.facebook.presto.sql.tree.BooleanLiteral;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.Insert;
+import com.facebook.presto.sql.tree.LongLiteral;
+import com.facebook.presto.sql.tree.Query;
+import com.facebook.presto.sql.tree.QuerySpecification;
+import com.facebook.presto.sql.tree.Row;
+import com.facebook.presto.sql.tree.Select;
+import com.facebook.presto.sql.tree.Statement;
+import com.facebook.presto.sql.tree.StringLiteral;
+import com.facebook.presto.sql.tree.Values;
 import ddlogapi.DDlogAPI;
 import ddlogapi.DDlogCommand;
 import ddlogapi.DDlogException;
@@ -25,7 +40,6 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 
 import static org.jooq.impl.DSL.field;
@@ -41,6 +55,10 @@ public class DDlogJooqProvider implements MockDataProvider {
     private final DSLContext dslContext;
     private final Field<Integer> updateCountField;
     private final Map<String, List<Field<?>>> tables = new HashMap<>();
+    private final SqlParser parser = new SqlParser();
+    private final ParsingOptions options = ParsingOptions.builder().build();
+    private final QueryVisitor queryVisitor = new QueryVisitor();
+    private final ParseLiterals parseLiterals = new ParseLiterals();
 
     public DDlogJooqProvider(final DDlogAPI dDlogAPI, final List<String> sqlStatements) {
         this.dDlogAPI = dDlogAPI;
@@ -73,74 +91,127 @@ public class DDlogJooqProvider implements MockDataProvider {
     }
 
     private MockResult execute(final String sql) throws SQLException {
-        if (sql.toUpperCase().startsWith("SELECT")) {
-            return executeSelectStar(sql);
-        } else if (sql.toUpperCase().startsWith("INSERT INTO")) {
-            return executeInsert(sql);
-        } else {
-            // Exceptions are propagated through the JDBC and jOOQ APIs
-            throw new SQLException("Statement not supported: " + sql);
+        final Statement statement = parser.createStatement(sql, options);
+        final MockResult result = queryVisitor.process(statement, sql);
+        if (result == null) {
+            throw new SQLException("Could not execute SQL statement " + sql);
         }
+        return result;
     }
 
-    private MockResult executeSelectStar(final String sql) throws SQLException {
-        final String[] s = sql.split("[ \t\n]+");
-        if (!(s.length == 4 && s[1].equalsIgnoreCase("*") && s[2].equalsIgnoreCase("FROM"))) {
-            throw new SQLException("Statement not supported: " + sql);
+    private class QueryVisitor extends AstVisitor<MockResult, String> {
+        @Override
+        protected MockResult visitQuerySpecification(final QuerySpecification node, String sql) {
+            final Select select = node.getSelect();
+            if (!(select.getSelectItems().size() == 1 && select.getSelectItems().get(0) instanceof AllColumns)) {
+                throw new RuntimeException("Statement not supported: " + sql);
+            }
+            assert node.getFrom().isPresent() && node.getFrom().get() instanceof com.facebook.presto.sql.tree.Table;
+            final String tableName = ((com.facebook.presto.sql.tree.Table) node.getFrom().get()).getName().toString();
+            final List<Field<?>> fields = tables.get(tableName.toUpperCase());
+            if (fields == null) {
+                throw new RuntimeException("Unknown table: " + tableName);
+            }
+            final Result<Record> result = dslContext.newResult(fields);
+            try {
+                dDlogAPI.dumpTable(ddlogRelationName(tableName), (record, l) -> {
+                    final Record jooqRecord = dslContext.newRecord(fields);
+                    final Object[] returnValue = new Object[fields.size()];
+                    for (int i = 0; i < fields.size(); i++) {
+                        returnValue[i] = structToValue(fields.get(i), record.getStructField(i));
+                    }
+                    jooqRecord.fromArray(returnValue);
+                    result.add(jooqRecord);
+                });
+            } catch (final DDlogException e) {
+                throw new RuntimeException(e);
+            }
+            return new MockResult(1, result);
         }
-        final String tableName = s[3];
-        final List<Field<?>> fields = tables.get(tableName.toUpperCase());
-        if (fields == null) {
-            throw new SQLException("Unknown table: " + tableName);
+
+        @Override
+        protected MockResult visitQuery(final Query node, final String context) {
+            final QuerySpecification specification = (QuerySpecification) node.getQueryBody();
+            return visitQuerySpecification(specification, context);
         }
-        final Result<Record> result = dslContext.newResult(fields);
-        try {
-            dDlogAPI.dumpTable("R" + tableName.toLowerCase(), (record, l) -> {
-                final Record jooqRecord = dslContext.newRecord(fields);
-                final Object[] returnValue = new Object[fields.size()];
-                for (int i = 0; i < fields.size(); i++) {
-                    returnValue[i] = structToValue(fields.get(i), record.getStructField(i));
+
+        @Override
+        protected MockResult visitInsert(final Insert node, final String sql) {
+            try {
+                assert node.getQuery().getQueryBody() instanceof Values;
+                final Values values = (Values) node.getQuery().getQueryBody();
+                final String tableName = node.getTarget().toString();
+                final List<Field<?>> fields = tables.get(tableName.toUpperCase());
+                final int tableId = dDlogAPI.getTableId(ddlogRelationName(tableName));
+                for (final Expression row: values.getRows()) {
+                    assert row instanceof Row;
+                    final List<Expression> items = ((Row) row).getItems();
+                    assert items.size() == fields.size();
+                    final DDlogRecord[] recordsArray = new DDlogRecord[items.size()];
+                    for (int i = 0; i < items.size(); i++) {
+                        recordsArray[i] = parseLiterals.process(items.get(i), fields.get(i).getDataType().nullable());
+                    }
+                    final DDlogRecord record = DDlogRecord.makeStruct(ddlogTableTypeName(tableName), recordsArray);
+                    final DDlogRecCommand command = new DDlogRecCommand(DDlogCommand.Kind.Insert, tableId, record);
+                    dDlogAPI.applyUpdates(new DDlogRecCommand[]{command});
                 }
-                jooqRecord.fromArray(returnValue);
-                result.add(jooqRecord);
-            });
-        } catch (final DDlogException e) {
-            throw new SQLException(e);
+                final Result<Record1<Integer>> result = dslContext.newResult(updateCountField);
+                final Record1<Integer> resultRecord = dslContext.newRecord(updateCountField);
+                resultRecord.setValue(updateCountField, values.getRows().size());
+                result.add(resultRecord);
+                return new MockResult(1, result);
+            } catch (DDlogException e) {
+                throw new RuntimeException(e);
+            }
         }
-        return new MockResult(1, result);
     }
 
-    private MockResult executeInsert(final String sql) throws SQLException {
-        final String[] s = sql.replaceAll("[(),]", "")
-                              .split("[ \t\n]+");
-        if (!(s.length >= 4 && s[1].equalsIgnoreCase("INTO")
-                && s[3].equalsIgnoreCase("VALUES"))) {
-            throw new SQLException("Statement not supported: " + sql);
+    private static class ParseLiterals extends AstVisitor<DDlogRecord, Boolean> {
+
+        @Override
+        protected DDlogRecord visitStringLiteral(final StringLiteral node, final Boolean isNullable) {
+            try {
+                return maybeOption(isNullable, new DDlogRecord(node.getValue()));
+            } catch (final DDlogException e) {
+                throw new RuntimeException(e);
+            }
         }
-        final String tableName = s[2];
-        final int valuesIndex = 4; // the index representing the 1st field of the value being inserted
-        final List<Field<?>> fields = tables.get(tableName.toUpperCase());
-        if (fields == null) {
-            throw new SQLException("Table cannot be queried: " + tableName);
+
+        @Override
+        protected DDlogRecord visitLongLiteral(final LongLiteral node, final Boolean isNullable) {
+            return maybeOption(isNullable, new DDlogRecord(node.getValue()));
         }
-        String[] valuesTuple = Arrays.copyOfRange(s, valuesIndex, s.length);
-        final DDlogRecord dDlogRecord = toDDlogRecord(tableName, valuesTuple);
-        final int tableId = dDlogAPI.getTableId("R" + tableName.toLowerCase());
-        final DDlogRecCommand command = new DDlogRecCommand(DDlogCommand.Kind.Insert, tableId, dDlogRecord);
-        try {
-            dDlogAPI.applyUpdates(new DDlogRecCommand[]{command});
-        } catch (final DDlogException e) {
-            throw new RuntimeException(e);
+
+        @Override
+        protected DDlogRecord visitBooleanLiteral(final BooleanLiteral node, final Boolean isNullable) {
+            return maybeOption(isNullable, new DDlogRecord(node.getValue()));
         }
-        final Result<Record1<Integer>> result = dslContext.newResult(updateCountField);
-        final Record1<Integer> resultRecord = dslContext.newRecord(updateCountField);
-        resultRecord.setValue(updateCountField, 1);
-        result.add(resultRecord);
-        return new MockResult(1, result);
+    }
+
+    private static String ddlogTableTypeName(final String tableName) {
+        return "T" + tableName.toLowerCase();
+    }
+
+    private static String ddlogRelationName(final String tableName) {
+        return "R" + tableName.toLowerCase();
+    }
+
+    private static DDlogRecord maybeOption(final Boolean isNullable, final DDlogRecord record) {
+        if (isNullable) {
+            try {
+                final DDlogRecord[] arr = new DDlogRecord[1];
+                arr[0] = record;
+                return DDlogRecord.makeStruct(DDLOG_SOME_TYPE, arr);
+            } catch (final DDlogException e) {
+                throw new RuntimeException(e);
+            }
+        } else {
+            return record;
+        }
     }
 
     @Nullable
-    private Object structToValue(final Field<?> field, final DDlogRecord record) {
+    private static Object structToValue(final Field<?> field, final DDlogRecord record) {
         final Class<?> cls = field.getType();
         if (record.isStruct() && record.getStructName().equals(DDLOG_NONE_TYPE)) {
             return null;
@@ -159,74 +230,6 @@ public class DDlogJooqProvider implements MockDataProvider {
                 return record.getString();
             default:
                 throw new RuntimeException("Unknown datatype %s of field %s in table %s in update received");
-        }
-    }
-
-    private DDlogRecord toDDlogRecord(final String tableName, final String[] args) {
-        final DDlogRecord[] recordsArray = new DDlogRecord[args.length];
-        final List<Field<?>> fields = tables.get(tableName.toUpperCase());
-
-        int fieldIndex = 0;
-        for (final Field<?> field : fields) {
-            final Class<?> cls = field.getType();
-            try {
-                // Handle nullable columns here
-                if (args[fieldIndex] == null) {
-                    recordsArray[fieldIndex] = DDlogRecord.makeStruct(DDLOG_NONE_TYPE, new DDlogRecord[0]);
-                }
-                else {
-                    switch (cls.getName()) {
-                        case BOOLEAN_TYPE:
-                            recordsArray[fieldIndex] = maybeOption(field,
-                                    new DDlogRecord(Boolean.parseBoolean(args[fieldIndex])));
-                            break;
-                        case INTEGER_TYPE:
-                            recordsArray[fieldIndex] = maybeOption(field,
-                                    new DDlogRecord(Integer.parseInt(args[fieldIndex])));
-                            break;
-                        case LONG_TYPE:
-                            recordsArray[fieldIndex] = maybeOption(field,
-                                    new DDlogRecord(Long.parseLong(args[fieldIndex])));
-                            break;
-                        case STRING_TYPE:
-                            // Strings have to be escaped by single quotes
-                            if (args[fieldIndex].startsWith("'") && args[fieldIndex].endsWith("'")) {
-                                recordsArray[fieldIndex] = maybeOption(field,
-                                        new DDlogRecord(args[fieldIndex].substring(1, args[fieldIndex].length() - 1)));
-                            } else {
-                                throw new RuntimeException("Unexpected string");
-                            }
-                            break;
-                        default:
-                            throw new RuntimeException(String.format("Unknown datatype %s of field %s in table %s" +
-                                            " while sending DB data to DDLog", args[fieldIndex].getClass().getName(),
-                                    field.getName(), tableName));
-                    }
-                }
-            } catch (final DDlogException e) {
-                throw new RuntimeException(e);
-            }
-            fieldIndex = fieldIndex + 1;
-        }
-
-        try {
-            return DDlogRecord.makeStruct("T" + tableName.toLowerCase(Locale.US), recordsArray);
-        } catch (final DDlogException | NullPointerException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public DDlogRecord maybeOption(final Field<?> field, final DDlogRecord record) {
-        if (field.getDataType().nullable()) {
-            try {
-                final DDlogRecord[] arr = new DDlogRecord[1];
-                arr[0] = record;
-                return DDlogRecord.makeStruct(DDLOG_SOME_TYPE, arr);
-            } catch (final DDlogException e) {
-                throw new RuntimeException(e);
-            }
-        } else {
-            return record;
         }
     }
 }

--- a/sql/src/test/java/ddlog/JooqProviderTest.java
+++ b/sql/src/test/java/ddlog/JooqProviderTest.java
@@ -8,11 +8,9 @@ import com.vmware.ddlog.DDlogJooqProvider;
 import com.vmware.ddlog.ir.DDlogProgram;
 import com.vmware.ddlog.translator.Translator;
 import ddlogapi.DDlogAPI;
-import ddlogapi.DDlogCommand;
 import ddlogapi.DDlogException;
-import ddlogapi.DDlogRecCommand;
-import ddlogapi.DDlogRecord;
 import org.jooq.DSLContext;
+import org.jooq.Field;
 import org.jooq.Record;
 import org.jooq.Result;
 import org.jooq.impl.DSL;
@@ -27,42 +25,27 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertTrue;
+import static org.jooq.impl.DSL.field;
 
 public class JooqProviderTest {
 
+    /*
+     * We can only have one DDlog program loaded in memory at a time. We
+     * therefore conduct a series of tests within a single method.
+     */
     @Test
-    public void testddlog() throws IOException, DDlogException {
-        final Translator t = new Translator(null);
-        final String s1 = "create table hosts (id integer, capacity integer)";
-        final String v2 = "create view hostsv as select distinct * from hosts";
-        final String v1 = "create view good_hosts as select distinct * from hosts where capacity < 50";
-        t.translateSqlStatement(s1);
-        t.translateSqlStatement(v2);
-        t.translateSqlStatement(v1);
-        final DDlogProgram dDlogProgram = t.getDDlogProgram();
-        writeProgramToFile(dDlogProgram.toString());
-        DDlogAPI.compileDDlogProgram("/tmp/program.dl", true, "../lib", "./lib");
-        DDlogAPI.loadDDlog();
-
-        final DDlogAPI dDlogAPI = new DDlogAPI(1, null, true);
-        final int numInserts = 5;
-        dDlogAPI.transactionStart();
-        for (int i = 0; i < numInserts; i++) {
-            final DDlogRecord rec = new DDlogRecord(i);
-            final DDlogRecord cap = new DDlogRecord(20);
-            final DDlogRecord struct = DDlogRecord.makeStruct("Thosts", rec, cap);
-            final int id = dDlogAPI.getTableId("Rhosts");
-            final DDlogRecCommand command = new DDlogRecCommand(DDlogCommand.Kind.Insert, id, struct);
-            dDlogAPI.applyUpdates(new DDlogRecCommand[]{command});
-        }
-        dDlogAPI.transactionCommit();
-
-        final List<String> ddl = new ArrayList<>();
+    public void testInsertAndSelect() throws IOException, DDlogException {
+        String s1 = "create table hosts (id varchar(36), capacity integer, up boolean)";
+        String v2 = "create view hostsv as select distinct * from hosts";
+        String v1 = "create view good_hosts as select distinct * from hosts where capacity < 10";
+        List<String> ddl = new ArrayList<>();
         ddl.add(s1);
         ddl.add(v2);
         ddl.add(v1);
+        compileAndLoad("testInserts", ddl);
+        final DDlogAPI dDlogAPI = new DDlogAPI(1, null, true);
 
         // Initialise the data provider
         MockDataProvider provider = new DDlogJooqProvider(dDlogAPI, ddl);
@@ -70,17 +53,55 @@ public class JooqProviderTest {
 
         // Pass the mock connection to a jOOQ DSLContext:
         DSLContext create = DSL.using(connection);
-        final Result<Record> fetch = create.fetch("select * from hostsv");
-        assertEquals(numInserts, fetch.size());
-        assertArrayEquals(new int[]{0, 1, 2, 3, 4},
-                          fetch.stream().mapToInt(r -> r.get(0, Integer.class)).toArray());
+
+        // Test 1: insert statements
+        create.execute("insert into hosts values ('n1', 10, true)");
+        create.batch("insert into hosts values ('n54', 18, false)",
+                     "insert into hosts values ('n9', 2, true)");
+        final Field<String> field1 = field("id", String.class);
+        final Field<Integer> field2 = field("capacity", Integer.class);
+        final Field<Boolean> field3 = field("up", Boolean.class);
+
+        final Record test1 = create.newRecord(field1, field2, field3);
+        final Record test2 = create.newRecord(field1, field2, field3);
+        final Record test3 = create.newRecord(field1, field2, field3);
+
+        test1.setValue(field1, "n1");
+        test1.setValue(field2, 10);
+        test1.setValue(field3, true);
+
+        test2.setValue(field1, "n54");
+        test2.setValue(field2, 18);
+        test2.setValue(field3, false);
+
+        test3.setValue(field1, "n9");
+        test3.setValue(field2, 2);
+        test3.setValue(field3, true);
+
+        // Test 2: make sure selects read out the same content inserted above
+        final Result<Record> hostsvResults = create.fetch("select * from hostsv");
+        assertTrue(hostsvResults.contains(test1));
+        assertTrue(hostsvResults.contains(test2));
+        assertTrue(hostsvResults.contains(test3));
+
+        final Result<Record> goodHostsResults = create.fetch("select * from good_hosts");
+        assertFalse(goodHostsResults.contains(test1));
+        assertFalse(goodHostsResults.contains(test2));
+        assertTrue(goodHostsResults.contains(test3));
     }
 
-    public static File writeProgramToFile(String programBody) throws IOException {
-        File tmp = new File("/tmp/program.dl");
+    public static void compileAndLoad(final String name, final List<String> ddl) throws IOException, DDlogException {
+        final Translator t = new Translator(null);
+        ddl.forEach(t::translateSqlStatement);
+        final DDlogProgram dDlogProgram = t.getDDlogProgram();
+        final String fileName = String.format("/tmp/%s.dl", name);
+        File tmp = new File(fileName);
         BufferedWriter bw = new BufferedWriter(new FileWriter(tmp));
-        bw.write(programBody);
+        bw.write(dDlogProgram.toString());
         bw.close();
-        return tmp;
+        if (!DDlogAPI.compileDDlogProgram(fileName, true, "../lib", "./lib")) {
+            throw new RuntimeException("Failed to compile ddlog program");
+        }
+        DDlogAPI.loadDDlog();
     }
 }

--- a/sql/src/test/java/ddlog/JooqProviderTest.java
+++ b/sql/src/test/java/ddlog/JooqProviderTest.java
@@ -54,10 +54,12 @@ public class JooqProviderTest {
         // Pass the mock connection to a jOOQ DSLContext:
         DSLContext create = DSL.using(connection);
 
-        // Test 1: insert statements
-        create.execute("insert into hosts values ('n1', 10, true)");
+        // Test 1: insert statements.
+        // We test single inserts as well as batch statements. We also test different
+        // kinds of whitespace (the \n below is deliberate).
+        create.execute("insert into \nhosts values ('n1', 10, true)");
         create.batch("insert into hosts values ('n54', 18, false)",
-                     "insert into hosts values ('n9', 2, true)");
+                     "insert into hosts values ('n9', 2, true)").execute();
         final Field<String> field1 = field("id", String.class);
         final Field<Integer> field2 = field("capacity", Integer.class);
         final Field<Boolean> field3 = field("up", Boolean.class);


### PR DESCRIPTION
This patch adds support for simple insert queries and batch queries via a jooq connection.