### PR TITLE
Refactored internment module and fixed some clippy lints

### DIFF
--- a/lib/internment.rs
+++ b/lib/internment.rs
@@ -10,12 +10,6 @@ use std::{
 
 /// An atomically reference counted handle to an interned value
 ///
-/// While this type is thread safe, it may cause logical bugs
-/// due to the underlying internment cache being a global variable,
-/// so don't rely on the existence or pre-internment of a variable
-/// since there's no way to know whether it will or will not exist
-/// within a threaded context.
-///
 /// The `PartialOrd` and `Ord` implementations for this type do not
 /// compare the underlying values but instead compare the pointers
 /// to them. Do not rely on the `PartialOrd` and `Ord` implementations

--- a/lib/internment.rs
+++ b/lib/internment.rs
@@ -1,190 +1,281 @@
-use differential_datalog::record;
-use differential_datalog::record::Record;
-use std::cmp;
-use std::fmt;
-use std::hash::Hash;
+use arc_interner::ArcIntern;
+use ddlog_std::Vec as DDlogVec;
+use differential_datalog::record::{self, Record};
+use serde::{de::Deserializer, ser::Serializer};
+use std::{
+    cmp::{self, Ordering},
+    fmt::{Debug, Display, Formatter, Result as FmtResult},
+    hash::Hash,
+};
 
+/// An atomically reference counted handle to an interned value
+///
+/// While this type is thread safe, it may cause logical bugs
+/// due to the underlying internment cache being a global variable,
+/// so don't rely on the existence or pre-internment of a variable
+/// since there's no way to know whether it will or will not exist
+/// within a threaded context.
+///
+/// The `PartialOrd` and `Ord` implementations for this type do not
+/// compare the underlying values but instead compare the pointers
+/// to them. Do not rely on the `PartialOrd` and `Ord` implementations
+/// for persistent storage, determinism or for the ordering of the
+/// underlying values, as pointers will change from run to run.
 #[derive(Default, Eq, PartialEq, Clone, Hash)]
 pub struct Intern<A>
 where
     A: Eq + Send + Sync + Hash + 'static,
 {
-    intern: arc_interner::ArcIntern<A>,
+    interned: ArcIntern<A>,
 }
 
-impl<A: Eq + Send + Sync + Hash + 'static> PartialOrd for Intern<A> {
-    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
-        let sptr = self.as_ref() as *const A as usize;
-        let optr = other.as_ref() as *const A as usize;
-
-        sptr.partial_cmp(&optr)
-    }
-}
-
-impl<A: Eq + Send + Sync + Hash + 'static> Ord for Intern<A> {
-    fn cmp(&self, other: &Self) -> cmp::Ordering {
-        let sptr = self.as_ref() as *const A as usize;
-        let optr = other.as_ref() as *const A as usize;
-
-        sptr.cmp(&optr)
-    }
-}
-
-impl<A: Eq + Send + Sync + Hash + 'static> Deref for Intern<A> {
-    type Target = A;
-
-    fn deref(&self) -> &Self::Target {
-        self.intern.deref()
-    }
-}
-
-impl<A: Eq + Hash + Send + Sync + 'static> Intern<A> {
-    pub fn new(x: A) -> Intern<A> {
+impl<T> Intern<T>
+where
+    T: Eq + Hash + Send + Sync + 'static,
+{
+    /// Create a new interned value
+    pub fn new(value: T) -> Self {
         Intern {
-            intern: arc_interner::ArcIntern::new(x),
+            interned: ArcIntern::new(value),
         }
     }
+
+    /// Get the current interned item's pointer as a `usize`
+    fn as_usize(&self) -> usize {
+        self.as_ref() as *const T as usize
+    }
 }
 
-impl<A> AsRef<A> for Intern<A>
+impl<T> PartialEq<T> for Intern<T>
 where
-    A: Eq + Hash + Send + Sync + 'static,
+    T: Eq + Send + Sync + Hash + 'static,
 {
-    fn as_ref(&self) -> &A {
-        self.intern.as_ref()
+    fn eq(&self, other: &T) -> bool {
+        self.as_ref().eq(&other)
     }
 }
 
-pub fn intern<A: Eq + Hash + Send + Sync + Clone + 'static>(x: &A) -> Intern<A> {
-    Intern::new(x.clone())
-}
-
-pub fn ival<A: Eq + Hash + Send + Sync + Clone>(x: &Intern<A>) -> &A {
-    x.intern.as_ref()
-}
-
-/*pub fn intern_istring_ord(s: &intern_istring) -> u32 {
-    s.x
-}*/
-
-impl<A: fmt::Display + Eq + Hash + Send + Sync + Clone> fmt::Display for Intern<A> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display::fmt(self.as_ref(), f)
-        //record::format_ddlog_str(&intern_istring_str(self), f)
+/// Order the interned values by their pointers
+impl<T> PartialOrd for Intern<T>
+where
+    T: Eq + Send + Sync + Hash + 'static,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.as_usize().partial_cmp(&other.as_usize())
     }
 }
 
