### PR TITLE
DDlog API refactoring Part 1.

### DIFF
--- a/go/cmd/example/main.go
+++ b/go/cmd/example/main.go
@@ -24,8 +24,6 @@ type Example struct {
 }
 
 var (
-	exampleRelationTableID = ddlog.GetTableID("ExampleRelation")
-	// memory will never be freed, which is fine
 	exampleRelationConstructor = ddlog.NewCString("ExampleRelation")
 )
 
@@ -96,7 +94,7 @@ func main() {
 	r1 := NewRecordExample(e1)
 
 	klog.Infof("Inserting record %s", r1.Dump())
-	cmdInsert1 := ddlog.NewInsertCommand(exampleRelationTableID, r1)
+	cmdInsert1 := ddlog.NewInsertCommand(ddlogProgram.GetTableID("ExampleRelation"), r1)
 	// In practice, each transction would likely include more than one command.
 	if err := ddlogProgram.ApplyUpdatesAsTransaction(cmdInsert1); err != nil {
 		klog.Errorf("Error during transaction: %v", err)
@@ -104,7 +102,7 @@ func main() {
 
 	k1 := NewRecordExampleKey(e1)
 	klog.Infof("Deleting record with key %s", k1.Dump())
-	cmdDelete1 := ddlog.NewDeleteKeyCommand(exampleRelationTableID, k1)
+	cmdDelete1 := ddlog.NewDeleteKeyCommand(ddlogProgram.GetTableID("ExampleRelation"), k1)
 	if err := ddlogProgram.ApplyUpdatesAsTransaction(cmdDelete1); err != nil {
 		klog.Errorf("Error during transaction: %v", err)
 	}

--- a/go/pkg/ddlog/ddlog_test.go
+++ b/go/pkg/ddlog/ddlog_test.go
@@ -13,19 +13,12 @@ const (
 	numDDlogWorkers = 2
 )
 
-func TestGetTableID(t *testing.T) {
-	// input relation BI(b: bool)
-	tableID := GetTableID("BI")
-	tableName := GetTableName(tableID)
-	assert.Equal(t, "BI", tableName)
-}
-
 type mockHandler struct {
 	mock.Mock
 	test *testing.T
 }
 
-func (m *mockHandler) Handle(tableID TableID, r Record, weight int64) {
+func (m *mockHandler) Handle(p *Program, tableID TableID, r Record, weight int64) {
 	m.Called(tableID, r, weight)
 }
 
@@ -35,8 +28,12 @@ func TestInsert(t *testing.T) {
 	ddlogProgram, err := NewProgram(numDDlogWorkers, m)
 	assert.Nil(t, err, "Error when running DDlog program")
 
-	tableID := GetTableID("L0I")
-	outTableID := GetTableID("OL0I")
+	biID := ddlogProgram.GetTableID("BI")
+	biName := ddlogProgram.GetTableName(biID)
+	assert.Equal(t, "BI", biName)
+
+	tableID := ddlogProgram.GetTableID("L0I")
+	outTableID := ddlogProgram.GetTableID("OL0I")
 	constructor := NewCString("L0I")
 	defer constructor.Free()
 	rStruct := NewRecordStructStatic(
@@ -71,7 +68,7 @@ func benchmarkTransaction(b *testing.B, commitFn func(p *Program) error) {
 	ddlogProgram, err := NewProgram(numDDlogWorkers, outRecordHandler)
 	assert.Nil(b, err, "Error when running DDlog program")
 
-	tableID := GetTableID("ZI21")
+	tableID := ddlogProgram.GetTableID("ZI21")
 	constructor := NewCString("ZI21")
 	defer constructor.Free()
 

--- a/java/ddlogapi.c
+++ b/java/ddlogapi.c
@@ -505,22 +505,22 @@ JNIEXPORT void JNICALL Java_ddlogapi_DDlogAPI_ddlog_1dump_1index_1to_1flatbuf(
             direct_buf, (jlong)resbuf_size, (jlong)resbuf_offset);
 }
 JNIEXPORT jint JNICALL Java_ddlogapi_DDlogAPI_ddlog_1clear_1relation(
-    JNIEnv *env, jclass obj, jlong progHandle, jint relid) {
+    JNIEnv *env, jobject obj, jlong progHandle, jint relid) {
     int result = ddlog_clear_relation((ddlog_prog)progHandle, relid);
     return (jint)result;
 }
 
 JNIEXPORT jint JNICALL Java_ddlogapi_DDlogAPI_ddlog_1get_1table_1id(
-    JNIEnv *env, jclass class, jstring table) {
+    JNIEnv *env, jobject obj, jlong progHandle, jstring table) {
     const char* tbl = (*env)->GetStringUTFChars(env, table, NULL);
-    table_id id = ddlog_get_table_id(tbl);
+    table_id id = ddlog_get_table_id((ddlog_prog)progHandle, tbl);
     (*env)->ReleaseStringUTFChars(env, table, tbl);
     return (jint)id;
 }
 
 JNIEXPORT jstring JNICALL Java_ddlogapi_DDlogAPI_ddlog_1get_1table_1name(
-    JNIEnv *env, jclass class, jint id) {
-    const char* table = ddlog_get_table_name(id);
+    JNIEnv *env, jobject obj, jlong progHandle, jint id) {
+    const char* table = ddlog_get_table_name((ddlog_prog)progHandle, id);
     if (table == NULL) {
         throwDDlogException(env, "Unknown table id");
         return NULL;
@@ -530,16 +530,16 @@ JNIEXPORT jstring JNICALL Java_ddlogapi_DDlogAPI_ddlog_1get_1table_1name(
 }
 
 JNIEXPORT jint JNICALL Java_ddlogapi_DDlogAPI_ddlog_1get_1index_1id(
-    JNIEnv *env, jclass class, jstring index) {
+    JNIEnv *env, jobject obj, jlong progHandle, jstring index) {
     const char* tbl = (*env)->GetStringUTFChars(env, index, NULL);
-    table_id id = ddlog_get_index_id(tbl);
+    table_id id = ddlog_get_index_id((ddlog_prog)progHandle, tbl);
     (*env)->ReleaseStringUTFChars(env, index, tbl);
     return (jint)id;
 }
 
 JNIEXPORT jstring JNICALL Java_ddlogapi_DDlogAPI_ddlog_1get_1index_1name(
-    JNIEnv *env, jclass class, jint id) {
-    const char* index = ddlog_get_index_name(id);
+    JNIEnv *env, jobject obj, jlong progHandle, jint id) {
+    const char* index = ddlog_get_index_name((ddlog_prog)progHandle, id);
     if (index == NULL) {
         throwDDlogException(env, "Unknown index id");
         return NULL;

--- a/java/ddlogapi/DDlogAPI.java
+++ b/java/ddlogapi/DDlogAPI.java
@@ -18,6 +18,10 @@ public class DDlogAPI {
      * The C ddlog API
      */
     native long ddlog_run(boolean storeData, int workers) throws DDlogException;
+    static native int ddlog_get_table_id(long hprog, String table);
+    static native String ddlog_get_table_name(long hprog,int id) throws DDlogException;
+    static native int ddlog_get_index_id(long hprog, String index);
+    static native String ddlog_get_index_name(long hprog, int id) throws DDlogException;
     static native int ddlog_record_commands(long hprog, String filename, boolean append) throws DDlogException, IOException;
     static native void ddlog_stop_recording(long hprog, int fd) throws DDlogException;
     static native void ddlog_dump_input_snapshot(long hprog, String filename, boolean append) throws DDlogException, IOException;
@@ -59,10 +63,6 @@ public class DDlogAPI {
     static native long ddlog_struct(String constructor, long[] handles) throws DDlogException;
     static native long ddlog_named_struct(String constructor, String[] names, long[] handles) throws DDlogException;
     // Getters
-    static native int ddlog_get_table_id(String table);
-    static native String ddlog_get_table_name(int id) throws DDlogException;
-    static native int ddlog_get_index_id(String index);
-    static native String ddlog_get_index_name(int id) throws DDlogException;
     static native boolean ddlog_is_bool(long handle);
     static native boolean ddlog_get_bool(long handle);
     static native boolean ddlog_is_int(long handle);
@@ -183,9 +183,10 @@ public class DDlogAPI {
      *
      * See <code>ddlog.h: ddlog_get_table_id()</code>
      */
-    public int getTableId(String table) {
+    public int getTableId(String table) throws DDlogException {
+        this.checkHandle();
         if (!this.tableId.containsKey(table)) {
-            int id = ddlog_get_table_id(table);
+            int id = ddlog_get_table_id(this.hprog, table);
             this.tableId.put(table, id);
             return id;
         }
@@ -198,7 +199,8 @@ public class DDlogAPI {
      * See <code>ddlog.h: ddlog_get_table_name()</code>
      */
     public String getTableName(int id) throws DDlogException {
-        return ddlog_get_table_name(id);
+        this.checkHandle();
+        return ddlog_get_table_name(this.hprog, id);
     }
 
     /**
@@ -209,8 +211,9 @@ public class DDlogAPI {
      *
      * See <code>ddlog.h: ddlog_get_index_id()</code>
      */
-    public int getIndexId(String table) {
-        return ddlog_get_index_id(table);
+    public int getIndexId(String table) throws DDlogException {
+        this.checkHandle();
+        return ddlog_get_index_id(this.hprog, table);
     }
 
     /**
@@ -219,7 +222,8 @@ public class DDlogAPI {
      * See <code>ddlog.h: ddlog_get_index_name()</code>
      */
     public String getIndexName(int id) throws DDlogException {
-        return ddlog_get_index_name(id);
+        this.checkHandle();
+        return ddlog_get_index_name(this.hprog, id);
     }
 
     /**

--- a/rust/template/ddlog.h
+++ b/rust/template/ddlog.h
@@ -114,43 +114,6 @@ typedef struct {
 } ddlog_record_update;
 
 /*
- * Get DDlog table id by name.  The table name is a null-terminated UTF8
- * string.
- *
- * NOTE: for tables declared outside of the main DDlog module, fully qualified
- * module names must be used, e.g., the fully qualified name of a table named
- * "Pod" declared inside the "k8spolicy" module is "k8spolicy.Pod".
- *
- * On error, returns -1.
- */
-extern table_id ddlog_get_table_id(const char* tname);
-
-/*
- * Get DDlog table name from id.
- *
- * Returns a null-terminated UTF8 string on success or NULL on error.
- */
-extern const char* ddlog_get_table_name(table_id id);
-
-/*
- * Get DDlog index id by name.  The index name is a null-terminated UTF8
- * string.
- *
- * NOTE: for indexes declared outside of the main DDlog module, fully qualified
- * module names must be used.
- *
- * On error, returns -1.
- */
-extern index_id ddlog_get_index_id(const char* iname);
-
-/*
- * Get DDlog index name from id.
- *
- * Returns a null-terminated UTF8 string on success or NULL on error.
- */
-extern const char* ddlog_get_index_name(index_id id);
-
-/*
  * Create an instance of DDlog program.
  *
  * `workers` is the number of DDlog worker threads that will be
@@ -188,6 +151,43 @@ extern ddlog_prog ddlog_run(
         bool do_store,
         void (*print_err_msg)(const char *msg),
         ddlog_delta **init_state);
+
+/*
+ * Get DDlog table id by name.  The table name is a null-terminated UTF8
+ * string.
+ *
+ * NOTE: for tables declared outside of the main DDlog module, fully qualified
+ * module names must be used, e.g., the fully qualified name of a table named
+ * "Pod" declared inside the "k8spolicy" module is "k8spolicy.Pod".
+ *
+ * On error, returns -1.
+ */
+extern table_id ddlog_get_table_id(ddlog_prog hprog, const char* tname);
+
+/*
+ * Get DDlog table name from id.
+ *
+ * Returns a null-terminated UTF8 string on success or NULL on error.
+ */
+extern const char* ddlog_get_table_name(ddlog_prog hprog, table_id id);
+
+/*
+ * Get DDlog index id by name.  The index name is a null-terminated UTF8
+ * string.
+ *
+ * NOTE: for indexes declared outside of the main DDlog module, fully qualified
+ * module names must be used.
+ *
+ * On error, returns -1.
+ */
+extern index_id ddlog_get_index_id(ddlog_prog hprog, const char* iname);
+
+/*
+ * Get DDlog index name from id.
+ *
+ * Returns a null-terminated UTF8 string on success or NULL on error.
+ */
+extern const char* ddlog_get_index_name(ddlog_prog hprog, index_id id);
 
 /*
  * Record commands issued to DDlog via this API in a file.

--- a/rust/template/ddlog_derive/src/mutator.rs
+++ b/rust/template/ddlog_derive/src/mutator.rs
@@ -183,7 +183,7 @@ fn named_struct_mutator<'a>(
             },
 
             #error => {
-                return std::result::Result::Err(std::format!("not a struct {:?}", #error));
+                return std::result::Result::Err(std::format!("not a named struct {:?}", #error));
             },
         }
     };

--- a/rust/template/differential_datalog/src/lib.rs
+++ b/rust/template/differential_datalog/src/lib.rs
@@ -9,7 +9,7 @@ mod callback;
 mod ddlog;
 mod profile;
 mod profile_statistics;
-mod replay;
+pub mod replay;
 mod valmap;
 mod variable;
 
@@ -24,9 +24,7 @@ pub mod record;
 mod test_record;
 
 pub use callback::Callback;
-pub use ddlog::DDlog;
 pub use ddlog::DDlogConvert;
-pub use replay::record_upd_cmds;
-pub use replay::record_val_upds;
-pub use replay::RecordReplay;
+pub use ddlog::{DDlogDump, DDlogInventory, DDlogProfiling, DDlogTyped, DDlogUntyped};
+pub use replay::CommandRecorder;
 pub use valmap::DeltaMap;

--- a/rust/template/differential_datalog/src/valmap.rs
+++ b/rust/template/differential_datalog/src/valmap.rs
@@ -9,7 +9,7 @@ use std::convert::{AsMut, AsRef};
 use std::fmt::Display;
 use std::io;
 
-use crate::ddlog::DDlogConvert;
+use crate::ddlog::DDlogInventory;
 use crate::program::RelId;
 
 /* Stores a set of changes to output tables.
@@ -61,12 +61,12 @@ impl<V: Display + Ord + Clone> DeltaMap<V> {
         Self { map }
     }
 
-    pub fn format<R>(&self, w: &mut dyn io::Write) -> io::Result<()>
-    where
-        R: DDlogConvert,
-    {
+    pub fn format(&self, w: &mut dyn io::Write, inventory: &dyn DDlogInventory) -> io::Result<()> {
         for (relid, relmap) in &self.map {
-            w.write_fmt(format_args!("{}:\n", R::relid2name(*relid).unwrap()))?;
+            w.write_fmt(format_args!(
+                "{}:\n",
+                inventory.get_table_name(*relid).unwrap()
+            ))?;
             for (val, weight) in relmap {
                 w.write_fmt(format_args!("{}: {}\n", *val, *weight))?;
             }
@@ -83,12 +83,16 @@ impl<V: Display + Ord + Clone> DeltaMap<V> {
         Ok(())
     }
 
-    pub fn format_as_sets<R>(&self, w: &mut dyn io::Write) -> io::Result<()>
-    where
-        R: DDlogConvert,
-    {
+    pub fn format_as_sets(
+        &self,
+        w: &mut dyn io::Write,
+        inventory: &dyn DDlogInventory,
+    ) -> io::Result<()> {
         for (relid, map) in &self.map {
-            w.write_fmt(format_args!("{}:\n", R::relid2name(*relid).unwrap()))?;
+            w.write_fmt(format_args!(
+                "{}:\n",
+                inventory.get_table_name(*relid).unwrap()
+            ))?;
             for (val, weight) in map {
                 if *weight == 1 {
                     w.write_fmt(format_args!("{}\n", *val))?;

--- a/rust/template/distributed_datalog/src/instantiate.rs
+++ b/rust/template/distributed_datalog/src/instantiate.rs
@@ -17,7 +17,7 @@ use std::time::Instant;
 use differential_datalog::ddval::DDValue;
 use differential_datalog::program::RelId;
 use differential_datalog::program::Update;
-use differential_datalog::{DDlog, DDlogConvert};
+use differential_datalog::{DDlogConvert, DDlogInventory, DDlogTyped};
 
 use crate::accumulate::Accumulator;
 use crate::accumulate::DistributingAccumulator;
@@ -92,13 +92,11 @@ fn deduce_redirects(config: &NodeCfg) -> HashMap<RelId, RelId> {
 }
 
 /// Create a `DDlogServer` as per the given node configuration.
-fn create_server<P>(node_cfg: &NodeCfg) -> Result<DDlogServer<P>, String>
+fn create_server<P>(node_cfg: &NodeCfg, program: Arc<P>) -> Result<DDlogServer<P>, String>
 where
-    P: Send + DDlog,
+    P: Send + DDlogTyped,
 {
     let redirects = deduce_redirects(node_cfg);
-    // TODO: Should the number of workers be made configurable?
-    let (program, _) = P::run(2, false)?;
 
     Ok(DDlogServer::new(Some(program), redirects))
 }
@@ -129,21 +127,30 @@ fn deduce_sinks_or_sources(node_cfg: &NodeCfg, sinks: bool) -> BTreeMap<&Path, B
 }
 
 /// Realize the given configuration locally.
-fn realize<P>(
+fn realize<P, C, D>(
     addr: &Addr,
     node_cfg: &NodeCfg,
     assignment: &Assignment,
-) -> Result<Realization<P>, String>
+    program: Arc<P>,
+) -> Result<Realization<C, D>, String>
 where
-    P: Send + DDlog + 'static,
-    P::Convert: Send + DDlogConvert,
+    P: Send + Sync + DDlogTyped + DDlogInventory + Debug + 'static,
+    C: Send + DDlogConvert + Debug,
+    D: Serialize
+        + DeserializeOwned
+        + Debug
+        + Into<Update<DDValue>>
+        + From<Update<DDValue>>
+        + Send
+        + 'static,
 {
+    let inventory = program.clone() as Arc<dyn DDlogInventory + Send + Sync>;
     let now = Instant::now();
     let mut realization = Realization::new();
-    let mut server = create_server::<P>(&node_cfg)?;
+    let mut server = create_server(&node_cfg, program)?;
 
-    realization.add_tcp_senders(node_cfg, &mut server, assignment)?;
-    realization.add_file_sinks(node_cfg, &mut server)?;
+    realization.add_tcp_senders(node_cfg, &mut server, assignment, inventory.clone())?;
+    realization.add_file_sinks(node_cfg, &mut server, inventory.clone())?;
     realization.subscribe_txnmux(server)?;
     match addr {
         Addr::Ip(addr) => realization.add_tcp_receiver(addr)?,
@@ -162,7 +169,7 @@ where
 #[derive(Debug)]
 enum SourceRealization<C, D>
 where
-    C: DDlogConvert,
+    C: DDlogConvert + Debug,
     D: DeserializeOwned + Debug + Into<Update<DDValue>> + Send,
 {
     File(Arc<Mutex<FileSource<C>>>),
@@ -171,12 +178,11 @@ where
 
 /// All possible sinks of a Realization
 #[derive(Debug)]
-enum SinkRealization<C, S>
+enum SinkRealization<S>
 where
-    C: DDlogConvert,
     S: Serialize + Debug + Send + 'static,
 {
-    File(SharedObserver<FileSink<C>>),
+    File(SharedObserver<FileSink>),
     Node(SharedObserver<TcpSender<S>>),
 }
 
@@ -185,16 +191,16 @@ where
 /// Right now all that clients can do with an object of this type is
 /// dropping it to tear everything down.
 #[derive(Debug)]
-pub struct Realization<P>
+pub struct Realization<C, D>
 where
-    P: Send + DDlog + 'static,
-    P::Convert: Send + DDlogConvert,
+    C: Send + DDlogConvert + Debug,
+    D: Serialize + DeserializeOwned + Debug + Into<Update<DDValue>> + Send + 'static,
 {
     /// All sources of this realization and the subscription the node has to them
     _sources: HashMap<
         Source,
         (
-            Option<SourceRealization<P::Convert, P::UpdateSerializer>>,
+            Option<SourceRealization<C, D>>,
             SharedObserver<DistributingAccumulator<Update<DDValue>, DDValue, String>>,
             usize,
         ),
@@ -207,15 +213,15 @@ where
         (
             SharedObserver<DistributingAccumulator<Update<DDValue>, DDValue, String>>,
             UpdatesObservable<Update<DDValue>, String>,
-            HashMap<Sink, (SinkRealization<P::Convert, P::UpdateSerializer>, usize)>,
+            HashMap<Sink, (SinkRealization<D>, usize)>,
         ),
     >,
 }
 
-impl<P> Default for Realization<P>
+impl<C, D> Default for Realization<C, D>
 where
-    P: Send + DDlog + 'static,
-    P::Convert: Send + DDlogConvert,
+    C: Send + DDlogConvert + Debug,
+    D: Serialize + DeserializeOwned + Debug + Into<Update<DDValue>> + Send + 'static,
 {
     fn default() -> Self {
         Realization {
@@ -226,18 +232,27 @@ where
     }
 }
 
-impl<P> Realization<P>
+impl<C, D> Realization<C, D>
 where
-    P: Send + DDlog + 'static,
-    P::Convert: Send + DDlogConvert,
+    C: Send + DDlogConvert + Debug,
+    D: Serialize
+        + DeserializeOwned
+        + Debug
+        + Into<Update<DDValue>>
+        + From<Update<DDValue>>
+        + Send
+        + 'static,
 {
     /// Instantiates a new, default Realization.
-    pub fn new() -> Realization<P> {
+    pub fn new() -> Realization<C, D> {
         Default::default()
     }
 
     /// Subscribe the `TxnMux` of the existing realization to the given server.
-    pub fn subscribe_txnmux(&mut self, server: DDlogServer<P>) -> Result<(), &str> {
+    pub fn subscribe_txnmux<P>(&mut self, server: DDlogServer<P>) -> Result<(), &str>
+    where
+        P: Send + Sync + DDlogTyped + Debug + 'static,
+    {
         self._txnmux
             .subscribe(Box::new(server))
             .map_err(|_| "failed to subscribe DDlogServer to TxnMux")
@@ -285,7 +300,7 @@ where
 
     /// Add a file source to an existing realization.
     pub fn add_file_source(&mut self, path: &Path) -> Result<(), String> {
-        let mut source = Arc::new(Mutex::new(FileSource::<P::Convert>::new(path)));
+        let mut source = Arc::new(Mutex::new(FileSource::<C>::new(path)));
 
         let accumulator = Arc::new(Mutex::new(DistributingAccumulator::new()));
 
@@ -335,12 +350,16 @@ where
     /// Creates and adds accumulator for this rel_ids to the Realization if needed.
     /// Subscribes the accumulator to the sink and adds the sink to
     /// the accumulator's map.
-    pub fn add_sink(
+    pub fn add_sink<P>(
         &mut self,
         sink: &Sink,
         rel_ids: BTreeSet<RelId>,
         server: &mut DDlogServer<P>,
-    ) -> Result<(), String> {
+        inventory: Arc<dyn DDlogInventory + Send + Sync>,
+    ) -> Result<(), String>
+    where
+        P: Send + Sync + DDlogTyped + Debug + 'static,
+    {
         // Add the accumulator to the realization if needed.
         self.add_sink_accumulator(rel_ids.clone(), server)?;
         let (accumulator, _, sink_map) = self._sinks.get_mut(&rel_ids).unwrap();
@@ -349,7 +368,7 @@ where
             Sink::File(path) => {
                 let file = File::create(path)
                     .map_err(|e| format!("failed to create file {}:, {}", path.display(), e))?;
-                let file_sink = Arc::new(Mutex::new(FileSink::<P::Convert>::new(file)));
+                let file_sink = Arc::new(Mutex::new(FileSink::new(file, inventory)));
 
                 // Subscribe the accumulator to this sink.
                 let subscription = accumulator
@@ -396,11 +415,14 @@ where
     /// - Unsubscribe the stream from the accumulator.
     /// - Remove the stream from the server.
     /// Clear the accumulator.
-    pub fn remove_sink_accumulator(
+    pub fn remove_sink_accumulator<P>(
         &mut self,
         rel_ids: BTreeSet<RelId>,
         server: &mut DDlogServer<P>,
-    ) -> Result<(), String> {
+    ) -> Result<(), String>
+    where
+        P: Send + DDlogTyped + Debug + 'static,
+    {
         if let Some(entry) = self._sinks.remove(&rel_ids) {
             let (_, mut stream, sink_map) = entry;
             if sink_map.is_empty() {
@@ -421,11 +443,14 @@ where
     /// Creates and adds a sink accumulator to the existing Realization.
     /// Adds a stream to the server for the accumulator.
     /// Creates an entry in Realization _sinks for this rel_ids.
-    pub fn add_sink_accumulator(
+    pub fn add_sink_accumulator<P>(
         &mut self,
         rel_ids: BTreeSet<RelId>,
         server: &mut DDlogServer<P>,
-    ) -> Result<(), String> {
+    ) -> Result<(), String>
+    where
+        P: Send + DDlogTyped + Debug + 'static,
+    {
         if !self._sinks.contains_key(&rel_ids) {
             let accumulator = Arc::new(Mutex::new(DistributingAccumulator::new()));
             let mut update_observ = server.add_stream(rel_ids.clone());
@@ -491,48 +516,65 @@ where
 
     /// Add file sinks to the given server object, as per the node
     /// configuration.
-    fn add_file_sinks(
+    fn add_file_sinks<P>(
         &mut self,
         node_cfg: &NodeCfg,
         server: &mut DDlogServer<P>,
-    ) -> Result<(), String> {
+        inventory: Arc<dyn DDlogInventory + Send + Sync>,
+    ) -> Result<(), String>
+    where
+        P: Send + Sync + DDlogTyped + Debug + 'static,
+    {
         deduce_sinks_or_sources(node_cfg, true)
             .iter()
-            .try_for_each(|(path, rel_ids)| {
+            .try_for_each(move |(path, rel_ids)| {
                 let file = PathBuf::from(path);
                 let file_sink = Sink::File(file);
-                self.add_sink(&file_sink, rel_ids.clone(), server)
+                self.add_sink(&file_sink, rel_ids.clone(), server, inventory.clone())
             })
     }
 
     /// Add as many `TcpSender` objects as required given the provided node
     /// configuration.
-    fn add_tcp_senders(
+    fn add_tcp_senders<P>(
         &mut self,
         node_cfg: &NodeCfg,
         server: &mut DDlogServer<P>,
         assignment: &Assignment,
-    ) -> Result<(), String> {
+        inventory: Arc<dyn DDlogInventory + Send + Sync>,
+    ) -> Result<(), String>
+    where
+        P: Send + Sync + DDlogTyped + Debug + 'static,
+    {
         deduce_outputs(node_cfg, assignment)?
             .into_iter()
-            .try_for_each(|(addr, rel_ids)| {
+            .try_for_each(move |(addr, rel_ids)| {
                 let addr_sink = Sink::TcpSender(addr);
-                self.add_sink(&addr_sink, rel_ids, server)
+                self.add_sink(&addr_sink, rel_ids, server, inventory.clone())
             })
     }
 }
 
 /// Instantiate a configuration on a particular node under the given
 /// assignment.
-pub fn instantiate<P>(
+pub fn instantiate<P, C, D>(
     sys_cfg: SysCfg,
     addr: &Addr,
     assignment: &Assignment,
-) -> Result<Vec<Realization<P>>, String>
+    program: P,
+) -> Result<Vec<Realization<C, D>>, String>
 where
-    P: Send + DDlog + 'static,
-    P::Convert: Send + DDlogConvert,
+    P: Send + Sync + DDlogTyped + DDlogInventory + Debug + 'static,
+    C: Send + DDlogConvert + Debug,
+    D: Serialize
+        + DeserializeOwned
+        + Debug
+        + Into<Update<DDValue>>
+        + From<Update<DDValue>>
+        + Send
+        + 'static,
 {
+    let prog_arc = Arc::new(program);
     assignment
         .iter()
         .filter_map(|(uuid, assigned_addr)| {
@@ -543,7 +585,7 @@ where
             }
         })
         .try_fold(Vec::new(), |mut accumulator, node_cfg| {
-            realize::<P>(addr, node_cfg, assignment).map(|realization| {
+            realize::<P, C, D>(addr, node_cfg, assignment, prog_arc.clone()).map(|realization| {
                 accumulator.push(realization);
                 accumulator
             })

--- a/rust/template/distributed_datalog/src/sinks/file.rs
+++ b/rust/template/distributed_datalog/src/sinks/file.rs
@@ -1,76 +1,62 @@
-use std::fs::File as FsFile;
-use std::marker::PhantomData;
-
-use log::trace;
-use uid::Id;
-
 use differential_datalog::ddval::DDValue;
 use differential_datalog::program::Update;
-use differential_datalog::record_val_upds;
-use differential_datalog::DDlogConvert;
-use differential_datalog::RecordReplay;
+use differential_datalog::{CommandRecorder, DDlogInventory, DDlogTyped, DDlogUntyped};
+use log::trace;
+use std::fs::File as FsFile;
+use std::sync::Arc;
+use uid::Id;
 
 use crate::Observer;
 
 /// An object implementing the `Observer` interface and dumping
 /// transaction traces into a file.
 #[derive(Debug)]
-pub struct File<C> {
+pub struct File {
     /// The file sink's unique ID.
     id: usize,
-    /// The file we dump our transaction traces into.
-    file: FsFile,
-    /// Unused phantom data.
-    _unused: PhantomData<C>,
+    /// The file-backed recorder we dump our transaction traces into.
+    recorder: CommandRecorder<FsFile, Arc<dyn DDlogInventory + Send + Sync>>,
 }
 
-impl<C> File<C> {
-    /// Create a new file based observer using the given file.
-    pub fn new(file: FsFile) -> Self {
+impl File {
+    /// Create a new file-based observer using the given file.
+    pub fn new(file: FsFile, inventory: Arc<dyn DDlogInventory + Send + Sync>) -> Self {
         let id = Id::<()>::new().get();
         trace!("File({})::new", id);
 
         Self {
             id,
-            file,
-            _unused: PhantomData,
+            recorder: CommandRecorder::new(file, inventory),
         }
     }
 }
 
-impl<C> Observer<Update<DDValue>, String> for File<C>
-where
-    C: Send + DDlogConvert,
-{
+impl Observer<Update<DDValue>, String> for File {
     fn on_start(&mut self) -> Result<(), String> {
         trace!("File({})::on_start", self.id);
 
-        self.file
-            .record_start()
+        self.recorder
+            .transaction_start()
             .map_err(|e| format!("failed to record 'on_start' event: {}", e))
     }
 
     fn on_commit(&mut self) -> Result<(), String> {
         trace!("File({})::on_commit", self.id);
 
-        self.file
-            .record_commit(false)
+        self.recorder
+            .transaction_commit()
             .map_err(|e| format!("failed to record 'on_commit' event: {}", e))
     }
 
     fn on_updates<'a>(
         &mut self,
-        updates: Box<dyn Iterator<Item = Update<DDValue>> + 'a>,
+        mut updates: Box<dyn Iterator<Item = Update<DDValue>> + 'a>,
     ) -> Result<(), String> {
         trace!("File({})::on_updates", self.id);
 
-        let mut result = Ok(());
-        record_val_upds::<C, _, _, _>(&mut self.file, updates, |e| {
-            result = Err(e);
-        })
-        .for_each(|_| ());
-
-        result.map_err(|e| format!("failed to record 'on_updates' event(s): {}", e))
+        self.recorder
+            .apply_updates(&mut *updates)
+            .map_err(|e| format!("failed to record 'on_updates' event(s): {}", e))
     }
 
     fn on_completed(&mut self) -> Result<(), String> {
@@ -83,51 +69,39 @@ where
 mod tests {
     use super::*;
 
+    use std::ffi::CStr;
     use std::io::Read;
-
     use tempfile::NamedTempFile;
 
     use differential_datalog::ddval::DDValConvert;
     use differential_datalog::program::IdxId;
     use differential_datalog::program::RelId;
-    use differential_datalog::record::Record;
-    use differential_datalog::record::RelIdentifier;
-    use differential_datalog::record::UpdCmd;
     use differential_datalog_test::test_value::*;
 
     #[derive(Debug)]
     struct DummyConverter;
 
-    impl DDlogConvert for DummyConverter {
-        fn relid2name(rel_id: RelId) -> Option<&'static str> {
-            match rel_id {
-                1 => Some("test_rel"),
-                _ => panic!("unexpected RelId {}", rel_id),
+    impl DDlogInventory for DummyConverter {
+        fn get_table_id(&self, _tname: &str) -> Result<RelId, std::string::String> {
+            Err("not implemented".to_string())
+        }
+        fn get_table_name(&self, tid: RelId) -> Result<&'static str, std::string::String> {
+            match tid {
+                1 => Ok("test_rel"),
+                _ => panic!("unexpected RelId {}", tid),
             }
         }
-
-        fn indexid2name(idx_id: IdxId) -> Option<&'static str> {
-            panic!("unexpected IdxId {}", idx_id)
+        fn get_table_cname(&self, _tid: RelId) -> Result<&'static CStr, std::string::String> {
+            Err("not implemented".to_string())
         }
-
-        fn updcmd2upd(upd_cmd: &UpdCmd) -> Result<Update<DDValue>, std::string::String> {
-            match upd_cmd {
-                UpdCmd::Insert(relident, record) => {
-                    let relid = match relident {
-                        RelIdentifier::RelId(relid) => *relid,
-                        _ => panic!(
-                            "encountered unexpected RelIdentifier variant: {:?}",
-                            relident
-                        ),
-                    };
-                    let v = match record {
-                        Record::String(string) => String(string.clone()).into_ddvalue(),
-                        _ => panic!("encountered unexpected Record variant: {:?}", record),
-                    };
-                    Ok(Update::Insert { relid, v })
-                }
-                _ => panic!("unsupported UpdCmd: {:?}", upd_cmd),
-            }
+        fn get_index_id(&self, _iname: &str) -> Result<IdxId, std::string::String> {
+            Err("not implemented".to_string())
+        }
+        fn get_index_name(&self, _iid: IdxId) -> Result<&'static str, std::string::String> {
+            Err("not implemented".to_string())
+        }
+        fn get_index_cname(&self, _iid: IdxId) -> Result<&'static CStr, std::string::String> {
+            Err("not implemented".to_string())
         }
     }
 
@@ -135,7 +109,7 @@ mod tests {
     fn dump_events() {
         let tempfile = NamedTempFile::new().unwrap();
         let mut file = tempfile.reopen().unwrap();
-        let mut sink = File::<DummyConverter>::new(tempfile.into_file());
+        let mut sink = File::new(tempfile.into_file(), Arc::new(DummyConverter));
         let observer = &mut sink as &mut dyn Observer<Update<DDValue>, _>;
 
         observer.on_start().unwrap();

--- a/rust/template/distributed_datalog/src/sources/file.rs
+++ b/rust/template/distributed_datalog/src/sources/file.rs
@@ -1,4 +1,5 @@
 use std::convert::TryFrom;
+use std::fmt::Debug;
 use std::fs::File as FsFile;
 use std::io::BufRead;
 use std::io::BufReader;
@@ -145,7 +146,7 @@ struct State {
 #[derive(Debug)]
 pub struct File<C>
 where
-    C: DDlogConvert,
+    C: DDlogConvert + Debug,
 {
     /// The file source's unique ID.
     id: usize,
@@ -159,7 +160,7 @@ where
 
 impl<C> File<C>
 where
-    C: DDlogConvert,
+    C: DDlogConvert + Debug,
 {
     /// Create a new adapter streaming data from the file at the given
     /// `path`.
@@ -200,7 +201,7 @@ where
 
 impl<C> Drop for File<C>
 where
-    C: DDlogConvert,
+    C: DDlogConvert + Debug,
 {
     fn drop(&mut self) {
         let _ = self.unsubscribe(&());
@@ -218,7 +219,7 @@ where
 
 impl<C> Observable<Update<DDValue>, String> for File<C>
 where
-    C: DDlogConvert,
+    C: DDlogConvert + Debug,
 {
     type Subscription = ();
 
@@ -277,8 +278,6 @@ mod tests {
     use test_env_log::test;
 
     use differential_datalog::ddval::DDValConvert;
-    use differential_datalog::program::IdxId;
-    use differential_datalog::program::RelId;
     use differential_datalog::record::UpdCmd;
     use differential_datalog_test::test_value::*;
 
@@ -292,14 +291,6 @@ mod tests {
     struct DummyConverter;
 
     impl DDlogConvert for DummyConverter {
-        fn relid2name(_rel_id: RelId) -> Option<&'static str> {
-            unimplemented!()
-        }
-
-        fn indexid2name(_idx_id: IdxId) -> Option<&'static str> {
-            unimplemented!()
-        }
-
         fn updcmd2upd(_upd_cmd: &UpdCmd) -> Result<Update<DDValue>, std::string::String> {
             // Exact details do not matter in this context, so just fake
             // some data.

--- a/rust/template/src/lib.rs
+++ b/rust/template/src/lib.rs
@@ -67,14 +67,6 @@ use serde::Serializer;
 pub struct DDlogConverter {}
 
 impl DDlogConvert for DDlogConverter {
-    fn relid2name(relId: program::RelId) -> Option<&'static str> {
-        relid2name(relId)
-    }
-
-    fn indexid2name(idxId: program::IdxId) -> Option<&'static str> {
-        indexid2name(idxId)
-    }
-
     fn updcmd2upd(upd_cmd: &UpdCmd) -> ::std::result::Result<program::Update<DDValue>, String> {
         updcmd2upd(upd_cmd)
     }

--- a/rust/template/src/ovsdb_api.rs
+++ b/rust/template/src/ovsdb_api.rs
@@ -12,9 +12,8 @@ use ddlog_ovsdb_adapter::*;
 use differential_datalog::ddval::*;
 use differential_datalog::program::*;
 use differential_datalog::record::{IntoRecord, Record, UpdCmd};
-use differential_datalog::record_upd_cmds;
-use differential_datalog::DDlog;
 use differential_datalog::DeltaMap;
+use differential_datalog::{DDlogTyped, DDlogUntyped};
 
 use crate::api::{updcmd2upd, HDDlog};
 use crate::DDlogConverter;
@@ -67,7 +66,7 @@ fn apply_updates(
 
     let updates: Result<Vec<Update<DDValue>>, String> =
         commands.iter().map(|c| updcmd2upd(c)).collect();
-    prog.apply_valupdates(updates?.into_iter())
+    prog.apply_updates(&mut updates?.into_iter())
 }
 
 /// Dump OVSDB Delta-Plus, Delta-Minus, and Delta-Update tables as a sequence of OVSDB

--- a/test/datalog_tests/rust_api_test/src/main.rs
+++ b/test/datalog_tests/rust_api_test/src/main.rs
@@ -19,7 +19,7 @@ use tutorial_ddlog::typedefs::*;
                                   // The differential_datalog crate contains the DDlog runtime that is
 // the same for all DDlog programs and simply gets copied to each generated
 // DDlog workspace unmodified (this will change in future releases).
-use differential_datalog::DDlog; // Trait that must be implemented by an instance of a DDlog program.
+use differential_datalog::{DDlogInventory, DDlogUntyped, DDlogTyped}; // Trait that must be implemented by an instance of a DDlog program.
 use differential_datalog::DeltaMap; // Type that represents a set of changes to DDlog relations.
                                     // Returned by `DDlog::transaction_commit_dump_changes()`.
 use differential_datalog::ddval::DDValue; // Generic type that wraps all DDlog value.
@@ -69,7 +69,7 @@ fn main() -> Result<(), String> {
     // when there is one in execution will return an error.
     hddlog.transaction_start()?;
 
-    // A transaction can consist of multiple `apply_valupdates()` calls, each taking
+    // A transaction can consist of multiple `apply_updates()` calls, each taking
     // multiple updates.  An update inserts, deletes or modifies a record in a DDlog
     // relation.
     let updates = vec![
@@ -92,7 +92,7 @@ fn main() -> Result<(), String> {
             .into_ddvalue(),
         },
     ];
-    hddlog.apply_valupdates(updates.into_iter())?;
+    hddlog.apply_updates(&mut updates.into_iter())?;
 
     // Commit the transaction; returns a `DeltaMap` object that contains the set
     // of changes to output relations produced by the transaction.
@@ -122,7 +122,7 @@ fn main() -> Result<(), String> {
 
     // `Record` type
 
-    let relid_word1 = HDDlog::get_table_id("Word1").unwrap() as RelId;
+    let relid_word1 = hddlog.get_table_id("Word1").unwrap() as RelId;
 
     // `UpdCmd` is a dynamically typed representaion of a DDlog command.
     // It takes a vector or `Record`'s, which represent dynamically typed
@@ -143,11 +143,11 @@ fn main() -> Result<(), String> {
         ),
     )];
 
-    // Use `apply_updates` instead of `apply_valupdates` for dynamically
+    // Use `apply_updates_untyped` instead of `apply_updates` for dynamically
     // typed commands.
     // This will fail if the records in `commands` don't match the DDlog type
     // declarations (e.g., missing constructor arguments, string instead of integer, etc.)
-    hddlog.apply_updates(commands.iter())?;
+    hddlog.apply_updates_untyped(&mut commands.into_iter())?;
 
     let delta = hddlog.transaction_commit_dump_changes()?;
 

--- a/test/datalog_tests/server_api/tests/config.rs
+++ b/test/datalog_tests/server_api/tests/config.rs
@@ -15,6 +15,7 @@ use distributed_datalog::Addr;
 use distributed_datalog::Member;
 
 use server_api_ddlog::api::HDDlog;
+use server_api_ddlog::{DDlogConverter, UpdateSerializer};
 use server_api_test::config;
 
 /// Test delta retrieval in the face of two concurrent transactions over
@@ -52,9 +53,9 @@ fn instantiate_configuration_end_to_end() -> Result<(), String> {
 
     let sys_cfg = config(path1.as_ref(), path2.as_ref(), path3.as_ref());
     let assignment = simple_assign(sys_cfg.keys(), members.iter()).unwrap();
-    let _realization1 = instantiate::<HDDlog>(sys_cfg.clone(), &node1, &assignment).unwrap();
-    let _realization2 = instantiate::<HDDlog>(sys_cfg.clone(), &node2, &assignment).unwrap();
-    let _realization3 = instantiate::<HDDlog>(sys_cfg.clone(), &node3, &assignment).unwrap();
+    let _realization1 = instantiate::<HDDlog, DDlogConverter, UpdateSerializer>(sys_cfg.clone(), &node1, &assignment, HDDlog::run(1, false).unwrap().0).unwrap();
+    let _realization2 = instantiate::<HDDlog, DDlogConverter, UpdateSerializer>(sys_cfg.clone(), &node2, &assignment, HDDlog::run(1, false).unwrap().0).unwrap();
+    let _realization3 = instantiate::<HDDlog, DDlogConverter, UpdateSerializer>(sys_cfg.clone(), &node3, &assignment, HDDlog::run(1, false).unwrap().0).unwrap();
 
     await_expected(move || {
         let mut string = String::new();

--- a/test/datalog_tests/server_api/tests/deltas.rs
+++ b/test/datalog_tests/server_api/tests/deltas.rs
@@ -6,7 +6,6 @@ use std::thread::spawn;
 use differential_datalog::ddval::{DDValue, DDValConvert};
 use differential_datalog::program::Update;
 use differential_datalog::record::{Record, RelIdentifier, UpdCmd};
-use differential_datalog::DDlog;
 use distributed_datalog::accumulate::{Accumulator, DistributingAccumulator};
 use distributed_datalog::await_expected;
 use distributed_datalog::DDlogServer as DDlogServerT;
@@ -43,12 +42,11 @@ where
     F: FnOnce(&mut UpdatesObservable, SharedObserver<DDlogServer>) -> Result<Box<dyn Any>, String>,
 {
     let (program1, _) = HDDlog::run(1, false).unwrap();
-    let mut server1 = DDlogServer::new(Some(program1), hashmap! {});
+    let mut server1 = DDlogServer::new(Some(Arc::new(program1)), hashmap! {});
 
-    let (program2, _) = HDDlog::run(1, false)
-    .unwrap();
+    let (program2, _) = HDDlog::run(1, false).unwrap();
     let mut server2 = DDlogServer::new(
-        Some(program2),
+        Some(Arc::new(program2)),
         hashmap! {
             server_api_1_P1Out as usize => server_api_2_P2In as usize,
         },
@@ -130,17 +128,17 @@ where
     //     P1[s1]     P2[s2]
     //
     let (program1, _) = HDDlog::run(1, false).unwrap();
-    let mut server1 = DDlogServer::new(Some(program1), hashmap! {});
+    let mut server1 = DDlogServer::new(Some(Arc::new(program1)), hashmap! {});
 
     let (program2, _) = HDDlog::run(1, false).unwrap();
-    let mut server2 = DDlogServer::new(Some(program2), hashmap! {});
+    let mut server2 = DDlogServer::new(Some(Arc::new(program2)), hashmap! {});
 
     let (program3, _) = HDDlog::run(1, false).unwrap();
     let redirect = hashmap! {
         server_api_1_P1Out as usize => server_api_3_P1Out as usize,
         server_api_2_P2Out as usize => server_api_3_P2Out as usize,
     };
-    let mut server3 = DDlogServer::new(Some(program3), redirect);
+    let mut server3 = DDlogServer::new(Some(Arc::new(program3)), redirect);
     let mut output_stream = server3.add_stream(btreeset! {server_api_3_P3Out as usize});
     // Accumulator to store output of server3.
     let acc = Arc::new(Mutex::new(DistributingAccumulator::new()));

--- a/test/datalog_tests/server_api/tests/events.rs
+++ b/test/datalog_tests/server_api/tests/events.rs
@@ -1,12 +1,11 @@
 use std::any::Any;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use differential_datalog::ddval::DDValue;
 use differential_datalog::program::Update;
 use differential_datalog::record::Record;
 use differential_datalog::record::RelIdentifier;
 use differential_datalog::record::UpdCmd;
-use differential_datalog::DDlog;
 use distributed_datalog::await_expected;
 use distributed_datalog::DDlogServer as DDlogServerT;
 use distributed_datalog::MockObserver as Mock;
@@ -277,7 +276,7 @@ fn multiple_transactions(
 
 fn setup() -> (DDlogServer, UpdatesObservable, MockObserver) {
     let (program, _) = HDDlog::run(1, false).unwrap();
-    let mut server = DDlogServer::new(Some(program), hashmap! {});
+    let mut server = DDlogServer::new(Some(Arc::new(program)), hashmap! {});
 
     let observer = SharedObserver::new(Mutex::new(Mock::new()));
     let mut stream = server.add_stream(btreeset! {server_api_1_P1Out as usize});
@@ -288,7 +287,7 @@ fn setup() -> (DDlogServer, UpdatesObservable, MockObserver) {
 
 fn setup_tcp() -> (DDlogServer, UpdatesObservable, MockObserver, Box<dyn Any>) {
     let (program, _) = HDDlog::run(1, false).unwrap();
-    let mut server = DDlogServer::new(Some(program), hashmap! {});
+    let mut server = DDlogServer::new(Some(Arc::new(program)), hashmap! {});
 
     let observer = SharedObserver::new(Mutex::new(Mock::new()));
     let mut stream = server.add_stream(btreeset! {server_api_1_P1Out as usize});

--- a/test/test-ovn.sh
+++ b/test/test-ovn.sh
@@ -38,7 +38,7 @@ clone_repo https://github.com/ddlog-dev/ovn-test-data.git ovn-test-data v5
 # TODO: use -j6 once build script is fixed
 # TODO: use primary OVN repo
 (cd ovn &&
- git checkout ddlog_ci15 &&
+ git checkout ddlog_ci16 &&
  ./boot.sh &&
  ./configure --with-ddlog=../../lib --with-ovs-source=../ovs --enable-shared &&
  (make northd/ddlog.stamp && make check -j1 NORTHD_CLI=1 ||


### PR DESCRIPTION
This is the first step towards making the DDlog API generic so that we
can have multiple implementations, including one that talks to a DDlog
server over the network (#794).

In this commit:

- Split `trait DDlog` into `trait DDlogUntyped` and `trait DDlogTyped`.
  The former works with data represented as records, the latter
  exports methods that work with `DDValue`'s.
- Move a bunch of methods that were in `HDDlog`, but not in `trait DDlog`
  to either one of the above traits or into one of several new traits:
  `DDlogProfiling`, `DDlogDump`, `DDlogInventory`.  This way the entire
  DDlog API is now abstracted away.
- Change method signatures to eliminate any generics.  This way we will
  be able to implement dynamic dispatch for the DDlog API (i.e., pass
  references to a DDlog program as `&dyn DDlogXXX`) in the future.