### PR TITLE
Parse Records with floats represented as integers.

### DIFF
--- a/rust/template/differential_datalog/record.rs
+++ b/rust/template/differential_datalog/record.rs
@@ -1095,6 +1095,10 @@ impl FromRecord for OrderedFloat<f32> {
             Record::Float(i) => Ok(*i),
             // Floating point values parsed from a command file are always stored as doubles.
             Record::Double(i) => Ok(OrderedFloat::<f32>::from(**i as f32)),
+            Record::Int(i) => i
+                .to_f32()
+                .map(OrderedFloat)
+                .ok_or_else(|| format!("Cannot convert {} to float", *i)),
             v => Err(format!("not a float {:?}", *v)),
         }
     }
@@ -1117,6 +1121,10 @@ impl FromRecord for OrderedFloat<f64> {
     fn from_record(val: &Record) -> Result<Self, String> {
         match val {
             Record::Double(i) => Ok(*i),
+            Record::Int(i) => i
+                .to_f64()
+                .map(OrderedFloat)
+                .ok_or_else(|| format!("Cannot convert {} to double", *i)),
             v => Err(format!("not a double {:?}", *v)),
         }
     }

--- a/test/datalog_tests/fp_test.dat
+++ b/test/datalog_tests/fp_test.dat
@@ -4,6 +4,7 @@ dump fp_test::BB;
 
 start;
 
+insert fp_test::FloatsFromRecord("1", 1),
 insert fp_test::FloatsFromRecord("0.5", 0.5),
 insert fp_test::DoublesFromRecord("0.5", 0.5),
 

--- a/test/datalog_tests/fp_test.dump.expected
+++ b/test/datalog_tests/fp_test.dump.expected
@@ -93,6 +93,7 @@ fp_test::FloatsFromRecord{.s = "-32.0e-2", .f = -0.32}
 fp_test::FloatsFromRecord{.s = "-32e2", .f = -3200}
 fp_test::FloatsFromRecord{.s = "0.32", .f = 0.32}
 fp_test::FloatsFromRecord{.s = "0.5", .f = 0.5}
+fp_test::FloatsFromRecord{.s = "1", .f = 1}
 fp_test::FloatsFromRecord{.s = "1.6487212181091308", .f = 1.6487212}
 fp_test::DoublesFromRecord{.s = "-0.5", .d = -0.5}
 fp_test::DoublesFromRecord{.s = "-32.0e-2", .d = -0.32}


### PR DESCRIPTION
DDlog serializes a value "1.0" of type `double` to `Record` as "1",
which is legit; however when parsing the resulting record, it throws
"not a double" error, as it refuses to convert `bigint` to `double`.
This commit fixes the `double` and `float` parsers to accept integer
values and convert them to the respective FP type.