-impl<A: fmt::Debug + Eq + Hash + Send + Sync + Clone> fmt::Debug for Intern<A> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Debug::fmt(self.as_ref(), f)
-        //record::format_ddlog_str(&intern_istring_str(self), f)
+/// Order the interned values by their pointers
+impl<T> Ord for Intern<T>
+where
+    T: Eq + Send + Sync + Hash + 'static,
+{
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.as_usize().cmp(&other.as_usize())
     }
 }
 
-impl<A: Serialize + Eq + Hash + Send + Sync + Clone> serde::Serialize for Intern<A> {
+impl<T> Deref for Intern<T>
+where
+    T: Eq + Send + Sync + Hash + 'static,
+{
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.interned.deref()
+    }
+}
+
+impl<T> AsRef<T> for Intern<T>
+where
+    T: Eq + Hash + Send + Sync + 'static,
+{
+    fn as_ref(&self) -> &T {
+        self.interned.as_ref()
+    }
+}
+
+impl<T> From<T> for Intern<T>
+where
+    T: Eq + Hash + Send + Sync + 'static,
+{
+    fn from(value: T) -> Self {
+        Self::new(value)
+    }
+}
+
+impl<T> From<&[T]> for Intern<Vec<T>>
+where
+    T: Eq + Hash + Send + Sync + Clone + 'static,
+{
+    fn from(slice: &[T]) -> Self {
+        Self::new(slice.to_vec())
+    }
+}
+
+impl From<&str> for Intern<String> {
+    fn from(string: &str) -> Self {
+        Self::new(string.to_owned())
+    }
+}
+
+impl<T> Display for Intern<T>
+where
+    T: Display + Eq + Hash + Send + Sync,
+{
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        Display::fmt(self.as_ref(), f)
+    }
+}
+
+impl<T> Debug for Intern<T>
+where
+    T: Debug + Eq + Hash + Send + Sync,
+{
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        Debug::fmt(self.as_ref(), f)
+    }
+}
+
+impl<T> Serialize for Intern<T>
+where
+    T: Serialize + Eq + Hash + Send + Sync,
+{
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: Serializer,
     {
         self.as_ref().serialize(serializer)
     }
 }
 
-impl<'de, A: Deserialize<'de> + Eq + Hash + Send + Sync + 'static> serde::Deserialize<'de>
-    for Intern<A>
+impl<'de, T> Deserialize<'de> for Intern<T>
+where
+    T: Deserialize<'de> + Eq + Hash + Send + Sync + 'static,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: Deserializer<'de>,
     {
-        A::deserialize(deserializer).map(Intern::new)
+        T::deserialize(deserializer).map(Intern::new)
     }
 }
 
-impl<A: FromRecord + Eq + Hash + Send + Sync + 'static> FromRecord for Intern<A> {
+impl<T> FromRecord for Intern<T>
+where
+    T: FromRecord + Eq + Hash + Send + Sync + 'static,
+{
     fn from_record(val: &Record) -> Result<Self, String> {
-        A::from_record(val).map(Intern::new)
+        T::from_record(val).map(Intern::new)
     }
 }
 
