### PR TITLE
Concurrent improvements

### DIFF
--- a/rust/template/Cargo.toml
+++ b/rust/template/Cargo.toml
@@ -45,6 +45,7 @@ num = { version = "0.3", features = ["serde"] }
 rustop = { version = "1.0.2", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 erased-serde = "0.3"
+crossbeam-channel = "0.5.0"
 
 # FlatBuffers dependency enabled by the `flatbuf` feature.
 # flatbuffers crate version must be in sync with the flatc compiler and Java

--- a/rust/template/differential_datalog/Cargo.toml
+++ b/rust/template/differential_datalog/Cargo.toml
@@ -25,6 +25,7 @@ num = { version = "0.3", features = ["serde"] }
 sequence_trie = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 erased-serde = "0.3"
+crossbeam-channel = "0.5.0"
 
 [dev-dependencies]
 byteorder = "0.4.2"

--- a/rust/template/differential_datalog/src/callback.rs
+++ b/rust/template/differential_datalog/src/callback.rs
@@ -1,5 +1,5 @@
 use crate::record::Record;
 
-pub trait Callback: 'static + FnMut(usize, &Record, isize) + Clone + Send + Sync {}
+pub trait Callback: 'static + Fn(usize, &Record, isize) + Clone + Send + Sync {}
 
-impl<CB> Callback for CB where CB: 'static + FnMut(usize, &Record, isize) + Clone + Send + Sync {}
+impl<CB> Callback for CB where CB: 'static + Fn(usize, &Record, isize) + Clone + Send + Sync {}

--- a/rust/template/differential_datalog/src/program/mod.rs
+++ b/rust/template/differential_datalog/src/program/mod.rs
@@ -170,13 +170,13 @@ pub struct RecursiveRelation {
     pub distinct: bool,
 }
 
-pub trait RelationCallback: FnMut(RelId, &DDValue, Weight) + Send + Sync {
+pub trait RelationCallback: Fn(RelId, &DDValue, Weight) + Send + Sync {
     fn clone_boxed(&self) -> Box<dyn RelationCallback>;
 }
 
 impl<T> RelationCallback for T
 where
-    T: FnMut(RelId, &DDValue, Weight) + Clone + Send + Sync + ?Sized + 'static,
+    T: Fn(RelId, &DDValue, Weight) + Clone + Send + Sync + ?Sized + 'static,
 {
     fn clone_boxed(&self) -> Box<dyn RelationCallback> {
         Box::new(self.clone())

--- a/rust/template/differential_datalog/src/program/worker.rs
+++ b/rust/template/differential_datalog/src/program/worker.rs
@@ -778,7 +778,7 @@ impl<'a> DDlogWorker<'a> {
             for (relid, collection) in collections {
                 // notify client about changes
                 if let Some(relation_callback) = &program.get_relation(relid).change_cb {
-                    let mut relation_callback = relation_callback.clone_boxed();
+                    let relation_callback = relation_callback.clone();
 
                     let consolidated = with_prof_context(
                         &format!("consolidate {}", relid),

--- a/rust/template/differential_datalog_test/lib.rs
+++ b/rust/template/differential_datalog_test/lib.rs
@@ -192,9 +192,7 @@ fn test_one_relation(nthreads: usize) {
             id: 1,
             rules: Vec::new(),
             arrangements: Vec::new(),
-            change_cb: Some(Arc::new(Mutex::new(Box::new(move |_, v, w| {
-                set_update("T1", &relset1, v, w)
-            })))),
+            change_cb: Some(Arc::new(move |_, v, w| set_update("T1", &relset1, v, w))),
         }
     };
 
@@ -289,9 +287,7 @@ fn test_two_relations(nthreads: usize) {
             id: 1,
             rules: Vec::new(),
             arrangements: Vec::new(),
-            change_cb: Some(Arc::new(Mutex::new(Box::new(move |_, v, w| {
-                set_update("T1", &relset1, v, w)
-            })))),
+            change_cb: Some(Arc::new(move |_, v, w| set_update("T1", &relset1, v, w))),
         }
     };
     let relset2: Arc<Mutex<Delta<U64>>> = Arc::new(Mutex::new(BTreeMap::default()));
@@ -314,9 +310,7 @@ fn test_two_relations(nthreads: usize) {
                 }),
             }],
             arrangements: Vec::new(),
-            change_cb: Some(Arc::new(Mutex::new(Box::new(move |_, v, w| {
-                set_update("T2", &relset2, v, w)
-            })))),
+            change_cb: Some(Arc::new(move |_, v, w| set_update("T2", &relset2, v, w))),
         }
     };
 
@@ -393,9 +387,7 @@ fn test_semijoin(nthreads: usize) {
             id: 1,
             rules: Vec::new(),
             arrangements: Vec::new(),
-            change_cb: Some(Arc::new(Mutex::new(Box::new(move |_, v, w| {
-                set_update("T1", &relset1, v, w)
-            })))),
+            change_cb: Some(Arc::new(move |_, v, w| set_update("T1", &relset1, v, w))),
         }
     };
     fn fmfun1(v: DDValue) -> Option<DDValue> {
@@ -422,9 +414,7 @@ fn test_semijoin(nthreads: usize) {
                 fmfun: fmfun1 as FilterMapFunc,
                 distinct: false,
             }],
