### PR TITLE
Fast serialization of sql records

### DIFF
--- a/java/ddlogapi/DDlogAPI.java
+++ b/java/ddlogapi/DDlogAPI.java
@@ -39,6 +39,10 @@ public class DDlogAPI {
     static native void ddlog_enable_cpu_profiling(long hprog, boolean enable) throws DDlogException;
     static native long ddlog_log_replace_callback(int module, long old_cbinfo, ObjIntConsumer<String> cb, int max_level);
     static native long ddlog_log_replace_default_callback(long old_cbinfo, ObjIntConsumer<String> cb, int max_level);
+    // These methods are here for supporting the SQL-to-DDlog compiler.
+    // Returns a handle to a ddlog_record.
+    public static native long ddlog_create_sql_record(byte[] buffer) throws DDlogException;
+    public static native byte[] ddlog_encode_record(long handle) throws DDlogException;
 
     static native void ddlog_free(long handle);
 
@@ -805,17 +809,23 @@ public class DDlogAPI {
 
     static boolean loaded = false;
 
+    public static void loadLibrary() {
+        if (loaded)
+            return;
+        final Path libraryPath = Paths.get(libName(ddlogLibrary)).toAbsolutePath();
+        System.load(libraryPath.toString());
+    }
+
     /**
      * Load the the ddlogLibrary in the current process.
      * @return The API that can be used to interact with this library.
      */
     public static DDlogAPI loadDDlog() throws DDlogException {
         if (loaded)
-            throw new RuntimeException("Attempt to load a secon dddlog library. "
+            throw new RuntimeException("Attempt to load a second dddlog library. "
                     + " Only one library can be loaded safely.");
+        loadLibrary();
         loaded = true;
-        final Path libraryPath = Paths.get(libName(ddlogLibrary)).toAbsolutePath();
-        System.load(libraryPath.toString());
         return new ddlogapi.DDlogAPI(1, null, false);
     }
 }

--- a/java/ddlogapi/DDlogRecord.java
+++ b/java/ddlogapi/DDlogRecord.java
@@ -57,7 +57,7 @@ public class DDlogRecord {
         return this.handle;
     }
 
-    private static DDlogRecord fromHandle(long handle) {
+    public static DDlogRecord fromHandle(long handle) {
         DDlogRecord result = new DDlogRecord();
         if (handle == 0)
             throw new RuntimeException("Received invalid handle.");
@@ -70,7 +70,7 @@ public class DDlogRecord {
      * Creates an object where the handle is shared with other
      * objects.
      */
-    static DDlogRecord fromSharedHandle(long handle) {
+    public static DDlogRecord fromSharedHandle(long handle) {
         DDlogRecord result = fromHandle(handle);
         result.shared = true;
         return result;
@@ -297,7 +297,7 @@ public class DDlogRecord {
             throw new RuntimeException("Unexpected error in DDlogAPI.ddlog_get_int()");
         return new BigInteger(buf);
     }
-
+    
     public int getTupleSize() {
         if (!DDlogAPI.ddlog_is_tuple(this.checkHandle()))
             throw new RuntimeException("Value is not a tuple");
@@ -426,9 +426,7 @@ public class DDlogRecord {
         }
 
         if (DDlogAPI.ddlog_is_string(this.handle)) {
-            String s = DDlogAPI.ddlog_get_str(this.handle);
-            // TODO: this should escape some characters...
-            return "\"" + s + "\"";
+            return DDlogAPI.ddlog_get_str(this.handle);
         }
 
         StringBuilder builder = new StringBuilder();

--- a/sql/install-ddlog-jar.sh
+++ b/sql/install-ddlog-jar.sh
@@ -1,4 +1,17 @@
-#!/bin/sh
+#!/bin/bash
 
-cd ../java
+pushd ../java
+make
 mvn install:install-file -Dfile=ddlogapi.jar -DgroupId=ddlog -DartifactId=ddlogapi -Dversion=0.1 -Dpackaging=jar
+popd
+## Generate flatbuf API for sqlRecord
+#cd lib
+#ddlog -i sqlRecord.dl -j
+#mkdir -p sqlRecord_ddlog/flatbuf/src/main
+#mv sqlRecord_ddlog/flatbuf/java sqlRecord_ddlog/flatbuf/src/main
+#cp sqlRecord-pom.xml sqlRecord_ddlog/flatbuf/pom.xml
+#pushd sqlRecord_ddlog/flatbuf || exit 1
+#mvn package
+#mvn install:install-file -Dfile=target/sqlRecord-1.0.jar -DgroupId=ddlog -DartifactId=sqlRecord -Dversion=1.0 -Dpackaging=jar
+#popd
+#

--- a/sql/src/main/java/com/vmware/ddlog/ir/DDlogProgram.java
+++ b/sql/src/main/java/com/vmware/ddlog/ir/DDlogProgram.java
@@ -13,6 +13,7 @@ package com.vmware.ddlog.ir;
 
 import com.vmware.ddlog.util.Linq;
 
+import javax.annotation.Nullable;
 import java.io.FileNotFoundException;
 import java.io.PrintWriter;
 import java.util.ArrayList;
@@ -79,6 +80,14 @@ public class DDlogProgram extends DDlogNode {
             if (!this.imports.get(i).compare(other.imports.get(i), policy))
                 return false;
         return true;
+    }
+
+    @Nullable
+    public DDlogRelationDeclaration getRelation(String name) {
+        for (DDlogRelationDeclaration d: this.relations)
+            if (d.getName().equals(name))
+                return d;
+        return null;
     }
 
     public void toFile(String filename) throws FileNotFoundException {

--- a/sql/src/main/java/com/vmware/ddlog/ir/DDlogRelationDeclaration.java
+++ b/sql/src/main/java/com/vmware/ddlog/ir/DDlogRelationDeclaration.java
@@ -71,6 +71,13 @@ public class DDlogRelationDeclaration extends DDlogNode {
         return this.type;
     }
 
+    @Nullable
+    public DDlogType getPrimaryKeyType() {
+        if (this.keyExpression != null)
+            return this.keyExpression.type;
+        return null;
+    }
+
     public static String relationName(String name) {
         return "R" + name;
     }

--- a/sql/src/main/java/com/vmware/ddlog/ir/DDlogType.java
+++ b/sql/src/main/java/com/vmware/ddlog/ir/DDlogType.java
@@ -38,7 +38,6 @@ public abstract class DDlogType extends DDlogNode {
      * True if the given type is a numeric type.
      * @param type  Type to analyze.
      */
-    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     public static boolean isNumeric(DDlogType type) {
         return type instanceof IsNumericType;
     }

--- a/sql/src/main/java/com/vmware/ddlog/ir/SqlRecord.java
+++ b/sql/src/main/java/com/vmware/ddlog/ir/SqlRecord.java
@@ -1,0 +1,171 @@
+package com.vmware.ddlog.ir;
+
+import ddlogapi.DDlogAPI;
+import ddlogapi.DDlogException;
+import ddlogapi.DDlogRecord;
+
+import javax.annotation.Nullable;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * This class is a simplified form of DDlogRecord optimized for SQL datatypes only.
+ */
+public class SqlRecord {
+    public final String constructor;
+    private final Object[] data;
+    private int index;
+    public final byte[] encodings;
+
+    SqlRecord(String constructor, int capacity, byte[] encodings) {
+        this.constructor = constructor;
+        this.data = new Object[capacity];
+        this.encodings = encodings.clone();
+        this.index = 0;
+        if (capacity > Byte.MAX_VALUE)
+            throw new RuntimeException("Record too large: " + capacity);
+    }
+
+    protected static String getString(ByteBuffer buffer, int size) {
+        String s = new String(buffer.array(), buffer.position(), size);
+        buffer.position(buffer.position() + size);
+        return s;
+    }
+
+    public SqlRecord(byte[] data) {
+        ByteBuffer bs = ByteBuffer.wrap(data);
+        if (ByteOrder.nativeOrder().equals(ByteOrder.BIG_ENDIAN))
+            bs.order(ByteOrder.BIG_ENDIAN);
+        else
+            bs.order(ByteOrder.LITTLE_ENDIAN);
+        int capacity = bs.getInt();
+        this.data = new Object[capacity];
+        this.encodings = new byte[capacity];
+        bs.get(this.encodings);
+        int size = bs.getInt();
+        this.constructor = getString(bs, size);
+        for (int i = 0; i < capacity; i++) {
+            byte enc = this.encodings[i];
+            if ((enc & DDlogTStruct.Kind.Null.encoding) != 0) {
+                this.data[i] = null;
+                continue;
+            }
+            enc &= 0x3F;
+            if (enc == DDlogTStruct.Kind.Bool.encoding) {
+                this.data[i] = bs.get() == 1;
+            } else if (enc == DDlogTStruct.Kind.Long.encoding) {
+                this.data[i] = bs.getLong();
+            } else if (enc == DDlogTStruct.Kind.String.encoding) {
+                size = bs.getInt();
+                this.data[i] = getString(bs, size);
+            } else {
+                throw new RuntimeException("Unexpected encoding: 0x" + Integer.toHexString(this.encodings[i]));
+            }
+        }
+        if (bs.position() != bs.capacity())
+            throw new RuntimeException("Not all data consumed");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SqlRecord sqlRecord = (SqlRecord) o;
+        return constructor.equals(sqlRecord.constructor) &&
+                Arrays.equals(data, sqlRecord.data);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(constructor);
+        result = 31 * result + Arrays.hashCode(data);
+        return result;
+    }
+
+    public int capacity() {
+        return this.data.length;
+    }
+
+    private void checkNull(@Nullable Object o) {
+        if (o == null)
+            this.encodings[this.index] |= DDlogTStruct.Kind.Null.encoding;
+    }
+
+    public void add(@Nullable Object i) {
+        this.checkNull(i);
+        this.data[this.index++] = i;
+    }
+
+    public byte[] getEncoding() {
+        if (this.index != this.capacity())
+            throw new RuntimeException("Object has " + this.capacity() + " size, but only " +
+                    this.index + " fields are present");
+        // First pass: compute buffer size
+        int size = 0;
+        size += 4; // capacity
+        size += this.encodings.length;
+        byte[] constructor = this.constructor.getBytes();
+        byte[][] bufs = new byte[this.capacity()][];
+        size += 4 + constructor.length;
+        for (int i = 0; i < this.data.length; i++) {
+            Object o = this.data[i];
+            if (o == null)
+                continue;
+            byte enc = (byte)(this.encodings[i] & 0x3F);
+            if (enc == DDlogTStruct.Kind.Bool.encoding) {
+                size += 1;
+            } else if (enc == DDlogTStruct.Kind.Long.encoding) {
+                size += 8;
+            } else if (enc == DDlogTStruct.Kind.String.encoding) {
+                bufs[i] = ((String)o).getBytes();
+                size += 4 + bufs[i].length;
+            } else {
+                throw new RuntimeException("Unhandled type " + o.getClass());
+            }
+        }
+
+        ByteBuffer bb = ByteBuffer.allocate(size);
+        if (ByteOrder.nativeOrder().equals(ByteOrder.BIG_ENDIAN))
+            bb.order(ByteOrder.BIG_ENDIAN);
+        else
+            bb.order(ByteOrder.LITTLE_ENDIAN);
+        bb.putInt(this.capacity());
+        bb.put(this.encodings);
+        bb.putInt(constructor.length);
+        bb.put(constructor);
+        for (int i = 0; i < this.data.length; i++) {
+            Object o = this.data[i];
+            byte enc = (byte)(this.encodings[i] & 0x3F);
+            if (o == null) {
+                assert (this.encodings[i] & DDlogTStruct.Kind.Nullable.encoding) != 0;
+                this.encodings[i] |= DDlogTStruct.Kind.Null.encoding;
+                continue;
+            }
+            if (enc == DDlogTStruct.Kind.Bool.encoding) {
+                bb.put((byte)((Boolean)o ? 1 : 0));
+            } else if (enc == DDlogTStruct.Kind.Long.encoding) {
+                bb.putLong((long)o);
+            } else if (enc == DDlogTStruct.Kind.String.encoding) {
+                bb.putInt(bufs[i].length);
+                bb.put(bufs[i]);
+            } else {
+                throw new RuntimeException("Unhandled type " + o.getClass());
+            }
+        }
+        return bb.array();
+    }
+
+    @Nullable
+    public Object getData(int index) {
+        return this.data[index];
+    }
+
+    public DDlogRecord createRecord() throws DDlogException {
+        byte[] encoding = this.getEncoding();
+        System.out.println();
+        long handle = DDlogAPI.ddlog_create_sql_record(encoding);
+        return DDlogRecord.fromHandle(handle);
+    }
+}

--- a/sql/src/test/java/ddlog/DynamicTest.java
+++ b/sql/src/test/java/ddlog/DynamicTest.java
@@ -45,8 +45,8 @@ public class DynamicTest extends BaseQueriesTest {
 
     @Test
     public void testDynamicLoading() throws IOException, DDlogException {
-        if (!runSlowTests)
-            return;
+        //if (!runSlowTests)
+        //    return;
         String ddlogProgram = "import sql\n" + // not needed, but we test the libraries too
                 "import sqlop\n" +
                 "input relation R(v: bit<16>)\n" +

--- a/sql/src/test/java/ddlog/SqlRecordTest.java
+++ b/sql/src/test/java/ddlog/SqlRecordTest.java
@@ -1,0 +1,185 @@
+package ddlog;
+
+import com.vmware.ddlog.ir.*;
+import ddlogapi.DDlogAPI;
+import ddlogapi.DDlogException;
+import ddlogapi.DDlogRecord;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SqlRecordTest {
+    @Test
+    public void sqlRecordTest() {
+        List<DDlogField> fields = new ArrayList<DDlogField>();
+        fields.add(new DDlogField(null,"s", DDlogTString.instance));
+        fields.add(new DDlogField(null,"x", DDlogTSigned.signed64));
+        fields.add(new DDlogField(null,"b", DDlogTBool.instance));
+        DDlogTStruct struct = new DDlogTStruct(null, "table", fields);
+        SqlRecord rec = struct.createEmptyRecord();
+        rec.add("String");
+        rec.add(2L);
+        rec.add(true);
+        byte[] encoding = rec.getEncoding();
+        SqlRecord rec1 = new SqlRecord(encoding);
+        Assert.assertEquals(rec.capacity(), rec1.capacity());
+        Assert.assertEquals(rec.constructor, rec1.constructor);
+        Assert.assertEquals("String", rec1.getData(0));
+        Assert.assertEquals(2L, rec1.getData(1));
+        Assert.assertEquals(true, rec1.getData(2));
+    }
+
+    @Test
+    public void sqlRecordTestNullable() {
+        List<DDlogField> fields = new ArrayList<DDlogField>();
+        fields.add(new DDlogField(null,"s", DDlogTString.instance.setMayBeNull(true)));
+        fields.add(new DDlogField(null,"x", DDlogTSigned.signed64.setMayBeNull(true)));
+        fields.add(new DDlogField(null,"b", DDlogTBool.instance.setMayBeNull(true)));
+        DDlogTStruct struct = new DDlogTStruct(null, "table", fields);
+        SqlRecord rec = struct.createEmptyRecord();
+        rec.add("String");
+        rec.add(2L);
+        rec.add(true);
+        byte[] encoding = rec.getEncoding();
+        SqlRecord rec1 = new SqlRecord(encoding);
+        Assert.assertEquals(rec.capacity(), rec1.capacity());
+        Assert.assertEquals(rec.constructor, rec1.constructor);
+        Assert.assertEquals("String", rec1.getData(0));
+        Assert.assertEquals(2L, rec1.getData(1));
+        Assert.assertEquals(true, rec1.getData(2));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void notEnoughFieldsTest() {
+        List<DDlogField> fields = new ArrayList<DDlogField>();
+        fields.add(new DDlogField(null,"s", DDlogTString.instance));
+        fields.add(new DDlogField(null,"x", DDlogTSigned.signed64));
+        fields.add(new DDlogField(null,"b", DDlogTBool.instance));
+        DDlogTStruct struct = new DDlogTStruct(null, "table", fields);
+        SqlRecord rec = struct.createEmptyRecord();
+        rec.add("String");
+        rec.add(2L);
+        rec.getEncoding();
+    }
+
+    @Test(expected = ClassCastException.class)
+    public void wrongDataTest() {
+        List<DDlogField> fields = new ArrayList<DDlogField>();
+        fields.add(new DDlogField(null,"s", DDlogTString.instance));
+        fields.add(new DDlogField(null,"x", DDlogTSigned.signed64));
+        fields.add(new DDlogField(null,"b", DDlogTBool.instance));
+        DDlogTStruct struct = new DDlogTStruct(null, "table", fields);
+        SqlRecord rec = struct.createEmptyRecord();
+        rec.add("String");
+        rec.add(2L);
+        rec.add(3L);
+        rec.getEncoding();
+    }
+
+    @Test
+    public void sqlRecordTestNull() {
+        List<DDlogField> fields = new ArrayList<DDlogField>();
+        fields.add(new DDlogField(null,"s", DDlogTString.instance.setMayBeNull(true)));
+        fields.add(new DDlogField(null,"x", DDlogTSigned.signed64.setMayBeNull(true)));
+        DDlogTStruct struct = new DDlogTStruct(null, "table", fields);
+        SqlRecord rec = struct.createEmptyRecord();
+        rec.add(null);
+        rec.add(null);
+        byte[] encoding = rec.getEncoding();
+        SqlRecord rec1 = new SqlRecord(encoding);
+        Assert.assertEquals(rec.capacity(), rec1.capacity());
+        Assert.assertEquals(rec.constructor, rec1.constructor);
+        Assert.assertNull(rec1.getData(0));
+        Assert.assertNull(rec1.getData(1));
+    }
+
+    @Test
+    public void sqlRecordTestSomeNull() {
+        List<DDlogField> fields = new ArrayList<DDlogField>();
+        fields.add(new DDlogField(null,"s", DDlogTString.instance.setMayBeNull(true)));
+        fields.add(new DDlogField(null,"x", DDlogTSigned.signed64));
+        fields.add(new DDlogField(null,"b", DDlogTBool.instance.setMayBeNull(true)));
+        DDlogTStruct struct = new DDlogTStruct(null, "table", fields);
+        SqlRecord rec = struct.createEmptyRecord();
+        rec.add(null);
+        rec.add(3L);
+        rec.add(null);
+        byte[] encoding = rec.getEncoding();
+        SqlRecord rec1 = new SqlRecord(encoding);
+        Assert.assertEquals(rec.capacity(), rec1.capacity());
+        Assert.assertEquals(rec.constructor, rec1.constructor);
+        Assert.assertNull(rec1.getData(0));
+        Assert.assertEquals(3L, rec1.getData(1));
+        Assert.assertNull(rec1.getData(2));
+    }
+
+    @Test
+    public void sqlToDDlogRecordTest() throws DDlogException {
+        DDlogAPI.loadLibrary();
+        List<DDlogField> fields = new ArrayList<DDlogField>();
+        fields.add(new DDlogField(null,"s", DDlogTString.instance));
+        fields.add(new DDlogField(null,"x", DDlogTSigned.signed64));
+        fields.add(new DDlogField(null,"b", DDlogTBool.instance));
+        DDlogTStruct struct = new DDlogTStruct(null, "table", fields);
+        SqlRecord rec = struct.createEmptyRecord();
+        rec.add("String");
+        rec.add(2L);
+        rec.add(true);
+        DDlogRecord ddrec = rec.createRecord();
+        Assert.assertNotNull(ddrec);
+        Assert.assertTrue(ddrec.isStruct());
+        Assert.assertEquals(rec.constructor, ddrec.getStructName());
+        Assert.assertEquals(rec.getData(0), ddrec.getStructField(0).getString());
+        Assert.assertEquals(rec.getData(1), ddrec.getStructField(1).getInt().longValue());
+        Assert.assertEquals(rec.getData(2), ddrec.getStructField(2).getBoolean());
+    }
+
+    @Test
+    public void sqlToDDlogRecordTestNullable() throws DDlogException {
+        DDlogAPI.loadLibrary();
+        List<DDlogField> fields = new ArrayList<DDlogField>();
+        fields.add(new DDlogField(null,"s", DDlogTString.instance.setMayBeNull(true)));
+        fields.add(new DDlogField(null,"x", DDlogTSigned.signed64.setMayBeNull(true)));
+        fields.add(new DDlogField(null,"b", DDlogTBool.instance.setMayBeNull(true)));
+        DDlogTStruct struct = new DDlogTStruct(null, "table", fields);
+        SqlRecord rec = struct.createEmptyRecord();
+        rec.add("String");
+        rec.add(2L);
+        rec.add(true);
+        DDlogRecord ddrec = rec.createRecord();
+        Assert.assertNotNull(ddrec);
+        Assert.assertTrue(ddrec.isStruct());
+        Assert.assertEquals(rec.constructor, ddrec.getStructName());
+        Assert.assertEquals(rec.getData(0), ddrec.getStructField(0).getStructField(0).getString());
+        Assert.assertEquals(rec.getData(1), ddrec.getStructField(1).getStructField(0).getInt().longValue());
+        Assert.assertEquals(rec.getData(2), ddrec.getStructField(2).getStructField(0).getBoolean());
+    }
+
+    void showByteArray(byte[] data) {
+        for (byte b: data)
+            System.out.print(Integer.toHexString(b) + " ");
+        System.out.println();
+    }
+
+    @Test
+    public void twoWayConversion() throws DDlogException {
+        DDlogAPI.loadLibrary();
+        List<DDlogField> fields = new ArrayList<DDlogField>();
+        fields.add(new DDlogField(null,"s", DDlogTString.instance));
+        fields.add(new DDlogField(null,"x", DDlogTSigned.signed64));
+        fields.add(new DDlogField(null,"b", DDlogTBool.instance));
+        DDlogTStruct struct = new DDlogTStruct(null, "table", fields);
+        SqlRecord rec = struct.createEmptyRecord();
+        rec.add("String");
+        rec.add(2L);
+        rec.add(true);
+        byte[] original = rec.getEncoding();
+        DDlogRecord ddrec = rec.createRecord();
+        byte[] encoding = DDlogAPI.ddlog_encode_record(ddrec.getHandleAndInvalidate());
+        Assert.assertArrayEquals(original, encoding);
+        SqlRecord rec1 = new SqlRecord(encoding);
+        Assert.assertEquals(rec, rec1);
+    }
+}


### PR DESCRIPTION
This commit introduces a more efficient way to move data from/to Java when using "SqlRecords" - these are structs with possibly nullable base types as fields. This is implemented by serializing the objects manually into byte[] and transferring the byte[] in a single JNI call, then deserializing it into a DDlogRecord. The reverse path is also supported.

This is a subset of what the flatbufs offers, but the flatbufs do not generate APIs to manipulate records, but rather collections.

Currently the SqlRecord lives in the src project, while the serialization support is in DDlogAPI. This is arguably wrong, we should choose one of the two locations. But this PR is here mostly to solicit an initial review.

We also need to support more base types and probably Tuples as well (needed for primary-key based operation).

The normal way to use the SqlRecord is shown in the test `createREcordFromRelation`:
```Java
        Translator t = this.createInputTables(false);
        DDlogProgram ddprogram = t.getDDlogProgram();
        DDlogRelationDeclaration decl = ddprogram.getRelation("Rt2");
        Assert.assertNotNull(decl);
        DDlogType type = decl.getType();
        DDlogTStruct ts = t.resolveType(type).to(DDlogTStruct.class);
        SqlRecord rec = ts.createEmptyRecord();
        rec.add(2L);
```