### PR TITLE
Support insert_or_update and delete_by_key using flatbufs 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [unreleased]
+
+- Support insert_or_update and delete_by_key in flatbuf API, including in Java.
+
 ## [0.35.0] - Jan 19, 2021
 
 ### Optimizations

--- a/doc/command_reference/command_reference.md
+++ b/doc/command_reference/command_reference.md
@@ -26,7 +26,7 @@ compiling and running DDlog programs.
 |                                | `insert Rel2(.x=10, .y=Constructor{.f1="foo", .f2=true});` | type constructor arguments can also be passed by name        |
 | `insert_or_update <record>,`   | same as `insert`, but replaces existing value with the same key, if it exists; only valid for relations with primary key  |
 | `delete <record>,`             | `delete Rel1(1,true,"foo");`                     | delete record from Rel1 (using argument syntax identical to `insert`)  |
-| `delete_key <relation> <key>,` | `delete Rel1 1;`                                 | delete record by key; only valid for relations with primary key        |
+| `delete_key <relation> <key>,` | `delete_key Rel1 1;`                             | delete record by key; only valid for relations with primary key        |
 | `modify <relation> <key> <- <record>,` | `modify Rel1 1 <- Rel1{.f1 = 5};`        | modify record; `<record>` specifies just the fields to be modified; only valid for relations with primary key.  See [below](#modify_command) for more details. |
 | comma-separated updates        | `insert Foo(1), delete Bar("buzz");`             | a sequence of insert and delete commands can be applied in one update  |
 | clear <relation>               | `clear Foo`                                      | remove all records from a relation; must be used within a transaction  |
@@ -57,7 +57,7 @@ The `<record>` argument describes how the value associated with the key must
 change.  Each field in the record represents an **update** to the corresponding
 field of the original record.  Think of it as a **delta** to be applied to the
 existing value.  If you want to overwrite existing value with a new value,
-rather than modify it, use the `insert_or_update` command instead.  
+rather than modify it, use the `insert_or_update` command instead.
 
 The delta only needs to contain fields to be modified:
 

--- a/java/test_flatbuf1/Test.java
+++ b/java/test_flatbuf1/Test.java
@@ -565,7 +565,9 @@ public class Test {
             builder.insert_KI(ki);
         }
         builder.insert_LI(true, (byte)-1, "something");
+        builder.insert_L0I(true, (byte)-1, "or not");
         builder.insert_L0I(false, (byte)-2, "else");
+        builder.insert_or_update_L0I(false, (byte)-2, "altogether");
         {
             Boolean[] v = new Boolean[] {true, false, true};
             builder.insert_MI(Arrays.asList(v));
@@ -758,6 +760,11 @@ public class Test {
             builder.applyUpdates(this.api);
             assert false: "Reusing UpdateBuilder should throw an exception.";
         } catch (IllegalStateException e) {}
+
+        // Test delete.  This fails if the element is not present in the collection.
+        builder = new typesTestUpdateBuilder();
+        builder.delete_by_key_L0I(true);
+        builder.applyUpdates(this.api);
     }
 
     void clear() throws DDlogException {

--- a/java/test_flatbuf1/fb.dump.expected
+++ b/java/test_flatbuf1/fb.dump.expected
@@ -15,7 +15,7 @@ From 23 Insert HI{773153186440202938}
 From 25 Insert II{7}
 From 26 Insert JI{(true, 10, "string")}
 From 27 Insert KI{(false, 9, "text")}
-From 28 Insert L0I{false,254,"else"}
+From 28 Insert L0I{false,254,"altogether"}
 From 29 Insert (true, 255, "something")
 From 30 Insert MI{[true, false, true]}
 From 31 Insert NI{[(true, 255, "check"), (false, 1, "fails")]}

--- a/java/test_flatbuf1/query.dump.expected
+++ b/java/test_flatbuf1/query.dump.expected
@@ -57,7 +57,7 @@ Query LI_by_all[true, -1, "something"]:
 (true, 255, "something")
 Query L0I[true]:
 Query L0I[false]:
-L0I{false,254,"else"}
+L0I{false,254,"altogether"}
 Query MI_by_v[true, false, true]:
 MI{[true, false, true]}
 Query NI_by_v[(true,-1,"check"), (false,1,"fails")]:
@@ -258,7 +258,7 @@ Dump LI_by_01:
 Dump LI_by_all:
 (true, 255, "something")
 Dump L0I:
-L0I{false,254,"else"}
+L0I{false,254,"altogether"}
 Dump MI_by_v:
 MI{[true, false, true]}
 Dump NI_by_v:

--- a/rust/template/Cargo.toml
+++ b/rust/template/Cargo.toml
@@ -46,6 +46,7 @@ rustop = { version = "1.0.2", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 erased-serde = "0.3"
 crossbeam-channel = "0.5.0"
+enum-primitive-derive = "0.2.1"
 
 # FlatBuffers dependency enabled by the `flatbuf` feature.
 # flatbuffers crate version must be in sync with the flatc compiler and Java

--- a/rust/template/differential_datalog/src/program/mod.rs
+++ b/rust/template/differential_datalog/src/program/mod.rs
@@ -2039,7 +2039,7 @@ impl RunningProgram {
         match upd {
             Update::Insert { relid, v } => match s.entry(key_func(&v)) {
                 hash_map::Entry::Occupied(_) => Err(format!(
-                    "Insert: duplicate key {:?} in value {:?}",
+                    "Insert: duplicate key '{:?}' in value '{:?}'",
                     key_func(&v),
                     v
                 )),
@@ -2083,7 +2083,7 @@ impl RunningProgram {
             Update::DeleteValue { relid, v } => match s.entry(key_func(&v)) {
                 hash_map::Entry::Occupied(oe) => {
                     if *oe.get() != v {
-                        Err(format!("DeleteValue: key exists with a different value. Value specified: {:?}; existing value: {:?}", v, oe.get()))
+                        Err(format!("DeleteValue: key exists but with a different value. Value specified: '{:?}'; existing value: '{:?}'", v, oe.get()))
                     } else {
                         Self::delta_dec(ds, oe.get());
                         oe.remove_entry();
@@ -2092,7 +2092,7 @@ impl RunningProgram {
                     }
                 }
                 hash_map::Entry::Vacant(_) => {
-                    Err(format!("DeleteValue: key not found {:?}", key_func(&v)))
+                    Err(format!("DeleteValue: key not found '{:?}'", key_func(&v)))
                 }
             },
 
@@ -2104,7 +2104,7 @@ impl RunningProgram {
                     updates.push(Update::DeleteValue { relid, v: old });
                     Ok(())
                 }
-                hash_map::Entry::Vacant(_) => Err(format!("DeleteKey: key not found {:?}", k)),
+                hash_map::Entry::Vacant(_) => Err(format!("DeleteKey: key not found '{:?}'", k)),
             },
 
             Update::Modify { relid, k, m } => match s.entry(k.clone()) {
@@ -2122,7 +2122,7 @@ impl RunningProgram {
 
                     Ok(())
                 }
-                hash_map::Entry::Vacant(_) => Err(format!("Modify: key not found {:?}", k)),
+                hash_map::Entry::Vacant(_) => Err(format!("Modify: key not found '{:?}'", k)),
             },
         }
     }

--- a/rust/template/src/flatbuf.rs
+++ b/rust/template/src/flatbuf.rs
@@ -4,8 +4,8 @@ use super::*;
 use differential_datalog::program;
 use differential_datalog::program::{Response, Update};
 use differential_datalog::DeltaMap;
-use flatbuffers as fbrt;
 use enum_primitive_derive::Primitive;
+use flatbuffers as fbrt;
 use num_traits::{FromPrimitive, ToPrimitive};
 
 /// Trait for types that can be de-serialized from FlatBuffer-embedded objects.

--- a/rust/template/src/flatbuf.rs
+++ b/rust/template/src/flatbuf.rs
@@ -472,16 +472,19 @@ impl<'a> FromFlatBuffer<fb::__Command<'a>> for DDValueUpdate {
                     (-1) => Ok(DDValueUpdate(Update::DeleteValue { relid, v: val })),
                     w => Err(format!("Update::from_flatbuf: non-unit weight {}", w)),
                 }
-            },
+            }
             Operation_InsertOrUpdate => {
                 let val = relval_from_flatbuf(relid, val_table)?;
                 Ok(DDValueUpdate(Update::InsertOrUpdate { relid, v: val }))
-            },
+            }
             Operation_DeleteByKey => {
                 let val = relkey_from_flatbuf(relid, val_table)?;
                 Ok(DDValueUpdate(Update::DeleteKey { relid, k: val }))
-            },
-            o => Err(format!("Update::from_flatbuf: unknown operation code {}", o)),
+            }
+            o => Err(format!(
+                "Update::from_flatbuf: unknown operation code {}",
+                o
+            )),
         }
     }
 }

