### PR TITLE
Use the latest timely and DD code.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+- Upgrade to the latest versions of timely and differential dataflow crates.
+
 ## [0.32.1] - Dec 22, 2020
 
 ### Optimizations

--- a/rust/template/Cargo.toml
+++ b/rust/template/Cargo.toml
@@ -34,9 +34,9 @@ time = { version = "0.2", features = ["serde"] }
 ordered-float = { version = "2.0.0", features = ["serde"] }
 cpuprofiler = { version = "0.0", optional = true }
 #differential-dataflow = "0.11.0"
-differential-dataflow = { git = "https://github.com/ddlog-dev/differential-dataflow", branch = "ddlog-1" }
+differential-dataflow = { git = "https://github.com/ddlog-dev/differential-dataflow", branch = "ddlog-2" }
 #timely = "0.11"
-timely = { git = "https://github.com/ddlog-dev/timely-dataflow", branch = "ddlog-1" }
+timely = { git = "https://github.com/ddlog-dev/timely-dataflow", branch = "ddlog-2" }
 fnv = "1.0.2"
 once_cell = "1.4.1"
 libc = "0.2"

--- a/rust/template/differential_datalog/Cargo.toml
+++ b/rust/template/differential_datalog/Cargo.toml
@@ -12,9 +12,9 @@ c_api = []
 
 [dependencies]
 #differential-dataflow = "0.11.0"
-differential-dataflow = { git = "https://github.com/ddlog-dev/differential-dataflow", branch = "ddlog-1" }
+differential-dataflow = { git = "https://github.com/ddlog-dev/differential-dataflow", branch = "ddlog-2" }
 #timely = "0.11"
-timely = { git = "https://github.com/ddlog-dev/timely-dataflow", branch = "ddlog-1" }
+timely = { git = "https://github.com/ddlog-dev/timely-dataflow", branch = "ddlog-2" }
 
 abomonation = "0.7"
 ordered-float = { version = "2.0.0", features = ["serde"] }

--- a/rust/template/differential_datalog/src/program/mod.rs
+++ b/rust/template/differential_datalog/src/program/mod.rs
@@ -18,7 +18,7 @@ mod update;
 mod worker;
 
 pub use arrange::concatenate_collections;
-pub use timestamp::{TSNested, TupleTS, TS, TS16};
+pub use timestamp::{TSNested, TupleTS, TS};
 pub use update::Update;
 
 use crate::{ddval::*, profile::*, record::Mutator};

--- a/rust/template/differential_datalog/src/program/timestamp.rs
+++ b/rust/template/differential_datalog/src/program/timestamp.rs
@@ -1,104 +1,7 @@
 //! Datalog timestamps
 
-use abomonation::Abomonation;
-use differential_dataflow::lattice::Lattice;
-use num::One;
-use std::{
-    ops::{Add, Mul},
-    sync::atomic::AtomicU32,
-};
-use timely::{
-    order::{PartialOrder, Product},
-    progress::{PathSummary, Timestamp},
-};
-
-/// 16-bit timestamp.
-// TODO: get rid of this and use `u16` directly when/if differential implements
-// `Lattice`, `Timestamp`, `PathSummary` traits for `u16`.
-#[derive(Copy, PartialOrd, PartialEq, Eq, Debug, Default, Clone, Hash, Ord)]
-pub struct TS16 {
-    pub x: u16,
-}
-
-impl TS16 {
-    pub const fn max_value() -> TS16 {
-        TS16 { x: 0xffff }
-    }
-}
-
-impl Abomonation for TS16 {}
-
-impl Mul for TS16 {
-    type Output = TS16;
-
-    fn mul(self, rhs: TS16) -> Self::Output {
-        TS16 { x: self.x * rhs.x }
-    }
-}
-
-impl Add for TS16 {
-    type Output = TS16;
-
-    fn add(self, rhs: TS16) -> Self::Output {
-        TS16 { x: self.x + rhs.x }
-    }
-}
-
-impl One for TS16 {
-    fn one() -> Self {
-        TS16 { x: 1 }
-    }
-}
-
-impl PartialOrder for TS16 {
-    fn less_equal(&self, other: &Self) -> bool {
-        self.x.less_equal(&other.x)
-    }
-
-    fn less_than(&self, other: &Self) -> bool {
-        self.x.less_than(&other.x)
-    }
-}
-
-impl Lattice for TS16 {
-    fn minimum() -> Self {
-        TS16 {
-            x: u16::min_value(),
-        }
-    }
-
-    fn join(&self, other: &Self) -> Self {
-        TS16 {
-            x: std::cmp::max(self.x, other.x),
-        }
-    }
-
-    fn meet(&self, other: &Self) -> Self {
-        TS16 {
-            x: std::cmp::min(self.x, other.x),
-        }
-    }
-}
-
-impl Timestamp for TS16 {
-    type Summary = TS16;
-}
-
-impl PathSummary<TS16> for TS16 {
-    fn results_in(&self, src: &TS16) -> Option<TS16> {
-        self.x.checked_add(src.x).map(|y| TS16 { x: y })
-    }
-
-    fn followed_by(&self, other: &TS16) -> Option<TS16> {
-        self.x.checked_add(other.x).map(|y| TS16 { x: y })
-    }
-}
-
-impl From<TS16> for u64 {
-    fn from(ts: TS16) -> Self {
-        ts.x as u64
-    }
-}
+use std::sync::atomic::AtomicU32;
+use timely::order::Product;
 
 /// Outer timestamp
 pub type TS = u32;
