### PR TITLE
Report dep cycle in stratified negation errors.

### DIFF
--- a/src/Language/DifferentialDatalog/DatalogProgram.hs
+++ b/src/Language/DifferentialDatalog/DatalogProgram.hs
@@ -223,6 +223,7 @@ fieldAttributeMapM fun f@Field{..} = do
 
 data DepGraphNode = DepNodeRel   String
                   | DepNodeApply Apply
+                  deriving (Eq)
 
 instance Show DepGraphNode where
     show (DepNodeRel rel) = rel

--- a/src/Language/DifferentialDatalog/Util.hs
+++ b/src/Language/DifferentialDatalog/Util.hs
@@ -61,8 +61,9 @@ grCycle g = case mapMaybe (grCycleThroughNode g) (nodes g) of
 -- Find a cycle through a specified node.
 grCycleThroughNode :: Graph gr => gr a b -> Node -> Maybe [LNode a]
 grCycleThroughNode g n =
-    listToMaybe $ map (\s -> map (\i -> (i, fromJust $ lab g i)) (n:(esp s n g))) $
-                  filter (\s -> elem n (reachable s g)) $ suc g n
+    listToMaybe $ map (\s -> map (\i -> (i, fromJust $ lab g i)) (n:(esp s n g)))
+                $ filter (\s -> elem n (reachable s g))
+                $ suc g n
 
 -- Group graph nodes; aggregate edges
 grGroup :: (DynGraph gr) => gr a b -> [[Node]] -> gr [Node] b

--- a/test/datalog_tests/rules.fail.ast.expected
+++ b/test/datalog_tests/rules.fail.ast.expected
@@ -7,8 +7,14 @@ expecting letter or digit, "_", "::", "(" or "["
   ./test/datalog_tests/rules.fail.dl:7:1-9:1
 
 
-error: ./test/datalog_tests/rules.fail.dl:10:1-11:1: Relation R3 is mutually recursive with R2 and therefore cannot appear negated in this rule
+error: ./test/datalog_tests/rules.fail.dl:10:1-11:1: Relation R3 is mutually recursive with R2 and therefore cannot appear negated in this rule.
+Dependency cycle: R3 -> R2 -> R3
 R2(x) :- R1(x), not R3(x, "foo").
+^
+
+error: ./test/datalog_tests/rules.fail.dl:9:1-11:1: Relation R2 is mutually recursive with R2 and therefore cannot appear negated in this rule.
+Dependency cycle: R2 -> R2
+R2(x) :- R1(x), not R2(x).
 ^
 
 error: ./test/datalog_tests/rules.fail.dl:9:28-9:39: Type mismatch:

--- a/test/datalog_tests/rules.fail.dl
+++ b/test/datalog_tests/rules.fail.dl
@@ -26,6 +26,16 @@ R3(x,"foo") :- R2(x).
 
 //---
 
+// non-stratified negation
+
+input relation R1(a1: string)
+
+relation R2(a2: string)
+
+R2(x) :- R1(x), not R2(x).
+
+//---
+
 // Aggregate function does not take enough arguments.
 
 input relation AggregateMe3(x: string, y: string, z: string)


### PR DESCRIPTION
Enhance stratified negation error messages by printing the dependency
cycle that caused the error:

```
Relation R3 is mutually recursive with R2 and therefore cannot appear negated in this rule.
Dependency cycle: R3 -> R2 -> R3 // This part of the message is new.
```