### PR TITLE
Support SQL binding variables for inserts and deletes

### DIFF
--- a/sql/src/main/java/com/vmware/ddlog/DDlogJooqProvider.java
+++ b/sql/src/main/java/com/vmware/ddlog/DDlogJooqProvider.java
@@ -137,13 +137,12 @@ public final class DDlogJooqProvider implements MockDataProvider {
                 mock[i] = executeOne(context);
             }
             dDlogAPI.transactionCommitDumpChanges(this::onChange);
-        } catch (final DDlogException e) {
+        } catch (final DDlogException | RuntimeException e) {
             try {
                 dDlogAPI.transactionRollback();
             } catch (DDlogException rollbackFailed) {
                 throw new RuntimeException(rollbackFailed);
             }
-            throw new RuntimeException(e);
         }
         return mock;
     }

--- a/sql/src/main/java/com/vmware/ddlog/DDlogJooqProvider.java
+++ b/sql/src/main/java/com/vmware/ddlog/DDlogJooqProvider.java
@@ -86,6 +86,7 @@ import static org.jooq.impl.DSL.field;
 public final class DDlogJooqProvider implements MockDataProvider {
     private static final String DDLOG_SOME = "ddlog_std::Some";
     private static final String DDLOG_NONE = "ddlog_std::None";
+    private static final Object[] DEFAULT_BINDING = new Object[0];
     private final DDlogAPI dDlogAPI;
     private final DSLContext dslContext;
     private final Field<Integer> updateCountField;
@@ -132,7 +133,7 @@ public final class DDlogJooqProvider implements MockDataProvider {
             dDlogAPI.transactionStart();
             final Object[][] bindings = ctx.batchBindings();
             for (int i = 0; i < batchSql.length; i++) {
-                final Object[] binding = bindings != null && bindings.length > i ? bindings[i] : new Object[0];
+                final Object[] binding = bindings != null && bindings.length > i ? bindings[i] : DEFAULT_BINDING;
                 final QueryContext context = new QueryContext(batchSql[i], binding);
                 mock[i] = executeOne(context);
             }

--- a/sql/src/main/java/com/vmware/ddlog/DDlogJooqProvider.java
+++ b/sql/src/main/java/com/vmware/ddlog/DDlogJooqProvider.java
@@ -31,6 +31,7 @@ import ddlogapi.DDlogException;
 import ddlogapi.DDlogRecCommand;
 import ddlogapi.DDlogRecord;
 import org.jooq.DSLContext;
+import org.jooq.DataType;
 import org.jooq.Field;
 import org.jooq.Record;
 import org.jooq.Record1;
@@ -43,6 +44,7 @@ import org.jooq.tools.jdbc.MockResult;
 
 import javax.annotation.Nullable;
 import java.sql.SQLException;
+import java.sql.Types;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -82,10 +84,6 @@ import static org.jooq.impl.DSL.field;
  *                                         where P1, P2... etc are columns in T's primary key.
  */
 public final class DDlogJooqProvider implements MockDataProvider {
-    private static final String INTEGER_TYPE = "java.lang.Integer";
-    private static final String STRING_TYPE = "java.lang.String";
-    private static final String BOOLEAN_TYPE = "java.lang.Boolean";
-    private static final String LONG_TYPE = "java.lang.Long";
     private static final String DDLOG_SOME = "ddlog_std::Some";
     private static final String DDLOG_NONE = "ddlog_std::None";
     private final DDlogAPI dDlogAPI;
@@ -458,42 +456,42 @@ public final class DDlogJooqProvider implements MockDataProvider {
     }
 
     private static DDlogRecord toValue(final Field<?> field, final Object in) {
-        final Class<?> cls = field.getType();
-        switch (cls.getName()) {
-            case BOOLEAN_TYPE:
+        final DataType<?> dataType = field.getDataType();
+        switch (dataType.getSQLType()) {
+            case Types.BOOLEAN:
                 return new DDlogRecord((boolean) in);
-            case INTEGER_TYPE:
+            case Types.INTEGER:
                 return new DDlogRecord((int) in);
-            case LONG_TYPE:
+            case Types.BIGINT:
                 return new DDlogRecord((long) in);
-            case STRING_TYPE:
+            case Types.VARCHAR:
                 try {
                     return new DDlogRecord((String) in);
                 } catch (final DDlogException e) {
                     throw new RuntimeException("Could not create String DDlogRecord for object: " + in);
                 }
             default:
-                throw new RuntimeException("Unknown datatype " + cls.getName());
+                throw new RuntimeException("Unknown datatype " + field);
         }
     }
 
     private static void setValue(final Field<?> field, final DDlogRecord in, final Record out) {
-        final Class<?> cls = field.getType();
-        switch (cls.getName()) {
-            case BOOLEAN_TYPE:
+        final DataType<?> dataType = field.getDataType();
+        switch (dataType.getSQLType()) {
+            case Types.BOOLEAN:
                 out.setValue((Field<Boolean>) field, in.getBoolean());
                 return;
-            case INTEGER_TYPE:
+            case Types.INTEGER:
                 out.setValue((Field<Integer>) field, in.getInt().intValue());
                 return;
-            case LONG_TYPE:
+            case Types.BIGINT:
                 out.setValue((Field<Long>) field, in.getInt().longValue());
                 return;
-            case STRING_TYPE:
+            case Types.VARCHAR:
                 out.setValue((Field<String>) field, in.getString());
                 return;
             default:
-                throw new RuntimeException("Unknown datatype " + cls.getName());
+                throw new RuntimeException("Unknown datatype " + field);
         }
     }
 

--- a/sql/src/main/java/com/vmware/ddlog/DDlogJooqProvider.java
+++ b/sql/src/main/java/com/vmware/ddlog/DDlogJooqProvider.java
@@ -504,10 +504,6 @@ public final class DDlogJooqProvider implements MockDataProvider {
             return sql;
         }
 
-        public Object[] binding() {
-            return binding;
-        }
-
         public Object nextBinding() {
             final Object ret = binding[bindingIndex];
             bindingIndex++;

--- a/sql/src/test/java/ddlog/JooqProviderTest.java
+++ b/sql/src/test/java/ddlog/JooqProviderTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertTrue;
 import static org.jooq.impl.DSL.field;
+import static org.jooq.impl.DSL.table;
 
 public class JooqProviderTest {
 
@@ -58,6 +59,7 @@ public class JooqProviderTest {
         // We test single inserts as well as batch statements. We also test different
         // kinds of whitespace (the \n below is deliberate).
         create.execute("insert into \nhosts values ('n1', 10, true)");
+//        create.insertInto(table("hosts")).values("n1", 10, true).execute();
         create.batch("insert into hosts values ('n54', 18, false)",
                      "insert into hosts values ('n9', 2, true)").execute();
         final Field<String> field1 = field("id", String.class);

--- a/sql/src/test/java/ddlog/JooqProviderTest.java
+++ b/sql/src/test/java/ddlog/JooqProviderTest.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static junit.framework.Assert.fail;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertTrue;
@@ -194,7 +195,7 @@ public class JooqProviderTest {
     }
 
     /*
-     * Test batches with a mix of insert and delete statements with bindings
+     * Test multi-row inserts
      */
     @Test
     public void testMultiRowInsertsNoBindings() {
@@ -207,7 +208,7 @@ public class JooqProviderTest {
     }
 
     /*
-     * Test batches with a mix of insert and delete statements with bindings
+     * Test multi-row inserts with bindings
      */
     @Test
     public void testMultiRowInsertsWithBindings() {
@@ -223,6 +224,19 @@ public class JooqProviderTest {
         assertTrue(results.contains(test3));
     }
 
+    /*
+     * Test inserts with a subset of fields specified. This is currently unsupported and should throw an exception
+     */
+    @Test
+    public void testPartialInserts() {
+        try {
+            create.insertInto(table("hosts"), field1, field2)
+                    .values("n1", 10)
+                    .execute();
+            fail();
+        } catch (final RuntimeException ignored) {
+        }
+    }
 
     public static void compileAndLoad(final List<String> ddl) throws IOException, DDlogException {
         final Translator t = new Translator(null);

--- a/sql/src/test/java/ddlog/JooqProviderTest.java
+++ b/sql/src/test/java/ddlog/JooqProviderTest.java
@@ -28,10 +28,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import static junit.framework.Assert.fail;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertTrue;
+import static junit.framework.TestCase.fail;
 import static org.jooq.impl.DSL.field;
 import static org.jooq.impl.DSL.table;
 


### PR DESCRIPTION
This patch supports binding variables in inserts and deletes.

Most SQL databases support static queries as well as queries where parameters are replaced with '?', where the bindings for these parameters are supplied separately. The latter is typically used with prepared statements. By default, using the JOOQ DSL to construct a query results in prepared statements, so this patch adds support for them in both inserts and deletes.

On the way, this patch also adds support for multi row inserts (`insert into T values (x1, x2, x3), (y1, y2, y3)...`), both with and without bindings.

Lastly, the tests have been refactored to have the ddlog compiler executed just once on the given schema, and re-used through various smaller tests. There are tests for both static and prepared statements.