### PR TITLE
Optimized string interning and removed some extra mutexes

### DIFF
--- a/lib/ddlog_std.rs
+++ b/lib/ddlog_std.rs
@@ -200,6 +200,8 @@ pub fn bigint_pow32(base: &ddlog_bigint::Int, exp: &u32) -> ddlog_bigint::Int {
 }
 
 // Option
+impl<T: Copy> Copy for Option<T> {}
+
 pub fn option2std<T>(x: StdOption<T>) -> Option<T> {
     match x {
         StdOption::None => Option::None,

--- a/lib/intern.rs
+++ b/lib/intern.rs
@@ -1,104 +1,85 @@
-use differential_datalog::record;
-use differential_datalog::record::*;
+use differential_datalog::record::{self, Record};
+use fxhash::FxBuildHasher;
+use lasso::{Capacity, Key, Spur, ThreadedRodeo};
 use once_cell::sync::Lazy;
-use serde;
-use std::collections;
-use std::fmt;
-use std::hash::Hash;
-use std::marker;
-use std::sync;
-use std::vec;
+use serde::{de::Deserializer, ser::Serializer};
+use std::{
+    fmt::{self, Debug, Display, Formatter},
+    marker::PhantomData,
+    num::NonZeroUsize,
+};
 
-type Symbol = u32;
+pub static GLOBAL_STRING_INTERNER: Lazy<ThreadedRodeo<Spur, FxBuildHasher>> = Lazy::new(|| {
+    // Safety: `NonZeroUsize::new_unchecked()` must be called with a non-zero
+    //         integer, and 4096 is not zero
+    ThreadedRodeo::with_capacity_and_hasher(
+        Capacity::new(512, unsafe { NonZeroUsize::new_unchecked(4096) }),
+        FxBuildHasher::default(),
+    )
+});
 
-#[derive(Eq, PartialOrd, PartialEq, Ord, Clone, Hash)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
 pub struct IObj<T> {
-    pub x: Symbol,
-    phantom: marker::PhantomData<T>,
+    key: Spur,
+    __type: PhantomData<T>,
 }
 
-struct Interner<T> {
-    vec: vec::Vec<T>,
-    map: collections::HashMap<T, Symbol>,
-}
-
-impl<T: Clone + Eq + Hash> Interner<T> {
-    pub fn new() -> Self {
-        Interner {
-            vec: vec::Vec::new(),
-            map: collections::HashMap::new(),
+impl<T> IObj<T> {
+    pub const fn new(key: Spur) -> Self {
+        Self {
+            key,
+            __type: PhantomData,
         }
     }
-    pub fn intern(&mut self, x: &T) -> Symbol {
-        if !self.map.contains_key(x) {
-            let len = self.map.len() as Symbol;
-            self.vec.push(x.clone());
-            self.map.insert(x.clone(), len);
-            len
-        } else {
-            *self.map.get(x).unwrap()
-        }
-    }
-    pub fn get(&self, sym: Symbol) -> &T {
-        &self.vec[sym as usize]
-    }
 }
-
-type StringInterner = Interner<String>;
-
-// TODO: Arc is unneeded
-static global_string_interner: Lazy<sync::Arc<sync::Mutex<StringInterner>>> =
-    Lazy::new(|| sync::Arc::new(sync::Mutex::new(StringInterner::new())));
-
-// TODO: Arc can be replaced by an `&'static Mutex<_>`
-thread_local!(static STRING_INTERNER: sync::Arc<sync::Mutex<StringInterner>> = global_string_interner.clone());
 
 impl Default for IString {
     fn default() -> Self {
-        string_intern(&String::default())
+        IObj::new(GLOBAL_STRING_INTERNER.get_or_intern_static(""))
     }
 }
 
-pub fn string_intern(s: &String) -> IString {
-    STRING_INTERNER.with(|si| IObj {
-        x: si.lock().unwrap().intern(s),
-        phantom: Default::default(),
-    })
+pub fn string_intern(string: &String) -> IString {
+    IObj::new(GLOBAL_STRING_INTERNER.get_or_intern(string))
 }
 
-pub fn istring_str(s: &IString) -> String {
-    STRING_INTERNER.with(|si| si.lock().unwrap().get(s.x).clone())
+pub fn istring_str(string: &IString) -> String {
+    GLOBAL_STRING_INTERNER.resolve(&string.key).to_owned()
 }
 
-pub fn istring_ord(s: &IString) -> u32 {
-    s.x
+pub fn istring_ord(string: &IString) -> u32 {
+    string.key.into_usize() as u32
 }
 
-impl fmt::Display for IString {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        record::format_ddlog_str(&istring_str(self), f)
+impl Display for IString {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        let string = GLOBAL_STRING_INTERNER.resolve(&self.key);
+        record::format_ddlog_str(string, f)
     }
 }
 
-impl fmt::Debug for IString {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        record::format_ddlog_str(&istring_str(self), f)
+impl Debug for IString {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        let string = GLOBAL_STRING_INTERNER.resolve(&self.key);
+        record::format_ddlog_str(string, f)
     }
 }
 
-impl serde::Serialize for IString {
+impl Serialize for IString {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: Serializer,
     {
-        istring_str(self).serialize(serializer)
+        let string = GLOBAL_STRING_INTERNER.resolve(&self.key);
+        string.serialize(serializer)
     }
 }
 
-impl<'de> serde::Deserialize<'de> for IString {
-    fn deserialize<D>(deserializer: D) -> Result<IString, D::Error>
+impl<'de> Deserialize<'de> for IString {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: Deserializer<'de>,
     {
         String::deserialize(deserializer).map(|s| string_intern(&s))
     }
@@ -121,6 +102,7 @@ impl Mutator<IString> for Record {
         let mut string = istring_str(s);
         self.mutate(&mut string)?;
         *s = string_intern(&string);
+
         Ok(())
     }
 }

--- a/lib/intern.toml
+++ b/lib/intern.toml
@@ -1,0 +1,6 @@
+[dependencies.lasso]
+version = "0.4.0"
+features = ["multi-threaded"]
+
+[dependencies.fxhash]
+version = "0.2.1"

--- a/rust/template/differential_datalog/src/profile_statistics.rs
+++ b/rust/template/differential_datalog/src/profile_statistics.rs
@@ -42,6 +42,7 @@ impl Default for CSVEventType {
 }
 
 /// Map from (worker_id, op_id) to start time for timely events.
+#[repr(transparent)]
 struct StartTimeKeeper<K> {
     start_times: HashMap<K, Duration>,
 }

--- a/rust/template/differential_datalog/src/program/mod.rs
+++ b/rust/template/differential_datalog/src/program/mod.rs
@@ -752,29 +752,28 @@ enum Reply {
 
 impl Program {
     /// Instantiate the program with `nworkers` timely threads.
-    pub fn run(&self, nworkers: usize) -> Result<RunningProgram, String> {
+    pub fn run(&self, number_workers: usize) -> Result<RunningProgram, String> {
         // Setup channels to communicate with the dataflow.
         // We use async channels to avoid deadlocks when workers are parked in
         // `step_or_park`.  This has the downside of introducing an unbounded buffer
         // that is only guaranteed to be fully flushed when the transaction commits.
-        let (request_send, request_recv): (Vec<_>, Vec<_>) = (0..nworkers)
+        let (request_send, request_recv): (Vec<_>, Vec<_>) = (0..number_workers)
             .map(|_| crossbeam_channel::unbounded::<Msg>())
             .unzip();
-        let request_recv: Arc<Mutex<Vec<Option<_>>>> =
-            Arc::new(Mutex::new(request_recv.into_iter().map(Some).collect()));
+        let request_recv = Arc::from(request_recv);
 
         // Channels for responses from worker threads.
-        let (reply_send, reply_recv): (Vec<_>, Vec<_>) = (0..nworkers)
+        let (reply_send, reply_recv): (Vec<_>, Vec<_>) = (0..number_workers)
             .map(|_| crossbeam_channel::unbounded::<Reply>())
             .unzip();
-        let reply_send: Arc<Mutex<Vec<Option<_>>>> =
-            Arc::new(Mutex::new(reply_send.into_iter().map(Some).collect()));
+        let reply_send = Arc::from(reply_send);
 
-        let (prof_send, prof_recv) = crossbeam_channel::bounded::<ProfMsg>(PROF_MSG_BUF_SIZE);
+        let (prof_send, prof_recv) = crossbeam_channel::bounded(PROF_MSG_BUF_SIZE);
 
         // Channel used by workers 1..n to send their thread handles to worker 0.
-        let (thandle_send, thandle_recv) = crossbeam_channel::bounded::<(usize, Thread)>(0);
-        let thandle_recv = Arc::new(Mutex::new(thandle_recv));
+        let (thread_handle_send, thread_handle_recv) =
+            crossbeam_channel::bounded::<(usize, Thread)>(0);
+        let thread_handle_recv = Arc::new(thread_handle_recv);
 
         // Profile data structure
         let profile = Arc::new(Mutex::new(Profile::new()));
@@ -789,7 +788,7 @@ impl Program {
 
         // Shared timestamp managed by worker 0 and read by all other workers
         let frontier_ts = TSAtomic::new(0);
-        let progress_barrier = Arc::new(Barrier::new(nworkers));
+        let progress_barrier = Arc::new(Barrier::new(number_workers));
 
         // Clone the program so that it can be moved into the timely computation
         let program = Arc::new(self.clone());
@@ -797,19 +796,19 @@ impl Program {
 
         // Start up timely computation.
         let worker_guards = timely::execute(
-            Configuration::Process(nworkers),
+            Configuration::Process(number_workers),
             move |worker: &mut Worker<Allocator>| -> Result<_, String> {
                 let worker = DDlogWorker::new(
                     worker,
                     program.clone(),
                     &frontier_ts,
-                    nworkers,
+                    number_workers,
                     progress_barrier.clone(),
                     profiling.clone(),
-                    request_recv.clone(),
-                    reply_send.clone(),
-                    thandle_send.clone(),
-                    thandle_recv.clone(),
+                    Arc::clone(&request_recv),
+                    Arc::clone(&reply_send),
+                    thread_handle_send.clone(),
+                    thread_handle_recv.clone(),
                 );
 
                 worker.run()
@@ -888,8 +887,8 @@ impl Program {
     fn prof_thread_func(channel: Receiver<ProfMsg>, profile: Arc<Mutex<Profile>>) {
         loop {
             match channel.recv() {
-                Ok(msg) => {
-                    profile.lock().unwrap().update(&msg);
+                Ok(message) => {
+                    profile.lock().unwrap().update(&message);
                 }
                 _ => return,
             }


### PR DESCRIPTION
* Removed some unneeded mutexes from the startup routine that are no longer needed after the switch to `crossbeam-channel`
* Switched from a DIY string interner to `lasso` with a `fxhash` hasher, this removes some mutex contention while also improving our memory footprint and interning strings faster
* Implemented `Copy` for `Option<T>` where `T` is `Copy`