### PR TITLE
Add checked conversions to DDValue

### DIFF
--- a/lib/ddlog_std.rs
+++ b/lib/ddlog_std.rs
@@ -1282,7 +1282,7 @@ pub fn hash128<T: Hash>(x: &T) -> u128 {
     ((w1 as u128) << 64) | (w2 as u128)
 }
 
-pub type ProjectFunc<X> = ::std::rc::Rc<dyn Fn(&DDValue) -> X>;
+pub type ProjectFunc<X> = ::std::sync::Arc<dyn Fn(&DDValue) -> X + Send + Sync>;
 
 /*
  * Group type (returned by the `group_by` operator).
@@ -1315,6 +1315,11 @@ pub type ProjectFunc<X> = ::std::rc::Rc<dyn Fn(&DDValue) -> X>;
  */
 
 pub type Group<K, V> = GroupEnum<'static, K, V>;
+
+fn test() {
+    fn is_sync<T: Send + Sync>() {}
+    is_sync::<Group<u8, u8>>(); // compiles only if true
+}
 
 pub enum GroupEnum<'a, K, V> {
     ByRef {

--- a/rust/template/differential_datalog/ddval/ddval_convert.rs
+++ b/rust/template/differential_datalog/ddval/ddval_convert.rs
@@ -1,210 +1,8 @@
-//! DDValue: Generic value type stored in all differential-dataflow relations.
-//!
-//! Rationale: Differential dataflow allows the user to assign an arbitrary user-defined type to
-//! each collection.  It relies on Rust's static dispatch mechanism to specialize its internal
-//! machinery for each user-defined type.  Unfortunately, beyond very simple programs this leads to
-//! extremely long compilation times.  One workaround that we used to rely on is to declare a
-//! single enum type with a variant per concrete type used in at least one relation.  This make
-//! compilation feasible, but still very slow (~6 minutes for a simple DDlog program and ~10
-//! minutes for complex programs).
-//!
-//! Another alternative we implement here is to use a fixed value type that does not depend on
-//! a concrete DDlog program and rely on dynamic dispatch to forward operations that DD expects
-//! all values to implement (comparison, hashing, etc.) to their concrete implementations.  This
-//! way this crate (differential-datalog) can be compiled all the way to binary code separately
-//! from the DDlog program using it and does not need to be re-compiled when the DDlog program
-//! changes.  Thus, the only part that must be re-compiled on changes to the DDlog code is the
-//! auto-generated crate that declares concrete value types and rules.  This is much faster than
-//! re-compiling both crates together.
-//!
-//! The next design decision is how to implement dynamic dispatch.  Rust trait objects is an
-//! obvious choice, with value type being declared as `Box<dyn SomeTrait>`.  However, this proved
-//! suboptimal in our experiments, as this design requires a dynamic memory allocation per value,
-//! no matter how small.  Furthermore, cloning a value (which DD does a lot, e.g., during
-//! compaction) requires another allocation.
-//!
-//! We improve over this naive design in two ways.  First, we use `Arc` instead of `Box`, which
-//! introduces extra space overhead to store the reference count, but avoids memory allocation due
-//! to cloning and shares the same heap allocation across multiple copies of the value.  Second, we
-//! store small objects <=`usize` bytes inline instead of wrapping them in an Arc to avoid dynamic
-//! memory allocation for such objects altogether.  Unfortunately, Rust's dynamic dispatch
-//! mechanism does not support this, so we roll our own instead, with the following `DDValue`
-//! declaration:
-//!
-//! ```
-//! use differential_datalog::ddval::*;
-//! pub struct DDValue {
-//!    val: DDVal,
-//!    vtable: &'static DDValMethods,
-//! }
-//! ```
-//!
-//! where `DDVal` is a `usize` that stores either an `Arc<T>` or `T` (where `T` is the actual type
-//! of value stored in the DDlog relation), and `DDValMethods` is a virtual table of methods that
-//! must be implemented for all DD values.
-//!
-//! This design still requires a separate heap allocation for each value >8 bytes, which slows
-//! things down quite a bit.  Nevertheless, it has the same performance as our earlier
-//! implementation using static dispatch and at least in some benchmarks uses less memory.  The
-//! only way to improve things further I can think of is to somehow co-design this with DD to use
-//! DD's knowledge of the context where a value is being created to, e.g., allocate blocks of
-//! values when possible.
-//!
-
-use std::fmt::Debug;
-use std::fmt::Display;
-use std::fmt::Formatter;
-use std::hash::Hash;
-use std::hash::Hasher;
-
-use serde::ser::Serialize;
-use serde::ser::Serializer;
-
-use abomonation::Abomonation;
-
-use crate::record::IntoRecord;
-use crate::record::Mutator;
-use crate::record::Record;
-
+use crate::{
+    ddval::{DDVal, DDValue},
+    record::IntoRecord,
+};
 use ordered_float::OrderedFloat;
-
-/// Type-erased representation of a value.  Can store the actual value or a pointer to it.
-/// This could be just a `usize`, but we wrap it in a struct as we don't want it to implement
-/// `Copy`.
-pub struct DDVal {
-    pub v: usize,
-}
-
-/// DDValue: this type is stored in all DD collections.
-/// It consists of value and associated vtable.
-pub struct DDValue {
-    val: DDVal,
-    vtable: &'static DDValMethods,
-}
-
-/// vtable of methods to be implemented by every value stored in DD.
-pub struct DDValMethods {
-    pub clone: fn(this: &DDVal) -> DDVal,
-    pub into_record: fn(this: DDVal) -> Record,
-    pub eq: fn(this: &DDVal, other: &DDVal) -> bool,
-    pub partial_cmp: fn(this: &DDVal, other: &DDVal) -> Option<std::cmp::Ordering>,
-    pub cmp: fn(this: &DDVal, other: &DDVal) -> std::cmp::Ordering,
-    pub hash: fn(this: &DDVal, state: &mut dyn Hasher),
-    pub mutate: fn(this: &mut DDVal, record: &Record) -> Result<(), String>,
-    pub fmt_debug: fn(this: &DDVal, f: &mut Formatter) -> Result<(), std::fmt::Error>,
-    pub fmt_display: fn(this: &DDVal, f: &mut Formatter) -> Result<(), std::fmt::Error>,
-    pub drop: fn(this: &mut DDVal),
-    pub ddval_serialize: fn(this: &DDVal) -> &dyn erased_serde::Serialize,
-}
-
-impl Drop for DDValue {
-    fn drop(&mut self) {
-        (self.vtable.drop)(&mut self.val);
-    }
-}
-
-impl DDValue {
-    pub fn new(val: DDVal, vtable: &'static DDValMethods) -> DDValue {
-        DDValue { val, vtable }
-    }
-
-    pub fn into_ddval(self) -> DDVal {
-        let res = DDVal { v: self.val.v };
-        std::mem::forget(self);
-        res
-    }
-}
-
-impl Mutator<DDValue> for Record {
-    fn mutate(&self, x: &mut DDValue) -> Result<(), String> {
-        (x.vtable.mutate)(&mut x.val, self)
-    }
-}
-
-impl IntoRecord for DDValue {
-    fn into_record(self) -> Record {
-        (self.vtable.into_record)(self.into_ddval())
-    }
-}
-
-impl Abomonation for DDValue {
-    unsafe fn entomb<W: std::io::Write>(&self, _write: &mut W) -> std::io::Result<()> {
-        panic!("DDValue::entomb: not implemented")
-    }
-    unsafe fn exhume<'a, 'b>(&'a mut self, _bytes: &'b mut [u8]) -> Option<&'b mut [u8]> {
-        panic!("DDValue::exhume: not implemented")
-    }
-    fn extent(&self) -> usize {
-        panic!("DDValue::extent: not implemented")
-    }
-}
-
-/* `Serialize` implementation simply forwards the `serialize` operation to the
- * inner object.
- * Note: we cannot provide a generic `Deserialize` implementation for `DDValue`,
- * as there is no object to forward `deserialize` to.  Instead, we are going
- * generate a `Deserialize` implementation for `Update<DDValue>` in the DDlog
- * compiler. This implementation will use relation id inside `Update` to figure
- * out which type to deserialize.  See `src/lib.rs` for more details.
- */
-impl Serialize for DDValue {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        erased_serde::serialize((self.vtable.ddval_serialize)(&self.val), serializer)
-    }
-}
-
-impl Display for DDValue {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), std::fmt::Error> {
-        (self.vtable.fmt_display)(&self.val, f)
-    }
-}
-
-impl Debug for DDValue {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), std::fmt::Error> {
-        (self.vtable.fmt_debug)(&self.val, f)
-    }
-}
-
-impl PartialOrd for DDValue {
-    fn partial_cmp(&self, other: &DDValue) -> Option<std::cmp::Ordering> {
-        (self.vtable.partial_cmp)(&self.val, &other.val)
-    }
-}
-
-impl PartialEq for DDValue {
-    fn eq(&self, other: &Self) -> bool {
-        (self.vtable.eq)(&self.val, &other.val)
-    }
-}
-
-impl Eq for DDValue {}
-
-impl Ord for DDValue {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        (self.vtable.cmp)(&self.val, &other.val)
-    }
-}
-
-impl Clone for DDValue {
-    fn clone(&self) -> Self {
-        DDValue {
-            val: (self.vtable.clone)(&self.val),
-            vtable: self.vtable,
-        }
-    }
-}
-
-impl Hash for DDValue {
-    fn hash<H>(&self, state: &mut H)
-    where
-        H: Hasher,
-    {
-        (self.vtable.hash)(&self.val, state)
-    }
-}
 
 /// Trait to convert `DDVal` into concrete value type and back.
 pub trait DDValConvert: Sized {
@@ -229,6 +27,7 @@ pub trait DDValConvert: Sized {
     fn into_ddval(self) -> DDVal;
 
     fn ddvalue(&self) -> DDValue;
+
     fn into_ddvalue(self) -> DDValue;
 }
 
@@ -294,7 +93,8 @@ macro_rules! decl_ddval_convert {
                                 let arc =
                                     unsafe { ::std::sync::Arc::from_raw(this.v as *const $t) };
                                 let res = $crate::ddval::DDVal {
-                                    v: ::std::sync::Arc::into_raw(arc.clone()) as usize,
+                                    v: ::std::sync::Arc::into_raw(::std::sync::Arc::clone(&arc))
+                                        as usize,
                                 };
                                 ::std::sync::Arc::into_raw(arc);
                                 res

--- a/rust/template/differential_datalog/ddval/ddval_convert.rs
+++ b/rust/template/differential_datalog/ddval/ddval_convert.rs
@@ -3,31 +3,102 @@ use crate::{
     record::IntoRecord,
 };
 use ordered_float::OrderedFloat;
+use std::any::TypeId;
 
 /// Trait to convert `DDVal` into concrete value type and back.
 pub trait DDValConvert: Sized {
-    /// Extract reference to concrete type from `&DDVal`.  This causes undefined behavior
-    /// if `v` does not contain a value of type `Self`.
-    unsafe fn from_ddval_ref(v: &DDVal) -> &Self;
+    /// Extract reference to concrete type from `&DDVal`.
+    ///
+    /// # Safety
+    ///
+    /// `value` **must** be the same type as the type the `DDVal` was created with
+    ///
+    unsafe fn from_ddval_ref(value: &DDVal) -> &Self;
 
-    unsafe fn from_ddvalue_ref(v: &DDValue) -> &Self {
-        Self::from_ddval_ref(&v.val)
+    /// Converts an `&DDValue` into a reference of the given type
+    ///
+    /// Returns `None` if the type given is not the same as the type the `DDValue`
+    /// was created with
+    ///
+    fn try_from_ddvalue_ref(value: &DDValue) -> Option<&Self>
+    where
+        Self: 'static,
+    {
+        let value_type = (value.vtable.type_id)(&value.val);
+        if value_type == TypeId::of::<Self>() {
+            // Safety: The type we're turning the value into is the same as the one
+            //         it was created with
+            Some(unsafe { Self::from_ddval_ref(&value.val) })
+        } else {
+            None
+        }
     }
 
-    /// Extracts concrete value contained in `v`.  Panics if `v` does not contain a
-    /// value of type `Self`.
-    unsafe fn from_ddval(v: DDVal) -> Self;
+    /// Converts an `&DDValue` into a reference of the given type
+    ///
+    /// # Panics
+    ///
+    /// Panics if the type given is not the same as the type the `DDValue`
+    /// was created with
+    ///
+    fn from_ddvalue_ref(value: &DDValue) -> &Self
+    where
+        Self: 'static,
+    {
+        Self::try_from_ddvalue_ref(value)
+            .expect("attempted to convert a DDValue into the incorrect type")
+    }
 
-    unsafe fn from_ddvalue(v: DDValue) -> Self {
-        Self::from_ddval(v.into_ddval())
+    /// Extracts concrete value contained in `value`.
+    ///
+    /// # Safety
+    ///
+    /// `value` **must** be the same type as the type the `DDValue` was created with
+    ///
+    unsafe fn from_ddval(value: DDVal) -> Self;
+
+    /// Converts a `DDValue` into a the given type
+    ///
+    /// Returns `None` if the type given is not the same as the type the `DDValue`
+    /// was created with
+    ///
+    fn try_from_ddvalue(value: DDValue) -> Option<Self>
+    where
+        Self: 'static,
+    {
+        let value_type = (value.vtable.type_id)(&value.val);
+        if value_type == TypeId::of::<Self>() {
+            // Safety: The type we're turning the value into is the same as the one
+            //         it was created with
+            Some(unsafe { Self::from_ddval(value.into_ddval()) })
+        } else {
+            None
+        }
+    }
+
+    /// Converts a `DDValue` into the given type
+    ///
+    /// # Panics
+    ///
+    /// Panics if the type given is not the same as the type the `DDValue`
+    /// was created with
+    ///
+    fn from_ddvalue(value: DDValue) -> Self
+    where
+        Self: 'static,
+    {
+        Self::try_from_ddvalue(value)
+            .expect("attempted to convert a DDValue into the incorrect type")
     }
 
     /// Convert a value to a `DDVal`, erasing its original type.  This is a safe conversion
     /// that cannot fail.
     fn into_ddval(self) -> DDVal;
 
+    /// Creates a `DDValue` from the current value
     fn ddvalue(&self) -> DDValue;
 
+    /// Converts the current value into a `DDValue`
     fn into_ddvalue(self) -> DDValue;
 }
 
@@ -41,7 +112,9 @@ macro_rules! decl_ddval_convert {
     ( $t:ty ) => {
         impl $crate::ddval::DDValConvert for $t {
             unsafe fn from_ddval_ref(v: &$crate::ddval::DDVal) -> &Self {
-                if ::std::mem::size_of::<Self>() <= ::std::mem::size_of::<usize>() {
+                use ::std::mem::size_of;
+
+                if size_of::<Self>() <= size_of::<usize>() {
                     &*(&v.v as *const usize as *const Self)
                 } else {
                     &*(v.v as *const Self)
@@ -49,32 +122,42 @@ macro_rules! decl_ddval_convert {
             }
 
             unsafe fn from_ddval(v: $crate::ddval::DDVal) -> Self {
-                if ::std::mem::size_of::<Self>() <= ::std::mem::size_of::<usize>() {
-                    let res: Self =
-                        ::std::mem::transmute::<[u8; ::std::mem::size_of::<Self>()], Self>(
-                            *(&v.v as *const usize as *const [u8; ::std::mem::size_of::<Self>()]),
-                        );
-                    ::std::mem::forget(v);
+                use ::std::{
+                    mem::{self, size_of, transmute},
+                    sync::Arc,
+                };
+
+                if size_of::<Self>() <= size_of::<usize>() {
+                    let res: Self = transmute::<[u8; size_of::<Self>()], Self>(
+                        *(&v.v as *const usize as *const [u8; size_of::<Self>()]),
+                    );
+                    mem::forget(v);
+
                     res
                 } else {
-                    let arc = ::std::sync::Arc::from_raw(v.v as *const Self);
-                    ::std::sync::Arc::try_unwrap(arc).unwrap_or_else(|a| (*a).clone())
+                    let arc = Arc::from_raw(v.v as *const Self);
+                    Arc::try_unwrap(arc).unwrap_or_else(|a| (*a).clone())
                 }
             }
 
             fn into_ddval(self) -> $crate::ddval::DDVal {
-                if ::std::mem::size_of::<Self>() <= ::std::mem::size_of::<usize>() {
+                use ::std::{
+                    mem::{size_of, transmute},
+                    sync::Arc,
+                };
+                use $crate::ddval::DDVal;
+
+                if size_of::<Self>() <= size_of::<usize>() {
                     let mut v: usize = 0;
                     unsafe {
-                        *(&mut v as *mut usize as *mut [u8; ::std::mem::size_of::<Self>()]) =
-                            ::std::mem::transmute::<Self, [u8; ::std::mem::size_of::<Self>()]>(
-                                self,
-                            );
+                        *(&mut v as *mut usize as *mut [u8; size_of::<Self>()]) =
+                            transmute::<Self, [u8; size_of::<Self>()]>(self);
                     };
-                    $crate::ddval::DDVal { v }
+
+                    DDVal { v }
                 } else {
-                    $crate::ddval::DDVal {
-                        v: ::std::sync::Arc::into_raw(::std::sync::Arc::new(self)) as usize,
+                    DDVal {
+                        v: Arc::into_raw(Arc::new(self)) as usize,
                     }
                 }
             }
@@ -84,96 +167,94 @@ macro_rules! decl_ddval_convert {
             }
 
             fn into_ddvalue(self) -> $crate::ddval::DDValue {
-                fn clone(this: &$crate::ddval::DDVal) -> $crate::ddval::DDVal {
-                    if ::std::mem::size_of::<$t>() <= ::std::mem::size_of::<usize>() {
+                use ::std::{
+                    any::TypeId,
+                    cmp::Ordering,
+                    fmt::{self, Debug, Display, Formatter},
+                    hash::{Hash, Hasher},
+                    mem::{self, size_of, transmute, ManuallyDrop},
+                    sync::Arc,
+                };
+                use $crate::{
+                    ddval::{DDVal, DDValMethods, DDValue},
+                    record::{Mutator, Record},
+                };
+
+                fn clone(this: &DDVal) -> DDVal {
+                    if size_of::<$t>() <= size_of::<usize>() {
                         unsafe { <$t>::from_ddval_ref(this) }.clone().into_ddval()
                     } else {
-                        let arc = unsafe {
-                            ::std::mem::ManuallyDrop::new(::std::sync::Arc::from_raw(
-                                this.v as *const $t,
-                            ))
-                        };
-                        let res = $crate::ddval::DDVal {
-                            v: ::std::sync::Arc::into_raw(::std::sync::Arc::clone(&arc)) as usize,
+                        let arc = unsafe { ManuallyDrop::new(Arc::from_raw(this.v as *const $t)) };
+                        let res = DDVal {
+                            v: Arc::into_raw(Arc::clone(&arc)) as usize,
                         };
 
                         res
                     }
                 }
 
-                fn into_record(this: $crate::ddval::DDVal) -> $crate::record::Record {
+                fn into_record(this: DDVal) -> Record {
                     unsafe { <$t>::from_ddval(this) }.into_record()
                 }
 
-                fn eq(this: &$crate::ddval::DDVal, other: &$crate::ddval::DDVal) -> bool {
+                fn eq(this: &DDVal, other: &DDVal) -> bool {
                     unsafe { <$t>::from_ddval_ref(this).eq(<$t>::from_ddval_ref(other)) }
                 }
 
-                fn partial_cmp(
-                    this: &$crate::ddval::DDVal,
-                    other: &$crate::ddval::DDVal,
-                ) -> Option<::std::cmp::Ordering> {
+                fn partial_cmp(this: &DDVal, other: &DDVal) -> Option<Ordering> {
                     unsafe { <$t>::from_ddval_ref(this).partial_cmp(<$t>::from_ddval_ref(other)) }
                 }
 
-                fn cmp(
-                    this: &$crate::ddval::DDVal,
-                    other: &$crate::ddval::DDVal,
-                ) -> ::std::cmp::Ordering {
+                fn cmp(this: &DDVal, other: &DDVal) -> Ordering {
                     unsafe { <$t>::from_ddval_ref(this).cmp(<$t>::from_ddval_ref(other)) }
                 }
 
-                fn hash(this: &$crate::ddval::DDVal, mut state: &mut dyn ::std::hash::Hasher) {
-                    ::std::hash::Hash::hash(unsafe { <$t>::from_ddval_ref(this) }, &mut state);
+                fn hash(this: &DDVal, mut state: &mut dyn Hasher) {
+                    Hash::hash(unsafe { <$t>::from_ddval_ref(this) }, &mut state);
                 }
 
-                fn mutate(
-                    this: &mut $crate::ddval::DDVal,
-                    record: &$crate::record::Record,
-                ) -> Result<(), ::std::string::String> {
+                fn mutate(this: &mut DDVal, record: &Record) -> Result<(), ::std::string::String> {
                     let mut clone = unsafe { <$t>::from_ddval_ref(this) }.clone();
-                    $crate::record::Mutator::mutate(record, &mut clone)?;
+                    Mutator::mutate(record, &mut clone)?;
                     *this = clone.into_ddval();
+
                     Ok(())
                 }
 
-                fn fmt_debug(
-                    this: &$crate::ddval::DDVal,
-                    f: &mut ::std::fmt::Formatter,
-                ) -> Result<(), ::std::fmt::Error> {
-                    ::std::fmt::Debug::fmt(unsafe { <$t>::from_ddval_ref(this) }, f)
+                fn fmt_debug(this: &DDVal, f: &mut Formatter) -> Result<(), fmt::Error> {
+                    Debug::fmt(unsafe { <$t>::from_ddval_ref(this) }, f)
                 }
 
-                fn fmt_display(
-                    this: &$crate::ddval::DDVal,
-                    f: &mut ::std::fmt::Formatter,
-                ) -> Result<(), ::std::fmt::Error> {
-                    ::std::fmt::Display::fmt(
+                fn fmt_display(this: &DDVal, f: &mut Formatter) -> Result<(), fmt::Error> {
+                    Display::fmt(
                         &unsafe { <$t>::from_ddval_ref(this) }.clone().into_record(),
                         f,
                     )
                 }
 
-                fn drop(this: &mut $crate::ddval::DDVal) {
-                    if ::std::mem::size_of::<$t>() <= ::std::mem::size_of::<usize>() {
+                fn drop(this: &mut DDVal) {
+                    if size_of::<$t>() <= size_of::<usize>() {
                         // Allow `_val`'s Drop impl to run automatically
                         let _val = unsafe {
-                            ::std::mem::transmute::<[u8; ::std::mem::size_of::<$t>()], $t>(
-                                *(&this.v as *const usize
-                                    as *const [u8; ::std::mem::size_of::<$t>()]),
+                            transmute::<[u8; size_of::<$t>()], $t>(
+                                *(&this.v as *const usize as *const [u8; size_of::<$t>()]),
                             );
                         };
                     } else {
-                        let arc = unsafe { ::std::sync::Arc::from_raw(this.v as *const $t) };
-                        ::std::mem::drop(arc);
+                        let arc = unsafe { Arc::from_raw(this.v as *const $t) };
+                        mem::drop(arc);
                     }
                 }
 
-                fn ddval_serialize(this: &$crate::ddval::DDVal) -> &dyn erased_serde::Serialize {
+                fn ddval_serialize(this: &DDVal) -> &dyn erased_serde::Serialize {
                     (unsafe { <$t>::from_ddval_ref(this) }) as &dyn erased_serde::Serialize
                 }
 
-                static VTABLE: $crate::ddval::DDValMethods = $crate::ddval::DDValMethods {
+                fn type_id(_this: &DDVal) -> TypeId {
+                    TypeId::of::<$t>()
+                }
+
+                static VTABLE: DDValMethods = DDValMethods {
                     clone,
                     into_record,
                     eq,
@@ -185,9 +266,10 @@ macro_rules! decl_ddval_convert {
                     fmt_display,
                     drop,
                     ddval_serialize,
+                    type_id,
                 };
 
-                $crate::ddval::DDValue::new(self.into_ddval(), &VTABLE)
+                DDValue::new(self.into_ddval(), &VTABLE)
             }
         }
     };

--- a/rust/template/differential_datalog/ddval/ddvalue.rs
+++ b/rust/template/differential_datalog/ddval/ddvalue.rs
@@ -1,0 +1,126 @@
+use crate::{
+    ddval::{DDVal, DDValMethods},
+    record::{IntoRecord, Mutator, Record},
+};
+use abomonation::Abomonation;
+use serde::ser::{Serialize, Serializer};
+use std::{
+    cmp::Ordering,
+    fmt::{self, Debug, Display, Formatter},
+    hash::{Hash, Hasher},
+};
+
+/// DDValue: this type is stored in all DD collections.
+/// It consists of value and associated vtable.
+pub struct DDValue {
+    pub(super) val: DDVal,
+    vtable: &'static DDValMethods,
+}
+
+impl Drop for DDValue {
+    fn drop(&mut self) {
+        (self.vtable.drop)(&mut self.val);
+    }
+}
+
+impl DDValue {
+    pub fn new(val: DDVal, vtable: &'static DDValMethods) -> DDValue {
+        DDValue { val, vtable }
+    }
+
+    pub fn into_ddval(self) -> DDVal {
+        let res = DDVal { v: self.val.v };
+        std::mem::forget(self);
+        res
+    }
+}
+
+impl Mutator<DDValue> for Record {
+    fn mutate(&self, x: &mut DDValue) -> Result<(), String> {
+        (x.vtable.mutate)(&mut x.val, self)
+    }
+}
+
+impl IntoRecord for DDValue {
+    fn into_record(self) -> Record {
+        (self.vtable.into_record)(self.into_ddval())
+    }
+}
+
+impl Abomonation for DDValue {
+    unsafe fn entomb<W: std::io::Write>(&self, _write: &mut W) -> std::io::Result<()> {
+        panic!("DDValue::entomb: not implemented")
+    }
+    unsafe fn exhume<'a, 'b>(&'a mut self, _bytes: &'b mut [u8]) -> Option<&'b mut [u8]> {
+        panic!("DDValue::exhume: not implemented")
+    }
+    fn extent(&self) -> usize {
+        panic!("DDValue::extent: not implemented")
+    }
+}
+
+/// `Serialize` implementation simply forwards the `serialize` operation to the
+/// inner object.
+/// Note: we cannot provide a generic `Deserialize` implementation for `DDValue`,
+/// as there is no object to forward `deserialize` to.  Instead, we are going
+/// generate a `Deserialize` implementation for `Update<DDValue>` in the DDlog
+/// compiler. This implementation will use relation id inside `Update` to figure
+/// out which type to deserialize.  See `src/lib.rs` for more details.
+impl Serialize for DDValue {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        erased_serde::serialize((self.vtable.ddval_serialize)(&self.val), serializer)
+    }
+}
+
+impl Display for DDValue {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+        (self.vtable.fmt_display)(&self.val, f)
+    }
+}
+
+impl Debug for DDValue {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+        (self.vtable.fmt_debug)(&self.val, f)
+    }
+}
+
+impl PartialOrd for DDValue {
+    fn partial_cmp(&self, other: &DDValue) -> Option<Ordering> {
+        (self.vtable.partial_cmp)(&self.val, &other.val)
+    }
+}
+
+impl PartialEq for DDValue {
+    fn eq(&self, other: &Self) -> bool {
+        (self.vtable.eq)(&self.val, &other.val)
+    }
+}
+
+impl Eq for DDValue {}
+
+impl Ord for DDValue {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        (self.vtable.cmp)(&self.val, &other.val)
+    }
+}
+
+impl Clone for DDValue {
+    fn clone(&self) -> Self {
+        DDValue {
+            val: (self.vtable.clone)(&self.val),
+            vtable: self.vtable,
+        }
+    }
+}
+
+impl Hash for DDValue {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        (self.vtable.hash)(&self.val, state)
+    }
+}

--- a/rust/template/differential_datalog/ddval/ddvalue.rs
+++ b/rust/template/differential_datalog/ddval/ddvalue.rs
@@ -97,25 +97,27 @@ impl Debug for DDValue {
 
 impl PartialOrd for DDValue {
     fn partial_cmp(&self, other: &DDValue) -> Option<Ordering> {
-        if (self.vtable.type_id)(&self.val) == (other.vtable.type_id)(&other.val) {
-            // Safety: The types of both values are the same
-            unsafe { (self.vtable.partial_cmp)(&self.val, &other.val) }
-        } else {
-            // TODO: Should this panic instead?
-            None
-        }
+        /* Safety: The types of both values are the same.
+         * This should be enforced by the DDlog type checker. */
+        debug_assert_eq!(
+            (self.vtable.type_id)(&self.val),
+            (other.vtable.type_id)(&other.val),
+            "DDValue::partial_cmp: attempted to compare two values of different types"
+        );
+        unsafe { (self.vtable.partial_cmp)(&self.val, &other.val) }
     }
 }
 
 impl PartialEq for DDValue {
     fn eq(&self, other: &Self) -> bool {
-        if (self.vtable.type_id)(&self.val) == (other.vtable.type_id)(&other.val) {
-            // Safety: The types of both values are the same
-            unsafe { (self.vtable.eq)(&self.val, &other.val) }
-        } else {
-            // TODO: Should this panic instead?
-            false
-        }
+        /* Safety: The types of both values are the same.
+         * This should be enforced by the DDlog type checker. */
+        debug_assert_eq!(
+            (self.vtable.type_id)(&self.val),
+            (other.vtable.type_id)(&other.val),
+            "DDValue::eq: attempted to compare two values of different types"
+        );
+        unsafe { (self.vtable.eq)(&self.val, &other.val) }
     }
 }
 
@@ -123,13 +125,13 @@ impl Eq for DDValue {}
 
 impl Ord for DDValue {
     fn cmp(&self, other: &Self) -> Ordering {
-        assert_eq!(
+        /* Safety: The types of both values are the same.
+         * This should be enforced by the DDlog type checker. */
+        debug_assert_eq!(
             (self.vtable.type_id)(&self.val),
             (other.vtable.type_id)(&other.val),
-            "attempted to compare two values of different types",
+            "DDValue::cmp: attempted to compare two values of different types"
         );
-
-        // Safety: The types of both values are the same
         unsafe { (self.vtable.cmp)(&self.val, &other.val) }
     }
 }

--- a/rust/template/differential_datalog/ddval/mod.rs
+++ b/rust/template/differential_datalog/ddval/mod.rs
@@ -59,7 +59,12 @@ pub use ddval_convert::DDValConvert;
 pub use ddvalue::DDValue;
 
 use crate::record::Record;
-use std::{any::TypeId, fmt::Formatter, hash::Hasher};
+use std::{
+    any::TypeId,
+    cmp::Ordering,
+    fmt::{Error, Formatter},
+    hash::Hasher,
+};
 
 /// Type-erased representation of a value.  Can store the actual value or a pointer to it.
 /// This could be just a `usize`, but we wrap it in a struct as we don't want it to implement
@@ -72,13 +77,20 @@ pub struct DDVal {
 pub struct DDValMethods {
     pub clone: fn(this: &DDVal) -> DDVal,
     pub into_record: fn(this: DDVal) -> Record,
-    pub eq: fn(this: &DDVal, other: &DDVal) -> bool,
-    pub partial_cmp: fn(this: &DDVal, other: &DDVal) -> Option<std::cmp::Ordering>,
-    pub cmp: fn(this: &DDVal, other: &DDVal) -> std::cmp::Ordering,
+
+    /// Safety: The types of the values contained in `this` and `other` must be the same
+    pub eq: unsafe fn(this: &DDVal, other: &DDVal) -> bool,
+
+    /// Safety: The types of the values contained in `this` and `other` must be the same
+    pub partial_cmp: unsafe fn(this: &DDVal, other: &DDVal) -> Option<Ordering>,
+
+    /// Safety: The types of the values contained in `this` and `other` must be the same
+    pub cmp: unsafe fn(this: &DDVal, other: &DDVal) -> Ordering,
+
     pub hash: fn(this: &DDVal, state: &mut dyn Hasher),
     pub mutate: fn(this: &mut DDVal, record: &Record) -> Result<(), String>,
-    pub fmt_debug: fn(this: &DDVal, f: &mut Formatter) -> Result<(), std::fmt::Error>,
-    pub fmt_display: fn(this: &DDVal, f: &mut Formatter) -> Result<(), std::fmt::Error>,
+    pub fmt_debug: fn(this: &DDVal, f: &mut Formatter) -> Result<(), Error>,
+    pub fmt_display: fn(this: &DDVal, f: &mut Formatter) -> Result<(), Error>,
     pub drop: fn(this: &mut DDVal),
     pub ddval_serialize: fn(this: &DDVal) -> &dyn erased_serde::Serialize,
     pub type_id: fn(this: &DDVal) -> TypeId,

--- a/rust/template/differential_datalog/ddval/mod.rs
+++ b/rust/template/differential_datalog/ddval/mod.rs
@@ -1,0 +1,84 @@
+//! DDValue: Generic value type stored in all differential-dataflow relations.
+//!
+//! Rationale: Differential dataflow allows the user to assign an arbitrary user-defined type to
+//! each collection.  It relies on Rust's static dispatch mechanism to specialize its internal
+//! machinery for each user-defined type.  Unfortunately, beyond very simple programs this leads to
+//! extremely long compilation times.  One workaround that we used to rely on is to declare a
+//! single enum type with a variant per concrete type used in at least one relation.  This make
+//! compilation feasible, but still very slow (~6 minutes for a simple DDlog program and ~10
+//! minutes for complex programs).
+//!
+//! Another alternative we implement here is to use a fixed value type that does not depend on
+//! a concrete DDlog program and rely on dynamic dispatch to forward operations that DD expects
+//! all values to implement (comparison, hashing, etc.) to their concrete implementations.  This
+//! way this crate (differential-datalog) can be compiled all the way to binary code separately
+//! from the DDlog program using it and does not need to be re-compiled when the DDlog program
+//! changes.  Thus, the only part that must be re-compiled on changes to the DDlog code is the
+//! auto-generated crate that declares concrete value types and rules.  This is much faster than
+//! re-compiling both crates together.
+//!
+//! The next design decision is how to implement dynamic dispatch.  Rust trait objects is an
+//! obvious choice, with value type being declared as `Box<dyn SomeTrait>`.  However, this proved
+//! suboptimal in our experiments, as this design requires a dynamic memory allocation per value,
+//! no matter how small.  Furthermore, cloning a value (which DD does a lot, e.g., during
+//! compaction) requires another allocation.
+//!
+//! We improve over this naive design in two ways.  First, we use `Arc` instead of `Box`, which
+//! introduces extra space overhead to store the reference count, but avoids memory allocation due
+//! to cloning and shares the same heap allocation across multiple copies of the value.  Second, we
+//! store small objects <=`usize` bytes inline instead of wrapping them in an Arc to avoid dynamic
+//! memory allocation for such objects altogether.  Unfortunately, Rust's dynamic dispatch
+//! mechanism does not support this, so we roll our own instead, with the following `DDValue`
+//! declaration:
+//!
+//! ```
+//! use differential_datalog::ddval::*;
+//! pub struct DDValue {
+//!    val: DDVal,
+//!    vtable: &'static DDValMethods,
+//! }
+//! ```
+//!
+//! where `DDVal` is a `usize` that stores either an `Arc<T>` or `T` (where `T` is the actual type
+//! of value stored in the DDlog relation), and `DDValMethods` is a virtual table of methods that
+//! must be implemented for all DD values.
+//!
+//! This design still requires a separate heap allocation for each value >8 bytes, which slows
+//! things down quite a bit.  Nevertheless, it has the same performance as our earlier
+//! implementation using static dispatch and at least in some benchmarks uses less memory.  The
+//! only way to improve things further I can think of is to somehow co-design this with DD to use
+//! DD's knowledge of the context where a value is being created to, e.g., allocate blocks of
+//! values when possible.
+//!
+
+#[macro_use]
+mod ddval_convert;
+mod ddvalue;
+
+pub use ddval_convert::DDValConvert;
+pub use ddvalue::DDValue;
+
+use crate::record::Record;
+use std::{fmt::Formatter, hash::Hasher};
+
+/// Type-erased representation of a value.  Can store the actual value or a pointer to it.
+/// This could be just a `usize`, but we wrap it in a struct as we don't want it to implement
+/// `Copy`.
+pub struct DDVal {
+    pub v: usize,
+}
+
+/// vtable of methods to be implemented by every value stored in DD.
+pub struct DDValMethods {
+    pub clone: fn(this: &DDVal) -> DDVal,
+    pub into_record: fn(this: DDVal) -> Record,
+    pub eq: fn(this: &DDVal, other: &DDVal) -> bool,
+    pub partial_cmp: fn(this: &DDVal, other: &DDVal) -> Option<std::cmp::Ordering>,
+    pub cmp: fn(this: &DDVal, other: &DDVal) -> std::cmp::Ordering,
+    pub hash: fn(this: &DDVal, state: &mut dyn Hasher),
+    pub mutate: fn(this: &mut DDVal, record: &Record) -> Result<(), String>,
+    pub fmt_debug: fn(this: &DDVal, f: &mut Formatter) -> Result<(), std::fmt::Error>,
+    pub fmt_display: fn(this: &DDVal, f: &mut Formatter) -> Result<(), std::fmt::Error>,
+    pub drop: fn(this: &mut DDVal),
+    pub ddval_serialize: fn(this: &DDVal) -> &dyn erased_serde::Serialize,
+}

--- a/rust/template/differential_datalog/ddval/mod.rs
+++ b/rust/template/differential_datalog/ddval/mod.rs
@@ -59,7 +59,7 @@ pub use ddval_convert::DDValConvert;
 pub use ddvalue::DDValue;
 
 use crate::record::Record;
-use std::{fmt::Formatter, hash::Hasher};
+use std::{any::TypeId, fmt::Formatter, hash::Hasher};
 
 /// Type-erased representation of a value.  Can store the actual value or a pointer to it.
 /// This could be just a `usize`, but we wrap it in a struct as we don't want it to implement
@@ -81,4 +81,5 @@ pub struct DDValMethods {
     pub fmt_display: fn(this: &DDVal, f: &mut Formatter) -> Result<(), std::fmt::Error>,
     pub drop: fn(this: &mut DDVal),
     pub ddval_serialize: fn(this: &DDVal) -> &dyn erased_serde::Serialize,
+    pub type_id: fn(this: &DDVal) -> TypeId,
 }

--- a/rust/template/differential_datalog/int.rs
+++ b/rust/template/differential_datalog/int.rs
@@ -33,8 +33,6 @@ impl Default for Int {
     }
 }
 
-decl_ddval_convert! {Int}
-
 impl Abomonation for Int {}
 
 impl Int {

--- a/rust/template/differential_datalog/program/update.rs
+++ b/rust/template/differential_datalog/program/update.rs
@@ -127,6 +127,16 @@ impl<V> Update<V> {
             _ => panic!("Update::key: not a DeleteKey command"),
         }
     }
+
+    /// Attempts to get the value of the current update
+    pub fn get_value(&self) -> Option<&V> {
+        match self {
+            Update::Insert { v, .. } => Some(v),
+            Update::InsertOrUpdate { v, .. } => Some(v),
+            Update::DeleteValue { v, .. } => Some(v),
+            _ => None,
+        }
+    }
 }
 
 // Manual implementation of `Debug` for `Update` because the latter

--- a/rust/template/differential_datalog/test.rs
+++ b/rust/template/differential_datalog/test.rs
@@ -69,11 +69,11 @@ type Delta<T> = BTreeMap<T, Weight>;
 
 fn set_update<T>(_rel: &str, s: &Arc<Mutex<Delta<T>>>, x: &DDValue, w: Weight)
 where
-    T: Ord + DDValConvert + Clone,
+    T: Ord + DDValConvert + Clone + 'static,
 {
     let mut delta = s.lock().unwrap();
 
-    let entry = delta.entry(unsafe { T::from_ddvalue_ref(x).clone() });
+    let entry = delta.entry(T::from_ddvalue_ref(x).clone());
     match entry {
         Entry::Vacant(vacant) => {
             vacant.insert(w);
@@ -388,11 +388,11 @@ fn test_semijoin(nthreads: usize) {
         }
     };
     fn fmfun1(v: DDValue) -> Option<DDValue> {
-        let Tuple2(ref v1, ref _v2) = unsafe { Tuple2::<U64>::from_ddvalue(v) };
+        let Tuple2(ref v1, ref _v2) = Tuple2::<U64>::from_ddvalue(v);
         Some(v1.clone().into_ddvalue())
     }
     fn afun1(v: DDValue) -> Option<(DDValue, DDValue)> {
-        let Tuple2(ref v1, ref v2) = unsafe { Tuple2::<U64>::from_ddvalue(v) };
+        let Tuple2(ref v1, ref v2) = Tuple2::<U64>::from_ddvalue(v);
         Some((v1.clone().into_ddvalue(), v2.clone().into_ddvalue()))
     }
 
@@ -419,8 +419,8 @@ fn test_semijoin(nthreads: usize) {
     fn jfun(_key: &DDValue, v1: &DDValue, _v2: &()) -> Option<DDValue> {
         Some(
             Tuple2(
-                Box::new(unsafe { U64::from_ddvalue(v1.clone()) }),
-                Box::new(unsafe { U64::from_ddvalue(v1.clone()) }),
+                Box::new(U64::from_ddvalue(v1.clone())),
+                Box::new(U64::from_ddvalue(v1.clone())),
             )
             .into_ddvalue(),
         )
@@ -517,7 +517,7 @@ fn test_join(nthreads: usize) {
         }
     };
     fn afun1(v: DDValue) -> Option<(DDValue, DDValue)> {
-        let Tuple2(ref v1, ref v2) = unsafe { Tuple2::<U64>::from_ddvalue(v) };
+        let Tuple2(ref v1, ref v2) = Tuple2::<U64>::from_ddvalue(v);
         Some((v1.clone().into_ddvalue(), v2.clone().into_ddvalue()))
     }
     let relset2: Arc<Mutex<Delta<Tuple2<U64>>>> = Arc::new(Mutex::new(BTreeMap::default()));
@@ -543,8 +543,8 @@ fn test_join(nthreads: usize) {
     fn jfun(_key: &DDValue, v1: &DDValue, v2: &DDValue) -> Option<DDValue> {
         Some(
             Tuple2(
-                Box::new((*unsafe { U64::from_ddvalue_ref(v1) }).clone()),
-                Box::new((*unsafe { U64::from_ddvalue_ref(v2) }).clone()),
+                Box::new((*U64::from_ddvalue_ref(v1)).clone()),
+                Box::new((*U64::from_ddvalue_ref(v2)).clone()),
             )
             .into_ddvalue(),
         )
@@ -613,8 +613,8 @@ fn test_join(nthreads: usize) {
                 let rel2_kv = rel2.flat_map(afun1);
                 rel1_kv.join(&rel2_kv).map(|(_, (v1, v2))| {
                     Tuple2(
-                        Box::new(unsafe { U64::from_ddvalue(v1) }),
-                        Box::new(unsafe { U64::from_ddvalue(v2) }),
+                        Box::new(U64::from_ddvalue(v1)),
+                        Box::new(U64::from_ddvalue(v2)),
                     )
                     .into_ddvalue()
                 })
@@ -702,7 +702,7 @@ fn test_antijoin(nthreads: usize) {
         }
     };
     fn afun1(v: DDValue) -> Option<(DDValue, DDValue)> {
-        let Tuple2(ref v1, _) = unsafe { Tuple2::<U64>::from_ddvalue_ref(&v) };
+        let Tuple2(ref v1, _) = Tuple2::<U64>::from_ddvalue_ref(&v);
         Some(((*v1).clone().into_ddvalue(), v.clone()))
     }
 
@@ -724,7 +724,7 @@ fn test_antijoin(nthreads: usize) {
     };
 
     fn mfun(v: DDValue) -> DDValue {
-        let Tuple2(ref v1, _) = unsafe { Tuple2::<U64>::from_ddvalue(v) };
+        let Tuple2(ref v1, _) = Tuple2::<U64>::from_ddvalue(v);
         v1.clone().into_ddvalue()
     }
 
@@ -863,7 +863,7 @@ fn test_map(nthreads: usize) {
     };
 
     fn mfun(v: DDValue) -> DDValue {
-        let U64(ref uv) = unsafe { U64::from_ddvalue_ref(&v) };
+        let U64(ref uv) = U64::from_ddvalue_ref(&v);
         U64(uv.clone() * 2).into_ddvalue()
     }
 
@@ -884,12 +884,12 @@ fn test_map(nthreads: usize) {
     }
 
     fn ffun(v: &DDValue) -> bool {
-        let U64(ref uv) = unsafe { U64::from_ddvalue_ref(&v) };
+        let U64(ref uv) = U64::from_ddvalue_ref(&v);
         *uv > 10
     }
 
     fn fmfun(v: DDValue) -> Option<DDValue> {
-        let U64(uv) = unsafe { U64::from_ddvalue_ref(&v) };
+        let U64(uv) = U64::from_ddvalue_ref(&v);
         if *uv > 12 {
             Some(U64(uv.clone() * 2).into_ddvalue())
         } else {
@@ -898,7 +898,7 @@ fn test_map(nthreads: usize) {
     }
 
     fn flatmapfun(v: DDValue) -> Option<Box<dyn Iterator<Item = DDValue>>> {
-        let U64(i) = unsafe { U64::from_ddvalue_ref(&v) };
+        let U64(i) = U64::from_ddvalue_ref(&v);
         if *i > 12 {
             Some(Box::new(
                 vec![
@@ -1035,7 +1035,7 @@ fn test_map(nthreads: usize) {
                 Some(iter) => iter,
                 None => Box::new(None.into_iter()),
             })
-            .map(|x| (unsafe { I64::from_ddvalue(x) }, 1)),
+            .map(|x| (I64::from_ddvalue(x), 1)),
     );
     let mut expected3 = BTreeMap::default();
     expected3.insert(U64(expected2.len() as u64), 1);
@@ -1067,12 +1067,12 @@ fn test_map_multi() {
 */
 fn test_recursion(nthreads: usize) {
     fn arrange_by_fst(v: DDValue) -> Option<(DDValue, DDValue)> {
-        let Tuple2(ref fst, ref snd) = unsafe { Tuple2::<String>::from_ddvalue_ref(&v) };
+        let Tuple2(ref fst, ref snd) = Tuple2::<String>::from_ddvalue_ref(&v);
         Some(((*fst).clone().into_ddvalue(), (*snd).clone().into_ddvalue()))
     }
 
     fn arrange_by_snd(v: DDValue) -> Option<(DDValue, DDValue)> {
-        let Tuple2(ref fst, ref snd) = unsafe { Tuple2::<String>::from_ddvalue_ref(&v) };
+        let Tuple2(ref fst, ref snd) = Tuple2::<String>::from_ddvalue_ref(&v);
         Some((
             (**snd).clone().into_ddvalue(),
             (**fst).clone().into_ddvalue(),
@@ -1084,7 +1084,7 @@ fn test_recursion(nthreads: usize) {
     }
 
     fn anti_arrange2(v: DDValue) -> Option<(DDValue, DDValue)> {
-        let Tuple2(ref fst, ref snd) = unsafe { Tuple2::<String>::from_ddvalue_ref(&v) };
+        let Tuple2(ref fst, ref snd) = Tuple2::<String>::from_ddvalue_ref(&v);
         Some((
             Tuple2(Box::new((**snd).clone()), Box::new((**fst).clone())).into_ddvalue(),
             v.clone(),
@@ -1094,8 +1094,8 @@ fn test_recursion(nthreads: usize) {
     fn jfun(_parent: &DDValue, ancestor: &DDValue, child: &DDValue) -> Option<DDValue> {
         Some(
             Tuple2(
-                Box::new(unsafe { String::from_ddvalue_ref(ancestor) }.clone()),
-                Box::new(unsafe { String::from_ddvalue_ref(child) }.clone()),
+                Box::new(String::from_ddvalue_ref(ancestor).clone()),
+                Box::new(String::from_ddvalue_ref(child).clone()),
             )
             .into_ddvalue(),
         )
@@ -1104,8 +1104,8 @@ fn test_recursion(nthreads: usize) {
     fn jfun2(_ancestor: &DDValue, descendant1: &DDValue, descendant2: &DDValue) -> Option<DDValue> {
         Some(
             Tuple2(
-                Box::new(unsafe { String::from_ddvalue_ref(descendant1) }.clone()),
-                Box::new(unsafe { String::from_ddvalue_ref(descendant2) }.clone()),
+                Box::new(String::from_ddvalue_ref(descendant1).clone()),
+                Box::new(String::from_ddvalue_ref(descendant2).clone()),
             )
             .into_ddvalue(),
         )
@@ -1189,7 +1189,7 @@ fn test_recursion(nthreads: usize) {
     };
 
     fn ffun(v: &DDValue) -> bool {
-        let Tuple2(ref fst, ref snd) = unsafe { Tuple2::<String>::from_ddvalue_ref(&v) };
+        let Tuple2(ref fst, ref snd) = Tuple2::<String>::from_ddvalue_ref(&v);
         *fst != *snd
     }
 

--- a/rust/template/differential_datalog/test_value.rs
+++ b/rust/template/differential_datalog/test_value.rs
@@ -33,8 +33,6 @@ impl Mutator<Empty> for Record {
     }
 }
 
-decl_ddval_convert! {Empty}
-
 #[derive(Default, Eq, Ord, Clone, Hash, PartialEq, PartialOrd, Serialize, Deserialize, Debug)]
 pub struct Bool(pub bool);
 impl Abomonation for Bool {}
@@ -53,8 +51,6 @@ impl Mutator<Bool> for Record {
         unimplemented!("Bool::Mutator");
     }
 }
-
-decl_ddval_convert! {Bool}
 
 #[derive(Default, Eq, Ord, Clone, Hash, PartialEq, PartialOrd, Serialize, Deserialize, Debug)]
 pub struct Uint(pub uint::Uint);
@@ -75,8 +71,6 @@ impl Mutator<Uint> for Record {
     }
 }
 
-decl_ddval_convert! {Uint}
-
 #[derive(Default, Eq, Ord, Clone, Hash, PartialEq, PartialOrd, Serialize, Deserialize, Debug)]
 pub struct String(pub std::string::String);
 impl Abomonation for String {}
@@ -95,8 +89,6 @@ impl Mutator<String> for Record {
         unimplemented!("String::Mutator");
     }
 }
-
-decl_ddval_convert! {String}
 
 #[derive(Default, Eq, Ord, Clone, Hash, PartialEq, PartialOrd, Serialize, Deserialize, Debug)]
 pub struct U8(pub u8);
@@ -117,8 +109,6 @@ impl Mutator<U8> for Record {
     }
 }
 
-decl_ddval_convert! {U8}
-
 #[derive(Default, Eq, Ord, Clone, Hash, PartialEq, PartialOrd, Serialize, Deserialize, Debug)]
 pub struct U16(pub u16);
 impl Abomonation for U16 {}
@@ -137,8 +127,6 @@ impl Mutator<U16> for Record {
         unimplemented!("U16::Mutator");
     }
 }
-
-decl_ddval_convert! {U16}
 
 #[derive(Default, Eq, Ord, Clone, Hash, PartialEq, PartialOrd, Serialize, Deserialize, Debug)]
 pub struct U32(pub u32);
@@ -159,8 +147,6 @@ impl Mutator<U32> for Record {
     }
 }
 
-decl_ddval_convert! {U32}
-
 #[derive(Default, Eq, Ord, Clone, Hash, PartialEq, PartialOrd, Serialize, Deserialize, Debug)]
 pub struct U64(pub u64);
 impl Abomonation for U64 {}
@@ -179,8 +165,6 @@ impl Mutator<U64> for Record {
         unimplemented!("U64::Mutator");
     }
 }
-
-decl_ddval_convert! {U64}
 
 #[derive(Default, Eq, Ord, Clone, Hash, PartialEq, PartialOrd, Serialize, Deserialize, Debug)]
 pub struct I64(pub i64);
@@ -201,8 +185,6 @@ impl Mutator<I64> for Record {
     }
 }
 
-decl_ddval_convert! {I64}
-
 #[derive(Default, Eq, Ord, Clone, Hash, PartialEq, PartialOrd, Serialize, Deserialize, Debug)]
 pub struct BoolTuple(pub (bool, bool));
 impl Abomonation for BoolTuple {}
@@ -222,8 +204,6 @@ impl Mutator<BoolTuple> for Record {
     }
 }
 
-decl_ddval_convert! {BoolTuple}
-
 #[derive(Default, Eq, Ord, Clone, Hash, PartialEq, PartialOrd, Serialize, Deserialize, Debug)]
 pub struct Tuple2<T>(pub Box<T>, pub Box<T>);
 impl<T: Abomonation> Abomonation for Tuple2<T> {}
@@ -242,10 +222,6 @@ impl<T> Mutator<Tuple2<T>> for Record {
         unimplemented!("Tuple2::Mutator");
     }
 }
-
-decl_ddval_convert! {Tuple2<U64>}
-
-decl_ddval_convert! {Tuple2<String>}
 
 #[derive(Default, Eq, Ord, Clone, Hash, PartialEq, PartialOrd, Serialize, Deserialize, Debug)]
 pub struct Q {
@@ -268,8 +244,6 @@ impl Mutator<Q> for Record {
         unimplemented!("Q::Mutator");
     }
 }
-
-decl_ddval_convert! {Q}
 
 #[derive(Eq, Ord, Clone, Hash, PartialEq, PartialOrd, Serialize, Deserialize, Debug)]
 pub enum S {
@@ -321,8 +295,6 @@ impl Mutator<S> for Record {
         unimplemented!("S::Mutator");
     }
 }
-
-decl_ddval_convert! {S}
 
 #[derive(Eq, Ord, Clone, Hash, PartialEq, PartialOrd, Serialize, Deserialize, Debug)]
 pub struct P {

--- a/rust/template/differential_datalog/uint.rs
+++ b/rust/template/differential_datalog/uint.rs
@@ -31,8 +31,6 @@ impl Default for Uint {
 
 impl Abomonation for Uint {}
 
-decl_ddval_convert! {Uint}
-
 impl Uint {
     pub fn from_biguint(v: BigUint) -> Uint {
         Uint { x: v }

--- a/rust/template/src/api/mod.rs
+++ b/rust/template/src/api/mod.rs
@@ -294,11 +294,11 @@ impl DDlog for HDDlog {
         // relation
         let inspect_update: fn(&Update<DDValue>) -> Result<(), String> = |update| {
             let relation = Relations::try_from(update.relid())
-                .map_err(|_| format!("unknown index {}", update.relid()))?;
+                .map_err(|_| format!("unknown relation id {}", update.relid()))?;
 
             if let Some(value) = update.get_value() {
                 if relation.type_id() != value.type_id() {
-                    return Err("attempted to insert the incorrect type into a relation".to_owned());
+                    return Err(format!("attempted to insert the incorrect type {:?} into relation {:?} whose value type is {:?}", value.type_id(), relation, relation.type_id()));
                 }
             }
 

--- a/rust/template/src/api/mod.rs
+++ b/rust/template/src/api/mod.rs
@@ -270,6 +270,7 @@ impl DDlog for HDDlog {
                 }
             }
         }));
+
         match msg {
             Some(e) => Err(e),
             None => res,
@@ -285,16 +286,38 @@ impl DDlog for HDDlog {
         self.apply_valupdates(upds?.into_iter())
     }
 
-    fn apply_valupdates<I>(&self, upds: I) -> Result<(), String>
+    fn apply_valupdates<I>(&self, updates: I) -> Result<(), String>
     where
         I: Iterator<Item = Update<DDValue>>,
     {
+        // Make sure that the updates being inserted have the correct value types for their
+        // relation
+        let inspect_update: fn(&Update<DDValue>) -> Result<(), String> = |update| {
+            let relation = Relations::try_from(update.relid())
+                .map_err(|_| format!("unknown index {}", update.relid()))?;
+
+            if let Some(value) = update.get_value() {
+                if relation.type_id() != value.type_id() {
+                    return Err("attempted to insert the incorrect type into a relation".to_owned());
+                }
+            }
+
+            Ok(())
+        };
+
         if let Some(ref f) = self.replay_file {
             let mut file = f.lock().unwrap();
-            let upds = record_val_upds::<Self::Convert, _, _, _>(&mut *file, upds, |_| ());
-            self.prog.lock().unwrap().apply_updates(upds)
+            let updates = record_val_upds::<Self::Convert, _, _, _>(&mut *file, updates, |_| ());
+
+            self.prog
+                .lock()
+                .unwrap()
+                .apply_updates(updates, inspect_update)
         } else {
-            self.prog.lock().unwrap().apply_updates(upds)
+            self.prog
+                .lock()
+                .unwrap()
+                .apply_updates(updates, inspect_update)
         }
     }
 

--- a/rust/template/src/lib.rs
+++ b/rust/template/src/lib.rs
@@ -27,7 +27,7 @@ use std::hash::Hash;
 use std::ops::Deref;
 use std::ptr;
 use std::result;
-use std::sync;
+use std::{any::TypeId, sync};
 
 use ordered_float::*;
 
@@ -231,6 +231,10 @@ impl Relations {
 
     pub fn is_output(&self) -> bool {
         panic!("Relations::is_output not implemented")
+    }
+
+    pub fn type_id(&self) -> TypeId {
+        panic!("Relations::type_id not implemented")
     }
 }
 

--- a/rust/template/types/closure.rs
+++ b/rust/template/types/closure.rs
@@ -41,7 +41,7 @@ use ::abomonation::Abomonation;
  * implementations of `Fn` trait (until `unboxed_closures` and `fn_traits` features are
  * stabilized).  Otherwise, we would just derive `Fn` and add methods for comparison and hashing.
  */
-pub trait Closure<Args, Output> {
+pub trait Closure<Args, Output>: Send + Sync {
     fn call(&self, args: Args) -> Output;
     /* Returns pointers to function and captured arguments, for use in comparison methods. */
     fn internals(&self) -> (usize, usize);
@@ -77,7 +77,7 @@ impl<Args, Output, Captured: Debug + Val> Serialize for ClosureImpl<Args, Output
 /* Rust forces 'static trait bound on `Args` and `Output`, as the borrow checker is not smart
  * enough to realize that they are only used as arguments to `f`.
  */
-impl<Args: Clone + 'static, Output: Clone + 'static, Captured: Debug + Val> Closure<Args, Output>
+impl<Args: Clone + 'static, Output: Clone + 'static, Captured: Debug + Val + Send + Sync> Closure<Args, Output>
     for ClosureImpl<Args, Output, Captured>
 {
     fn call(&self, args: Args) -> Output {

--- a/rust/template/types/closure.rs
+++ b/rust/template/types/closure.rs
@@ -77,8 +77,8 @@ impl<Args, Output, Captured: Debug + Val> Serialize for ClosureImpl<Args, Output
 /* Rust forces 'static trait bound on `Args` and `Output`, as the borrow checker is not smart
  * enough to realize that they are only used as arguments to `f`.
  */
-impl<Args: Clone + 'static, Output: Clone + 'static, Captured: Debug + Val + Send + Sync> Closure<Args, Output>
-    for ClosureImpl<Args, Output, Captured>
+impl<Args: Clone + 'static, Output: Clone + 'static, Captured: Debug + Val + Send + Sync>
+    Closure<Args, Output> for ClosureImpl<Args, Output, Captured>
 {
     fn call(&self, args: Args) -> Output {
         (self.f)(args, &self.captured)

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -1824,7 +1824,7 @@ mkGroupBy d filters input_val rl@Rule{..} idx = do
                else openTuple d vALUE_VAR group_vars
     let project = "{fn __f(" <> vALUE_VAR <> ": &DDValue) -> " <+> mkType d False (exprType d ctx rhsProject) $$
                   (braces' $ open $$ mkExpr d ctx rhsProject EVal)                                            $$
-                  "::std::rc::Rc::new(__f)}"
+                  "::std::sync::Arc::new(__f)}"
     -- * Create 'struct Group'
     -- * Apply filters following group_by.
     -- * Return variables still in scope after the last filter.

--- a/src/Language/DifferentialDatalog/FlatBuffer.hs
+++ b/src/Language/DifferentialDatalog/FlatBuffer.hs
@@ -1518,13 +1518,13 @@ rustValueFromFlatbuf =
                     $ M.elems $ progIndexes ?d
     rel_to_enums = map (\rel@Relation{..} ->
                     pp (relIdentifier ?d rel) <+> "=> {"                                                                           $$
-                    "    (fb::__Value::" <> typeTableName relType <> ", unsafe {<" <+> R.mkType ?d False rel <> ">::from_ddvalue_ref(val) }.to_flatbuf_table(fbb).as_union_value())"   $$
+                    "    (fb::__Value::" <> typeTableName relType <> ", <" <+> R.mkType ?d False rel <> ">::from_ddvalue_ref(val).to_flatbuf_table(fbb).as_union_value())"   $$
                     "},")
                    $ progIORelations
     idx_to_enums = map (\idx@Index{} ->
                     let t = relType $ idxRelation ?d idx in
                     pp (idxIdentifier ?d idx) <+> "=> {"                                                                           $$
-                    "    (fb::__Value::" <> typeTableName t <> ", unsafe {<" <+> R.mkType ?d False t <> ">::from_ddvalue_ref(val) }.to_flatbuf_table(fbb).as_union_value())"   $$
+                    "    (fb::__Value::" <> typeTableName t <> ", <" <+> R.mkType ?d False t <> ">::from_ddvalue_ref(val).to_flatbuf_table(fbb).as_union_value())"   $$
                     "},")
                    $ M.elems $ progIndexes ?d
 


### PR DESCRIPTION
- Refactored `ddval.rs`
- Removed the `decl_ddval_convert!()` macro and replaced it with a blanket implementation of `DDValConvert`
- Added the `type_id` function to get a `DDValue`'s `TypeId` (This is used for checking the types of `DDValue`s)
- Made `eq`, `cmp` and `partial_cmp` in `DDValMethods` unsafe functions since they're UB if applied to `DDVal`s of different types
- Added the ability to inspect values during `apply_updates()`
- Added the `type_id()` function to `Relations`
- Use the inspect function + `Relations::type_id()` to check that the proper values are being inserted in ddlog updates