### PR TITLE
jooq-ddlog: migrate away from dumpTables and use incremental API

### DIFF
--- a/sql/src/main/java/com/vmware/ddlog/DDlogJooqProvider.java
+++ b/sql/src/main/java/com/vmware/ddlog/DDlogJooqProvider.java
@@ -382,6 +382,7 @@ public class DDlogJooqProvider implements MockDataProvider {
         if (isStruct) {
             final String structName = record.getStructName();
             if (structName.equals(DDLOG_NONE)) {
+                jooqRecord.setValue(field,null);
                 return;
             }
             if (structName.equals(DDLOG_SOME)) {

--- a/sql/src/main/java/com/vmware/ddlog/DDlogJooqProvider.java
+++ b/sql/src/main/java/com/vmware/ddlog/DDlogJooqProvider.java
@@ -144,7 +144,7 @@ public class DDlogJooqProvider implements MockDataProvider {
     private void onChange(final DDlogCommand<DDlogRecord> command) {
         final int relationId = command.relid();
         final String relationName = dDlogAPI.getTableName(relationId);
-        final String tableName = relationName.substring(1).toUpperCase();
+        final String tableName = relationNameToTableName(relationName);
         final List<Field<?>> fields = tablesToFields.get(tableName);
         final DDlogRecord record = command.value();
         final Record jooqRecord = dslContext.newRecord(fields);
@@ -356,6 +356,13 @@ public class DDlogJooqProvider implements MockDataProvider {
      */
     private static String ddlogRelationName(final String tableName) {
         return "R" + tableName.toLowerCase();
+    }
+
+    /*
+     * This corresponds to the naming convention followed by the SQL -> DDlog compiler
+     */
+    private static String relationNameToTableName(final String relationName) {
+        return relationName.substring(1).toUpperCase();
     }
 
     /*

--- a/sql/src/test/java/ddlog/JooqProviderTest.java
+++ b/sql/src/test/java/ddlog/JooqProviderTest.java
@@ -45,7 +45,7 @@ public class JooqProviderTest {
         ddl.add(v2);
         ddl.add(v1);
         compileAndLoad(ddl);
-        final DDlogAPI dDlogAPI = new DDlogAPI(1, null, true);
+        final DDlogAPI dDlogAPI = new DDlogAPI(1, null, false);
 
         // Initialise the data provider
         MockDataProvider provider = new DDlogJooqProvider(dDlogAPI, ddl);


### PR DESCRIPTION
This patch materializes records in Java and uses ddlog's incremental API instead of dumpTables.

Signed-off-by: Lalith Suresh <lsuresh@vmware.com>