### PR TITLE
Allow copies between DDlog PosStruct and NamedStruct

### DIFF
--- a/rust/template/ddlog_derive/src/from_record.rs
+++ b/rust/template/ddlog_derive/src/from_record.rs
@@ -44,7 +44,7 @@ pub fn from_record_inner(input: DeriveInput) -> Result<TokenStream> {
         // the user will have to manually enforce invariants on it
         Data::Union(union) => Err(Error::new_spanned(
             union.union_token,
-            "`FromRecord` is not able to be automatically implemented on unions",
+            "`FromRecord` cannot be automatically implemented on unions",
         )),
     }
 }

--- a/rust/template/ddlog_derive/src/into_record.rs
+++ b/rust/template/ddlog_derive/src/into_record.rs
@@ -38,7 +38,7 @@ pub fn into_record_inner(input: DeriveInput) -> Result<TokenStream> {
         // the user will have to manually enforce invariants on it
         Data::Union(union) => Err(Error::new_spanned(
             union.union_token,
-            "`IntoRecord` is not able to be automatically implemented on unions",
+            "`IntoRecord` cannot be automatically implemented on unions",
         )),
     }
 }

--- a/rust/template/ddlog_derive/src/mutator.rs
+++ b/rust/template/ddlog_derive/src/mutator.rs
@@ -63,7 +63,7 @@ pub fn mutator_inner(mut input: DeriveInput) -> Result<TokenStream> {
         // the user will have to manually enforce invariants on it
         Data::Union(union) => Err(Error::new_spanned(
             union.union_token,
-            "`Mutator` is not able to be automatically implemented on unions",
+            "`Mutator` cannot be automatically implemented on unions",
         )),
     }
 }
@@ -91,7 +91,7 @@ fn unit_struct_mutator(args: &Ident, error: &Ident) -> TokenStream {
             },
 
             #error => {
-                return std::result::Result::Err(std::format!("not a struct {:?}", #error));
+                return std::result::Result::Err(std::format!("not a unit struct {:?}", #error));
             },
         }
     }
@@ -148,7 +148,7 @@ fn tuple_struct_mutator<'a>(
             },
 
             #error => {
-                return std::result::Result::Err(std::format!("not a struct {:?}", #error));
+                return std::result::Result::Err(std::format!("not a tuple struct {:?}", #error));
             },
         }
     };
@@ -176,11 +176,26 @@ fn named_struct_mutator<'a>(
     })
     .collect::<Result<TokenStream>>()?;
 
+    let field_copies = named_struct.named.iter().enumerate().map(|(index, field)| {
+        let field_ty = &field.ty;
+        let field_ident = field.ident.as_ref().expect("named structs have field names");
+        quote! {
+            <dyn differential_datalog::record::Mutator<#field_ty>>::mutate(&#args[#index], #field_ident)?;
+        }
+    })
+    .collect::<TokenStream>();
+
+    let num_fields = named_struct.named.len();
     let mutator = quote! {
         match self {
             differential_datalog::record::Record::NamedStruct(_, #args) => {
                 #field_mutations
             },
+
+            differential_datalog::record::Record::PosStruct(_, #args)
+                if #args.len() == #num_fields => {
+                    #field_copies
+                },
 
             #error => {
                 return std::result::Result::Err(std::format!("not a struct {:?}", #error));

--- a/rust/template/ddlog_derive/src/mutator.rs
+++ b/rust/template/ddlog_derive/src/mutator.rs
@@ -176,7 +176,7 @@ fn named_struct_mutator<'a>(
     })
     .collect::<Result<TokenStream>>()?;
 
-    let field_copies = named_struct.named.iter().enumerate().map(|(index, field)| {
+    let positional_mutations = named_struct.named.iter().enumerate().map(|(index, field)| {
         let field_ty = &field.ty;
         let field_ident = field.ident.as_ref().expect("named structs have field names");
         quote! {
@@ -194,7 +194,7 @@ fn named_struct_mutator<'a>(
 
             differential_datalog::record::Record::PosStruct(_, #args)
                 if #args.len() == #num_fields => {
-                    #field_copies
+                    #positional_mutations
                 },
 
             #error => {

--- a/rust/template/ddlog_derive/tests/ui/fail/reject_unions.stderr
+++ b/rust/template/ddlog_derive/tests/ui/fail/reject_unions.stderr
@@ -1,16 +1,16 @@
-error: `Mutator` is not able to be automatically implemented on unions
+error: `Mutator` cannot be automatically implemented on unions
  --> $DIR/reject_unions.rs:6:1
   |
 6 | union Foo {
   | ^^^^^
 
-error: `IntoRecord` is not able to be automatically implemented on unions
+error: `IntoRecord` cannot be automatically implemented on unions
  --> $DIR/reject_unions.rs:6:1
   |
 6 | union Foo {
   | ^^^^^
 
-error: `FromRecord` is not able to be automatically implemented on unions
+error: `FromRecord` cannot be automatically implemented on unions
  --> $DIR/reject_unions.rs:6:1
   |
 6 | union Foo {


### PR DESCRIPTION
This is necessary because some NamedStructs can have fields that are PosStruct.
There is no unit test in this PR, but this change is needed to solve #843, and that PR will contain a test (generated by the SQL -> DDlog compiler).