### PR TITLE
Keep track of source position for constructor fields

### DIFF
--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -2517,7 +2517,7 @@ arrangeInput d fstatom arrange_input_by = do
               etype = exprType' d ctx' e
               (TStruct _ [cons]) = typDeref' d etype
               estruct = eStruct (name cons)
-                                (map (\a -> (name a, if name a == f then e' else ePHolder)) $ consArgs cons)
+                                (map (\a -> (makeIdentifierWithPos $ name a, if name a == f then e' else ePHolder)) $ consArgs cons)
                                 (typDeref' d etype)
               e'' = foldl' (\_e _ -> eRef _e) estruct [(1::Int)..nref etype]
     substVar' (E par@(ETupField _ e idx), ctx) e' = substVar' (e, ctx') e''

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -2517,7 +2517,7 @@ arrangeInput d fstatom arrange_input_by = do
               etype = exprType' d ctx' e
               (TStruct _ [cons]) = typDeref' d etype
               estruct = eStruct (name cons)
-                                (map (\a -> (makeIdentifierWithPos $ name a, if name a == f then e' else ePHolder)) $ consArgs cons)
+                                (map (\a -> (IdentifierWithPos nopos $ name a, if name a == f then e' else ePHolder)) $ consArgs cons)
                                 (typDeref' d etype)
               e'' = foldl' (\_e _ -> eRef _e) estruct [(1::Int)..nref etype]
     substVar' (E par@(ETupField _ e idx), ctx) e' = substVar' (e, ctx') e''

--- a/src/Language/DifferentialDatalog/Parse.hs
+++ b/src/Language/DifferentialDatalog/Parse.hs
@@ -485,12 +485,12 @@ atom is_head = withPos $ do
                           else val
        return $ Atom nopos rname $ maybe val' (\b -> E $ EBinding (p1, p2) b val') binding
 
-anonarg = ((makeIdentifierWithPos ""),) <$> expr
-namedarg = (,) <$> (dot *> posIdent) <*> (reservedOp "=" *> expr)
+anonarg = ((IdentifierWithPos nopos ""),) <$> expr
+namedarg = (,) <$> (dot *> posVarIdent) <*> (reservedOp "=" *> expr)
 
 -- Identifier with position
-posIdent :: ParsecT String () Identity IdentifierWithPos
-posIdent = withPos $ makeIdentifierWithPos <$> varIdent
+posVarIdent :: ParsecT String () Identity IdentifierWithPos
+posVarIdent = withPos $ makeIdentifierWithPos <$> varIdent
 
 typeSpec = withPos $
             bitType
@@ -649,8 +649,8 @@ pterm = (withPos $
        <|> enumber)
       <?> "match term"
 
-anonpat = (makeIdentifierWithPos "",) <$> pattern
-namedpat = (,) <$> (dot *> posIdent) <*> (reservedOp "=" *> pattern)
+anonpat = (IdentifierWithPos nopos "",) <$> pattern
+namedpat = (,) <$> (dot *> posVarIdent) <*> (reservedOp "=" *> pattern)
 
 lhs = (withPos $
            eTuple <$> (parens $ commaSepEnd lhs)
@@ -662,8 +662,8 @@ lhs = (withPos $
 elhs = islhs *> lhs
     where islhs = try $ lookAhead $ lhs *> reservedOp "="
 
-anonlhs = (makeIdentifierWithPos "",) <$> lhs
-namedlhs = (,) <$> (dot *> posIdent) <*> (reservedOp "=" *> lhs)
+anonlhs = (IdentifierWithPos nopos "",) <$> lhs
+namedlhs = (,) <$> (dot *> posVarIdent) <*> (reservedOp "=" *> lhs)
 
 enumber  = lexeme enumber'
 estring =   equoted_string

--- a/src/Language/DifferentialDatalog/Parse.hs
+++ b/src/Language/DifferentialDatalog/Parse.hs
@@ -452,7 +452,7 @@ aggregate = do
     before_func <- getPosition
     f <- comma *> funcIdent
     after_func <- getPosition
-    project <- parens expr 
+    project <- parens expr
     after_project <- getPosition
     _ <- symbol ")"
     end <- getPosition
@@ -485,8 +485,12 @@ atom is_head = withPos $ do
                           else val
        return $ Atom nopos rname $ maybe val' (\b -> E $ EBinding (p1, p2) b val') binding
 
-anonarg = ("",) <$> expr
-namedarg = (,) <$> (dot *> varIdent) <*> (reservedOp "=" *> expr)
+anonarg = ((makeIdentifierWithPos ""),) <$> expr
+namedarg = (,) <$> (dot *> posIdent) <*> (reservedOp "=" *> expr)
+
+-- Identifier with position
+posIdent :: ParsecT String () Identity IdentifierWithPos
+posIdent = withPos $ makeIdentifierWithPos <$> varIdent
 
 typeSpec = withPos $
             bitType
@@ -645,8 +649,8 @@ pterm = (withPos $
        <|> enumber)
       <?> "match term"
 
-anonpat = ("",) <$> pattern
-namedpat = (,) <$> (dot *> varIdent) <*> (reservedOp "=" *> pattern)
+anonpat = (makeIdentifierWithPos "",) <$> pattern
+namedpat = (,) <$> (dot *> posIdent) <*> (reservedOp "=" *> pattern)
 
 lhs = (withPos $
            eTuple <$> (parens $ commaSepEnd lhs)
@@ -658,8 +662,8 @@ lhs = (withPos $
 elhs = islhs *> lhs
     where islhs = try $ lookAhead $ lhs *> reservedOp "="
 
-anonlhs = ("",) <$> lhs
-namedlhs = (,) <$> (dot *> varIdent) <*> (reservedOp "=" *> lhs)
+anonlhs = (makeIdentifierWithPos "",) <$> lhs
+namedlhs = (,) <$> (dot *> posIdent) <*> (reservedOp "=" *> lhs)
 
 enumber  = lexeme enumber'
 estring =   equoted_string

--- a/src/Language/DifferentialDatalog/Parse.hs
+++ b/src/Language/DifferentialDatalog/Parse.hs
@@ -490,7 +490,7 @@ namedarg = (,) <$> (dot *> posVarIdent) <*> (reservedOp "=" *> expr)
 
 -- Identifier with position
 posVarIdent :: ParsecT String () Identity IdentifierWithPos
-posVarIdent = withPos $ makeIdentifierWithPos <$> varIdent
+posVarIdent = withPos $ IdentifierWithPos nopos <$> varIdent
 
 typeSpec = withPos $
             bitType

--- a/src/Language/DifferentialDatalog/Syntax.hs
+++ b/src/Language/DifferentialDatalog/Syntax.hs
@@ -54,7 +54,6 @@ module Language.DifferentialDatalog.Syntax (
         structLookupField,
         structGetField,
         structFieldGuarded,
-        makeIdentifierWithPos,
         Field(..),
         IdentifierWithPos(..),
         TypeDef(..),
@@ -233,7 +232,6 @@ instance PP ArgType where
     pp ArgType{..} = (if atypeMut then "mut" else empty) <+> pp atypeType
 
 data IdentifierWithPos = IdentifierWithPos { idPos :: Pos, idName :: String }
-makeIdentifierWithPos str = IdentifierWithPos nopos str
 
 instance Eq IdentifierWithPos where
     (==) (IdentifierWithPos _ n1) (IdentifierWithPos _ n2) = n1 == n2
@@ -247,6 +245,10 @@ instance WithPos IdentifierWithPos where
 
 instance PP IdentifierWithPos where
     pp IdentifierWithPos{..} = pp idName
+
+instance WithName IdentifierWithPos where
+    name = idName
+    setName i n = i{idName = n}
 
 data Type = TBool     {typePos :: Pos}
           | TInt      {typePos :: Pos}
@@ -597,7 +599,7 @@ instance WithPos Atom where
 instance PP Atom where
     pp (Atom _ rel (E (EStruct _ cons as))) | rel == cons
                 = pp rel <> (parens $ commaSep $
-                             map (\(n,e) -> (if null (idName n) then empty else ("." <> pp n <> "=")) <> pp e) as)
+                             map (\(n,e) -> (if null (name n) then empty else ("." <> pp n <> "=")) <> pp e) as)
     pp Atom{..} = pp atomRelation <> "[" <> pp atomVal <> "]"
 
 instance Show Atom where
@@ -900,7 +902,7 @@ instance PP e => PP (ExprNode e) where
     pp (EBit _ w v)          = pp w <> "'d" <> pp v
     pp (ESigned _ w v)       = pp w <> "'sd" <> pp v
     pp (EStruct _ s fs)      = pp s <> (braces $ commaSep
-                                        $ map (\(n,e) -> (if null (idName n) then empty else ("." <> pp n <> "=")) <> pp e) fs)
+                                        $ map (\(n,e) -> (if null (name n) then empty else ("." <> pp n <> "=")) <> pp e) fs)
     pp (ETuple _ fs)         = parens $ commaSep $ map pp fs
     pp (ESlice _ e h l)      = parens $ pp e <> (brackets $ pp h <> colon <> pp l)
     pp (EMatch _ e cs)       = "match" <+> parens (pp e) <+> "{"

--- a/src/Language/DifferentialDatalog/Syntax.hs
+++ b/src/Language/DifferentialDatalog/Syntax.hs
@@ -54,7 +54,9 @@ module Language.DifferentialDatalog.Syntax (
         structLookupField,
         structGetField,
         structFieldGuarded,
+        makeIdentifierWithPos,
         Field(..),
+        IdentifierWithPos(..),
         TypeDef(..),
         Constructor(..),
         consType,
@@ -229,6 +231,22 @@ instance WithPos ArgType where
 
 instance PP ArgType where
     pp ArgType{..} = (if atypeMut then "mut" else empty) <+> pp atypeType
+
+data IdentifierWithPos = IdentifierWithPos { idPos :: Pos, idName :: String }
+makeIdentifierWithPos str = IdentifierWithPos nopos str
+
+instance Eq IdentifierWithPos where
+    (==) (IdentifierWithPos _ n1) (IdentifierWithPos _ n2) = n1 == n2
+
+instance Ord IdentifierWithPos where
+    compare (IdentifierWithPos _ n1) (IdentifierWithPos _ n2) = compare n1 n2
+
+instance WithPos IdentifierWithPos where
+    pos = idPos
+    atPos i p = i{idPos = p}
+
+instance PP IdentifierWithPos where
+    pp IdentifierWithPos{..} = pp idName
 
 data Type = TBool     {typePos :: Pos}
           | TInt      {typePos :: Pos}
@@ -579,7 +597,7 @@ instance WithPos Atom where
 instance PP Atom where
     pp (Atom _ rel (E (EStruct _ cons as))) | rel == cons
                 = pp rel <> (parens $ commaSep $
-                             map (\(n,e) -> (if null n then empty else ("." <> pp n <> "=")) <> pp e) as)
+                             map (\(n,e) -> (if null (idName n) then empty else ("." <> pp n <> "=")) <> pp e) as)
     pp Atom{..} = pp atomRelation <> "[" <> pp atomVal <> "]"
 
 instance Show Atom where
@@ -697,7 +715,7 @@ data ExprNode e = EVar          {exprPos :: Pos, exprVar :: String}
                 | EString       {exprPos :: Pos, exprString :: String}
                 | EBit          {exprPos :: Pos, exprWidth :: Int, exprIVal :: Integer}
                 | ESigned       {exprPos :: Pos, exprWidth :: Int, exprIVal :: Integer}
-                | EStruct       {exprPos :: Pos, exprConstructor :: String, exprStructFields :: [(String, e)]}
+                | EStruct       {exprPos :: Pos, exprConstructor :: String, exprStructFields :: [(IdentifierWithPos, e)]}
                 | ETuple        {exprPos :: Pos, exprTupleFields :: [e]}
                 | ESlice        {exprPos :: Pos, exprOp :: e, exprH :: Int, exprL :: Int}
                 | EMatch        {exprPos :: Pos, exprMatchExpr :: e, exprCases :: [(e, e)]}
@@ -882,7 +900,7 @@ instance PP e => PP (ExprNode e) where
     pp (EBit _ w v)          = pp w <> "'d" <> pp v
     pp (ESigned _ w v)       = pp w <> "'sd" <> pp v
     pp (EStruct _ s fs)      = pp s <> (braces $ commaSep
-                                        $ map (\(n,e) -> (if null n then empty else ("." <> pp n <> "=")) <> pp e) fs)
+                                        $ map (\(n,e) -> (if null (idName n) then empty else ("." <> pp n <> "=")) <> pp e) fs)
     pp (ETuple _ fs)         = parens $ commaSep $ map pp fs
     pp (ESlice _ e h l)      = parens $ pp e <> (brackets $ pp h <> colon <> pp l)
     pp (EMatch _ e cs)       = "match" <+> parens (pp e) <+> "{"
@@ -1321,7 +1339,7 @@ data ECtx = -- | Top-level context. Serves as the root of the context hierarchy.
             -- | Tuple field expression: 'X.N'
           | CtxTupField       {ctxParExpr::ENode, ctxPar::ECtx}
             -- | Argument passed to a type constructor: 'Cons(X, y, z)'
-          | CtxStruct         {ctxParExpr::ENode, ctxPar::ECtx, ctxArg::(Int, String)}
+          | CtxStruct         {ctxParExpr::ENode, ctxPar::ECtx, ctxArg::(Int, IdentifierWithPos)}
             -- | Argument passed to a tuple expression: '(X, y, z)'
           | CtxTuple          {ctxParExpr::ENode, ctxPar::ECtx, ctxIdx::Int}
             -- | Bit slice: 'X[h:l]'

--- a/src/Language/DifferentialDatalog/Type.hs
+++ b/src/Language/DifferentialDatalog/Type.hs
@@ -258,7 +258,7 @@ exprNodeType' d ctx (EFunc _ [f]) | -- Type inference engine type-annotates poly
 exprNodeType' _ _   e@EFunc{} = error $ "exprNodeType' called with unresolved function name: " ++ show e
 
 exprNodeType' d _   (EField _ e f) =
-    let t@TStruct{} = typDeref' d e 
+    let t@TStruct{} = typDeref' d e
         fld = fromJust $ find ((==f) . name) $ structFields t
     in fieldType fld
 
@@ -593,7 +593,7 @@ consTreeNodeExpand :: DatalogProgram -> Type -> [CTreeNode]
 consTreeNodeExpand d t =
     case typ' d t of
          TStruct _ cs               -> map (\c -> EStruct nopos (name c)
-                                                  $ map (\a -> (name a, CT (typ a) [EPHolder nopos]))
+                                                  $ map (\a -> (IdentifierWithPos (pos a) $ name a, CT (typ a) [EPHolder nopos]))
                                                   $ consArgs c) cs
          TTuple _ fs                -> [ETuple nopos $ map (\f -> CT (typ f) [EPHolder nopos]) fs]
          TBool{}                    -> [EBool nopos False, EBool nopos True]
@@ -703,7 +703,7 @@ typeMap :: (Type -> Type) -> Type -> Type
 typeMap f t = runIdentity $ typeMapM (return . f) t
 
 -- Returns iterator type when iterating over a collection (element type for
--- sets, vectors, and groups, key-value pair for maps).  The Boolean flag in 
+-- sets, vectors, and groups, key-value pair for maps).  The Boolean flag in
 -- the returned tuple indicates whether the collection iterates by reference
 -- (True) or by value (False) in Rust.
 typeIterType :: DatalogProgram -> Type -> (Type, Bool)
@@ -746,8 +746,8 @@ varType d (FlatMapVar rl i)                = case typ' d $ exprType d (CtxRuleRF
                                                   TOpaque _ tname [kt,vt] | tname == mAP_TYPE
                                                                        -> tTuple [kt,vt]
                                                                           | tname == gROUP_TYPE
-                                                                       -> vt 
-                                                  _                    -> error $ "varType FlatMapVar " ++ show rl ++ " " ++ show i 
+                                                                       -> vt
+                                                  _                    -> error $ "varType FlatMapVar " ++ show rl ++ " " ++ show i
 varType d (GroupVar rl i)                  = let ktype = ruleGroupByKeyType d rl i
                                                  vtype = ruleGroupByValType d rl i
                                              in tOpaque gROUP_TYPE [ktype, vtype]

--- a/src/Language/DifferentialDatalog/TypeInference.hs
+++ b/src/Language/DifferentialDatalog/TypeInference.hs
@@ -497,15 +497,15 @@ inferTypes d es = do
                  ETry{..} | isOption ?d inner_type && isOption ?d ret_type
                              -> E $ EMatch (pos e) inner_expr
                                     [(eStruct nONE_CONSTRUCTOR [] inner_type, eReturn (eStruct nONE_CONSTRUCTOR [] ret_type) t),
-                                     (eStruct sOME_CONSTRUCTOR [(makeIdentifierWithPos "x", eVarDecl "__x" t)] inner_type, eVar "__x")]
+                                     (eStruct sOME_CONSTRUCTOR [(IdentifierWithPos nopos "x", eVarDecl "__x" t)] inner_type, eVar "__x")]
                           | isResult ?d inner_type && isOption ?d ret_type
                              -> E $ EMatch (pos e) inner_expr
-                                    [(eStruct eRR_CONSTRUCTOR [(makeIdentifierWithPos "err", eTyped ePHolder inner_etype)] inner_type, eReturn (eStruct nONE_CONSTRUCTOR [] ret_type) t),
-                                     (eStruct oK_CONSTRUCTOR [(makeIdentifierWithPos "res", eVarDecl "__x" t)] inner_type, eVar "__x")]
+                                    [(eStruct eRR_CONSTRUCTOR [(IdentifierWithPos nopos "err", eTyped ePHolder inner_etype)] inner_type, eReturn (eStruct nONE_CONSTRUCTOR [] ret_type) t),
+                                     (eStruct oK_CONSTRUCTOR [(IdentifierWithPos nopos "res", eVarDecl "__x" t)] inner_type, eVar "__x")]
                           | isResult ?d inner_type && isResult ?d ret_type
                              -> E $ EMatch (pos e) inner_expr
-                                    [(eStruct eRR_CONSTRUCTOR [(makeIdentifierWithPos "err", eVarDecl "__e" etype)] inner_type, eReturn (eStruct eRR_CONSTRUCTOR [(makeIdentifierWithPos "err", eVar "__e")] ret_type) t),
-                                     (eStruct oK_CONSTRUCTOR [(makeIdentifierWithPos "res", eVarDecl "__x" t)] inner_type, eVar "__x")]
+                                    [(eStruct eRR_CONSTRUCTOR [(IdentifierWithPos nopos "err", eVarDecl "__e" etype)] inner_type, eReturn (eStruct eRR_CONSTRUCTOR [(makeIdentifierWithPos "err", eVar "__e")] ret_type) t),
+                                     (eStruct oK_CONSTRUCTOR [(IdentifierWithPos nopos "res", eVarDecl "__x" t)] inner_type, eVar "__x")]
                           | otherwise -> error $ "TypeInference.add_types: e=" ++ show expr ++ " type=" ++ show inner_type ++ " function or closure: " ++ show ctx'
                     where
                     ctx' = fromMaybe (error $ "inferTypes '" ++ show expr ++ "': '?' not inside function or closure")

--- a/src/Language/DifferentialDatalog/TypeInference.hs
+++ b/src/Language/DifferentialDatalog/TypeInference.hs
@@ -497,15 +497,15 @@ inferTypes d es = do
                  ETry{..} | isOption ?d inner_type && isOption ?d ret_type
                              -> E $ EMatch (pos e) inner_expr
                                     [(eStruct nONE_CONSTRUCTOR [] inner_type, eReturn (eStruct nONE_CONSTRUCTOR [] ret_type) t),
-                                     (eStruct sOME_CONSTRUCTOR [("x", eVarDecl "__x" t)] inner_type, eVar "__x")]
+                                     (eStruct sOME_CONSTRUCTOR [(makeIdentifierWithPos "x", eVarDecl "__x" t)] inner_type, eVar "__x")]
                           | isResult ?d inner_type && isOption ?d ret_type
                              -> E $ EMatch (pos e) inner_expr
-                                    [(eStruct eRR_CONSTRUCTOR [("err", eTyped ePHolder inner_etype)] inner_type, eReturn (eStruct nONE_CONSTRUCTOR [] ret_type) t),
-                                     (eStruct oK_CONSTRUCTOR [("res", eVarDecl "__x" t)] inner_type, eVar "__x")]
+                                    [(eStruct eRR_CONSTRUCTOR [(makeIdentifierWithPos "err", eTyped ePHolder inner_etype)] inner_type, eReturn (eStruct nONE_CONSTRUCTOR [] ret_type) t),
+                                     (eStruct oK_CONSTRUCTOR [(makeIdentifierWithPos "res", eVarDecl "__x" t)] inner_type, eVar "__x")]
                           | isResult ?d inner_type && isResult ?d ret_type
                              -> E $ EMatch (pos e) inner_expr
-                                    [(eStruct eRR_CONSTRUCTOR [("err", eVarDecl "__e" etype)] inner_type, eReturn (eStruct eRR_CONSTRUCTOR [("err", eVar "__e")] ret_type) t),
-                                     (eStruct oK_CONSTRUCTOR [("res", eVarDecl "__x" t)] inner_type, eVar "__x")]
+                                    [(eStruct eRR_CONSTRUCTOR [(makeIdentifierWithPos "err", eVarDecl "__e" etype)] inner_type, eReturn (eStruct eRR_CONSTRUCTOR [(makeIdentifierWithPos "err", eVar "__e")] ret_type) t),
+                                     (eStruct oK_CONSTRUCTOR [(makeIdentifierWithPos "res", eVarDecl "__x" t)] inner_type, eVar "__x")]
                           | otherwise -> error $ "TypeInference.add_types: e=" ++ show expr ++ " type=" ++ show inner_type ++ " function or closure: " ++ show ctx'
                     where
                     ctx' = fromMaybe (error $ "inferTypes '" ++ show expr ++ "': '?' not inside function or closure")
@@ -769,7 +769,7 @@ exprConstraints_ de@(DDExpr ctx (E e@ETupField{..})) = do
 -- 'is_MyStruct |de| and |e1|=MyStruct_f1 |e| and ... and |en| = MyStruct_fn |e|'
 exprConstraints_ de@(DDExpr ctx (E e@EStruct{..})) = do
     addConstraint =<< deIsStruct de tdefName
-    addConstraints =<< mapIdxM (\(arg, efield) i -> tvarTypeOfExpr (DDExpr (CtxStruct e ctx (i, name arg)) efield) <~~~~> typeToTExpr' de (typ arg))
+    addConstraints =<< mapIdxM (\(arg, efield) i -> tvarTypeOfExpr (DDExpr (CtxStruct e ctx (i, IdentifierWithPos (pos arg) $ name arg)) efield) <~~~~> typeToTExpr' de (typ arg))
                             (zip consArgs $ map snd exprStructFields)
     where
     Constructor{..} = getConstructor ?d exprConstructor

--- a/src/Language/DifferentialDatalog/TypeInference.hs
+++ b/src/Language/DifferentialDatalog/TypeInference.hs
@@ -504,7 +504,7 @@ inferTypes d es = do
                                      (eStruct oK_CONSTRUCTOR [(IdentifierWithPos nopos "res", eVarDecl "__x" t)] inner_type, eVar "__x")]
                           | isResult ?d inner_type && isResult ?d ret_type
                              -> E $ EMatch (pos e) inner_expr
-                                    [(eStruct eRR_CONSTRUCTOR [(IdentifierWithPos nopos "err", eVarDecl "__e" etype)] inner_type, eReturn (eStruct eRR_CONSTRUCTOR [(makeIdentifierWithPos "err", eVar "__e")] ret_type) t),
+                                    [(eStruct eRR_CONSTRUCTOR [(IdentifierWithPos nopos "err", eVarDecl "__e" etype)] inner_type, eReturn (eStruct eRR_CONSTRUCTOR [(IdentifierWithPos nopos "err", eVar "__e")] ret_type) t),
                                      (eStruct oK_CONSTRUCTOR [(IdentifierWithPos nopos "res", eVarDecl "__x" t)] inner_type, eVar "__x")]
                           | otherwise -> error $ "TypeInference.add_types: e=" ++ show expr ++ " type=" ++ show inner_type ++ " function or closure: " ++ show ctx'
                     where

--- a/src/Language/DifferentialDatalog/Validate.hs
+++ b/src/Language/DifferentialDatalog/Validate.hs
@@ -108,19 +108,19 @@ exprDesugar d _ e =
             let desugarPos = do
                     check d (length as == length consArgs) p
                            $ "Number of arguments does not match constructor declaration: " ++ show cons
-                    return $ zip (map name consArgs) (map snd as)
+                    return $ zip (map (makeIdentifierWithPos . name) consArgs) (map snd as)
             let desugarNamed = do
-                    uniq' (Just d) (\_ -> p) id ("Multiple occurrences of a field " ++) $ map fst as
-                    mapM_ (\(n,e') -> check d (isJust $ find ((==n) . name) consArgs) (pos e')
-                                           $ "Unknown field " ++ n) as
-                    return $ map (\f -> (name f, maybe (E $ EPHolder p) id $ lookup (name f) as)) consArgs
+                    uniq' (Just d) (\_ -> p) id ("Multiple occurrences of a field " ++) $ map (idName . fst) as
+                    mapM_ (\(n,_) -> check d (isJust $ find ((== idName n) . name) consArgs) (pos n)
+                                           $ "Unknown field " ++ (idName n)) as
+                    return $ map (\f -> (makeIdentifierWithPos $ name f, maybe (E $ EPHolder p) id $ lookup (name f) $ map (\(i,ex) -> (idName i, ex)) as)) consArgs
             as' <- case as of
                         [] | null consArgs
                            -> return as
                         [] -> desugarNamed
-                        _  | all (null . fst) as
+                        _  | all (null . (idName . fst)) as
                            -> desugarPos
-                        _  | any (null . fst) as
+                        _  | any (null . (idName . fst)) as
                            -> err d (pos e) $ "Expression mixes named and positional arguments to type constructor " ++ c
                         _  -> desugarNamed
             return $ E e{exprStructFields = as'}
@@ -643,7 +643,7 @@ exprValidate1 _ _ _   EUnOp{}             = return ()
 
 exprValidate1 d _ ctx (EPHolder p)        = do
     let msg = case ctx of
-                   CtxStruct EStruct{..} _ (_,f) -> "Missing field '" ++ f ++ "' in constructor " ++ exprConstructor
+                   CtxStruct EStruct{..} _ (_,f) -> "Missing field '" ++ (idName f) ++ "' in constructor " ++ exprConstructor
                    _               -> "_ is not allowed in this context"
     check d (ctxPHolderAllowed ctx) p msg
 exprValidate1 d _ ctx (EBinding p v _)    = do

--- a/src/Language/DifferentialDatalog/Validate.hs
+++ b/src/Language/DifferentialDatalog/Validate.hs
@@ -108,19 +108,19 @@ exprDesugar d _ e =
             let desugarPos = do
                     check d (length as == length consArgs) p
                            $ "Number of arguments does not match constructor declaration: " ++ show cons
-                    return $ zip (map (makeIdentifierWithPos . name) consArgs) (map snd as)
+                    return $ zip (map ((IdentifierWithPos nopos) . name) consArgs) (map snd as)
             let desugarNamed = do
-                    uniq' (Just d) (\_ -> p) id ("Multiple occurrences of a field " ++) $ map (idName . fst) as
-                    mapM_ (\(n,_) -> check d (isJust $ find ((== idName n) . name) consArgs) (pos n)
-                                           $ "Unknown field " ++ (idName n)) as
-                    return $ map (\f -> (makeIdentifierWithPos $ name f, maybe (E $ EPHolder p) id $ lookup (name f) $ map (\(i,ex) -> (idName i, ex)) as)) consArgs
+                    uniq' (Just d) (\_ -> p) id ("Multiple occurrences of a field " ++) $ map (name . fst) as
+                    mapM_ (\(n,_) -> check d (isJust $ find ((== name n) . name) consArgs) (pos n)
+                                           $ "Unknown field " ++ (name n)) as
+                    return $ map (\f -> (IdentifierWithPos nopos $ name f, maybe (E $ EPHolder p) id $ lookup (name f) $ map (\(i,ex) -> (name i, ex)) as)) consArgs
             as' <- case as of
                         [] | null consArgs
                            -> return as
                         [] -> desugarNamed
-                        _  | all (null . (idName . fst)) as
+                        _  | all (null . (name . fst)) as
                            -> desugarPos
-                        _  | any (null . (idName . fst)) as
+                        _  | any (null . (name . fst)) as
                            -> err d (pos e) $ "Expression mixes named and positional arguments to type constructor " ++ c
                         _  -> desugarNamed
             return $ E e{exprStructFields = as'}
@@ -643,7 +643,7 @@ exprValidate1 _ _ _   EUnOp{}             = return ()
 
 exprValidate1 d _ ctx (EPHolder p)        = do
     let msg = case ctx of
-                   CtxStruct EStruct{..} _ (_,f) -> "Missing field '" ++ (idName f) ++ "' in constructor " ++ exprConstructor
+                   CtxStruct EStruct{..} _ (_,f) -> "Missing field '" ++ (name f) ++ "' in constructor " ++ exprConstructor
                    _               -> "_ is not allowed in this context"
     check d (ctxPHolderAllowed ctx) p msg
 exprValidate1 d _ ctx (EBinding p v _)    = do


### PR DESCRIPTION
Fixes #894 
I added a new IdentifierWithPos object in the compiler, which may be useful in other contexts where today String is used, but I have only used it to fix the issue specified above.