### PR TITLE
Add OS X warning fix to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,11 @@ but somewhat limits the flexibility, as changes to the relational schema or rule
 
 To install a precompiled version of DDlog, download the [latest binary release](https://github.com/vmware/differential-datalog/releases), extract it from archive, add `ddlog/bin` to your `$PATH`, and set `$DDLOG_HOME` to point to the `ddlog` directory. You will also need to install the Rust toolchain (see instructions below).
 
-If you're using OS X, you will need to override the binary's security settings through [these instructions](https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unidentified-developer-mh40616/mac).
+If you're using OS X, you will need to override the binary's security settings through [these instructions](https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unidentified-developer-mh40616/mac). Else, when first running the DDlog compiler (through calling `ddlog`), you will get the following warning dialog:
+```
+"ddlog" cannot be opened because the developer cannot be verified.
+macOS cannot verify that this app is free from malware.
+```
 
 You are now ready to [start coding in DDlog](doc/tutorial/tutorial.md).
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ but somewhat limits the flexibility, as changes to the relational schema or rule
 
 To install a precompiled version of DDlog, download the [latest binary release](https://github.com/vmware/differential-datalog/releases), extract it from archive, add `ddlog/bin` to your `$PATH`, and set `$DDLOG_HOME` to point to the `ddlog` directory. You will also need to install the Rust toolchain (see instructions below).
 
+If you're using OS X, you will need to override the binary's security settings through [these instructions](https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unidentified-developer-mh40616/mac).
+
 You are now ready to [start coding in DDlog](doc/tutorial/tutorial.md).
 
 ### Compiling DDlog from sources


### PR DESCRIPTION
I added instructions to work around the "unverified developer" security warning when using the precompiled binary on OS X. If not fixed, the user will encounter the warning when first using `ddlog`, likely in the tutorial.
The desktop popup will have the following text:
```
"ddlog" cannot be opened because the developer cannot be verified.
macOS cannot verify that this app is free from malware.

Chrome downloaded this file ... from `github.com`
```

An image of the popup is below for additional reference. 
<img width="449" alt="OS X unverified developer security warning" src="https://user-images.githubusercontent.com/1740974/105927113-2d366600-5ff8-11eb-8ed0-9fc328ed080a.png">


