### PR TITLE
Added ddlog benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,7 @@ node_modules/
 # We actually cannot commit package-lock.json to the repo, since some corporate
 # sites rewrite urls to npm repositories
 package-lock.json
+rust/ddlog_benches/generated/*_ddlog
+!rust/ddlog_benches/ddlog
+rust/ddlog_benches/data
+!rust/ddlog_benches/data/.gitkeep

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -245,3 +245,11 @@ test-golang:
 test-stream:
     stage: test
     script: ./test.sh stream
+
+# Twitter microbenchmark.
+bench-twitter:
+    extends: .private_runner
+    tags:
+        - ddlog-ci-1
+    stage: test
+    script: ./test.sh twitter_micro

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ members = [
     "rust/template/differential_datalog",
     "rust/template/differential_datalog_test",
 ]
-exclude = ["test/"]
+exclude = ["test/", "rust/ddlog_benches"]

--- a/rust/ddlog_benches/Cargo.toml
+++ b/rust/ddlog_benches/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "ddlog_benches"
+version = "0.1.0"
+edition = "2018"
+license = "MIT"
+
+[features]
+default = []
+
+[dependencies]
+criterion = "0.3.3"
+flate2 = "1.0.19"
+csv = "1.1.5"
+
+[dependencies.benchmarks_ddlog]
+package = "benchmarks"
+path = "generated/benchmarks_ddlog"
+default-features = false
+
+[dependencies.benchmarks_differential_datalog]
+package = "differential_datalog"
+path = "generated/benchmarks_ddlog/differential_datalog"
+
+[dev-dependencies]
+criterion = "0.3.3"
+
+[[bench]]
+name = "twitter"
+harness = false
+
+[[bench]]
+name = "live_journal"
+harness = false

--- a/rust/ddlog_benches/Makefile.toml
+++ b/rust/ddlog_benches/Makefile.toml
@@ -5,13 +5,19 @@ dependencies = ["download-data", "bench-twitter", "bench-livejournal"]
 # Runs the benchmark suite on the citations dataset
 [tasks.bench-livejournal]
 command = "cargo"
-args = ["bench", "LiveJournal"]
+args = ["bench", "LiveJournal", "--bench", "live_journal"]
 dependencies = ["build-ddlog", "download-livejournal"]
 
 # Runs the benchmark suite on the twitter dataset
 [tasks.bench-twitter]
 command = "cargo"
-args = ["bench", "twitter"]
+args = ["bench", "--bench", "twitter"]
+dependencies = ["build-ddlog", "download-twitter"]
+
+# Run twitter microbenchmarks only
+[tasks.bench-twitter-micro]
+command = "cargo"
+args = ["bench", "twitter-micro", "--bench", "twitter"]
 dependencies = ["build-ddlog", "download-twitter"]
 
 # Runs `ddlog` to generate ddlog code

--- a/rust/ddlog_benches/Makefile.toml
+++ b/rust/ddlog_benches/Makefile.toml
@@ -6,13 +6,13 @@ dependencies = ["download-data", "bench-twitter", "bench-livejournal"]
 [tasks.bench-livejournal]
 command = "cargo"
 args = ["bench", "LiveJournal"]
-dependencies = ["build-ddlog"]
+dependencies = ["build-ddlog", "download-livejournal"]
 
 # Runs the benchmark suite on the twitter dataset
 [tasks.bench-twitter]
 command = "cargo"
 args = ["bench", "twitter"]
-dependencies = ["build-ddlog"]
+dependencies = ["build-ddlog", "download-twitter"]
 
 # Runs `ddlog` to generate ddlog code
 [tasks.build-ddlog]
@@ -42,6 +42,14 @@ touch generated/.gitkeep
 """
 private = true
 
+[tasks.download-twitter]
+env = { DATA_URL = "https://snap.stanford.edu/data/twitter-2010-ids.csv.gz", DATA_FILE = "twitter-2010-ids.csv.gz" }
+run_task = "download-data"
+
+[tasks.download-livejournal]
+env = { DATA_URL = "https://snap.stanford.edu/data/soc-LiveJournal1.txt.gz", DATA_FILE = "soc-LiveJournal1.txt.gz" }
+run_task = "download-data"
+
 [tasks.download-data]
 script_runner = "@duckscript"
 script = """
@@ -64,6 +72,5 @@ fn <scope> download_file
     end
 end
 
-download_file twitter-2010-ids.csv.gz https://snap.stanford.edu/data/twitter-2010-ids.csv.gz
-download_file soc-LiveJournal1.txt.gz https://snap.stanford.edu/data/soc-LiveJournal1.txt.gz
+download_file ${DATA_FILE} ${DATA_URL}
 """

--- a/rust/ddlog_benches/Makefile.toml
+++ b/rust/ddlog_benches/Makefile.toml
@@ -32,7 +32,14 @@ args = [
     "--omit-profile",
     "--omit-workspace",
 ]
-dependencies = ["clean-generated"]
+dependencies = ["clean-generated", "install-ddlog"]
+
+# Run `stack install`.
+[tasks.install-ddlog]
+# In CI, DDlog is installed by a separate pipeline stage.
+condition = { env_not_set = ["IS_CI_RUN"] }
+command = "stack"
+args = ["install"]
 
 # Remove the old generated code (prevents OS errors and errors that
 # occur when switching between different versions of ddlog that each

--- a/rust/ddlog_benches/Makefile.toml
+++ b/rust/ddlog_benches/Makefile.toml
@@ -1,0 +1,69 @@
+# Runs all ddlog benchmarks
+[tasks.benchmarks]
+dependencies = ["download-data", "bench-twitter", "bench-livejournal"]
+
+# Runs the benchmark suite on the citations dataset
+[tasks.bench-livejournal]
+command = "cargo"
+args = ["bench", "LiveJournal"]
+dependencies = ["build-ddlog"]
+
+# Runs the benchmark suite on the twitter dataset
+[tasks.bench-twitter]
+command = "cargo"
+args = ["bench", "twitter"]
+dependencies = ["build-ddlog"]
+
+# Runs `ddlog` to generate ddlog code
+[tasks.build-ddlog]
+command = "ddlog"
+args = [
+    "-i",
+    "ddlog/benchmarks.dl",
+    "--output-dir",
+    "generated",
+    "--nested-ts-32",
+    "--omit-profile",
+    "--omit-workspace",
+]
+dependencies = ["clean-generated"]
+
+# Remove the old generated code (prevents OS errors and errors that
+# occur when switching between different versions of ddlog that each
+# generated & depend on different generated files)
+#
+# Note: This is by *no* means a bottleneck or slowdown, the benchmarks
+# themselves take *vastly* more time to run
+[tasks.clean-generated]
+script_runner = "@duckscript"
+script = """
+rm -rf generated
+touch generated/.gitkeep
+"""
+private = true
+
+[tasks.download-data]
+script_runner = "@duckscript"
+script = """
+fn <scope> download_file
+    file = set ${1}
+    url = set ${2}
+
+    if not is_path_exists data/${file}
+        echo downloading '${url}' to 'data/${file}'
+
+        start_time = current_time
+        wget -O data/${file} ${url}
+        end_time = current_time
+
+        millis = calc ${end_time} - ${start_time}
+        sec = calc ${millis} / 1000
+        echo downloaded 'data/${file}' in ${sec}sec
+    else
+        echo '${file}' has already been downloaded, skipping
+    end
+end
+
+download_file twitter-2010-ids.csv.gz https://snap.stanford.edu/data/twitter-2010-ids.csv.gz
+download_file soc-LiveJournal1.txt.gz https://snap.stanford.edu/data/soc-LiveJournal1.txt.gz
+"""

--- a/rust/ddlog_benches/README.md
+++ b/rust/ddlog_benches/README.md
@@ -22,8 +22,8 @@ For info on writing benchmarks see the [criterion user guide] and the [criterion
 
 ### Other supported commands
 
-- `cargo make benchmark-twitter`: Only run the Twitter benchmarks
-- `cargo make benchmark-livejournal`: Only run the LiveJournal benchmarks
+- `cargo make bench-twitter`: Only run the Twitter benchmarks
+- `cargo make bench-livejournal`: Only run the LiveJournal benchmarks
 - `cargo make build-ddlog`: Only build the generated ddlog code
 - `cargo make download-data`: Download the datasets required for benchmarking
 

--- a/rust/ddlog_benches/README.md
+++ b/rust/ddlog_benches/README.md
@@ -1,0 +1,32 @@
+# ddlog_benches
+
+DDlog has a unique benchmarking scenario since it's a compiler, so benchmarking the programs
+it generates is a little more involved than normal, which is why we use [`cargo-make`] to automate
+the setup, build and bench process in a cross-platform way. To run the benchmarks in this crate,
+first install `cargo-make` with the following command (`--force` makes cargo install the latest version)
+
+```sh
+cargo install --force cargo-make
+```
+
+To run all benchmarks use the following command
+
+```sh
+cargo make benchmarks
+```
+
+When adding a benchmark, add the required ddlog code to `/ddlog`, any datasets to `/data` (preferably in a
+compressed format), add a module within `/src` containing your support code and the actual benchmark within
+`/benches` and finally add a `[[bench]]` entry into the `Cargo.toml` along with any required dependencies.
+For info on writing benchmarks see the [criterion user guide] and the [criterion docs].
+
+### Other supported commands
+
+- `cargo make benchmark-twitter`: Only run the Twitter benchmarks
+- `cargo make benchmark-livejournal`: Only run the LiveJournal benchmarks
+- `cargo make build-ddlog`: Only build the generated ddlog code
+- `cargo make download-data`: Download the datasets required for benchmarking
+
+[`cargo-make`]: https://github.com/sagiegurari/cargo-make
+[criterion user guide]: https://bheisler.github.io/criterion.rs/book/index.html
+[criterion docs]: https://docs.rs/criterion

--- a/rust/ddlog_benches/benches/live_journal.rs
+++ b/rust/ddlog_benches/benches/live_journal.rs
@@ -14,8 +14,8 @@ fn record_counts() -> impl Iterator<Item = usize> {
     (50_000..=200_000).step_by(50_000)
 }
 
-fn live_journal(c: &mut Criterion) {
-    let mut group = c.benchmark_group("LiveJournal");
+fn live_journal_micro(c: &mut Criterion) {
+    let mut group = c.benchmark_group("LiveJournal-micro");
     group.sampling_mode(SamplingMode::Flat);
     group.sample_size(10);
 
@@ -73,5 +73,5 @@ fn live_journal_macro(c: &mut Criterion) {
     }
 }
 
-criterion_group!(benches, live_journal, live_journal_macro);
+criterion_group!(benches, live_journal_micro, live_journal_macro);
 criterion_main!(benches);

--- a/rust/ddlog_benches/benches/live_journal.rs
+++ b/rust/ddlog_benches/benches/live_journal.rs
@@ -1,0 +1,77 @@
+use criterion::{
+    black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, SamplingMode,
+};
+use ddlog_benches::live_journal;
+use std::ops::RangeInclusive;
+
+/// Benchmark all targets using 1, 2, 3, and 4 threads
+const DDLOG_WORKERS: RangeInclusive<usize> = 1..=4;
+
+const MACRO_SAMPLES: Option<usize> = Some(10_000_000);
+
+// Step by 50k records from 50k to 200k records
+fn record_counts() -> impl Iterator<Item = usize> {
+    (50_000..=200_000).step_by(50_000)
+}
+
+fn live_journal(c: &mut Criterion) {
+    let mut group = c.benchmark_group("LiveJournal");
+    group.sampling_mode(SamplingMode::Flat);
+    group.sample_size(10);
+
+    for record_count in record_counts() {
+        let dataset = live_journal::dataset(Some(record_count));
+
+        for thread_count in DDLOG_WORKERS.rev() {
+            group.bench_with_input(
+                BenchmarkId::new(
+                    format!(
+                        "{} thread{}",
+                        thread_count,
+                        if thread_count == 1 { "" } else { "s" },
+                    ),
+                    format!("{} records", record_count),
+                ),
+                &dataset,
+                |b, dataset| {
+                    b.iter_batched(
+                        || (live_journal::init(thread_count), dataset.to_owned()),
+                        |(ddlog, dataset)| live_journal::run(black_box(ddlog), black_box(dataset)),
+                        BatchSize::PerIteration,
+                    )
+                },
+            );
+        }
+    }
+}
+
+fn live_journal_macro(c: &mut Criterion) {
+    let mut group = c.benchmark_group("LiveJournal-macro");
+    group.sampling_mode(SamplingMode::Flat);
+    group.sample_size(10);
+
+    let dataset = live_journal::dataset(MACRO_SAMPLES);
+    for thread_count in DDLOG_WORKERS.rev() {
+        group.bench_with_input(
+            BenchmarkId::new(
+                format!(
+                    "{} thread{}",
+                    thread_count,
+                    if thread_count == 1 { "" } else { "s" },
+                ),
+                format!("{} samples", dataset.len()),
+            ),
+            &dataset,
+            |b, dataset| {
+                b.iter_batched(
+                    || (live_journal::init(thread_count), dataset.clone()),
+                    |(ddlog, data)| live_journal::run(ddlog, data),
+                    BatchSize::PerIteration,
+                )
+            },
+        );
+    }
+}
+
+criterion_group!(benches, live_journal, live_journal_macro);
+criterion_main!(benches);

--- a/rust/ddlog_benches/benches/twitter.rs
+++ b/rust/ddlog_benches/benches/twitter.rs
@@ -14,8 +14,8 @@ fn record_counts() -> impl Iterator<Item = usize> {
     (50_000..=200_000).step_by(50_000)
 }
 
-fn twitter(c: &mut Criterion) {
-    let mut group = c.benchmark_group("twitter");
+fn twitter_micro(c: &mut Criterion) {
+    let mut group = c.benchmark_group("twitter-micro");
     group.sampling_mode(SamplingMode::Flat);
     group.sample_size(10);
 
@@ -73,5 +73,5 @@ fn twitter_macro(c: &mut Criterion) {
     }
 }
 
-criterion_group!(benches, twitter, twitter_macro);
+criterion_group!(benches, twitter_micro, twitter_macro);
 criterion_main!(benches);

--- a/rust/ddlog_benches/benches/twitter.rs
+++ b/rust/ddlog_benches/benches/twitter.rs
@@ -1,0 +1,77 @@
+use criterion::{
+    black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, SamplingMode,
+};
+use ddlog_benches::twitter;
+use std::ops::RangeInclusive;
+
+/// Benchmark all targets using 1, 2, 3, and 4 threads
+const DDLOG_WORKERS: RangeInclusive<usize> = 1..=4;
+
+const MACRO_SAMPLES: Option<usize> = Some(10_000_000);
+
+// Step by 50k records from 50k to 200k records
+fn record_counts() -> impl Iterator<Item = usize> {
+    (50_000..=200_000).step_by(50_000)
+}
+
+fn twitter(c: &mut Criterion) {
+    let mut group = c.benchmark_group("twitter");
+    group.sampling_mode(SamplingMode::Flat);
+    group.sample_size(10);
+
+    for record_count in record_counts() {
+        let dataset = twitter::dataset(Some(record_count));
+
+        for thread_count in DDLOG_WORKERS.rev() {
+            group.bench_with_input(
+                BenchmarkId::new(
+                    format!(
+                        "{} thread{}",
+                        thread_count,
+                        if thread_count == 1 { "" } else { "s" },
+                    ),
+                    format!("{} records", record_count),
+                ),
+                &dataset,
+                |b, dataset| {
+                    b.iter_batched(
+                        || (twitter::init(thread_count), dataset.to_owned()),
+                        |(ddlog, dataset)| twitter::run(black_box(ddlog), black_box(dataset)),
+                        BatchSize::PerIteration,
+                    )
+                },
+            );
+        }
+    }
+}
+
+fn twitter_macro(c: &mut Criterion) {
+    let mut group = c.benchmark_group("twitter-macro");
+    group.sampling_mode(SamplingMode::Flat);
+    group.sample_size(10);
+
+    let dataset = twitter::dataset(MACRO_SAMPLES);
+    for thread_count in DDLOG_WORKERS.rev() {
+        group.bench_with_input(
+            BenchmarkId::new(
+                format!(
+                    "{} thread{}",
+                    thread_count,
+                    if thread_count == 1 { "" } else { "s" },
+                ),
+                format!("{} samples", dataset.len()),
+            ),
+            &dataset,
+            |b, dataset| {
+                b.iter_batched(
+                    || (twitter::init(thread_count), dataset.clone()),
+                    |(ddlog, data)| twitter::run(ddlog, data),
+                    BatchSize::PerIteration,
+                )
+            },
+        );
+    }
+}
+
+criterion_group!(benches, twitter, twitter_macro);
+criterion_main!(benches);

--- a/rust/ddlog_benches/ddlog/benchmarks.dl
+++ b/rust/ddlog_benches/ddlog/benchmarks.dl
@@ -1,0 +1,2 @@
+import twitter
+import live_journal

--- a/rust/ddlog_benches/ddlog/live_journal.dl
+++ b/rust/ddlog_benches/ddlog/live_journal.dl
@@ -1,0 +1,8 @@
+input relation Edge(from: u32, to: u32)
+
+output relation Path(from: u32, to: u32)
+Path(from, to) :- Edge(from, to).
+Path(from, to) :- Edge(from, path), Path(path, to).
+
+output relation Triangles(a: u32, b: u32, c: u32)
+Triangles(a, b, c) :- Edge(a, b), Edge(b, c), Edge(c, a).

--- a/rust/ddlog_benches/ddlog/twitter.dl
+++ b/rust/ddlog_benches/ddlog/twitter.dl
@@ -1,0 +1,14 @@
+input relation Edge(from: u32, to: u32)
+
+output relation Path(from: u32, to: u32)
+Path(from, to) :- Edge(from, to).
+Path(from, to) :- Edge(from, path), Path(path, to).
+
+output relation Triangles(a: u32, b: u32, c: u32)
+Triangles(a, b, c) :- Edge(a, b), Edge(b, c), Edge(c, a).
+
+output relation NaiveQuadClique(a: u32, b: u32, c: u32, d: u32)
+NaiveQuadClique(a, b, c, d) :-
+    Edge(a, b), Edge(a, c), Edge(a, d),
+    Edge(b, c), Edge(b, d),
+    Edge(c, d).

--- a/rust/ddlog_benches/src/lib.rs
+++ b/rust/ddlog_benches/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod live_journal;
+pub mod twitter;
+pub mod utils;

--- a/rust/ddlog_benches/src/live_journal.rs
+++ b/rust/ddlog_benches/src/live_journal.rs
@@ -1,0 +1,65 @@
+use benchmarks_ddlog::{api::HDDlog as DDlog, typedefs::live_journal::Edge, Relations};
+use benchmarks_differential_datalog::{
+    ddval::{DDValConvert, DDValue},
+    program::{RelId, Update},
+    DDlog as _,
+};
+use flate2::bufread::GzDecoder;
+use std::{
+    fs::File,
+    io::{BufRead, BufReader},
+};
+
+pub fn dataset(samples: Option<usize>) -> Vec<Update<DDValue>> {
+    // Grab the file and wrap it in a buffered reader so it doesn't take forever
+    // to read the entire thing in one go
+    let reader = BufReader::new(GzDecoder::new(BufReader::new(
+        File::open(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/data/soc-LiveJournal1.txt.gz",
+        ))
+        .expect("could not open data file"),
+    )));
+
+    let mut edges = Vec::with_capacity(samples.unwrap_or(40_000_000));
+
+    for line in reader
+        .lines()
+        .flat_map(|line| line.ok())
+        .take(samples.unwrap_or_else(usize::max_value))
+    {
+        if line.starts_with('#') {
+            continue;
+        }
+
+        let mut split = line.trim().split('\t');
+        let from = split.next().unwrap().trim().parse().unwrap();
+        let to = split.next().unwrap().trim().parse().unwrap();
+
+        edges.push(Update::Insert {
+            relid: Relations::live_journal_Edge as RelId,
+            v: Edge { from, to }.into_ddvalue(),
+        });
+    }
+
+    edges
+}
+
+pub fn init(workers: usize) -> DDlog {
+    let (ddlog, _) = DDlog::run(workers, false).expect("failed to create DDlog instance");
+    ddlog
+}
+
+pub fn run(ddlog: DDlog, dataset: Vec<Update<DDValue>>) -> DDlog {
+    ddlog
+        .transaction_start()
+        .expect("failed to start transaction");
+    ddlog
+        .apply_valupdates(dataset.into_iter())
+        .expect("failed to give transaction input");
+    ddlog
+        .transaction_commit()
+        .expect("failed to commit transaction");
+
+    ddlog
+}

--- a/rust/ddlog_benches/src/twitter.rs
+++ b/rust/ddlog_benches/src/twitter.rs
@@ -1,0 +1,64 @@
+use benchmarks_ddlog::{api::HDDlog as DDlog, typedefs::twitter::Edge, Relations};
+use benchmarks_differential_datalog::{
+    ddval::{DDValConvert, DDValue},
+    program::{RelId, Update},
+    DDlog as _,
+};
+use csv::Reader;
+use flate2::bufread::GzDecoder;
+use std::{fs::File, io::BufReader};
+
+pub fn dataset(samples: Option<usize>) -> Vec<Update<DDValue>> {
+    // The indices of the csv rows
+    const NODE_ID: usize = 0;
+    const TWITTER_ID: usize = 1;
+
+    // Grab the file and wrap it in a buffered reader so it doesn't take forever
+    // to read the entire thing in one go
+    let reader = Reader::from_reader(GzDecoder::new(BufReader::new(
+        File::open(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/data/twitter-2010-ids.csv.gz",
+        ))
+        .expect("could not open data file"),
+    )));
+
+    let mut edges = Vec::with_capacity(samples.unwrap_or(40_000_000));
+
+    for record in reader
+        .into_records()
+        .flat_map(|record| record.ok())
+        .take(samples.unwrap_or_else(usize::max_value))
+    {
+        let edge = Edge {
+            from: record.get(NODE_ID).unwrap().parse().unwrap(),
+            to: record.get(TWITTER_ID).unwrap().parse().unwrap(),
+        };
+
+        edges.push(Update::Insert {
+            relid: Relations::twitter_Edge as RelId,
+            v: edge.into_ddvalue(),
+        });
+    }
+
+    edges
+}
+
+pub fn init(workers: usize) -> DDlog {
+    let (ddlog, _) = DDlog::run(workers, false).expect("failed to create DDlog instance");
+    ddlog
+}
+
+pub fn run(ddlog: DDlog, dataset: Vec<Update<DDValue>>) -> DDlog {
+    ddlog
+        .transaction_start()
+        .expect("failed to start transaction");
+    ddlog
+        .apply_valupdates(dataset.into_iter())
+        .expect("failed to give transaction input");
+    ddlog
+        .transaction_commit()
+        .expect("failed to commit transaction");
+
+    ddlog
+}

--- a/rust/ddlog_benches/src/utils.rs
+++ b/rust/ddlog_benches/src/utils.rs
@@ -1,0 +1,108 @@
+use criterion::{
+    measurement::{Measurement, ValueFormatter},
+    Throughput,
+};
+use std::time::{Duration, Instant};
+
+/// A custom criterion measurement that measures the number of records
+/// ingested for a given time period
+pub struct RecordsIngested;
+
+impl Measurement for RecordsIngested {
+    type Intermediate = Instant;
+    type Value = Duration;
+
+    fn start(&self) -> Self::Intermediate {
+        Instant::now()
+    }
+
+    fn end(&self, start_time: Self::Intermediate) -> Self::Value {
+        start_time.elapsed()
+    }
+
+    fn add(&self, &elapsed1: &Self::Value, &elapsed2: &Self::Value) -> Self::Value {
+        elapsed1 + elapsed2
+    }
+
+    fn zero(&self) -> Self::Value {
+        Duration::from_secs(0)
+    }
+
+    fn to_f64(&self, elapsed: &Self::Value) -> f64 {
+        elapsed.as_secs_f64()
+    }
+
+    fn formatter(&self) -> &dyn ValueFormatter {
+        &RecordsIngestedFormatter
+    }
+}
+
+/// A custom criterion formatter for the number of records ingested for
+/// a given period of time
+pub struct RecordsIngestedFormatter;
+
+impl RecordsIngestedFormatter {
+    fn records_per_second(&self, records: f64, typical: f64, values: &mut [f64]) -> &'static str {
+        let records_per_second = records * (1e9 / typical);
+
+        let (denominator, unit) = if records_per_second < 1000.0 {
+            (1.0, " records/s")
+        } else if records_per_second < 1000.0 * 1000.0 {
+            (1000.0, "thousand records/s")
+        } else if records_per_second < 1000.0 * 1000.0 * 1000.0 {
+            (1000.0 * 1000.0, "million records/s")
+        } else {
+            (1000.0 * 1000.0 * 1000.0, "billion records/s")
+        };
+
+        for val in values {
+            let records_per_second = records * (1e9 / *val);
+            *val = records_per_second / denominator;
+        }
+
+        unit
+    }
+}
+
+impl ValueFormatter for RecordsIngestedFormatter {
+    fn scale_throughputs(
+        &self,
+        typical: f64,
+        throughput: &Throughput,
+        values: &mut [f64],
+    ) -> &'static str {
+        match *throughput {
+            Throughput::Elements(records) => {
+                self.records_per_second(records as f64, typical, values)
+            }
+
+            Throughput::Bytes(_) => {
+                panic!("RecordsPerSecond can only be called with `Throughput::Elements`")
+            }
+        }
+    }
+
+    fn scale_values(&self, ns: f64, values: &mut [f64]) -> &'static str {
+        let (factor, unit) = if ns < 10f64.powi(0) {
+            (10f64.powi(3), "ps")
+        } else if ns < 10f64.powi(3) {
+            (10f64.powi(0), "ns")
+        } else if ns < 10f64.powi(6) {
+            (10f64.powi(-3), "μs")
+        } else if ns < 10f64.powi(9) {
+            (10f64.powi(-6), "ms")
+        } else {
+            (10f64.powi(-9), "s")
+        };
+
+        for val in values {
+            *val *= factor;
+        }
+
+        unit
+    }
+
+    fn scale_for_machines(&self, _values: &mut [f64]) -> &'static str {
+        "records/s"
+    }
+}

--- a/rust/template/differential_datalog/Cargo.toml
+++ b/rust/template/differential_datalog/Cargo.toml
@@ -29,7 +29,7 @@ erased-serde = "0.3"
 crossbeam-channel = "0.5.0"
 
 [dev-dependencies]
-byteorder = "0.4.2"
-getopts = "0.2.14"
-itertools = "^0.6"
-serde_derive = "1.0"
+byteorder = "1.4.2"
+getopts = "0.2.21"
+itertools = "0.10.0"
+serde_derive = "1.0.119"

--- a/test.sh
+++ b/test.sh
@@ -46,7 +46,8 @@ test_groups=("crates:Test DDlog runtime crates."
              "souffle:Tests imported from Souffle Datalog."
              "d3log:Distributed DDlog (D3log) tests."
              "misc:Miscellaneous other tests."
-             "stack:Tests using Haskell stack infrastructure.")
+             "stack:Tests using Haskell stack infrastructure."
+             "bench:DDlog benchmarks.")
 
 # List of tests in each group.  Test name must match the name of a function below.
 
@@ -112,6 +113,8 @@ stack=("modules:Test modules and imports"
        "ovn_mockup:OVN-inspired example"
        "redist:'redist' example"
        "negative:Negative tests that validate compiler error handling")
+
+bench=("twitter_micro:twitter microbenchmark")
 
 # 'crates' test group.
 
@@ -367,6 +370,12 @@ span_uuid() {
 
 path() {
     (cd "${THIS_DIR}/test/datalog_tests" && ./run-test.sh path release)
+}
+
+# 'bench' test group.
+
+twitter_micro() {
+    (export DDLOG_HOME="${THIS_DIR}" && cd "${THIS_DIR}/rust/ddlog_benches" && cargo make bench-twitter-micro)
 }
 
 #==========================================

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -20,7 +20,10 @@ RUN apt-get update &&   \
     time                \
     zookeeper           \
     libgoogle-perftools-dev \
-    maven
+    maven               \
+    openssl             \
+    gnuplot-qt          \
+    pkg-config
 
 ###############################################################################
 ## If you modify this file don't forget to also update install-dependencies.sh
@@ -39,6 +42,7 @@ ENV CLASSPATH=$CLASSPATH:/flatbuffers/java
 RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.47.0 -y
 RUN rustup component add rustfmt
 RUN rustup component add clippy
+RUN cargo install cargo-make
 
 # Install Haskell dependencies to speed up builds
 RUN git clone https://github.com/vmware/differential-datalog.git


### PR DESCRIPTION
Added the `citations` benchmark, which is a real-world ddlog use case, it tests ddlog's parallelism and throughput under very large workloads. I also set up the framework for adding more benchmarks in the future, which I plan to do

Current Results:
```
citations/1 thread/100000 records
time:   [28.364 s 28.846 s 29.341 s]
thrpt:  [3.5355 Kelem/s 3.5716 Kelem/s 3.6108 Kelem/s]

citations/2 threads/100000 records
time:   [26.284 s 26.793 s 27.179 s]
thrpt:  [4.1461 Kelem/s 4.1977 Kelem/s 4.2499 Kelem/s]

citations/3 threads/100000 records
time:   [28.088 s 28.492 s 28.880 s]
thrpt:  [3.7379 Kelem/s 3.7988 Kelem/s 3.8680 Kelem/s]

citations/4 threads/100000 records
time:   [28.033 s 28.593 s 29.278 s]
thrpt:  [3.4992 Kelem/s 3.5749 Kelem/s 3.6543 Kelem/s]
```