### PR TITLE
Hygiene improvements to Mutator

### DIFF
--- a/rust/template/ddlog_derive/src/mutator.rs
+++ b/rust/template/ddlog_derive/src/mutator.rs
@@ -1,5 +1,5 @@
 use super::{add_trait_bounds, get_rename};
-use proc_macro2::TokenStream;
+use proc_macro2::{Span, TokenStream};
 use quote::{format_ident, quote};
 use syn::{
     parse_quote, spanned::Spanned, Data, DataEnum, DataStruct, DeriveInput, Error, Fields,
@@ -41,12 +41,23 @@ pub fn mutator_inner(mut input: DeriveInput) -> Result<TokenStream> {
 
     let generics = generics.split_for_impl();
 
+    // Created some idents with mixed spans so they act hygienically within the generated code
+    let generated_idents = (
+        Ident::new("args", Span::mixed_site()),
+        Ident::new("mutated", Span::mixed_site()),
+        Ident::new("error", Span::mixed_site()),
+    );
+
     match input.data {
         // Derive for structs
-        Data::Struct(derive_struct) => mutator_struct(struct_ident, derive_struct, generics),
+        Data::Struct(derive_struct) => {
+            mutator_struct(struct_ident, derive_struct, generics, generated_idents)
+        }
 
         // Derive for enums
-        Data::Enum(derive_enum) => mutator_enum(struct_ident, derive_enum, generics),
+        Data::Enum(derive_enum) => {
+            mutator_enum(struct_ident, derive_enum, generics, generated_idents)
+        }
 
         // Unions can't safely/soundly be automatically implemented over,
         // the user will have to manually enforce invariants on it
@@ -59,28 +70,28 @@ pub fn mutator_inner(mut input: DeriveInput) -> Result<TokenStream> {
 
 /// Unit structs have nothing to mutate, so make sure the constructor is correct and that
 /// there's no fields on the record
-fn unit_struct_mutator() -> TokenStream {
+fn unit_struct_mutator(args: &Ident, error: &Ident) -> TokenStream {
     quote! {
         match self {
-            differential_datalog::record::Record::PosStruct(_constructor, args) if args.is_empty() => {},
-            differential_datalog::record::Record::NamedStruct(_constructor, args) if args.is_empty() => {},
+            differential_datalog::record::Record::PosStruct(_, #args) if #args.is_empty() => {},
+            differential_datalog::record::Record::NamedStruct(_, #args) if #args.is_empty() => {},
 
-            differential_datalog::record::Record::PosStruct(_, args) => {
+            differential_datalog::record::Record::PosStruct(_, #args) => {
                 return std::result::Result::Err(std::format!(
                     "incompatible struct, expected a struct with 0 fields and got a struct with {} fields",
-                    args.len(),
+                    #args.len(),
                 ));
             },
 
-            differential_datalog::record::Record::NamedStruct(_, args) => {
+            differential_datalog::record::Record::NamedStruct(_, #args) => {
                 return std::result::Result::Err(std::format!(
                     "incompatible struct, expected a struct with 0 fields and got a struct with {} fields",
-                    args.len(),
+                    #args.len(),
                 ));
             },
 
-            error => {
-                return std::result::Result::Err(std::format!("not a struct {:?}", error));
+            #error => {
+                return std::result::Result::Err(std::format!("not a struct {:?}", #error));
             },
         }
     }
@@ -88,6 +99,8 @@ fn unit_struct_mutator() -> TokenStream {
 
 fn tuple_struct_mutator<'a>(
     tuple_struct: &'a FieldsUnnamed,
+    args: &Ident,
+    error: &Ident,
 ) -> (TokenStream, impl Iterator<Item = Ident> + 'a) {
     let num_fields = tuple_struct.unnamed.len();
 
@@ -109,21 +122,21 @@ fn tuple_struct_mutator<'a>(
             let field_ty = &field.ty;
 
             quote! {
-                <dyn differential_datalog::record::Mutator<#field_ty>>::mutate(&args[#idx], #index)?;
+                <dyn differential_datalog::record::Mutator<#field_ty>>::mutate(&#args[#idx], #index)?;
             }
         });
 
     let mutator = quote! {
         match self {
-            differential_datalog::record::Record::PosStruct(constructor, args)
-                if args.len() == #num_fields => {
+            differential_datalog::record::Record::PosStruct(_, #args)
+                if #args.len() == #num_fields => {
                     #( #field_mutations )*
                 },
 
-            differential_datalog::record::Record::PosStruct(_, args) => {
+            differential_datalog::record::Record::PosStruct(_, #args) => {
                 return std::result::Result::Err(std::format!(
                     "incompatible struct, expected a positional struct with {} fields and got a positional struct with {} fields",
-                    #num_fields, args.len(),
+                    #num_fields, #args.len(),
                 ));
             },
 
@@ -134,8 +147,8 @@ fn tuple_struct_mutator<'a>(
                 ));
             },
 
-            error => {
-                return std::result::Result::Err(std::format!("not a struct {:?}", error));
+            #error => {
+                return std::result::Result::Err(std::format!("not a struct {:?}", #error));
             },
         }
     };
@@ -145,6 +158,8 @@ fn tuple_struct_mutator<'a>(
 
 fn named_struct_mutator<'a>(
     named_struct: &'a FieldsNamed,
+    args: &Ident,
+    error: &Ident,
 ) -> Result<(TokenStream, impl Iterator<Item = &'a Ident> + 'a)> {
     let field_mutations = named_struct.named.iter().map(|field| {
         let field_ty = &field.ty;
@@ -154,8 +169,8 @@ fn named_struct_mutator<'a>(
             .unwrap_or_else(|| field_ident.to_string());
 
         Ok(quote! {
-            if let Some(field_record) = differential_datalog::record::arg_find(args, #field_record_name) {
-                <dyn differential_datalog::record::Mutator<#field_ty>>::mutate(field_record, #field_ident)?;
+            if let Some(r#__ddlog_generated__field_record) = differential_datalog::record::arg_find(#args, #field_record_name) {
+                <dyn differential_datalog::record::Mutator<#field_ty>>::mutate(r#__ddlog_generated__field_record, #field_ident)?;
             }
         })
     })
@@ -163,12 +178,12 @@ fn named_struct_mutator<'a>(
 
     let mutator = quote! {
         match self {
-            differential_datalog::record::Record::NamedStruct(constructor, args) => {
+            differential_datalog::record::Record::NamedStruct(_, #args) => {
                 #field_mutations
             },
 
-            error => {
-                return std::result::Result::Err(std::format!("not a struct {:?}", error));
+            #error => {
+                return std::result::Result::Err(std::format!("not a struct {:?}", #error));
             },
         }
     };
@@ -191,31 +206,32 @@ fn mutator_struct(
         TypeGenerics,
         Option<&WhereClause>,
     ),
+    (args, mutated, error): (Ident, Ident, Ident),
 ) -> Result<TokenStream> {
     let generated_mutator = match derive_enum.fields {
         Fields::Named(named_struct) => {
-            let (mutator, field_idents) = named_struct_mutator(&named_struct)?;
+            let (mutator, field_idents) = named_struct_mutator(&named_struct, &args, &error)?;
 
             quote! {
-                let #struct_ident { #( #field_idents, )* } = mutated;
+                let #struct_ident { #( #field_idents, )* } = #mutated;
                 #mutator
             }
         }
         Fields::Unnamed(unnamed_struct) => {
-            let (mutator, tuple_elems) = tuple_struct_mutator(&unnamed_struct);
+            let (mutator, tuple_elems) = tuple_struct_mutator(&unnamed_struct, &args, &error);
 
             quote! {
-                let #struct_ident(#( #tuple_elems, )*) = mutated;
+                let #struct_ident(#( #tuple_elems, )*) = #mutated;
                 #mutator
             }
         }
-        Fields::Unit => unit_struct_mutator(),
+        Fields::Unit => unit_struct_mutator(&args, &error),
     };
 
     Ok(quote! {
         #[automatically_derived]
         impl #impl_generics differential_datalog::record::Mutator<#struct_ident #type_generics> for differential_datalog::record::Record #where_clause {
-            fn mutate(&self, mutated: &mut #struct_ident #type_generics) -> std::result::Result<(), std::string::String> {
+            fn mutate(&self, #mutated: &mut #struct_ident #type_generics) -> std::result::Result<(), std::string::String> {
                 #generated_mutator
 
                 std::result::Result::Ok(())
@@ -232,6 +248,7 @@ fn mutator_enum(
         TypeGenerics,
         Option<&WhereClause>,
     ),
+    (args, mutated, error): (Ident, Ident, Ident),
 ) -> Result<TokenStream> {
     let generated_mutators = derive_enum
         .variants
@@ -241,20 +258,21 @@ fn mutator_enum(
 
             let (guard, mutator) = match &variant.fields {
                 Fields::Named(named_struct) => {
-                    let (mutator, field_idents) = named_struct_mutator(named_struct)?;
+                    let (mutator, field_idents) =
+                        named_struct_mutator(named_struct, &args, &error)?;
                     let guard = quote! { #enum_ident::#variant_ident { #( #field_idents, )* } };
 
                     (guard, mutator)
                 }
                 Fields::Unnamed(tuple_struct) => {
-                    let (mutator, tuple_fields) = tuple_struct_mutator(tuple_struct);
+                    let (mutator, tuple_fields) = tuple_struct_mutator(tuple_struct, &args, &error);
                     let guard = quote! { #enum_ident::#variant_ident(#( #tuple_fields, )*) };
 
                     (guard, mutator)
                 }
                 Fields::Unit => {
                     let guard = quote! { #enum_ident::#variant_ident };
-                    let mutator = unit_struct_mutator();
+                    let mutator = unit_struct_mutator(&args, &error);
 
                     (guard, mutator)
                 }
@@ -269,8 +287,8 @@ fn mutator_enum(
     Ok(quote! {
         #[automatically_derived]
         impl #impl_generics differential_datalog::record::Mutator<#enum_ident #type_generics> for differential_datalog::record::Record #where_clause {
-            fn mutate(&self, mutated: &mut #enum_ident #type_generics) -> std::result::Result<(), std::string::String> {
-                match mutated {
+            fn mutate(&self, #mutated: &mut #enum_ident #type_generics) -> std::result::Result<(), std::string::String> {
+                match #mutated {
                     #generated_mutators
                 }
 

--- a/rust/template/ddlog_derive/tests/ui/pass/name_conflicts.rs
+++ b/rust/template/ddlog_derive/tests/ui/pass/name_conflicts.rs
@@ -1,0 +1,15 @@
+use ddlog_derive::{FromRecord, IntoRecord, Mutator};
+use serde::Deserialize;
+
+fn main() {}
+
+#[derive(FromRecord, IntoRecord, Mutator, Debug, Clone, PartialEq, Deserialize)]
+struct Struct {
+    args: u64,
+    constructor: u64,
+}
+
+#[derive(FromRecord, IntoRecord, Mutator, Debug, Clone, PartialEq, Deserialize)]
+enum Enum {
+    Variant { args: u64, constructor: u64 },
+}

--- a/rust/template/ddlog_derive/tests/ui/pass/realworld.rs
+++ b/rust/template/ddlog_derive/tests/ui/pass/realworld.rs
@@ -1,0 +1,156 @@
+use ddlog_derive::{FromRecord, IntoRecord, Mutator};
+use serde::{Deserialize, Serialize};
+
+fn main() {}
+
+#[derive(
+    Eq,
+    Ord,
+    Clone,
+    Hash,
+    PartialEq,
+    PartialOrd,
+    IntoRecord,
+    Mutator,
+    Serialize,
+    Deserialize,
+    FromRecord,
+)]
+#[ddlog(rename = "ast::ExprKind")]
+enum ExprKind {
+    #[ddlog(rename = "ast::ExprLit")]
+    ExprLit { kind: LitKind },
+    #[ddlog(rename = "ast::ExprNameRef")]
+    ExprNameRef,
+    #[ddlog(rename = "ast::ExprYield")]
+    ExprYield,
+    #[ddlog(rename = "ast::ExprAwait")]
+    ExprAwait,
+    #[ddlog(rename = "ast::ExprArrow")]
+    ExprArrow,
+    #[ddlog(rename = "ast::ExprUnaryOp")]
+    ExprUnaryOp,
+    #[ddlog(rename = "ast::ExprBinOp")]
+    ExprBinOp,
+    #[ddlog(rename = "ast::ExprTernary")]
+    ExprTernary,
+    #[ddlog(rename = "ast::ExprThis")]
+    ExprThis,
+    #[ddlog(rename = "ast::ExprTemplate")]
+    ExprTemplate,
+    #[ddlog(rename = "ast::ExprArray")]
+    ExprArray,
+    #[ddlog(rename = "ast::ExprObject")]
+    ExprObject,
+    #[ddlog(rename = "ast::ExprGrouping")]
+    ExprGrouping { inner: ddlog_std::Option<ExprId> },
+    #[ddlog(rename = "ast::ExprBracket")]
+    ExprBracket,
+    #[ddlog(rename = "ast::ExprDot")]
+    ExprDot,
+    #[ddlog(rename = "ast::ExprNew")]
+    ExprNew,
+    #[ddlog(rename = "ast::ExprCall")]
+    ExprCall,
+    #[ddlog(rename = "ast::ExprAssign")]
+    ExprAssign,
+    #[ddlog(rename = "ast::ExprSequence")]
+    ExprSequence { exprs: ddlog_std::Vec<ExprId> },
+    #[ddlog(rename = "ast::ExprNewTarget")]
+    ExprNewTarget,
+    #[ddlog(rename = "ast::ExprImportMeta")]
+    ExprImportMeta,
+    #[ddlog(rename = "ast::ExprInlineFunc")]
+    ExprInlineFunc,
+    #[ddlog(rename = "ast::ExprSuperCall")]
+    ExprSuperCall {
+        args: ddlog_std::Option<ddlog_std::Vec<ExprId>>,
+    },
+    #[ddlog(rename = "ast::ExprImportCall")]
+    ExprImportCall { arg: ddlog_std::Option<ExprId> },
+    #[ddlog(rename = "ast::ExprClass")]
+    ExprClass,
+}
+
+#[derive(
+    Eq,
+    Ord,
+    Clone,
+    Hash,
+    PartialEq,
+    PartialOrd,
+    IntoRecord,
+    Mutator,
+    Serialize,
+    Deserialize,
+    FromRecord,
+)]
+enum LitKind {
+    Integer,
+}
+
+impl Default for LitKind {
+    fn default() -> Self {
+        Self::Integer
+    }
+}
+
+#[derive(
+    Eq,
+    Ord,
+    Clone,
+    Hash,
+    PartialEq,
+    PartialOrd,
+    IntoRecord,
+    Mutator,
+    Serialize,
+    Deserialize,
+    FromRecord,
+    Default,
+)]
+struct ExprId;
+
+mod ddlog_std {
+    use super::*;
+
+    #[derive(
+        Eq,
+        Ord,
+        Clone,
+        Hash,
+        PartialEq,
+        PartialOrd,
+        IntoRecord,
+        Mutator,
+        Serialize,
+        Deserialize,
+        FromRecord,
+    )]
+    pub enum Option<T> {
+        Some(T),
+        None,
+    }
+
+    impl<T> Default for Option<T> {
+        fn default() -> Self {
+            Self::None
+        }
+    }
+
+    #[derive(
+        Eq,
+        Ord,
+        Clone,
+        Hash,
+        PartialEq,
+        PartialOrd,
+        IntoRecord,
+        Mutator,
+        Serialize,
+        Deserialize,
+        FromRecord,
+        Default,
+    )]
+    pub struct Vec<T>(T);
+}

--- a/rust/template/differential_datalog/src/test_record.rs
+++ b/rust/template/differential_datalog/src/test_record.rs
@@ -1,6 +1,5 @@
 //! Tests for functions and macros in `record.rs`
 
-use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
 use std::iter::FromIterator;
 use std::vec;


### PR DESCRIPTION
* Made the names used within the `Mutator` macro use mixed spans so that they're hygienic, otherwise any fields with the name `args` would clash with the `args` ident declared in the macro, causing compile errors
* Added tests for this as well as some code ripped straight from what ddlog actually generates just for a real-world test case