### PR TITLE
Capture stdout/stderr of processes invoked

### DIFF
--- a/sql/install-ddlog-jar.sh
+++ b/sql/install-ddlog-jar.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 
 cd ../java
+make
 mvn install:install-file -Dfile=ddlogapi.jar -DgroupId=ddlog -DartifactId=ddlogapi -Dversion=0.1 -Dpackaging=jar

--- a/sql/src/test/java/ddlog/BaseQueriesTest.java
+++ b/sql/src/test/java/ddlog/BaseQueriesTest.java
@@ -116,9 +116,10 @@ public class BaseQueriesTest {
             File tmp = this.writeProgramToFile(programBody);
             basename = tmp.getName();
             //Compiling all the way takes too long
-            //boolean success = DDlogAPI.compileDDlogProgram(tmp.getName(), true,"../lib", "./lib");
-            boolean success = DDlogAPI.compileDDlogProgramToRust(tmp.getName(), true,"../lib", "./lib");
-            if (!success) {
+            DDlogAPI.CompilationResult result = new DDlogAPI.CompilationResult(true);
+            //DDlogAPI.compileDDlogProgram(tmp.getName(), result, "../lib", "./lib");
+            DDlogAPI.compileDDlogProgramToRust(tmp.getName(), result,"../lib", "./lib");
+            if (!result.isSuccess()) {
                 String[] lines = programBody.split("\n");
                 for (int i = 0; i < lines.length; i++) {
                     System.out.printf("%3s ", i+1);
@@ -203,8 +204,9 @@ public class BaseQueriesTest {
             final DDlogProgram dDlogProgram = t.getDDlogProgram();
             final String ddlogProgramAsString = dDlogProgram.toString();
             File tmp = this.writeProgramToFile(ddlogProgramAsString);
-            boolean success = DDlogAPI.compileDDlogProgram(tmp.toString(), false,"..", "lib");
-            Assert.assertTrue(success);
+            DDlogAPI.CompilationResult result = new DDlogAPI.CompilationResult(false);
+            DDlogAPI.compileDDlogProgram(tmp.toString(), result,"..", "lib");
+            Assert.assertTrue(result.isSuccess());
         } catch (IOException | DDlogException e) {
             throw new RuntimeException(e);
         }

--- a/sql/src/test/java/ddlog/DynamicTest.java
+++ b/sql/src/test/java/ddlog/DynamicTest.java
@@ -46,8 +46,8 @@ public class DynamicTest extends BaseQueriesTest {
 
     @Test
     public void testDynamicLoading() throws IOException, DDlogException {
-        //if (!runSlowTests)
-        //    return;
+        if (!runSlowTests)
+            return;
         String ddlogProgram = "import sql\n" + // not needed, but we test the libraries too
                 "import sqlop\n" +
                 "input relation R(v: bit<16>)\n" +

--- a/sql/src/test/java/ddlog/DynamicTest.java
+++ b/sql/src/test/java/ddlog/DynamicTest.java
@@ -1,5 +1,6 @@
 package ddlog;
 
+import com.google.common.collect.ComputationException;
 import ddlogapi.*;
 import org.jooq.DSLContext;
 import org.jooq.SQLDialect;
@@ -45,8 +46,8 @@ public class DynamicTest extends BaseQueriesTest {
 
     @Test
     public void testDynamicLoading() throws IOException, DDlogException {
-        if (!runSlowTests)
-            return;
+        //if (!runSlowTests)
+        //    return;
         String ddlogProgram = "import sql\n" + // not needed, but we test the libraries too
                 "import sqlop\n" +
                 "input relation R(v: bit<16>)\n" +
@@ -54,8 +55,9 @@ public class DynamicTest extends BaseQueriesTest {
                 "O(v) :- R(v).";
         File file = this.writeProgramToFile(ddlogProgram);
         DDlogAPI api = null;
-        boolean success = DDlogAPI.compileDDlogProgram(file.toString(), true, "../lib", "./lib");
-        if (success) {
+        DDlogAPI.CompilationResult result = new DDlogAPI.CompilationResult(true);
+        DDlogAPI.compileDDlogProgram(file.toString(), result, "../lib", "./lib");
+        if (result.isSuccess()) {
             api = DDlogAPI.loadDDlog();
         }
         if (api == null)
@@ -65,6 +67,7 @@ public class DynamicTest extends BaseQueriesTest {
         DDlogRecord[] fields = { field };
         DDlogRecord record = DDlogRecord.makeStruct("R", fields);
         int id = api.getTableId("R");
+        Assert.assertTrue(id >= 0);
         Assert.assertTrue(id < 10);
         DDlogRecCommand command = new DDlogRecCommand(
                 DDlogCommand.Kind.Insert, id, record);

--- a/sql/src/test/java/ddlog/JooqProviderTest.java
+++ b/sql/src/test/java/ddlog/JooqProviderTest.java
@@ -247,9 +247,10 @@ public class JooqProviderTest {
         BufferedWriter bw = new BufferedWriter(new FileWriter(tmp));
         bw.write(dDlogProgram.toString());
         bw.close();
-        if (!DDlogAPI.compileDDlogProgram(fileName, true, "../lib", "./lib")) {
+        DDlogAPI.CompilationResult result = new DDlogAPI.CompilationResult(true);
+        DDlogAPI.compileDDlogProgram(fileName, result, "../lib", "./lib");
+        if (!result.isSuccess())
             throw new RuntimeException("Failed to compile ddlog program");
-        }
         DDlogAPI.loadDDlog();
     }
 }

--- a/test/run-souffle-tests.py
+++ b/test/run-souffle-tests.py
@@ -37,6 +37,7 @@ xfail = [
     "indexed_inequalities", # DDlog cannot infer the type of `2` in `2^32`.
     "magic_aggregates",  # 227
     "count",       # 227
+    "choice_total_order", # Takes too much time
     "magic_count", # 227
     "magic_samegen", # computes a very large join
     "circuit_sat", # issue 221 - starting state is very large

--- a/tools/souffle-grammar.pg
+++ b/tools/souffle-grammar.pg
@@ -104,15 +104,8 @@ RelationDecl: DECL RelationList RelationBody Qualifiers DependencyList
             ;
 
 DependencyList: EMPTY
-            | KEYS DependencyListAux
-            ;
-
-DependencyListAux: Dependency
-            | DependencyListAux "," Dependency
-            ;
-
-Dependency: Identifier
-            | "(" IdentifierList ")"
+            | KEYS Identifier
+            | KEYS "(" NonEmptyIdentifierList ")"
             ;
 
 RelationList: Identifier
@@ -173,6 +166,10 @@ Parameter: Identifier ":" Identifier
 
 IdentifierList: EMPTY
               | IdentifierList "," Identifier
+              ;
+
+NonEmptyIdentifierList: Identifier
+              | NonEmptyIdentifierList "," Identifier
               ;
 
 ArgumentList: Argument

--- a/tools/souffle-grammar.pg
+++ b/tools/souffle-grammar.pg
@@ -100,7 +100,19 @@ RecordType: Identifier ":" TypeId
           | Identifier ":" TypeId "," RecordType
           ;
 
-RelationDecl: DECL RelationList RelationBody Qualifiers
+RelationDecl: DECL RelationList RelationBody Qualifiers DependencyList
+            ;
+
+DependencyList: EMPTY
+            | KEYS DependencyListAux
+            ;
+
+DependencyListAux: Dependency
+            | DependencyListAux "," Dependency
+            ;
+
+Dependency: Identifier
+            | "(" IdentifierList ")"
             ;
 
 RelationList: Identifier
@@ -403,3 +415,4 @@ TNUMBER: "number" ;
 TSYMBOL: "symbol" ;
 TUNSIGNED: "unsigned" ;
 TFLOAT: "float" ;
+KEYS: "keys" ;

--- a/tools/souffle-grammar.pg
+++ b/tools/souffle-grammar.pg
@@ -104,9 +104,16 @@ RelationDecl: DECL RelationList RelationBody Qualifiers DependencyList
             ;
 
 DependencyList: EMPTY
-            | KEYS Identifier
-            | KEYS "(" NonEmptyIdentifierList ")"
+            | KEYS DependencyListAux
             ;
+
+DependencyListAux: Dependency
+                 | DependencyListAux "," Dependency
+                 ;
+
+Dependency: Identifier
+          | "(" NonEmptyIdentifierList ")"
+          ;
 
 RelationList: Identifier
             | Identifier "," RelationList


### PR DESCRIPTION
Fixes #838
The class CompilationOutput is now available. It is passed as an argument to functions that compile generated programs.
After the compilation is finished the function gives access to the exit code and to stdout and stderr of the compilation processes.