### PR TITLE
An optimized implementation of `distinct`.

### DIFF
--- a/rust/template/differential_datalog/src/program/mod.rs
+++ b/rust/template/differential_datalog/src/program/mod.rs
@@ -12,12 +12,12 @@
 // TODO: namespace cleanup
 // TODO: single input relation
 
-mod arrange;
+pub mod arrange;
 mod timestamp;
 mod update;
 mod worker;
 
-pub use arrange::concatenate_collections;
+pub use arrange::{concatenate_collections, diff_distinct};
 pub use timestamp::{TSNested, TupleTS, TS};
 pub use update::Update;
 
@@ -603,12 +603,7 @@ impl Arrangement {
             } => {
                 let filtered = collection.flat_map(fmfun);
                 if distinct {
-                    ArrangedCollection::Set(
-                        filtered
-                            .threshold(|_, c| if c.is_zero() { 0 } else { 1 })
-                            .map(|k| (k, ()))
-                            .arrange(),
-                    )
+                    ArrangedCollection::Set(diff_distinct(&filtered).map(|k| (k, ())).arrange())
                 } else {
                     ArrangedCollection::Set(filtered.map(|k| (k, ())).arrange())
                 }

--- a/rust/template/differential_datalog/src/record/mod.rs
+++ b/rust/template/differential_datalog/src/record/mod.rs
@@ -8,11 +8,14 @@ use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::collections::{btree_map, BTreeMap, BTreeSet};
+#[cfg(feature = "c_api")]
 use std::ffi::{CStr, CString};
 use std::fmt;
 use std::fmt::Write;
 use std::iter::FromIterator;
+#[cfg(feature = "c_api")]
 use std::ptr;
+#[cfg(feature = "c_api")]
 use std::slice;
 use std::str;
 use std::vec;

--- a/rust/template/differential_datalog/src/variable.rs
+++ b/rust/template/differential_datalog/src/variable.rs
@@ -1,6 +1,4 @@
-use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
-use differential_dataflow::operators::*;
 use differential_dataflow::{Collection, Data, ExchangeData, Hashable};
 use num::One;
 use timely::dataflow::operators::feedback::Handle;
@@ -10,7 +8,7 @@ use timely::dataflow::*;
 use timely::order::Product;
 
 use crate::profile::*;
-use crate::program::{TSNested, Weight};
+use crate::program::{arrange::diff_distinct, TSNested, Weight};
 
 /// A collection defined by multiple mutually recursive rules.
 ///
@@ -94,8 +92,7 @@ where
         if let Some(feedback) = self.feedback.take() {
             with_prof_context(&format!("Variable: {}", self.name), || {
                 if self.distinct {
-                    self.current
-                        .threshold(|_, c| if c.is_zero() { 0 } else { 1 })
+                    diff_distinct(&self.current)
                         .inner
                         .map(|(x, t, d)| (x, Product::new(t.outer, t.inner + TSNested::one()), d))
                         .connect_loop(feedback)


### PR DESCRIPTION
The implementation of `distinct` in differential dataflow maintains both
its input and output arrangements, which can be expensive in terms of
both memory and CPU.

@frankmcsherry suggested an alternative design, implemented in this
commit that uses a single arrangement that produces the number of
"surplus" records, which are then subtracted from the input to get an
output with distinct records.  This has the advantage that for keys that
are already distinct, there is no additional memory used in the output
(nothing to subtract).  It has the downside that if the input changes a
lot, the output may have more changes (to track the input changes) than
if it just recorded distinct records (which is pretty stable).