-            change_cb: Some(Arc::new(Mutex::new(Box::new(move |_, v, w| {
-                set_update("T2", &relset2, v, w)
-            })))),
+            change_cb: Some(Arc::new(move |_, v, w| set_update("T2", &relset2, v, w))),
         }
     };
     fn jfun(_key: &DDValue, v1: &DDValue, _v2: &()) -> Option<DDValue> {
@@ -463,9 +453,7 @@ fn test_semijoin(nthreads: usize) {
                 }),
             }],
             arrangements: Vec::new(),
-            change_cb: Some(Arc::new(Mutex::new(Box::new(move |_, v, w| {
-                set_update("T3", &relset3, v, w)
-            })))),
+            change_cb: Some(Arc::new(move |_, v, w| set_update("T3", &relset3, v, w))),
         }
     };
 
@@ -522,9 +510,7 @@ fn test_join(nthreads: usize) {
             id: 1,
             rules: Vec::new(),
             arrangements: Vec::new(),
-            change_cb: Some(Arc::new(Mutex::new(Box::new(move |_, v, w| {
-                set_update("T1", &relset1, v, w)
-            })))),
+            change_cb: Some(Arc::new(move |_, v, w| set_update("T1", &relset1, v, w))),
         }
     };
     fn afun1(v: DDValue) -> Option<(DDValue, DDValue)> {
@@ -546,9 +532,7 @@ fn test_join(nthreads: usize) {
                 afun: afun1 as ArrangeFunc,
                 queryable: true,
             }],
-            change_cb: Some(Arc::new(Mutex::new(Box::new(move |_, v, w| {
-                set_update("T2", &relset2, v, w)
-            })))),
+            change_cb: Some(Arc::new(move |_, v, w| set_update("T2", &relset2, v, w))),
         }
     };
     fn jfun(_key: &DDValue, v1: &DDValue, v2: &DDValue) -> Option<DDValue> {
@@ -587,9 +571,7 @@ fn test_join(nthreads: usize) {
                 }),
             }],
             arrangements: Vec::new(),
-            change_cb: Some(Arc::new(Mutex::new(Box::new(move |_, v, w| {
-                set_update("T3", &relset3, v, w)
-            })))),
+            change_cb: Some(Arc::new(move |_, v, w| set_update("T3", &relset3, v, w))),
         }
     };
 
@@ -605,9 +587,7 @@ fn test_join(nthreads: usize) {
             id: 4,
             rules: Vec::new(),
             arrangements: Vec::new(),
-            change_cb: Some(Arc::new(Mutex::new(Box::new(move |_, v, w| {
-                set_update("T4", &relset4, v, w)
-            })))),
+            change_cb: Some(Arc::new(move |_, v, w| set_update("T4", &relset4, v, w))),
         }
     };
 
@@ -707,9 +687,7 @@ fn test_antijoin(nthreads: usize) {
             id: 1,
             rules: Vec::new(),
             arrangements: Vec::new(),
-            change_cb: Some(Arc::new(Mutex::new(Box::new(move |_, v, w| {
-                set_update("T1", &relset1, v, w)
-            })))),
+            change_cb: Some(Arc::new(move |_, v, w| set_update("T1", &relset1, v, w))),
         }
     };
     fn afun1(v: DDValue) -> Option<(DDValue, DDValue)> {
@@ -728,9 +706,7 @@ fn test_antijoin(nthreads: usize) {
             id: 2,
             rules: Vec::new(),
             arrangements: vec![],
-            change_cb: Some(Arc::new(Mutex::new(Box::new(move |_, v, w| {
-                set_update("T2", &relset2, v, w)
-            })))),
+            change_cb: Some(Arc::new(move |_, v, w| set_update("T2", &relset2, v, w))),
         }
     };
 
@@ -766,9 +742,7 @@ fn test_antijoin(nthreads: usize) {
                 fmfun: fmnull_fun as FilterMapFunc,
                 distinct: true,
             }],
-            change_cb: Some(Arc::new(Mutex::new(Box::new(move |_, v, w| {
-                set_update("T21", &relset21, v, w)
-            })))),
+            change_cb: Some(Arc::new(move |_, v, w| set_update("T21", &relset21, v, w))),
         }
     };
 
@@ -797,9 +771,7 @@ fn test_antijoin(nthreads: usize) {
                 }),
             }],
             arrangements: Vec::new(),
-            change_cb: Some(Arc::new(Mutex::new(Box::new(move |_, v, w| {
-                set_update("T3", &relset3, v, w)
-            })))),
+            change_cb: Some(Arc::new(move |_, v, w| set_update("T3", &relset3, v, w))),
         }
     };
 
@@ -867,9 +839,7 @@ fn test_map(nthreads: usize) {
             id: 1,
             rules: Vec::new(),
             arrangements: Vec::new(),
-            change_cb: Some(Arc::new(Mutex::new(Box::new(move |_, v, w| {
-                set_update("T1", &relset1, v, w)
-            })))),
+            change_cb: Some(Arc::new(move |_, v, w| set_update("T1", &relset1, v, w))),
         }
     };
 
@@ -955,9 +925,7 @@ fn test_map(nthreads: usize) {
                 }),
             }],
             arrangements: Vec::new(),
