### PR TITLE
Rust serde lib no longer re-exports std.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [Unreleased]
+## [0.34.0] - Jan 11, 2021
+
+### Bug fixes
+
+- A change in serde caused DDlog-generated Rust code to stop compiling,
+  affecting all recent DDlog releases.
 
 ### API changes
 

--- a/rust/template/differential_datalog/src/profile_statistics.rs
+++ b/rust/template/differential_datalog/src/profile_statistics.rs
@@ -6,7 +6,6 @@ use csv::Writer;
 use serde::{Deserialize, Serialize};
 
 use fnv::FnvHashMap;
-use serde::export::Formatter;
 use std::fmt;
 use std::fmt::Debug;
 use std::fs::File;
@@ -233,7 +232,7 @@ pub struct Statistics {
 
 /// Create Debug
 impl Debug for Statistics {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("Statistics")
     }
 }


### PR DESCRIPTION
serde release 1.0.119 changed the public interface of the library
without incrementing the version number.  Specifically, it no longer
re-exports bits of the standard library.