### PR TITLE
Made transactions start using transaction handles

### DIFF
--- a/rust/template/differential_datalog/program/mod.rs
+++ b/rust/template/differential_datalog/program/mod.rs
@@ -14,10 +14,12 @@
 
 mod arrange;
 mod timestamp;
+mod transaction;
 mod update;
 
 pub use arrange::concatenate_collections;
 pub use timestamp::{TSNested, TupleTS, TS, TS16};
+pub use transaction::TransactionHandle;
 pub use update::Update;
 
 use crate::{ddval::*, profile::*, record::Mutator, variable::*};
@@ -27,15 +29,17 @@ use std::{
     collections::{hash_map, BTreeMap, BTreeSet, HashMap},
     fmt::{self, Debug, Formatter},
     iter,
+    num::NonZeroU64,
     ops::Deref,
     sync::{
         atomic::{AtomicBool, Ordering},
         mpsc, Arc, Barrier, Mutex,
     },
-    thread,
+    thread::{self, JoinHandle, Thread},
     time::Duration,
 };
 use timestamp::{TSAtomic, ToTupleTS};
+use transaction::TransactionId;
 
 use differential_dataflow::difference::Semigroup;
 use differential_dataflow::input::{Input, InputSession};
@@ -579,7 +583,7 @@ impl Arrangement {
                         filtered
                             .threshold_total(|_, c| if c.is_zero() { 0 } else { 1 })
                             .map(|k| (k, ()))
-                            .arrange(), /* arrange_by_self() */
+                            .arrange(), // arrange_by_self()
                     )
                 } else {
                     ArrangedCollection::Set(filtered.map(|k| (k, ())).arrange())
@@ -648,17 +652,18 @@ pub struct RunningProgram {
     reply_recv: Vec<mpsc::Receiver<Reply>>,
     relations: FnvHashMap<RelId, RelationInstance>,
     /// Join handle of the thread running timely computation.
-    thread_handle: Option<thread::JoinHandle<Result<(), String>>>,
+    thread_handle: Option<JoinHandle<Result<(), String>>>,
     /// Timely worker threads.
-    worker_threads: Vec<thread::Thread>,
-    transaction_in_progress: bool,
+    worker_threads: Vec<Thread>,
+    transaction_in_progress: Option<TransactionId>,
+    transaction_counter: NonZeroU64,
     need_to_flush: bool,
     /// CPU profiling enabled (can be expensive).
     profile_cpu: Arc<AtomicBool>,
     /// Consume timely_events and output them to CSV file. Can be expensive.
     profile_timely: Arc<AtomicBool>,
     /// Profiling thread.
-    prof_thread_handle: Option<thread::JoinHandle<()>>,
+    prof_thread_handle: Option<JoinHandle<()>>,
     /// Profiling statistics.
     pub profile: Arc<Mutex<Profile>>,
 }
@@ -786,11 +791,11 @@ impl Program {
         let (prof_send, prof_recv) = mpsc::sync_channel::<ProfMsg>(PROF_MSG_BUF_SIZE);
 
         // Channel used by workers 1..n to send their thread handles to worker 0.
-        let (thandle_send, thandle_recv) = mpsc::sync_channel::<(usize, thread::Thread)>(0);
+        let (thandle_send, thandle_recv) = mpsc::sync_channel::<(usize, Thread)>(0);
         let thandle_recv = Arc::new(Mutex::new(thandle_recv));
 
         // Channel used by the main timely thread to send worker 0 handle to the caller.
-        let (wsend, wrecv) = mpsc::sync_channel::<Vec<thread::Thread>>(0);
+        let (wsend, wrecv) = mpsc::sync_channel::<Vec<Thread>>(0);
 
         // Profile data structure
         let profile = Arc::new(Mutex::new(Profile::new()));
@@ -819,7 +824,7 @@ impl Program {
                 let worker_index = worker.index();
 
                 // Peer workers thread handles; only used by worker 0.
-                let mut peers: FnvHashMap<usize, thread::Thread> = FnvHashMap::default();
+                let mut peers: FnvHashMap<usize, Thread> = FnvHashMap::default();
                 if worker_index != 0 {
                     // Send worker's thread handle to worker 0.
                     thandle_send.send((worker_index, thread::current())).unwrap();
@@ -1376,7 +1381,8 @@ impl Program {
             relations: rels,
             thread_handle: Some(h),
             worker_threads,
-            transaction_in_progress: false,
+            transaction_in_progress: None,
+            transaction_counter: NonZeroU64::new(1).expect("one is not zero"),
             need_to_flush: false,
             profile_cpu,
             profile_timely,
@@ -1423,7 +1429,7 @@ impl Program {
         sessions: &mut FnvHashMap<RelId, InputSession<TS, DDValue, Weight>>,
         probe: &ProbeHandle<TS>,
         worker: &mut Worker<Allocator>,
-        peers: &FnvHashMap<usize, thread::Thread>,
+        peers: &FnvHashMap<usize, Thread>,
         frontier_ts: &TSAtomic,
         progress_barrier: &Barrier,
     ) {
@@ -1448,7 +1454,7 @@ impl Program {
     }
 
     fn stop_workers(
-        peers: &FnvHashMap<usize, thread::Thread>,
+        peers: &FnvHashMap<usize, Thread>,
         frontier_ts: &TSAtomic,
         progress_barrier: &Barrier,
     ) {
@@ -1531,7 +1537,7 @@ impl Program {
         Ok(())
     }
 
-    fn unpark_peers(peers: &FnvHashMap<usize, thread::Thread>) {
+    fn unpark_peers(peers: &FnvHashMap<usize, Thread>) {
         for (_, t) in peers.iter() {
             t.unpark();
         }
@@ -1967,59 +1973,45 @@ impl RunningProgram {
         Ok(())
     }
 
-    /// Start a transaction. Does not return a transaction handle, as there
-    /// can be at most one transaction in progress at any given time. Fails
-    /// if there is already a transaction in progress.
-    pub fn transaction_start(&mut self) -> Response<()> {
-        if self.transaction_in_progress {
-            return Err("transaction already in progress".to_string());
-        }
-
-        self.transaction_in_progress = true;
-        Result::Ok(())
-    }
-
-    /// Commit a transaction.
-    pub fn transaction_commit(&mut self) -> Response<()> {
-        if !self.transaction_in_progress {
-            return Err("transaction_commit: no transaction in progress".to_string());
-        }
-
-        self.flush().and_then(|_| self.delta_cleanup()).map(|_| {
-            self.transaction_in_progress = false;
-        })
-    }
-
-    /// Rollback the transaction, undoing all changes.
-    pub fn transaction_rollback(&mut self) -> Response<()> {
-        if !self.transaction_in_progress {
-            return Err("transaction_rollback: no transaction in progress".to_string());
-        }
-
-        self.flush().and_then(|_| self.delta_undo()).map(|_| {
-            self.transaction_in_progress = false;
-        })
-    }
-
     /// Insert one record into input relation. Relations have set semantics, i.e.,
     /// adding an existing record is a no-op.
-    pub fn insert(&mut self, relid: RelId, v: DDValue) -> Response<()> {
-        self.apply_updates(iter::once(Update::Insert { relid, v }))
+    pub fn insert(
+        &mut self,
+        relid: RelId,
+        v: DDValue,
+        transaction: &TransactionHandle,
+    ) -> Response<()> {
+        self.apply_updates(iter::once(Update::Insert { relid, v }), transaction)
     }
 
     /// Insert one record into input relation or replace existing record with the same key.
-    pub fn insert_or_update(&mut self, relid: RelId, v: DDValue) -> Response<()> {
-        self.apply_updates(iter::once(Update::InsertOrUpdate { relid, v }))
+    pub fn insert_or_update(
+        &mut self,
+        relid: RelId,
+        v: DDValue,
+        transaction: &TransactionHandle,
+    ) -> Response<()> {
+        self.apply_updates(iter::once(Update::InsertOrUpdate { relid, v }), transaction)
     }
 
     /// Remove a record if it exists in the relation.
-    pub fn delete_value(&mut self, relid: RelId, v: DDValue) -> Response<()> {
-        self.apply_updates(iter::once(Update::DeleteValue { relid, v }))
+    pub fn delete_value(
+        &mut self,
+        relid: RelId,
+        v: DDValue,
+        transaction: &TransactionHandle,
+    ) -> Response<()> {
+        self.apply_updates(iter::once(Update::DeleteValue { relid, v }), transaction)
     }
 
     /// Remove a key if it exists in the relation.
-    pub fn delete_key(&mut self, relid: RelId, k: DDValue) -> Response<()> {
-        self.apply_updates(iter::once(Update::DeleteKey { relid, k }))
+    pub fn delete_key(
+        &mut self,
+        relid: RelId,
+        k: DDValue,
+        transaction: &TransactionHandle,
+    ) -> Response<()> {
+        self.apply_updates(iter::once(Update::DeleteKey { relid, k }), transaction)
     }
 
     /// Modify a key if it exists in the relation.
@@ -2028,8 +2020,9 @@ impl RunningProgram {
         relid: RelId,
         k: DDValue,
         m: Arc<dyn Mutator<DDValue> + Send + Sync>,
+        transaction: &TransactionHandle,
     ) -> Response<()> {
-        self.apply_updates(iter::once(Update::Modify { relid, k, m }))
+        self.apply_updates(iter::once(Update::Modify { relid, k, m }), transaction)
     }
 
     /// Applies a single update.
@@ -2066,8 +2059,10 @@ impl RunningProgram {
     pub fn apply_updates<I: Iterator<Item = Update<DDValue>>>(
         &mut self,
         updates: I,
+        transaction: &TransactionHandle,
     ) -> Response<()> {
-        if !self.transaction_in_progress {
+        // FIXME: Use `Option::contains()` https://github.com/rust-lang/rust/issues/62358
+        if self.transaction_in_progress.as_ref() != Some(transaction.id()) {
             return Err("apply_updates: no transaction in progress".to_string());
         }
 
@@ -2083,8 +2078,13 @@ impl RunningProgram {
     }
 
     /// Deletes all values in an input table
-    pub fn clear_relation(&mut self, relid: RelId) -> Response<()> {
-        if !self.transaction_in_progress {
+    pub fn clear_relation(
+        &mut self,
+        relid: RelId,
+        transaction: &TransactionHandle,
+    ) -> Response<()> {
+        // FIXME: Use `Option::contains()` https://github.com/rust-lang/rust/issues/62358
+        if self.transaction_in_progress.as_ref() != Some(transaction.id()) {
             return Err("clear_relation: no transaction in progress".to_string());
         }
 
@@ -2129,7 +2129,7 @@ impl RunningProgram {
             }
         };
 
-        self.apply_updates(updates.into_iter())
+        self.apply_updates(updates.into_iter(), transaction)
     }
 
     /// Returns all values in the arrangement with the specified key.
@@ -2535,8 +2535,8 @@ impl RunningProgram {
     fn send(&self, worker_index: usize, msg: Msg) -> Response<()> {
         match self.senders[worker_index].send(msg) {
             Ok(()) => {
-                /* Worker 0 may be blocked in `step_or_park`.  Unpark to ensure receipt of the
-                 * message. */
+                // Worker 0 may be blocked in `step_or_park`. Unpark to ensure receipt of the
+                // message.
                 self.worker_threads[worker_index].unpark();
                 Ok(())
             }
@@ -2590,14 +2590,14 @@ impl RunningProgram {
     }
 
     /// Reverse all changes recorded in delta sets to rollback the transaction.
-    fn delta_undo(&mut self) -> Response<()> {
+    fn delta_undo(&mut self, transaction: &TransactionHandle) -> Response<()> {
         let mut updates = Vec::with_capacity(self.relations.len());
         for (relid, rel) in &self.relations {
             Self::delta_undo_updates(*relid, rel.delta(), &mut updates);
         }
 
         // println!("updates: {:?}", updates);
-        self.apply_updates(updates.into_iter())
+        self.apply_updates(updates.into_iter(), transaction)
             .and_then(|_| self.flush())
             .map(|_| {
                 /* validation: all deltas must be empty */

--- a/rust/template/differential_datalog/program/transaction.rs
+++ b/rust/template/differential_datalog/program/transaction.rs
@@ -1,0 +1,124 @@
+use crate::program::{Response, RunningProgram};
+use std::num::NonZeroU64;
+
+/// The id of a transaction
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct TransactionId(NonZeroU64);
+
+/// A handle to a ddlog transaction
+#[derive(Debug, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+#[must_use = "transactions can only be used with their transaction handles"]
+pub struct TransactionHandle {
+    id: TransactionId,
+}
+
+impl TransactionHandle {
+    /// Create a new transaction handle
+    #[doc(hidden)]
+    pub const fn new(id: NonZeroU64) -> Self {
+        Self {
+            id: TransactionId(id),
+        }
+    }
+
+    /// Turn the transaction handle into a u64
+    #[doc(hidden)]
+    pub const fn as_u64(&self) -> u64 {
+        self.id.0.get()
+    }
+
+    /// Get the current handle's transaction id
+    pub(super) const fn id(&self) -> &TransactionId {
+        &self.id
+    }
+}
+
+impl RunningProgram {
+    /// Start a transaction.
+    ///
+    /// Fails if there is already a transaction in progress.
+    pub fn transaction_start(&mut self) -> Response<TransactionHandle> {
+        if self.transaction_in_progress.is_some() {
+            return Err("transaction already in progress".to_string());
+        }
+
+        let id = TransactionId(self.transaction_counter);
+        self.transaction_in_progress = Some(id);
+        self.transaction_counter = NonZeroU64::new(self.transaction_counter.get() + 1)
+            .expect("transaction_counter + 1 will always be non-zero");
+
+        Ok(TransactionHandle { id })
+    }
+
+    /// Commit a transaction.
+    pub fn transaction_commit(&mut self, transaction: TransactionHandle) -> Response<()> {
+        if self.transaction_in_progress.is_none() {
+            return Err("transaction_commit: no transaction in progress".to_string());
+        // FIXME: Use `Option::contains()` https://github.com/rust-lang/rust/issues/62358
+        } else if self.transaction_in_progress.as_ref() != Some(transaction.id()) {
+            return Err("transaction_commit: invalid transaction handle given".to_string());
+        }
+
+        self.flush().and_then(|_| self.delta_cleanup()).map(|_| {
+            self.transaction_in_progress = None;
+        })
+    }
+
+    /// Rollback the transaction, undoing all changes.
+    pub fn transaction_rollback(&mut self, transaction: TransactionHandle) -> Response<()> {
+        if self.transaction_in_progress.is_none() {
+            return Err("transaction_rollback: no transaction in progress".to_string());
+        // FIXME: Use `Option::contains()` https://github.com/rust-lang/rust/issues/62358
+        } else if self.transaction_in_progress.as_ref() != Some(transaction.id()) {
+            return Err("transaction_rollback: invalid transaction handle given".to_string());
+        }
+
+        self.flush()
+            .and_then(|_| self.delta_undo(&transaction))
+            .map(|_| {
+                self.transaction_in_progress = None;
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::program::Program;
+
+    fn ddlog() -> RunningProgram {
+        let prog: Program = Program {
+            nodes: vec![],
+            init_data: vec![],
+        };
+
+        prog.run(1).unwrap()
+    }
+
+    #[test]
+    fn transaction_succeeds() {
+        let mut ddlog = ddlog();
+        let trans = ddlog.transaction_start().unwrap();
+        ddlog.transaction_commit(trans).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "transaction already in progress")]
+    fn double_transaction_fails() {
+        let mut ddlog = ddlog();
+        let _ = ddlog.transaction_start().unwrap();
+        let _ = ddlog.transaction_start().unwrap();
+    }
+
+    #[test]
+    fn successive_transactions() {
+        let mut ddlog = ddlog();
+        let trans = ddlog.transaction_start().unwrap();
+        ddlog.transaction_commit(trans).unwrap();
+
+        let trans = ddlog.transaction_start().unwrap();
+        ddlog.transaction_commit(trans).unwrap();
+    }
+}

--- a/rust/template/src/api/mod.rs
+++ b/rust/template/src/api/mod.rs
@@ -143,9 +143,13 @@ impl HDDlog {
         Ok(())
     }
 
-    pub fn clear_relation(&self, table: usize) -> Result<(), String> {
+    pub fn clear_relation(
+        &self,
+        table: usize,
+        transaction: &TransactionHandle,
+    ) -> Result<(), String> {
         self.record_clear_relation(table);
-        self.prog.lock().unwrap().clear_relation(table)
+        self.prog.lock().unwrap().clear_relation(table, transaction)
     }
 
     pub fn dump_table<F>(&self, table: usize, cb: Option<F>) -> Result<(), &'static str>
@@ -199,17 +203,20 @@ impl DDlog for HDDlog {
         Self::do_run(workers, do_store, CallbackUpdateHandler::new(cb), None)
     }
 
-    fn transaction_start(&self) -> Result<(), String> {
+    fn transaction_start(&self) -> Result<TransactionHandle, String> {
         self.record_transaction_start();
         self.prog.lock().unwrap().transaction_start()
     }
 
-    fn transaction_commit_dump_changes(&self) -> Result<DeltaMap<DDValue>, String> {
+    fn transaction_commit_dump_changes(
+        &self,
+        transaction: TransactionHandle,
+    ) -> Result<DeltaMap<DDValue>, String> {
         self.record_transaction_commit(true);
         *self.deltadb.lock().unwrap() = Some(DeltaMap::new());
 
         self.update_handler.before_commit();
-        match (self.prog.lock().unwrap().transaction_commit()) {
+        match (self.prog.lock().unwrap().transaction_commit(transaction)) {
             Ok(()) => {
                 self.update_handler.after_commit(true);
                 let mut delta = self.deltadb.lock().unwrap();
@@ -222,11 +229,11 @@ impl DDlog for HDDlog {
         }
     }
 
-    fn transaction_commit(&self) -> Result<(), String> {
+    fn transaction_commit(&self, transaction: TransactionHandle) -> Result<(), String> {
         self.record_transaction_commit(false);
         self.update_handler.before_commit();
 
-        match (self.prog.lock().unwrap().transaction_commit()) {
+        match (self.prog.lock().unwrap().transaction_commit(transaction)) {
             Ok(()) => {
                 self.update_handler.after_commit(true);
                 Ok(())
@@ -238,13 +245,13 @@ impl DDlog for HDDlog {
         }
     }
 
-    fn transaction_rollback(&self) -> Result<(), String> {
+    fn transaction_rollback(&self, transaction: TransactionHandle) -> Result<(), String> {
         self.record_transaction_rollback();
-        self.prog.lock().unwrap().transaction_rollback()
+        self.prog.lock().unwrap().transaction_rollback(transaction)
     }
 
     /// Two implementations of `apply_updates`: one that takes `Record`s and one that takes `DDValue`s.
-    fn apply_updates<V, I>(&self, upds: I) -> Result<(), String>
+    fn apply_updates<V, I>(&self, upds: I, transaction: &TransactionHandle) -> Result<(), String>
     where
         V: Deref<Target = record::UpdCmd>,
         I: iter::Iterator<Item = V>,
@@ -256,20 +263,23 @@ impl DDlog for HDDlog {
         // the first invalid command.
         // XXX: We must iterate till the end of `upds`, as `ddlog_apply_updates` relies on this to
         // deallocate all commands.
-        let res = self.apply_valupdates(upds.flat_map(|u| {
-            if conversion_err {
-                None
-            } else {
-                match updcmd2upd(u.deref()) {
-                    Ok(u) => Some(u),
-                    Err(e) => {
-                        conversion_err = true;
-                        msg = Some(format!("invalid command {:?}: {}", *u, e));
-                        None
+        let res = self.apply_valupdates(
+            upds.flat_map(|u| {
+                if conversion_err {
+                    None
+                } else {
+                    match updcmd2upd(u.deref()) {
+                        Ok(u) => Some(u),
+                        Err(e) => {
+                            conversion_err = true;
+                            msg = Some(format!("invalid command {:?}: {}", *u, e));
+                            None
+                        }
                     }
                 }
-            }
-        }));
+            }),
+            transaction,
+        );
         match msg {
             Some(e) => Err(e),
             None => res,
@@ -277,24 +287,28 @@ impl DDlog for HDDlog {
     }
 
     #[cfg(feature = "flatbuf")]
-    fn apply_updates_from_flatbuf(&self, buf: &[u8]) -> Result<(), String> {
+    fn apply_updates_from_flatbuf(
+        &self,
+        buf: &[u8],
+        transaction: &TransactionHandle,
+    ) -> Result<(), String> {
         let cmditer = flatbuf::updates_from_flatbuf(buf)?;
         let upds: Result<Vec<Update<DDValue>>, String> = cmditer
             .map(|cmd| flatbuf::DDValueUpdate::from_flatbuf(cmd).map(|x| x.0))
             .collect();
-        self.apply_valupdates(upds?.into_iter())
+        self.apply_valupdates(upds?.into_iter(), transaction)
     }
 
-    fn apply_valupdates<I>(&self, upds: I) -> Result<(), String>
+    fn apply_valupdates<I>(&self, upds: I, transaction: &TransactionHandle) -> Result<(), String>
     where
         I: Iterator<Item = Update<DDValue>>,
     {
         if let Some(ref f) = self.replay_file {
             let mut file = f.lock().unwrap();
             let upds = record_val_upds::<Self::Convert, _, _, _>(&mut *file, upds, |_| ());
-            self.prog.lock().unwrap().apply_updates(upds)
+            self.prog.lock().unwrap().apply_updates(upds, transaction)
         } else {
-            self.prog.lock().unwrap().apply_updates(upds)
+            self.prog.lock().unwrap().apply_updates(upds, transaction)
         }
     }
 

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -192,6 +192,7 @@ rustLibFiles specname =
         , (dir </> "differential_datalog/program/update.rs"               , $(embedFile "rust/template/differential_datalog/program/update.rs"))
         , (dir </> "differential_datalog/program/arrange.rs"              , $(embedFile "rust/template/differential_datalog/program/arrange.rs"))
         , (dir </> "differential_datalog/program/timestamp.rs"            , $(embedFile "rust/template/differential_datalog/program/timestamp.rs"))
+        , (dir </> "differential_datalog/program/transaction.rs"          , $(embedFile "rust/template/differential_datalog/program/transaction.rs"))
         , (dir </> "differential_datalog/record.rs"                       , $(embedFile "rust/template/differential_datalog/record.rs"))
         , (dir </> "differential_datalog/replay.rs"                       , $(embedFile "rust/template/differential_datalog/replay.rs"))
         , (dir </> "differential_datalog/test.rs"                         , $(embedFile "rust/template/differential_datalog/test.rs"))


### PR DESCRIPTION
Made transactions (and operations that require an active transaction) start using handles.
A first step towards #823 with the idea that concurrent transactions can more easily be implemented when handles already exist