-            change_cb: Some(Arc::new(Mutex::new(Box::new(move |_, v, w| {
-                set_update("T2", &relset2, v, w)
-            })))),
+            change_cb: Some(Arc::new(move |_, v, w| set_update("T2", &relset2, v, w))),
         }
     };
     let relset3: Arc<Mutex<Delta<U64>>> = Arc::new(Mutex::new(BTreeMap::default()));
@@ -985,9 +953,7 @@ fn test_map(nthreads: usize) {
                 }),
             }],
             arrangements: Vec::new(),
-            change_cb: Some(Arc::new(Mutex::new(Box::new(move |_, v, w| {
-                set_update("T3", &relset3, v, w)
-            })))),
+            change_cb: Some(Arc::new(move |_, v, w| set_update("T3", &relset3, v, w))),
         }
     };
 
@@ -1016,9 +982,7 @@ fn test_map(nthreads: usize) {
                 }),
             }],
             arrangements: Vec::new(),
-            change_cb: Some(Arc::new(Mutex::new(Box::new(move |_, v, w| {
-                set_update("T4", &relset4, v, w)
-            })))),
+            change_cb: Some(Arc::new(move |_, v, w| set_update("T4", &relset4, v, w))),
         }
     };
 
@@ -1142,9 +1106,9 @@ fn test_recursion(nthreads: usize) {
                 afun: arrange_by_fst as ArrangeFunc,
                 queryable: false,
             }],
-            change_cb: Some(Arc::new(Mutex::new(Box::new(move |_, v, w| {
+            change_cb: Some(Arc::new(move |_, v, w| {
                 set_update("parent", &parentset, v, w)
-            })))),
+            })),
         }
     };
 
@@ -1193,9 +1157,9 @@ fn test_recursion(nthreads: usize) {
                     queryable: false,
                 },
             ],
-            change_cb: Some(Arc::new(Mutex::new(Box::new(move |_, v, w| {
+            change_cb: Some(Arc::new(move |_, v, w| {
                 set_update("ancestor", &ancestorset, v, w)
-            })))),
+            })),
         }
     };
 
@@ -1249,9 +1213,9 @@ fn test_recursion(nthreads: usize) {
                 },
             }],
             arrangements: Vec::new(),
-            change_cb: Some(Arc::new(Mutex::new(Box::new(move |_, v, w| {
+            change_cb: Some(Arc::new(move |_, v, w| {
                 set_update("common_ancestor", &common_ancestorset, v, w)
-            })))),
+            })),
         }
     };
 

--- a/rust/template/src/api/mod.rs
+++ b/rust/template/src/api/mod.rs
@@ -378,18 +378,15 @@ impl HDDlog {
                  * actually used. */
                 let delta_handler = DeltaUpdateHandler::new(deltadb2);
 
-                let store_handler = if do_store {
-                    Some(ValMapUpdateHandler::new(db2))
+                if do_store {
+                    let handlers: Vec<Box<dyn UpdateHandler>> = vec![
+                        Box::new(delta_handler),
+                        Box::new(ValMapUpdateHandler::new(db2)),
+                    ];
+                    Box::new(ChainedUpdateHandler::new(handlers)) as Box<dyn UpdateHandler>
                 } else {
-                    None
-                };
-
-                let mut handlers: Vec<Box<dyn UpdateHandler>> = Vec::new();
-                handlers.push(Box::new(delta_handler));
-                if let Some(h) = store_handler {
-                    handlers.push(Box::new(h))
-                };
-                Box::new(ChainedUpdateHandler::new(handlers)) as Box<dyn UpdateHandler>
+                    Box::new(delta_handler) as Box<dyn UpdateHandler>
+                }
             };
             Box::new(ThreadUpdateHandler::new(handler_generator))
         };

--- a/rust/template/src/lib.rs
+++ b/rust/template/src/lib.rs
@@ -212,7 +212,7 @@ pub mod ddlog_bigint;
 #[path = "../../../lib/ddlog_log.rs"]
 pub mod ddlog_log;
 
