### PR TITLE
ddlog-jooq: support SQL Delete statements

### DIFF
--- a/sql/src/main/java/com/vmware/ddlog/DDlogJooqProvider.java
+++ b/sql/src/main/java/com/vmware/ddlog/DDlogJooqProvider.java
@@ -95,6 +95,10 @@ public class DDlogJooqProvider implements MockDataProvider {
         this.dDlogAPI = dDlogAPI;
         this.dslContext = DSL.using("jdbc:h2:mem:");
         this.updateCountField = field("UPDATE_COUNT", Integer.class);
+
+        // We translate DDL statements from the Presto dialect to H2.
+        // We then execute these statements in a temporary database so that JOOQ can extract useful metadata
+        // that we will use later (for example, the record types for views).
         for (final String sql : sqlStatements) {
             final Statement statement = parser.createStatement(sql, options);
             final String statementInH2Dialect = translateCreateTableDialect.process(statement, sql);

--- a/sql/src/main/java/com/vmware/ddlog/DDlogJooqProvider.java
+++ b/sql/src/main/java/com/vmware/ddlog/DDlogJooqProvider.java
@@ -72,6 +72,10 @@ import static org.jooq.impl.DSL.field;
  *                        "create view T as ..." that is passed to the  DdlogJooqProvider.
  *   A2. "insert into T values (<row>)" where T is a base table. That is, there should be a corresponding
  *                                     "create table T..." DDL statement that is passed to the DDlogJooqProvider.
+ *   A3. "delete from T where P1 = A and P2 = B..." where T is a base table and P1, P2... are columns in T's
+ *                                         primary key. That is, there should be a corresponding
+ *                                        "create table T..." DDL statement that is passed to the DDlogJooqProvider
+ *                                         where P1, P2... etc are columns in T's primary key.
  */
 public class DDlogJooqProvider implements MockDataProvider {
     private static final String INTEGER_TYPE = "java.lang.Integer";
@@ -224,6 +228,8 @@ public class DDlogJooqProvider implements MockDataProvider {
 
         @Override
         protected MockResult visitDelete(final Delete node, final String sql) {
+            // The assertions below, and in the ParseWhereClauseForDeletes visitor encode assumption A3
+            // (see javadoc for the DDlogJooqProvider class)
             final String tableName = node.getTable().getName().toString();
             if (!node.getWhere().isPresent()) {
                 throw new RuntimeException("Delete queries without where clauses are unsupported: " + sql);

--- a/sql/src/main/java/com/vmware/ddlog/TranslateCreateTableDialect.java
+++ b/sql/src/main/java/com/vmware/ddlog/TranslateCreateTableDialect.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018-2020 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: BSD-2
+ */
+
+package com.vmware.ddlog;
+
+import com.facebook.presto.sql.tree.AstVisitor;
+import com.facebook.presto.sql.tree.ColumnDefinition;
+import com.facebook.presto.sql.tree.CreateTable;
+import com.facebook.presto.sql.tree.CreateView;
+import com.facebook.presto.sql.tree.TableElement;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class TranslateCreateTableDialect extends AstVisitor<String, String> {
+    @Override
+    protected String visitCreateTable(final CreateTable node, final String sql) {
+        final List<String> primaryKeyColumns = new ArrayList<>();
+        final List<String> columnsToCreate = new ArrayList<>();
+        for (final TableElement element : node.getElements()) {
+            if (element instanceof ColumnDefinition) {
+                final ColumnDefinition cd = (ColumnDefinition) element;
+                if (cd.getProperties().size() == 1) {
+                    final String propertyName = cd.getProperties().get(0).getName().getValue();
+                    final String propertyValue = cd.getProperties().get(0).getValue().toString();
+                    if (propertyName.equals("primary_key") && propertyValue.equals("true")) {
+                        primaryKeyColumns.add(cd.getName().getValue());
+                    } else {
+                        throw new RuntimeException(String.format("Unsupported property %s in sql: %s",
+                                propertyName, sql));
+                    }
+                }
+                if (cd.getProperties().size() > 1) {
+                    throw new RuntimeException(String.format("Unsupported properties %s in sql: %s",
+                            cd.getProperties(), sql));
+                }
+                columnsToCreate.add(String.format("%s %s", cd.getName().getValue(), cd.getType()));
+            }
+        }
+
+        final String columns = String.join(", ", columnsToCreate);
+        if (primaryKeyColumns.size() > 0) {
+            final String primaryKeyColumnsStr = String.join(", ", primaryKeyColumns);
+            return String.format("create table %s (%s, primary key (%s))", node.getName().toString(), columns,
+                    primaryKeyColumnsStr);
+        } else {
+            return String.format("create table %s (%s)", node.getName().toString(), columns);
+        }
+    }
+
+    @Override
+    protected String visitCreateView(final CreateView node, final String sql) {
+        return sql;
+    }
+}

--- a/sql/src/test/java/ddlog/JooqProviderTest.java
+++ b/sql/src/test/java/ddlog/JooqProviderTest.java
@@ -37,7 +37,7 @@ public class JooqProviderTest {
      */
     @Test
     public void testInsertAndSelect() throws IOException, DDlogException {
-        String s1 = "create table hosts (id varchar(36), capacity integer, up boolean)";
+        String s1 = "create table hosts (id varchar(36) with (primary_key = true), capacity integer, up boolean)";
         String v2 = "create view hostsv as select distinct * from hosts";
         String v1 = "create view good_hosts as select distinct * from hosts where capacity < 10";
         List<String> ddl = new ArrayList<>();
@@ -90,6 +90,8 @@ public class JooqProviderTest {
         assertFalse(goodHostsResults.contains(test1));
         assertFalse(goodHostsResults.contains(test2));
         assertTrue(goodHostsResults.contains(test3));
+
+        // Test 3: make sure selects read out the same content inserted above
     }
 
     public static void compileAndLoad(final String name, final List<String> ddl) throws IOException, DDlogException {


### PR DESCRIPTION
Adds support for Delete statements of the form `delete from T where <condition>`. The condition has to be a series of equality checks, separated by ANDs, for each of the columns that are part of T's primary key.