### PR TITLE
Workaround for OS X linker error.

### DIFF
--- a/rust/template/src/lib.rs
+++ b/rust/template/src/lib.rs
@@ -61,6 +61,12 @@ use serde::Deserializer;
 use serde::Serialize;
 use serde::Serializer;
 
+// This import is only needed to convince the OS X compiler to export
+// `extern C` functions declared in ddlog_log.rs in the generated lib.
+#[doc(hidden)]
+#[cfg(feature = "c_api")]
+pub use ddlog_log as hidden_ddlog_log;
+
 /// A default implementation of `DDlogConvert` that just forwards calls
 /// to generated functions of equal name.
 #[derive(Debug)]


### PR DESCRIPTION
`extern C` functions declared in `ddlog_log.rs` do not get exported on
Mac OS unless the program explicitly does `import log`.  This is most
likely due to Rust's arbitrary treatment of extern functions that are
not directly visible in the main crate of the program.  The fix is to
import `ddlog_log` in `template/src/lib.rs`.