### PR TITLE
internment.rs: Remove `impl PartialEq`.

### DIFF
--- a/lib/internment.rs
+++ b/lib/internment.rs
@@ -40,15 +40,6 @@ where
     }
 }
 
-impl<T> PartialEq<T> for Intern<T>
-where
-    T: Eq + Send + Sync + Hash + 'static,
-{
-    fn eq(&self, other: &T) -> bool {
-        self.as_ref().eq(&other)
-    }
-}
-
 /// Order the interned values by their pointers
 impl<T> PartialOrd for Intern<T>
 where


### PR DESCRIPTION
As part of internment lib refactoring in
d8b7850e48b793bc594304426cc7eddf6b2a6c25, a `PartialEq` impl was
introduced for the `Intern<T>` type.  This implementation performed
actual value comparison instead of pointer comparison, thus eliminating
some of the performance benefits of interning.  We remove this impl in
favor of the auto-derived one that should have the correct behavior.

@Kixiron, can you have a look at this PR? I don't think there was a real reason to introduce this impl, was there?  I am also surprised Rust did not complain about conflicting auto-derived impl.  Looks like it was quietly suppressed.