### PR TITLE
Replace arc-interner crate with internment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.35.0] - Jan 19, 2021
+
+### Optimizations
+
+- Use `internment` crate instead of `arc-interner` to make `Intern<T>`
+  more scalable.
+
 ## [0.34.2] - Jan 18, 2021
 
 ### New features

--- a/lib/internment.rs
+++ b/lib/internment.rs
@@ -1,6 +1,6 @@
-use arc_interner::ArcIntern;
 use ddlog_std::Vec as DDlogVec;
 use differential_datalog::record::{self, Record};
+use internment::ArcIntern;
 use serde::{de::Deserializer, ser::Serializer};
 use std::{
     cmp::{self, Ordering},

--- a/lib/internment.toml
+++ b/lib/internment.toml
@@ -1,2 +1,2 @@
-[dependencies.arc-interner]
-version="0.1"
+[dependencies.internment]
+version="0.4.1"


### PR DESCRIPTION
A while ago a race condition in the `internment` crate forced us to
abandon it and build our own `arc-interner` crate using similar design but
written in safe Rust only.  However, `arc-interner` has some tricky
performance issues.  The old 0.1 version of the crate uses the `state`
crate to protect its global type map.  The latter uses spinlocks,
which is never a good idea in user land and has just caused a performance
disaster in a deployment with a large number of threads.  Newer version
0.5, based on dashmaps, computes a hash of the interned object on each
reference drop, which is prohibitively expensive when working with
really large interned objects.

We therefore go back to using `internment` which has since fixed the
race condition and added a bunch of tests to hopefully avoid those in
the future.