@@ -112,7 +15,7 @@ pub type TSNested = u32;
 /// Timestamp for the nested scope
 /// Use 16-bit timestamps for inner scopes to save memory
 #[cfg(not(feature = "nested_ts_32"))]
-pub type TSNested = TS16;
+pub type TSNested = u16;
 
 /// `Inspect` operator expects the timestampt to be a tuple.
 pub type TupleTS = (TS, TSNested);

--- a/rust/template/differential_datalog/src/program/worker.rs
+++ b/rust/template/differential_datalog/src/program/worker.rs
@@ -38,6 +38,7 @@ use timely::{
     communication::Allocator,
     dataflow::{operators::probe::Handle as ProbeHandle, scopes::Child, Scope},
     logging::TimelyEvent,
+    progress::frontier::AntichainRef,
     worker::Worker,
 };
 
@@ -366,8 +367,10 @@ impl<'a> DDlogWorker<'a> {
         }
 
         for (_, trace) in traces.iter_mut() {
-            trace.distinguish_since(&[epoch]);
-            trace.advance_by(&[epoch]);
+            let e = [epoch];
+            let ac = AntichainRef::new(&e);
+            trace.distinguish_since(ac);
+            trace.advance_by(ac);
         }
     }
 

--- a/rust/template/differential_datalog_test/Cargo.toml
+++ b/rust/template/differential_datalog_test/Cargo.toml
@@ -5,11 +5,11 @@ edition = "2018"
 
 [dependencies]
 # differential-dataflow = "0.11.0"
-differential-dataflow = { git = "https://github.com/ddlog-dev/differential-dataflow", branch = "ddlog-1" }
+differential-dataflow = { git = "https://github.com/ddlog-dev/differential-dataflow", branch = "ddlog-2" }
 abomonation = "0.7"
 fnv = "1.0.2"
 # timely = "0.11"
-timely = { git = "https://github.com/ddlog-dev/timely-dataflow", branch = "ddlog-1" }
+timely = { git = "https://github.com/ddlog-dev/timely-dataflow", branch = "ddlog-2" }
 serde = { version = "1.0", features = ["derive"] }
 erased-serde = "0.3"
 differential_datalog = { path = "../differential_datalog" }

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -670,8 +670,8 @@ mkCargoToml rs_code crate crate_id =
            "erased-serde = \"0.3\""                                                        $$
            --"differential-dataflow = \"0.11.0\""                                            $$
            --"timely = \"0.11\""                                                             $$
-           "differential-dataflow = { git = \"https://github.com/ddlog-dev/differential-dataflow\", branch = \"ddlog-1\" }" $$
-           "timely = { git = \"https://github.com/ddlog-dev/timely-dataflow\", branch = \"ddlog-1\" }"  $$
+           "differential-dataflow = { git = \"https://github.com/ddlog-dev/differential-dataflow\", branch = \"ddlog-2\" }" $$
+           "timely = { git = \"https://github.com/ddlog-dev/timely-dataflow\", branch = \"ddlog-2\" }"  $$
            ""                                                                              $$
            dependencies                                                                    $$
            ""                                                                              $$


### PR DESCRIPTION
Upgrade DDlog to use the latest master branch of timely and DD.
Surprisingly, the required change is very small: a slight change in the
trace API, plus, since DD now natively supports 16-bit timestamps, we no
longer need the custom TS16 type.