### PR TITLE
ddlog-jooq: support UPDATE queries

### DIFF
--- a/sql/pom.xml
+++ b/sql/pom.xml
@@ -18,6 +18,12 @@
       <artifactId>presto-parser</artifactId>
       <version>0.228</version>
     </dependency>
+    <!-- Alternative parser -->
+    <dependency>
+      <groupId>org.apache.calcite</groupId>
+      <artifactId>calcite-core</artifactId>
+      <version>1.26.0</version>
+    </dependency>
     <!-- dynamically query db for schemas -->
     <dependency>
       <groupId>com.h2database</groupId>

--- a/sql/src/main/java/com/vmware/ddlog/ParseLiterals.java
+++ b/sql/src/main/java/com/vmware/ddlog/ParseLiterals.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2018-2020 VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: BSD-2
+ */
+
+package com.vmware.ddlog;
+
+import ddlogapi.DDlogException;
+import ddlogapi.DDlogRecord;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.util.SqlBasicVisitor;
+
+/*
+ * Translates literals into corresponding DDlogRecord instances
+ */
+class ParseLiterals extends SqlBasicVisitor<DDlogRecord> {
+
+    @Override
+    public DDlogRecord visit(final SqlLiteral sqlLiteral) {
+        switch (sqlLiteral.getTypeName()) {
+            case BOOLEAN:
+                return new DDlogRecord(sqlLiteral.booleanValue());
+            case DECIMAL:
+                return new DDlogRecord(sqlLiteral.intValue(false));
+            case CHAR:
+                try {
+                    return new DDlogRecord(sqlLiteral.toValue());
+                } catch (final DDlogException ignored) {
+                }
+            default:
+                throw new UnsupportedOperationException(sqlLiteral.toValue());
+        }
+    }
+}

--- a/sql/src/test/java/ddlog/JooqProviderTest.java
+++ b/sql/src/test/java/ddlog/JooqProviderTest.java
@@ -15,7 +15,6 @@ import org.jooq.Record;
 import org.jooq.Result;
 import org.jooq.impl.DSL;
 import org.jooq.tools.jdbc.MockConnection;
-import org.jooq.tools.jdbc.MockDataProvider;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -39,6 +38,7 @@ public class JooqProviderTest {
 
     @Nullable
     private static DSLContext create;
+    private static DDlogJooqProvider provider;
     private final Field<String> field1 = field("id", String.class);
     private final Field<Integer> field2 = field("capacity", Integer.class);
     private final Field<Boolean> field3 = field("up", Boolean.class);
@@ -74,7 +74,7 @@ public class JooqProviderTest {
         final DDlogAPI dDlogAPI = new DDlogAPI(1, false);
 
         // Initialise the data provider
-        MockDataProvider provider = new DDlogJooqProvider(dDlogAPI, ddl);
+        provider = new DDlogJooqProvider(dDlogAPI, ddl);
         MockConnection connection = new MockConnection(provider);
 
         // Pass the mock connection to a jOOQ DSLContext
@@ -248,7 +248,6 @@ public class JooqProviderTest {
         final Result<Record> results = create.selectFrom(table("hostsv")).fetch();
         System.out.println(results);
     }
-
 
     public static void compileAndLoad(final List<String> ddl) throws IOException, DDlogException {
         final Translator t = new Translator(null);

--- a/sql/src/test/java/ddlog/JooqProviderTest.java
+++ b/sql/src/test/java/ddlog/JooqProviderTest.java
@@ -244,7 +244,7 @@ public class JooqProviderTest {
     @Test
     public void testUpdates() {
         create.execute("insert into hosts values ('n1', 10, true)");
-        create.execute("insert into hosts values ('n1', 11, false)");
+        create.execute("update hosts set capacity = 11 where id = 'n1'");
         final Result<Record> results = create.selectFrom(table("hostsv")).fetch();
         System.out.println(results);
     }

--- a/sql/src/test/java/ddlog/JooqProviderTest.java
+++ b/sql/src/test/java/ddlog/JooqProviderTest.java
@@ -247,6 +247,7 @@ public class JooqProviderTest {
         create.execute("update hosts set capacity = 11 where id = 'n1'");
         final Result<Record> results = create.selectFrom(table("hostsv")).fetch();
         System.out.println(results);
+        assertEquals(results.get(0).get(1), 11);
     }
 
     public static void compileAndLoad(final List<String> ddl) throws IOException, DDlogException {

--- a/sql/src/test/java/ddlog/JooqProviderTest.java
+++ b/sql/src/test/java/ddlog/JooqProviderTest.java
@@ -246,7 +246,17 @@ public class JooqProviderTest {
         create.execute("insert into hosts values ('n1', 10, true)");
         create.execute("update hosts set capacity = 11 where id = 'n1'");
         final Result<Record> results = create.selectFrom(table("hostsv")).fetch();
-        System.out.println(results);
+        assertEquals(results.get(0).get(1), 11);
+    }
+
+    /*
+     * Test updates
+     */
+    @Test
+    public void testUpdatesWithBindings() {
+        create.execute("insert into hosts values ('n1', 10, true)");
+        create.update(table("hosts")).set(field2, 11).where(field1.eq("n1")).execute();
+        final Result<Record> results = create.selectFrom(table("hostsv")).fetch();
         assertEquals(results.get(0).get(1), 11);
     }
 

--- a/sql/src/test/java/ddlog/JooqProviderTest.java
+++ b/sql/src/test/java/ddlog/JooqProviderTest.java
@@ -238,6 +238,18 @@ public class JooqProviderTest {
         }
     }
 
+    /*
+     * Test updates
+     */
+    @Test
+    public void testUpdates() {
+        create.execute("insert into hosts values ('n1', 10, true)");
+        create.execute("insert into hosts values ('n1', 11, false)");
+        final Result<Record> results = create.selectFrom(table("hostsv")).fetch();
+        System.out.println(results);
+    }
+
+
     public static void compileAndLoad(final List<String> ddl) throws IOException, DDlogException {
         final Translator t = new Translator(null);
         ddl.forEach(t::translateSqlStatement);


### PR DESCRIPTION
This PR uses the recently adds support for `UPDATE` queries in ddlog-jooq. The queries should be of the form:

`update from T set C1 = A... where P1 = B...`

It uses the recently add `Modify` command in the DDlog API.

It also uses a new parser (Apache Calcite) because the Presto parser does not support `UPDATE` queries. It retains the use of the Presto parser to deal with DDL statements.