### PR TITLE
Support FlatMap over groups.

### DIFF
--- a/src/Language/DifferentialDatalog/Type.hs
+++ b/src/Language/DifferentialDatalog/Type.hs
@@ -745,6 +745,8 @@ varType d (FlatMapVar rl i)                = case typ' d $ exprType d (CtxRuleRF
                                                   TOpaque _ _ [t']     -> t'
                                                   TOpaque _ tname [kt,vt] | tname == mAP_TYPE
                                                                        -> tTuple [kt,vt]
+                                                                          | tname == gROUP_TYPE
+                                                                       -> vt 
                                                   _                    -> error $ "varType FlatMapVar " ++ show rl ++ " " ++ show i 
 varType d (GroupVar rl i)                  = let ktype = ruleGroupByKeyType d rl i
                                                  vtype = ruleGroupByValType d rl i

--- a/test/datalog_tests/simple2.dat
+++ b/test/datalog_tests/simple2.dat
@@ -98,3 +98,14 @@ insert Rletter("bar"),
 insert Rseqs(TSeq1{("buzz", TSeqNone)}),
 
 commit dump_changes;
+
+start;
+
+insert GroupThis(1, "1"),
+insert GroupThis(11, "1"),
+insert GroupThis(111, "1"),
+insert GroupThis(2, "2"),
+insert GroupThis(2, "2"),
+insert GroupThis(222, "2"),
+
+commit dump_changes;

--- a/test/datalog_tests/simple2.dl
+++ b/test/datalog_tests/simple2.dl
@@ -461,3 +461,13 @@ ApplyTransform("5*10", {
     apply_transform(x, |x| x = x*factor);
     "${x}"
 }).
+
+// FlatMap a group.
+input relation GroupThis(x: u32, y: string)
+
+output relation FlatGroup(x: u32)
+
+FlatGroup(x) :-
+    GroupThis(x, y),
+    var g = x.group_by(y),
+    var x = FlatMap(g).

--- a/test/datalog_tests/simple2.dump.expected
+++ b/test/datalog_tests/simple2.dump.expected
@@ -165,3 +165,9 @@ Ack{.m = 2, .n = 1, .a = 5}
 Rseq:
 Rseq{._s = TSeq1{.x = ("bar", TSeq1{.x = ("buzz", TSeqNone{})})}}: +1
 Rseq{._s = TSeq1{.x = ("foo", TSeq1{.x = ("buzz", TSeqNone{})})}}: +1
+FlatGroup:
+FlatGroup{.x = 1}: +1
+FlatGroup{.x = 2}: +1
+FlatGroup{.x = 11}: +1
+FlatGroup{.x = 111}: +1
+FlatGroup{.x = 222}: +1


### PR DESCRIPTION
`FlatMap(g)`, where `g` is of type `Group<>` crashed the compiler.
Implementing it required fixing the compiler, but also implementing
`IntoIterator` for `Group` in `ddlog_std.rs`.