-impl<A: IntoRecord + Eq + Hash + Send + Sync + Clone> IntoRecord for Intern<A> {
+impl<T> IntoRecord for Intern<T>
+where
+    T: IntoRecord + Eq + Hash + Send + Sync + Clone,
+{
     fn into_record(self) -> Record {
         ival(&self).clone().into_record()
     }
 }
 
-impl<A> Mutator<Intern<A>> for Record
+impl<T> Mutator<Intern<T>> for Record
 where
-    A: Clone + Eq + Send + Sync + Hash,
-    Record: Mutator<A>,
+    T: Clone + Eq + Send + Sync + Hash,
+    Record: Mutator<T>,
 {
-    fn mutate(&self, x: &mut Intern<A>) -> Result<(), String> {
-        let mut v = ival(x).clone();
-        self.mutate(&mut v)?;
-        *x = intern(&v);
+    fn mutate(&self, value: &mut Intern<T>) -> Result<(), String> {
+        let mut mutated = ival(value).clone();
+        self.mutate(&mut mutated)?;
+        *value = intern(&mutated);
+
         Ok(())
     }
 }
 
-pub fn istring_join(strings: &ddlog_std::Vec<istring>, sep: &String) -> String {
+/// Create a new interned value
+pub fn intern<T>(value: &T) -> Intern<T>
+where
+    T: Eq + Hash + Send + Sync + Clone + 'static,
+{
+    Intern::new(value.clone())
+}
+
+/// Get the inner value of an interned value
+pub fn ival<T>(value: &Intern<T>) -> &T
+where
+    T: Eq + Hash + Send + Sync + Clone,
+{
+    value.interned.as_ref()
+}
+
+/// Join interned strings with a separator
+pub fn istring_join(strings: &DDlogVec<istring>, separator: &String) -> String {
     strings
         .x
         .iter()
-        .map(|s| s.as_ref())
+        .map(|string| string.as_ref())
         .cloned()
         .collect::<Vec<String>>()
-        .join(sep.as_str())
+        .join(separator.as_str())
 }
 
-pub fn istring_split(s: &istring, sep: &String) -> ddlog_std::Vec<String> {
-    ddlog_std::Vec {
-        x: s.as_ref().split(sep).map(|x| x.to_owned()).collect(),
+/// Split an interned string by a separator
+pub fn istring_split(string: &istring, separator: &String) -> DDlogVec<String> {
+    DDlogVec {
+        x: string
+            .as_ref()
+            .split(separator)
+            .map(|string| string.to_owned())
+            .collect(),
     }
 }
 
-pub fn istring_contains(s1: &istring, s2: &String) -> bool {
-    s1.as_ref().contains(s2.as_str())
+/// Returns true if the interned string contains the given pattern
+pub fn istring_contains(interned: &istring, pattern: &String) -> bool {
+    interned.as_ref().contains(pattern.as_str())
 }
 
-pub fn istring_substr(s: &istring, start: &std_usize, end: &std_usize) -> String {
-    let len = s.as_ref().len();
+pub fn istring_substr(string: &istring, start: &std_usize, end: &std_usize) -> String {
+    let len = string.as_ref().len();
     let from = cmp::min(*start as usize, len);
     let to = cmp::max(from, cmp::min(*end as usize, len));
-    s.as_ref()[from..to].to_string()
+
+    string.as_ref()[from..to].to_string()
 }
 
-pub fn istring_replace(s: &istring, from: &String, to: &String) -> String {
-    s.as_ref().replace(from, to)
+pub fn istring_replace(string: &istring, from: &String, to: &String) -> String {
+    string.as_ref().replace(from, to)
 }
 
-pub fn istring_starts_with(s: &istring, prefix: &String) -> bool {
-    s.as_ref().starts_with(prefix)
+pub fn istring_starts_with(string: &istring, prefix: &String) -> bool {
+    string.as_ref().starts_with(prefix)
 }
 
-pub fn istring_ends_with(s: &istring, suffix: &String) -> bool {
-    s.as_ref().ends_with(suffix)
+pub fn istring_ends_with(string: &istring, suffix: &String) -> bool {
+    string.as_ref().ends_with(suffix)
 }
 
-pub fn istring_trim(s: &istring) -> String {
-    s.as_ref().trim().to_string()
+pub fn istring_trim(string: &istring) -> String {
+    string.as_ref().trim().to_string()
 }
 
-pub fn istring_len(s: &istring) -> std_usize {
-    s.as_ref().len() as std_usize
+pub fn istring_len(string: &istring) -> std_usize {
+    string.as_ref().len() as std_usize
 }
 
-pub fn istring_to_bytes(s: &istring) -> ddlog_std::Vec<u8> {
-    ddlog_std::Vec::from(s.as_ref().as_bytes())
+pub fn istring_to_bytes(string: &istring) -> DDlogVec<u8> {
+    DDlogVec::from(string.as_ref().as_bytes())
 }
 
-pub fn istring_to_lowercase(s: &istring) -> String {
-    s.as_ref().to_lowercase()
+pub fn istring_to_lowercase(string: &istring) -> String {
+    string.as_ref().to_lowercase()
 }
 
-pub fn istring_to_uppercase(s: &istring) -> String {
-    s.as_ref().to_uppercase()
+pub fn istring_to_uppercase(string: &istring) -> String {
+    string.as_ref().to_uppercase()
 }
 
-pub fn istring_reverse(s: &istring) -> String {
-    s.as_ref().chars().rev().collect()
+pub fn istring_reverse(string: &istring) -> String {
+    string.as_ref().chars().rev().collect()
 }


### PR DESCRIPTION
* Adds some docs and `From` implementations to the `internment` module
* Adds `#[automatically_derived]` attributes to some macros to disable some lints