--- a/rust/template/src/flatbuf.rs
+++ b/rust/template/src/flatbuf.rs
@@ -483,12 +483,9 @@ impl<'a> FromFlatBuffer<fb::__Command<'a>> for DDValueUpdate {
                 let val = relkey_from_flatbuf(relid, val_table)?;
                 Ok(DDValueUpdate(Update::DeleteKey { relid, k: val }))
             }
-            Some(o) => Err(format!(
-                "Update::from_flatbuf: unknown operation code {}",
-                cmd.operation()
-            )),
             _ => Err(format!(
-                "Update::from_flatbuf: could not convert operation code",
+                "Update::from_flatbuf: could not convert operation code {}",
+                cmd.operation()
             )),
         }
     }

--- a/rust/template/src/flatbuf.rs
+++ b/rust/template/src/flatbuf.rs
@@ -485,8 +485,8 @@ impl<'a> FromFlatBuffer<fb::__Command<'a>> for DDValueUpdate {
             }
             Some(o) => Err(format!(
                 "Update::from_flatbuf: unknown operation code {}",
-                cmd.operation())
-            ),
+                cmd.operation()
+            )),
             _ => Err(format!(
                 "Update::from_flatbuf: could not convert operation code",
             )),

--- a/src/Language/DifferentialDatalog/FlatBuffer.hs
+++ b/src/Language/DifferentialDatalog/FlatBuffer.hs
@@ -195,8 +195,18 @@ compileFlatBufferSchema d prog_name =
     "    key: __Value;"                                                         $$
     "}"                                                                         $$
     ""                                                                          $$