-pub fn prog(__update_cb: Box<dyn program::CBFn>) -> program::Program {
+pub fn prog(__update_cb: Box<dyn program::RelationCallback>) -> program::Program {
     panic!("prog not implemented")
 }
 

--- a/rust/template/src/lib.rs
+++ b/rust/template/src/lib.rs
@@ -212,7 +212,7 @@ pub mod ddlog_bigint;
 #[path = "../../../lib/ddlog_log.rs"]
 pub mod ddlog_log;
 
-pub fn prog(__update_cb: Box<dyn program::RelationCallback>) -> program::Program {
+pub fn prog(__update_cb: std::sync::Arc<dyn program::RelationCallback>) -> program::Program {
     panic!("prog not implemented")
 }
 

--- a/rust/template/src/update_handler.rs
+++ b/rust/template/src/update_handler.rs
@@ -27,28 +27,22 @@ use std::{
 };
 
 /// Single-threaded (non-thread-safe callback)
-pub trait ST_RelationCallback: FnMut(RelId, &DDValue, isize) {
+pub trait ST_RelationCallback: Fn(RelId, &DDValue, isize) {
     fn clone_boxed(&self) -> Box<dyn ST_RelationCallback>;
 }
 
 impl<T> ST_RelationCallback for T
 where
-    T: 'static + Clone + FnMut(RelId, &DDValue, isize),
+    T: 'static + Clone + Fn(RelId, &DDValue, isize),
 {
     fn clone_boxed(&self) -> Box<dyn ST_RelationCallback> {
-        Box::new(self.clone())
-    }
-}
-
-impl Clone for Box<dyn ST_RelationCallback> {
-    fn clone(&self) -> Self {
-        self.as_ref().clone_boxed()
+        Box::new((&*self).clone())
     }
 }
 
 pub trait UpdateHandler: Debug {
     /// Returns a handler to be invoked on each output relation update.
-    fn update_cb(&self) -> Box<dyn ST_RelationCallback>;
+    fn update_cb(&self) -> Arc<dyn ST_RelationCallback>;
 
     /// Notifies the handler that a transaction_commit method is about to be
     /// called. The handler has an opportunity to prepare to handle
@@ -65,26 +59,20 @@ pub trait UpdateHandler: Debug {
 pub trait MTUpdateHandler: UpdateHandler + Sync + Send {
     /// Returns a thread-safe handler to be invoked on each output
     /// relation update.
-    fn mt_update_cb(&self) -> Box<dyn RelationCallback>;
+    fn mt_update_cb(&self) -> Arc<dyn RelationCallback>;
 }
 
 /// Rust magic to make `MTUpdateHandler` clonable.
 pub trait IMTUpdateHandler: MTUpdateHandler {
-    fn clone_boxed(&self) -> Box<dyn IMTUpdateHandler>;
+    fn clone_boxed(&self) -> Arc<dyn IMTUpdateHandler>;
 }
 
 impl<T> IMTUpdateHandler for T
 where
     T: MTUpdateHandler + Clone + 'static,
 {
-    fn clone_boxed(&self) -> Box<dyn IMTUpdateHandler> {
-        Box::new(self.clone())
-    }
-}
-
-impl Clone for Box<dyn IMTUpdateHandler> {
-    fn clone(&self) -> Self {
-        self.as_ref().clone_boxed()
+    fn clone_boxed(&self) -> Arc<dyn IMTUpdateHandler> {
+        Arc::new(self.clone())
     }
 }
 
@@ -99,16 +87,16 @@ impl NullUpdateHandler {
 }
 
 impl UpdateHandler for NullUpdateHandler {
-    fn update_cb(&self) -> Box<dyn ST_RelationCallback> {
-        Box::new(|_, _, _| {})
+    fn update_cb(&self) -> Arc<dyn ST_RelationCallback> {
+        Arc::new(|_, _, _| {})
     }
     fn before_commit(&self) {}
     fn after_commit(&self, _success: bool) {}
 }
 
 impl MTUpdateHandler for NullUpdateHandler {
-    fn mt_update_cb(&self) -> Box<dyn RelationCallback> {
-        Box::new(|_, _, _| {})
+    fn mt_update_cb(&self) -> Arc<dyn RelationCallback> {
+        Arc::new(|_, _, _| {})
     }
 }
 
@@ -133,18 +121,18 @@ impl<F: Callback> Debug for CallbackUpdateHandler<F> {
 }
 
 impl<F: Callback> UpdateHandler for CallbackUpdateHandler<F> {
-    fn update_cb(&self) -> Box<dyn ST_RelationCallback> {
-        let mut cb = self.cb.clone();
-        Box::new(move |relid, v, w| cb(relid, &v.clone().into_record(), w))
+    fn update_cb(&self) -> Arc<dyn ST_RelationCallback> {
+        let cb = self.cb.clone();
+        Arc::new(move |relid, v, w| cb(relid, &v.clone().into_record(), w))
     }
     fn before_commit(&self) {}
     fn after_commit(&self, _success: bool) {}
 }
 
 impl<F: Callback> MTUpdateHandler for CallbackUpdateHandler<F> {
-    fn mt_update_cb(&self) -> Box<dyn RelationCallback> {
-        let mut cb = self.cb.clone();
-        Box::new(move |relid, v, w| cb(relid, &v.clone().into_record(), w as isize))
+    fn mt_update_cb(&self) -> Arc<dyn RelationCallback> {
+        let cb = self.cb.clone();
+        Arc::new(move |relid, v, w| cb(relid, &v.clone().into_record(), w as isize))
     }
 }
 
@@ -173,10 +161,10 @@ impl ExternCUpdateHandler {
 
 #[cfg(feature = "c_api")]
 impl UpdateHandler for ExternCUpdateHandler {
-    fn update_cb(&self) -> Box<dyn ST_RelationCallback> {
+    fn update_cb(&self) -> Arc<dyn ST_RelationCallback> {
         let cb = self.cb;
         let cb_arg = self.cb_arg;
-        Box::new(move |relid, v, w| {
+        Arc::new(move |relid, v, w| {
             cb(
                 cb_arg,
                 relid,
@@ -191,10 +179,10 @@ impl UpdateHandler for ExternCUpdateHandler {
 
 #[cfg(feature = "c_api")]
 impl MTUpdateHandler for ExternCUpdateHandler {
-    fn mt_update_cb(&self) -> Box<dyn RelationCallback> {
+    fn mt_update_cb(&self) -> Arc<dyn RelationCallback> {
         let cb = self.cb;
         let cb_arg = self.cb_arg;
-        Box::new(move |relid, v, w| {
+        Arc::new(move |relid, v, w| {
             cb(
                 cb_arg,
                 relid,
@@ -219,18 +207,18 @@ impl MTValMapUpdateHandler {
 }
 
 impl UpdateHandler for MTValMapUpdateHandler {
-    fn update_cb(&self) -> Box<dyn ST_RelationCallback> {
+    fn update_cb(&self) -> Arc<dyn ST_RelationCallback> {
         let db = self.db.clone();
-        Box::new(move |relid, v, w| db.lock().unwrap().update(relid, v, w))
+        Arc::new(move |relid, v, w| db.lock().unwrap().update(relid, v, w))
     }
     fn before_commit(&self) {}
     fn after_commit(&self, _success: bool) {}
 }
 
 impl MTUpdateHandler for MTValMapUpdateHandler {
-    fn mt_update_cb(&self) -> Box<dyn RelationCallback> {
+    fn mt_update_cb(&self) -> Arc<dyn RelationCallback> {
         let db = self.db.clone();
-        Box::new(move |relid, v, w| db.lock().unwrap().update(relid, v, w as isize))
+        Arc::new(move |relid, v, w| db.lock().unwrap().update(relid, v, w as isize))
     }
 }
 
@@ -270,9 +258,9 @@ impl ValMapUpdateHandler {
 }
 
 impl UpdateHandler for ValMapUpdateHandler {
-    fn update_cb(&self) -> Box<dyn ST_RelationCallback> {
+    fn update_cb(&self) -> Arc<dyn ST_RelationCallback> {
         let handler = self.clone();
-        Box::new(move |relid, v, w| {
+        Arc::new(move |relid, v, w| {
             let guard_ptr = handler.locked.get();
             // `update_cb` can also be called during rollback and stop operations.
             // Ignore those.
@@ -328,9 +316,9 @@ impl DeltaUpdateHandler {
 }
 
 impl UpdateHandler for DeltaUpdateHandler {
-    fn update_cb(&self) -> Box<dyn ST_RelationCallback> {
+    fn update_cb(&self) -> Arc<dyn ST_RelationCallback> {
         let handler = self.clone();
-        Box::new(move |relid, v, w| {
+        Arc::new(move |relid, v, w| {
             let guard_ptr = handler.locked.get();
             if !guard_ptr.is_null() {
                 let mut guard: Box<MutexGuard<'_, Option<DeltaMap<DDValue>>>> = unsafe {
@@ -371,11 +359,12 @@ impl ChainedUpdateHandler {
 }
 
 impl UpdateHandler for ChainedUpdateHandler {
-    fn update_cb(&self) -> Box<dyn ST_RelationCallback> {
-        let mut cbs: Vec<Box<dyn ST_RelationCallback>> =
+    fn update_cb(&self) -> Arc<dyn ST_RelationCallback> {
+        let cbs: Vec<Arc<dyn ST_RelationCallback>> =
             self.handlers.iter().map(|h| h.update_cb()).collect();
-        Box::new(move |relid, v, w| {
-            for cb in cbs.iter_mut() {
+
+        Arc::new(move |relid, v, w| {
+            for cb in cbs.iter() {
                 cb(relid, v, w);
             }
         })
@@ -397,21 +386,22 @@ impl UpdateHandler for ChainedUpdateHandler {
 /// handlers.
 #[derive(Clone, Debug)]
 pub struct MTChainedUpdateHandler {
-    handlers: Vec<Box<dyn IMTUpdateHandler>>,
+    handlers: Vec<Arc<dyn IMTUpdateHandler>>,
 }
 
 impl MTChainedUpdateHandler {
-    pub fn new(handlers: Vec<Box<dyn IMTUpdateHandler>>) -> Self {
+    pub fn new(handlers: Vec<Arc<dyn IMTUpdateHandler>>) -> Self {
         Self { handlers }
     }
 }
 
 impl UpdateHandler for MTChainedUpdateHandler {
-    fn update_cb(&self) -> Box<dyn ST_RelationCallback> {
-        let mut cbs: Vec<Box<dyn ST_RelationCallback>> =
+    fn update_cb(&self) -> Arc<dyn ST_RelationCallback> {
+        let cbs: Vec<Arc<dyn ST_RelationCallback>> =
             self.handlers.iter().map(|h| h.update_cb()).collect();
-        Box::new(move |relid, v, w| {
-            for cb in cbs.iter_mut() {
+
+        Arc::new(move |relid, v, w| {
+            for cb in cbs.iter() {
                 cb(relid, v, w);
             }
         })
@@ -430,11 +420,12 @@ impl UpdateHandler for MTChainedUpdateHandler {
 }
 
 impl MTUpdateHandler for MTChainedUpdateHandler {
-    fn mt_update_cb(&self) -> Box<dyn RelationCallback> {
-        let mut cbs: Vec<Box<dyn RelationCallback>> =
+    fn mt_update_cb(&self) -> Arc<dyn RelationCallback> {
+        let cbs: Vec<Arc<dyn RelationCallback>> =
             self.handlers.iter().map(|h| h.mt_update_cb()).collect();
-        Box::new(move |relid, v, w| {
-            for cb in cbs.iter_mut() {
+
+        Arc::new(move |relid, v, w| {
+            for cb in cbs.iter() {
                 cb(relid, v, w);
             }
         })
@@ -472,7 +463,8 @@ impl ThreadUpdateHandler {
 
         thread::spawn(move || {
             let handler = handler_generator();
-            let mut update_cb = handler.update_cb();
+            let update_cb = handler.update_cb();
+
             loop {
                 match rx_message_channel.recv() {
                     Ok(Msg::Update { relid, v, w }) => {
@@ -514,10 +506,10 @@ impl Drop for ThreadUpdateHandler {
 }
 
 impl UpdateHandler for ThreadUpdateHandler {
-    fn update_cb(&self) -> Box<dyn ST_RelationCallback> {
+    fn update_cb(&self) -> Arc<dyn ST_RelationCallback> {
         let channel = self.msg_channel.clone();
 
-        Box::new(move |relid, v, w| {
+        Arc::new(move |relid, v, w| {
             channel
                 .send(Msg::Update {
                     relid,
@@ -541,9 +533,9 @@ impl UpdateHandler for ThreadUpdateHandler {
 }
 
 impl MTUpdateHandler for ThreadUpdateHandler {
-    fn mt_update_cb(&self) -> Box<dyn RelationCallback> {
+    fn mt_update_cb(&self) -> Arc<dyn RelationCallback> {
         let channel = self.msg_channel.clone();
-        Box::new(move |relid, v, w| {
+        Arc::new(move |relid, v, w| {
             channel
                 .send(Msg::Update {
                     relid,

--- a/rust/template/src/update_handler.rs
+++ b/rust/template/src/update_handler.rs
@@ -14,33 +14,33 @@
 //! - all of the above, but processed by a pool of worker threads
 
 use super::*;
-
-use std::cell::Cell;
-use std::fmt::{self, Debug, Formatter};
-use std::sync::mpsc::*;
-use std::sync::{Arc, Barrier, Mutex, MutexGuard};
-use std::thread::*;
-
-use differential_datalog::program::CBFn;
-use differential_datalog::program::RelId;
-use differential_datalog::Callback;
-use differential_datalog::DeltaMap;
+use crossbeam_channel::{Receiver, Sender};
+use differential_datalog::{
+    program::{RelId, RelationCallback},
+    Callback, DeltaMap,
+};
+use std::{
+    cell::Cell,
+    fmt::{self, Debug, Formatter},
+    sync::{Arc, Barrier, Mutex, MutexGuard},
+    thread,
+};
 
 /// Single-threaded (non-thread-safe callback)
-pub trait ST_CBFn: FnMut(RelId, &DDValue, isize) {
-    fn clone_boxed(&self) -> Box<dyn ST_CBFn>;
+pub trait ST_RelationCallback: FnMut(RelId, &DDValue, isize) {
+    fn clone_boxed(&self) -> Box<dyn ST_RelationCallback>;
 }
 
-impl<T> ST_CBFn for T
+impl<T> ST_RelationCallback for T
 where
     T: 'static + Clone + FnMut(RelId, &DDValue, isize),
 {
-    fn clone_boxed(&self) -> Box<dyn ST_CBFn> {
+    fn clone_boxed(&self) -> Box<dyn ST_RelationCallback> {
         Box::new(self.clone())
     }
 }
 
-impl Clone for Box<dyn ST_CBFn> {
+impl Clone for Box<dyn ST_RelationCallback> {
     fn clone(&self) -> Self {
         self.as_ref().clone_boxed()
     }
@@ -48,7 +48,7 @@ impl Clone for Box<dyn ST_CBFn> {
 
 pub trait UpdateHandler: Debug {
     /// Returns a handler to be invoked on each output relation update.
-    fn update_cb(&self) -> Box<dyn ST_CBFn>;
+    fn update_cb(&self) -> Box<dyn ST_RelationCallback>;
 
     /// Notifies the handler that a transaction_commit method is about to be
     /// called. The handler has an opportunity to prepare to handle
@@ -65,7 +65,7 @@ pub trait UpdateHandler: Debug {
 pub trait MTUpdateHandler: UpdateHandler + Sync + Send {
     /// Returns a thread-safe handler to be invoked on each output
     /// relation update.
-    fn mt_update_cb(&self) -> Box<dyn CBFn>;
+    fn mt_update_cb(&self) -> Box<dyn RelationCallback>;
 }
 
 /// Rust magic to make `MTUpdateHandler` clonable.
@@ -99,7 +99,7 @@ impl NullUpdateHandler {
 }
 
 impl UpdateHandler for NullUpdateHandler {
-    fn update_cb(&self) -> Box<dyn ST_CBFn> {
+    fn update_cb(&self) -> Box<dyn ST_RelationCallback> {
         Box::new(|_, _, _| {})
     }
     fn before_commit(&self) {}
@@ -107,7 +107,7 @@ impl UpdateHandler for NullUpdateHandler {
 }
 
 impl MTUpdateHandler for NullUpdateHandler {
-    fn mt_update_cb(&self) -> Box<dyn CBFn> {
+    fn mt_update_cb(&self) -> Box<dyn RelationCallback> {
         Box::new(|_, _, _| {})
     }
 }
@@ -133,7 +133,7 @@ impl<F: Callback> Debug for CallbackUpdateHandler<F> {
 }
 
 impl<F: Callback> UpdateHandler for CallbackUpdateHandler<F> {
-    fn update_cb(&self) -> Box<dyn ST_CBFn> {
+    fn update_cb(&self) -> Box<dyn ST_RelationCallback> {
         let mut cb = self.cb.clone();
         Box::new(move |relid, v, w| cb(relid, &v.clone().into_record(), w))
     }
@@ -142,7 +142,7 @@ impl<F: Callback> UpdateHandler for CallbackUpdateHandler<F> {
 }
 
 impl<F: Callback> MTUpdateHandler for CallbackUpdateHandler<F> {
-    fn mt_update_cb(&self) -> Box<dyn CBFn> {
+    fn mt_update_cb(&self) -> Box<dyn RelationCallback> {
         let mut cb = self.cb.clone();
         Box::new(move |relid, v, w| cb(relid, &v.clone().into_record(), w as isize))
     }
@@ -173,7 +173,7 @@ impl ExternCUpdateHandler {
 
 #[cfg(feature = "c_api")]
 impl UpdateHandler for ExternCUpdateHandler {
-    fn update_cb(&self) -> Box<dyn ST_CBFn> {
+    fn update_cb(&self) -> Box<dyn ST_RelationCallback> {
         let cb = self.cb;
         let cb_arg = self.cb_arg;
         Box::new(move |relid, v, w| {
@@ -191,7 +191,7 @@ impl UpdateHandler for ExternCUpdateHandler {
 
 #[cfg(feature = "c_api")]
 impl MTUpdateHandler for ExternCUpdateHandler {
-    fn mt_update_cb(&self) -> Box<dyn CBFn> {
+    fn mt_update_cb(&self) -> Box<dyn RelationCallback> {
         let cb = self.cb;
         let cb_arg = self.cb_arg;
         Box::new(move |relid, v, w| {
@@ -219,7 +219,7 @@ impl MTValMapUpdateHandler {
 }
 
 impl UpdateHandler for MTValMapUpdateHandler {
-    fn update_cb(&self) -> Box<dyn ST_CBFn> {
+    fn update_cb(&self) -> Box<dyn ST_RelationCallback> {
         let db = self.db.clone();
         Box::new(move |relid, v, w| db.lock().unwrap().update(relid, v, w))
     }
@@ -228,7 +228,7 @@ impl UpdateHandler for MTValMapUpdateHandler {
 }
 
 impl MTUpdateHandler for MTValMapUpdateHandler {
-    fn mt_update_cb(&self) -> Box<dyn CBFn> {
+    fn mt_update_cb(&self) -> Box<dyn RelationCallback> {
         let db = self.db.clone();
         Box::new(move |relid, v, w| db.lock().unwrap().update(relid, v, w as isize))
     }
@@ -270,7 +270,7 @@ impl ValMapUpdateHandler {
 }
 
 impl UpdateHandler for ValMapUpdateHandler {
-    fn update_cb(&self) -> Box<dyn ST_CBFn> {
+    fn update_cb(&self) -> Box<dyn ST_RelationCallback> {
         let handler = self.clone();
         Box::new(move |relid, v, w| {
             let guard_ptr = handler.locked.get();
@@ -328,7 +328,7 @@ impl DeltaUpdateHandler {
 }
 
 impl UpdateHandler for DeltaUpdateHandler {
-    fn update_cb(&self) -> Box<dyn ST_CBFn> {
+    fn update_cb(&self) -> Box<dyn ST_RelationCallback> {
         let handler = self.clone();
         Box::new(move |relid, v, w| {
             let guard_ptr = handler.locked.get();
@@ -371,8 +371,9 @@ impl ChainedUpdateHandler {
 }
 
 impl UpdateHandler for ChainedUpdateHandler {
-    fn update_cb(&self) -> Box<dyn ST_CBFn> {
-        let mut cbs: Vec<Box<dyn ST_CBFn>> = self.handlers.iter().map(|h| h.update_cb()).collect();
+    fn update_cb(&self) -> Box<dyn ST_RelationCallback> {
+        let mut cbs: Vec<Box<dyn ST_RelationCallback>> =
+            self.handlers.iter().map(|h| h.update_cb()).collect();
         Box::new(move |relid, v, w| {
             for cb in cbs.iter_mut() {
                 cb(relid, v, w);
@@ -406,8 +407,9 @@ impl MTChainedUpdateHandler {
 }
 
 impl UpdateHandler for MTChainedUpdateHandler {
-    fn update_cb(&self) -> Box<dyn ST_CBFn> {
-        let mut cbs: Vec<Box<dyn ST_CBFn>> = self.handlers.iter().map(|h| h.update_cb()).collect();
+    fn update_cb(&self) -> Box<dyn ST_RelationCallback> {
+        let mut cbs: Vec<Box<dyn ST_RelationCallback>> =
+            self.handlers.iter().map(|h| h.update_cb()).collect();
         Box::new(move |relid, v, w| {
             for cb in cbs.iter_mut() {
                 cb(relid, v, w);
@@ -428,8 +430,9 @@ impl UpdateHandler for MTChainedUpdateHandler {
 }
 
 impl MTUpdateHandler for MTChainedUpdateHandler {
-    fn mt_update_cb(&self) -> Box<dyn CBFn> {
-        let mut cbs: Vec<Box<dyn CBFn>> = self.handlers.iter().map(|h| h.mt_update_cb()).collect();
+    fn mt_update_cb(&self) -> Box<dyn RelationCallback> {
+        let mut cbs: Vec<Box<dyn RelationCallback>> =
+            self.handlers.iter().map(|h| h.mt_update_cb()).collect();
         Box::new(move |relid, v, w| {
             for cb in cbs.iter_mut() {
                 cb(relid, v, w);
@@ -452,7 +455,7 @@ enum Msg {
 #[derive(Clone, Debug)]
 pub struct ThreadUpdateHandler {
     /// Channel to worker thread.
-    msg_channel: Arc<Mutex<Sender<Msg>>>,
+    msg_channel: Sender<Msg>,
 
     /// Barrier to synchronize completion of transaction with worker.
     commit_barrier: Arc<Barrier>,
@@ -463,11 +466,11 @@ impl ThreadUpdateHandler {
     where
         F: FnOnce() -> Box<dyn UpdateHandler> + Send + 'static,
     {
-        let (tx_msg_channel, rx_message_channel) = channel();
+        let (tx_msg_channel, rx_message_channel) = crossbeam_channel::unbounded();
         let commit_barrier = Arc::new(Barrier::new(2));
         let commit_barrier2 = commit_barrier.clone();
 
-        spawn(move || {
+        thread::spawn(move || {
             let handler = handler_generator();
             let mut update_cb = handler.update_cb();
             loop {
@@ -498,7 +501,7 @@ impl ThreadUpdateHandler {
         });
 
         Self {
-            msg_channel: Arc::new(Mutex::new(tx_msg_channel)),
+            msg_channel: tx_msg_channel,
             commit_barrier,
         }
     }
@@ -506,13 +509,14 @@ impl ThreadUpdateHandler {
 
 impl Drop for ThreadUpdateHandler {
     fn drop(&mut self) {
-        self.msg_channel.lock().unwrap().send(Msg::Stop).unwrap();
+        self.msg_channel.send(Msg::Stop).unwrap();
     }
 }
 
 impl UpdateHandler for ThreadUpdateHandler {
-    fn update_cb(&self) -> Box<dyn ST_CBFn> {
-        let channel = self.msg_channel.lock().unwrap().clone();
+    fn update_cb(&self) -> Box<dyn ST_RelationCallback> {
+        let channel = self.msg_channel.clone();
+
         Box::new(move |relid, v, w| {
             channel
                 .send(Msg::Update {
@@ -525,21 +529,11 @@ impl UpdateHandler for ThreadUpdateHandler {
     }
 
     fn before_commit(&self) {
-        self.msg_channel
-            .lock()
-            .unwrap()
-            .send(Msg::BeforeCommit)
-            .unwrap();
+        self.msg_channel.send(Msg::BeforeCommit).unwrap();
     }
 
     fn after_commit(&self, success: bool) {
-        if self
-            .msg_channel
-            .lock()
-            .unwrap()
-            .send(Msg::AfterCommit { success })
-            .is_ok()
-        {
+        if self.msg_channel.send(Msg::AfterCommit { success }).is_ok() {
             // Wait for all queued updates to get processed by worker.
             self.commit_barrier.wait();
         }
@@ -547,8 +541,8 @@ impl UpdateHandler for ThreadUpdateHandler {
 }
 
 impl MTUpdateHandler for ThreadUpdateHandler {
-    fn mt_update_cb(&self) -> Box<dyn CBFn> {
-        let channel = self.msg_channel.lock().unwrap().clone();
+    fn mt_update_cb(&self) -> Box<dyn RelationCallback> {
+        let channel = self.msg_channel.clone();
         Box::new(move |relid, v, w| {
             channel
                 .send(Msg::Update {

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -1775,7 +1775,7 @@ compileRelation d statics rn = do
                                       , Just code))
                                relPrimaryKey
     let cb = if relRole == RelOutput
-                then "change_cb:    Some(sync::Arc::new(sync::Mutex::new(__update_cb.clone())))"
+                then "change_cb:    Some(std::sync::Arc::clone(&__update_cb))"
                 else "change_cb:    None"
     arrangements <- gets $ (M.! rn) . cArrangements
     let compiled_arrangements = mapIdx (\arng i ->
@@ -2505,7 +2505,7 @@ rhsVarsAfter d rl i =
 
 mkProg :: (?crate_graph :: CrateGraph, ?specname :: String) => [ProgNode] -> Doc
 mkProg nodes =
-    "pub fn prog(__update_cb: Box<dyn program::RelationCallback>) -> program::Program {"
+    "pub fn prog(__update_cb: std::sync::Arc<dyn program::RelationCallback>) -> program::Program {"
         $$ (nest' relations)
         $$ "    let nodes: std::vec::Vec<program::ProgNode> = vec!["
         $$ (nest' $ nest' program_nodes)

--- a/test/datalog_tests/api/src/lib.rs
+++ b/test/datalog_tests/api/src/lib.rs
@@ -8,7 +8,7 @@ mod tests {
 
     #[test]
     fn start_stop() -> Result<(), String> {
-        let (prog, _) = HDDlog::run(1, false, |_, _: &Record, _| {});
+        let (prog, _) = HDDlog::run(1, false);
 
         // the update consists of inserting a single bool
         let table = HDDlog::get_table_id("Rin").unwrap();


### PR DESCRIPTION
* Switches ddlog channels to use `crossbeam_channel` (mainly done to make `Sender<T>` `Send`, will likely also bring performance improvements)
* Remove `Mutex<Box<_>>` from `Relation::change_cb`
* Made callback closures now use `Fn()` instead of `FnMut()`, this more accurately reflects what should be happening within them and allows us to locklessly interact with them
* Removed a couple `Mutex`s from within various update handlers, less locks should lead to less runtime overhead