+    "// enum __Operation : byte {"                                              $$
+    "//   InsertOrDelete = 0,"                                                  $$
+    "//   InsertOrUpdate = 1,"                                                  $$
+    "//   DeleteByKey = 2"                                                      $$
+    "// }"                                                                      $$
+    ""                                                                          $$
     "// DDlog commands"                                                         $$
     "table __Command {"                                                         $$
+    "// encoding of operation to perform."                                      $$
+    "// Ideally this should use the enum __Operation, but"                      $$
+    "// I don't know how to make this visible in Rust."                         $$
+    "   operation: byte;"                                                       $$
     "   weight: int64;"                                                         $$
     "   relid: uint64 =" <+> default_relid <> ";"                               $$
     "   val:  __Value;"                                                         $$
@@ -1084,36 +1094,52 @@ mkJavaUpdateBuilder = ("ddlog" </> ?prog_name </> updateBuilderClass <.> "java",
     mk_command_constructors :: Relation -> Doc
     mk_command_constructors rel =
         mk_command_constructor "Insert" rel $$
-        mk_command_constructor "Delete" rel
+        mk_command_constructor "Delete" rel $$
+        (if isJust $ relPrimaryKey rel
+        then mk_command_constructor "Insert_Or_Update" rel $$
+             mk_command_constructor "Delete_By_Key" rel
+        else "")
 
     mk_command_constructor cmd rel@Relation{..} =
-        let lcmd = pp $ (toLower $ head cmd) : tail cmd in
-        if typeHasUniqueConstructor relType
-           then -- Relation type has a unique constructor (e.g., it's a struct with a
+        let lcmd = pp $ map toLower cmd
+            weight = if cmd == "Insert" then "1"
+                     else if cmd == "Delete" then "-1"
+                     else "0"
+            gentype = if cmd == "Delete_By_Key" then fromJust $ relKeyType ?d rel
+                      else relType
+            -- command ids to be kept in sync with flatbuf.rs
+            fbcommand = if cmd == "Insert" then "0"  -- InsertOrDelete
+                        else if cmd == "Delete" then "0" -- InsertOrDelete again
+                        else if cmd == "Insert_Or_Update" then "1" -- InsertOrUpdate
+                        else "2" -- Delete_By_Key
+        in if typeHasUniqueConstructor gentype
+           then -- gentype has a unique constructor (e.g., it's a struct with a
                 -- unique constructor, a tuple or a primitive type).
-                let args = case typ' ?d $ typeNormalizeForFlatBuf relType of
+                let args = case typ' ?d $ typeNormalizeForFlatBuf gentype of
                                 TStruct{..} -> map (\a -> jConvTypeW a <+> pp (name a)) $ consArgs $ typeCons !! 0
                                 TTuple{..}  -> mapIdx (\a i -> jConvTypeW a <+> "a" <> pp i) typeTupArgs
-                                _           -> [jConvTypeW relType <+> "v"] in
+                                _           -> [jConvTypeW gentype <+> "v"] in
                 "public void" <+> lcmd <> "_" <> mkRelId rel <> "(" <> commaSep args <> ")" $$
                 (braces' $ "int cmd =" <+> jFBCallConstructor "__Command"
-                                           [ if cmd == "Insert" then "1" else "-1"
+                                           [ "(byte)" <> fbcommand
+                                           , weight
                                            , (pp $ relIdentifier ?d rel)
-                                           , jFBPackage <> ".__Value." <> typeTableName relType
-                                           , jConvCreateTable relType Nothing] <> ";"  $$
+                                           , jFBPackage <> ".__Value." <> typeTableName gentype
+                                           , jConvCreateTable gentype Nothing] <> ";"  $$
                            "this.commands.add(Integer.valueOf(cmd));")
-           else -- Relation type is a struct with multiple constructors
+           else -- gentype is a struct with multiple constructors
                 vcat $
                 map (\c@Constructor{..} ->
                      "public void" <+> lcmd <> "_" <> mkRelId rel <> "_" <> (pp $ legalize $ name c) <>
                          "(" <> (commaSep $ map (\a -> jConvTypeW a <+> pp (name a)) consArgs) <> ")" $$
                      (braces' $ "int cmd =" <+> jFBCallConstructor "__Command"
-                                                [ if cmd == "Insert" then "1" else "-1"
+                                                [ "(byte)" <> fbcommand
+                                                , weight
                                                 , (pp $ relIdentifier ?d rel)
-                                                , jFBPackage <> ".__Value." <> typeTableName relType
-                                                , jConvCreateTable relType (Just c)] <> ";"  $$
+                                                , jFBPackage <> ".__Value." <> typeTableName gentype
+                                                , jConvCreateTable gentype (Just c)] <> ";"  $$
                                 "this.commands.add(Integer.valueOf(cmd));"))
-                    $ typeCons $ typ' ?d $ typeNormalizeForFlatBuf relType
+                    $ typeCons $ typ' ?d $ typeNormalizeForFlatBuf gentype
 
 -- Class with methods to query DDlog indexes.
 mkJavaQuery :: (?d::DatalogProgram, ?prog_name::String) => (FilePath, Doc)
@@ -1472,7 +1498,7 @@ jReadField nesting fbctx e t =
 
 rustValueFromFlatbuf :: (?d::DatalogProgram, ?cfg::Config, ?crate_graph::CrateGraph, ?specname::String) => Doc
 rustValueFromFlatbuf =
-    "fn relval_from_flatbuf(relid: program::RelId, v: fbrt::Table) -> Response<DDValue> {"               $$
+    "fn relval_from_flatbuf(relid: program::RelId, v: fbrt::Table) -> Response<DDValue> {"      $$
     "    match relid {"                                                                         $$
     (nest' $ nest' $ vcat rel_enums)                                                            $$
     "        _ => Err(format!(\"DDValue::relval_from_flatbuf: invalid relid {}\", relid))"      $$
@@ -1482,6 +1508,12 @@ rustValueFromFlatbuf =
     "    match idxid {"                                                                         $$
     (nest' $ nest' $ vcat idx_enums)                                                            $$
     "        _ => Err(format!(\"DDValue::idxkey_from_flatbuf: invalid idxid {}\", idxid))"      $$
+    "    }"                                                                                     $$
+    "}"                                                                                         $$
+    "fn relkey_from_flatbuf(relid: program::RelId, v: fbrt::Table) -> Response<DDValue> {"      $$
+    "    match relid {"                                                                         $$
+    (nest' $ nest' $ vcat relkey_enums)                                                         $$
+    "        _ => Err(format!(\"DDValue::rekkey_from_flatbuf: invalid relid {}\", relid))"      $$
     "    }"                                                                                     $$
     "}"                                                                                         $$
     "fn relval_to_flatbuf<'b>(relid: program::RelId, val: &DDValue, fbb: &mut fbrt::FlatBufferBuilder<'b>) -> (fb::__Value, fbrt::WIPOffset<fbrt::UnionWIPOffset>) {" $$
@@ -1511,6 +1543,11 @@ rustValueFromFlatbuf =
                      pp (relIdentifier ?d rel) <+> "=> Ok(" <>
                          "<" <> R.mkType ?d Nothing relType <> ">::from_flatbuf(fb::" <> typeTableName relType <> "::init_from_table(v))?.into_ddvalue()),")
                     progIORelations
+    relkey_enums = map (\rel@Relation{..} ->
+                     let t = fromJust $ relKeyType ?d rel in
+                     pp (relIdentifier ?d rel) <+> "=> Ok(" <>
+                         "<" <> R.mkType ?d Nothing t <> ">::from_flatbuf(fb::" <> typeTableName t <> "::init_from_table(v))?.into_ddvalue()),")
+                    $ filter (isJust . (relKeyType ?d)) progIORelations
     idx_enums = map (\idx@Index{} ->
                      let t = idxKeyType idx in
                      pp (idxIdentifier ?d idx) <+> "=> Ok(" <>


### PR DESCRIPTION
Expose them in the Java API.

I tried to have an enum in flatbuf.fbs with operation names, but I am not sure how to import it from the rust code in flatbuf.rs, since the namespace is only known at compile-time. So for now I hardwired the constant values instead of using an enum.