### PR TITLE
Use GCC-like error message format that Emacs can parse.

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,5 +1,5 @@
 {-
-Copyright (c) 2018-2020 VMware, Inc.
+Copyright (c) 2018-2021 VMware, Inc.
 SPDX-License-Identifier: MIT
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -192,7 +192,7 @@ parseValidate Config{..} = do
     when confDumpFlat $
         writeFile (replaceExtension confDatalogFile ".flat.ast") (show d''')
     d'''' <- case validate d''' of
-               Left e   -> errorWithoutStackTrace $ "\nerror: " ++ e
+               Left e   -> compilerError e
                Right d'''' -> return d''''
     when confDumpValid $
         writeFile (replaceExtension confDatalogFile ".valid.ast") (show d'''')
@@ -203,7 +203,7 @@ parseValidate Config{..} = do
         writeFile (replaceExtension confDatalogFile ".debug.ast") (show d')
     when confJava $
         case flatBufferValidate d of
-             Left e  -> errorWithoutStackTrace $ "error: " ++ e
+             Left e  -> compilerError e
              Right{} -> return ()
     return (modules, d', rs_code)
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -192,7 +192,7 @@ parseValidate Config{..} = do
     when confDumpFlat $
         writeFile (replaceExtension confDatalogFile ".flat.ast") (show d''')
     d'''' <- case validate d''' of
-               Left e   -> errorWithoutStackTrace $ "error: " ++ e
+               Left e   -> errorWithoutStackTrace $ "\nerror: " ++ e
                Right d'''' -> return d''''
     when confDumpValid $
         writeFile (replaceExtension confDatalogFile ".valid.ast") (show d'''')

--- a/package.yaml
+++ b/package.yaml
@@ -33,6 +33,7 @@ dependencies:
 #- MissingH
 - raw-strings-qq
 - time
+- transformers
 - tuple
 - file-embed
 - filepath

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -3201,7 +3201,7 @@ mkType' _ _       t@TSigned{..} | typeWidth == 8  = "i8"
                                 | typeWidth == 32 = "i32"
                                 | typeWidth == 64 = "i64"
                                 | typeWidth == 128= "i128"
-                                | otherwise       = errorWithoutStackTrace $ "Only machine widths (8/16/32/64/128) supported: " ++ show t
+                                | otherwise  = errorWithoutStackTrace $ "Only machine widths (8/16/32/64/128) supported: " ++ show t
 mkType' _ _       TDouble{}                  = "::ordered_float::OrderedFloat<f64>"
 mkType' _ _       TFloat{}                   = "::ordered_float::OrderedFloat<f32>"
 mkType' d scope   TTuple{..} | length typeTupArgs == 0

--- a/src/Language/DifferentialDatalog/Module.hs-boot
+++ b/src/Language/DifferentialDatalog/Module.hs-boot
@@ -2,6 +2,7 @@ module Language.DifferentialDatalog.Module where
 
 import qualified Data.Map as M
 import Text.PrettyPrint
+import Control.Monad.Trans.Except
 
 import Language.DifferentialDatalog.Syntax
 import Language.DifferentialDatalog.Name
@@ -18,5 +19,5 @@ nameScope :: (WithName a) => a -> ModuleName
 nameLocal :: (WithName a) => a -> Doc
 nameLocalStr :: (WithName a) => a -> String
 scoped :: ModuleName -> String -> String
-parseDatalogProgram :: [FilePath] -> Bool -> String -> FilePath -> IO ([DatalogModule], DatalogProgram, M.Map ModuleName (Doc, Doc, Doc))
+parseDatalogProgram :: [FilePath] -> Bool -> String -> FilePath -> ExceptT String IO ([DatalogModule], DatalogProgram, M.Map ModuleName (Doc, Doc, Doc))
 stdLibs :: [ModuleName]

--- a/src/Language/DifferentialDatalog/OVSDB/Compile.hs
+++ b/src/Language/DifferentialDatalog/OVSDB/Compile.hs
@@ -141,10 +141,10 @@ compileSchemaFile :: FilePath -> Config -> IO Doc
 compileSchemaFile fname config = do
     content <- readFile fname
     schema <- case parseSchema content fname of
-                   Left  e    -> errorWithoutStackTrace $ "Failed to parse input file: " ++ e
+                   Left  e    -> compilerError $ "failed to parse input file: " ++ e
                    Right prog -> return prog
     case compileSchema schema config of
-         Left e    -> errorWithoutStackTrace e
+         Left e    -> compilerError e
          Right doc -> return doc
 
 compileSchema :: (MonadError String me) => OVSDBSchema -> Config -> me Doc

--- a/src/Language/DifferentialDatalog/Parse.hs
+++ b/src/Language/DifferentialDatalog/Parse.hs
@@ -1,5 +1,5 @@
 {-
-Copyright (c) 2018-2020 VMware, Inc.
+Copyright (c) 2018-2021 VMware, Inc.
 SPDX-License-Identifier: MIT
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -32,6 +32,7 @@ module Language.DifferentialDatalog.Parse (
 
 import Control.Applicative hiding (many,optional,Const)
 import Control.Monad.Except
+import Control.Monad.Trans.Except
 import qualified Control.Monad.State as ST
 import Text.Parsec hiding ((<|>))
 import Text.Parsec.Expr
@@ -57,10 +58,10 @@ import Language.DifferentialDatalog.Error
 import {-# SOURCE #-} Language.DifferentialDatalog.Expr
 
 -- parse a string containing a datalog program and produce the intermediate representation
-parseDatalogString :: String -> String -> IO DatalogProgram
+parseDatalogString :: String -> String -> ExceptT String IO DatalogProgram
 parseDatalogString program file = do
   case parse datalogGrammar file program of
-       Left  e    -> errorWithoutStackTrace $ "Failed to parse input file: " ++ show e
+       Left  e    -> throwE $ "failed to parse input file: " ++ show e
        Right prog -> return prog { progSources = M.singleton file program }
 
 -- The following Rust keywords are declared as Datalog keywords to

--- a/src/Language/DifferentialDatalog/Pos.hs
+++ b/src/Language/DifferentialDatalog/Pos.hs
@@ -49,13 +49,13 @@ instance WithPos Pos where
 
 spos :: (WithPos a) => a -> String
 spos x = let (s,e) = pos x
-         in sourceName s ++ ":" ++ (show $ sourceLine s) ++ ":" ++ (show $ sourceColumn s) ++ "-"
-                                ++ (show $ sourceLine e) ++ ":" ++ (show $ sourceColumn e)
+         in sourceName s ++ ":" ++ (show $ sourceLine s) ++ "." ++ (show $ sourceColumn s) ++ "-"
+                                ++ (show $ sourceLine e) ++ "." ++ (show $ sourceColumn e)
 
 -- Returns a string describing a program position and a fragment of the
 -- source program around the position (if the position is valid)
 -- Here is an example result:
--- error: ./test/datalog_tests/function.fail.dl:4:5-4:6:Expression is not a struct
+-- error: ./test/datalog_tests/function.fail.dl:4.5-4.6:Expression is not a struct
 --    x.bar
 --    ^
 sposFragment :: (WithPos a) => a -> M.Map String String -> String -> String

--- a/src/Language/DifferentialDatalog/Util.hs
+++ b/src/Language/DifferentialDatalog/Util.hs
@@ -1,5 +1,5 @@
 {-
-Copyright (c) 2018-2020 VMware, Inc.
+Copyright (c) 2018-2021 VMware, Inc.
 SPDX-License-Identifier: MIT
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -36,9 +36,10 @@ import Data.Word
 import Data.Binary.Get
 import qualified Data.Map as M
 import qualified Data.ByteString.Lazy as BL
+import System.Console.ANSI
 import System.Directory
 import System.FilePath
-import System.IO hiding (readFile, writeFile, stdout, stderr)
+import System.IO hiding (readFile, writeFile, stdout)
 import System.Process
 import System.Exit
 
@@ -256,3 +257,12 @@ runCommandReportingErr process_name command args working_dir = do
 -- non-Windows-compatibles 'MissingH' crate.
 replace :: (Eq a) => [a] -> [a] -> [a] -> [a]
 replace old replacement = intercalate replacement . splitOn old
+
+-- | Print compilation error and exit the program.
+compilerError :: String -> IO a
+compilerError e = do
+    hPutStrLn stderr ""
+    hSetSGR stderr [SetColor Foreground Vivid Red]
+    hPutStrLn stderr $ "error: " ++ e
+    hSetSGR stderr []
+    exitWith $ ExitFailure 1

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -194,7 +194,10 @@ parserTest fname = do
         writeFile astfile (show prog ++ "\n")
         -- parse reference output
         fdata <- readFile astfile
-        prog' <- parseDatalogString fdata astfile
+        parsed <- runExceptT $ parseDatalogString fdata astfile
+        prog' <- case parsed of
+                      Left e    -> errorWithoutStackTrace e
+                      Right res -> return res
         removeFile astfile
         -- expect the same result
         assertEqual "Pretty-printed Datalog differs from original input" (show prog) (show prog')

--- a/test/datalog_tests/comment.fail.ast.expected
+++ b/test/datalog_tests/comment.fail.ast.expected
@@ -1,3 +1,3 @@
-Failed to parse input file: "./test/datalog_tests/comment.fail.dl" (line 2, column 1):
+error: failed to parse input file: "./test/datalog_tests/comment.fail.dl" (line 2, column 1):
 unexpected end of input
 expecting end of comment

--- a/test/datalog_tests/constr.fail.ast.expected
+++ b/test/datalog_tests/constr.fail.ast.expected
@@ -28,4 +28,4 @@ error: ./test/datalog_tests/constr.fail.dl:4.1-7.1: The following type variables
 typedef Parameterized<'A,'B,'C,'D> = Option1{x: 'A}
 ^
 
-./test/datalog_tests/constr.fail.dl:6.54-7.1: Unknown module vm.  Did you forget to import it?
+error: ./test/datalog_tests/constr.fail.dl:6.54-7.1: Unknown module vm.  Did you forget to import it?

--- a/test/datalog_tests/constr.fail.ast.expected
+++ b/test/datalog_tests/constr.fail.ast.expected
@@ -2,9 +2,9 @@ Failed to parse input file: "./test/datalog_tests/constr.fail.dl" (line 2, colum
 unexpected '{'
 expecting "#", "import", "typedef", "extern", "input", "output", "relation", "stream", "multiset", "index", "function", "transformer", variable name, "&", relation name, "apply", "for" or end of input
 
-error: ./test/datalog_tests/constr.fail.dl:4:13-4:29: Multiple definitions of constructor C at the following locations:
-  ./test/datalog_tests/constr.fail.dl:4:13-4:29
-  ./test/datalog_tests/constr.fail.dl:5:13-7:1
+error: ./test/datalog_tests/constr.fail.dl:4.13-4.29: Multiple definitions of constructor C at the following locations:
+  ./test/datalog_tests/constr.fail.dl:4.13-4.29
+  ./test/datalog_tests/constr.fail.dl:5.13-7.1
 typedef t = C { f: bigint } |
             ^^^^^^^^^^^^^^^^
 
@@ -20,12 +20,12 @@ Failed to parse input file: "./test/datalog_tests/constr.fail.dl" (line 4, colum
 unexpected F
 expecting function name
 
-error: ./test/datalog_tests/constr.fail.dl:4:15-7:1: Field x is declared with different types
+error: ./test/datalog_tests/constr.fail.dl:4.15-7.1: Field x is declared with different types
 typedef Alt = C0{x: bit<16>}
               ^
 
-error: ./test/datalog_tests/constr.fail.dl:4:1-7:1: The following type variables are not used in type definition: D
+error: ./test/datalog_tests/constr.fail.dl:4.1-7.1: The following type variables are not used in type definition: D
 typedef Parameterized<'A,'B,'C,'D> = Option1{x: 'A}
 ^
 
-./test/datalog_tests/constr.fail.dl:6:54-7:1: Unknown module vm.  Did you forget to import it?
+./test/datalog_tests/constr.fail.dl:6.54-7.1: Unknown module vm.  Did you forget to import it?

--- a/test/datalog_tests/constr.fail.ast.expected
+++ b/test/datalog_tests/constr.fail.ast.expected
@@ -1,4 +1,4 @@
-Failed to parse input file: "./test/datalog_tests/constr.fail.dl" (line 2, column 23):
+error: failed to parse input file: "./test/datalog_tests/constr.fail.dl" (line 2, column 23):
 unexpected '{'
 expecting "#", "import", "typedef", "extern", "input", "output", "relation", "stream", "multiset", "index", "function", "transformer", variable name, "&", relation name, "apply", "for" or end of input
 
@@ -8,15 +8,15 @@ error: ./test/datalog_tests/constr.fail.dl:4.13-4.29: Multiple definitions of co
 typedef t = C { f: bigint } |
             ^^^^^^^^^^^^^^^^
 
-Failed to parse input file: "./test/datalog_tests/constr.fail.dl" (line 4, column 9):
+error: failed to parse input file: "./test/datalog_tests/constr.fail.dl" (line 4, column 9):
 unexpected "("
 expecting end of "function" or function name
 
-Failed to parse input file: "./test/datalog_tests/constr.fail.dl" (line 4, column 34):
+error: failed to parse input file: "./test/datalog_tests/constr.fail.dl" (line 4, column 34):
 unexpected "{"
 expecting "::", "<", "," or "}"
 
-Failed to parse input file: "./test/datalog_tests/constr.fail.dl" (line 4, column 10):
+error: failed to parse input file: "./test/datalog_tests/constr.fail.dl" (line 4, column 10):
 unexpected F
 expecting function name
 

--- a/test/datalog_tests/dupfield.fail.ast.expected
+++ b/test/datalog_tests/dupfield.fail.ast.expected
@@ -4,6 +4,6 @@ error: ./test/datalog_tests/dupfield.fail.dl:2.22-2.31: Multiple definitions of 
 typedef t = Constr { f: bigint, f: bigint }
                      ^^^^^^^^^
 
-Failed to parse input file: "./test/datalog_tests/dupfield.fail.dl" (line 6, column 1):
+error: failed to parse input file: "./test/datalog_tests/dupfield.fail.dl" (line 6, column 1):
 unexpected end of input
 expecting "=" or "{"

--- a/test/datalog_tests/dupfield.fail.ast.expected
+++ b/test/datalog_tests/dupfield.fail.ast.expected
@@ -1,6 +1,6 @@
-error: ./test/datalog_tests/dupfield.fail.dl:2:22-2:31: Multiple definitions of argument f at the following locations:
-  ./test/datalog_tests/dupfield.fail.dl:2:22-2:31
-  ./test/datalog_tests/dupfield.fail.dl:2:33-2:43
+error: ./test/datalog_tests/dupfield.fail.dl:2.22-2.31: Multiple definitions of argument f at the following locations:
+  ./test/datalog_tests/dupfield.fail.dl:2.22-2.31
+  ./test/datalog_tests/dupfield.fail.dl:2.33-2.43
 typedef t = Constr { f: bigint, f: bigint }
                      ^^^^^^^^^
 

--- a/test/datalog_tests/function.fail.ast.expected
+++ b/test/datalog_tests/function.fail.ast.expected
@@ -26,7 +26,7 @@ error: ./test/datalog_tests/function.fail.dl:8.16-8.27: Type constructor in the 
     T{.field = Some{var s}} = x
                ^^^^^^^^^^^
 
-Failed to parse input file: "./test/datalog_tests/function.fail.dl" (line 5, column 1):
+error: failed to parse input file: "./test/datalog_tests/function.fail.dl" (line 5, column 1):
 unexpected "f"
 expecting "=" or "{"
 
@@ -50,7 +50,7 @@ error: ./test/datalog_tests/function.fail.dl:3.35-5.1: Cannot type-cast expressi
 function cast(x: bit<16>): bool = x as bool
                                   ^
 
-Failed to parse input file: "./test/datalog_tests/function.fail.dl" (line 3, column 30):
+error: failed to parse input file: "./test/datalog_tests/function.fail.dl" (line 3, column 30):
 unexpected "3"
 expecting "bit", "signed", "bigint", "double", "float", "string", "bool", "#", constructor name, type name, "'", "function", "|", "(" or ">"
 
@@ -78,7 +78,7 @@ expression 'false'
     return false
            ^
 
-Failed to parse input file: "./test/datalog_tests/function.fail.dl" (line 9, column 1):
+error: failed to parse input file: "./test/datalog_tests/function.fail.dl" (line 9, column 1):
 unexpected end of input
 expecting "," or "."
 

--- a/test/datalog_tests/function.fail.ast.expected
+++ b/test/datalog_tests/function.fail.ast.expected
@@ -1,12 +1,12 @@
-error: ./test/datalog_tests/function.fail.dl:3:5-3:10: Variable declaration is not allowed in this context
+error: ./test/datalog_tests/function.fail.dl:3.5-3.10: Variable declaration is not allowed in this context
     var x: bigint
     ^^^^^
 
-error: ./test/datalog_tests/function.fail.dl:13:13-14:1: Missing field 'f2' in constructor C
+error: ./test/datalog_tests/function.fail.dl:13.13-14.1: Missing field 'f2' in constructor C
     var z = C{.f1 = "foo"}
             ^
 
-error: ./test/datalog_tests/function.fail.dl:11:17-11:18: Type mismatch:
+error: ./test/datalog_tests/function.fail.dl:11.17-11.18: Type mismatch:
 expected type: bool
 actual type: bit<32>
 in
@@ -14,15 +14,15 @@ expression 'var w'
         C0{.x = w: bool} -> w,
                 ^
 
-error: ./test/datalog_tests/function.fail.dl:6:13-7:1: Access to guarded field 'x' (not all constructors of type 'ddlog_std::Option' have this field).
+error: ./test/datalog_tests/function.fail.dl:6.13-7.1: Access to guarded field 'x' (not all constructors of type 'ddlog_std::Option' have this field).
     var b = a.x
             ^
 
-error: ./test/datalog_tests/function.fail.dl:6:5-6:17: Type constructor in the left-hand side of an assignment is only allowed for types with one constructor,  but "ddlog_std::Option" has multiple constructors
+error: ./test/datalog_tests/function.fail.dl:6.5-6.17: Type constructor in the left-hand side of an assignment is only allowed for types with one constructor,  but "ddlog_std::Option" has multiple constructors
     Some{var s} = x
     ^^^^^^^^^^^^
 
-error: ./test/datalog_tests/function.fail.dl:8:16-8:27: Type constructor in the left-hand side of an assignment is only allowed for types with one constructor,  but "ddlog_std::Option" has multiple constructors
+error: ./test/datalog_tests/function.fail.dl:8.16-8.27: Type constructor in the left-hand side of an assignment is only allowed for types with one constructor,  but "ddlog_std::Option" has multiple constructors
     T{.field = Some{var s}} = x
                ^^^^^^^^^^^
 
@@ -30,23 +30,23 @@ Failed to parse input file: "./test/datalog_tests/function.fail.dl" (line 5, col
 unexpected "f"
 expecting "=" or "{"
 
-error: ./test/datalog_tests/function.fail.dl:4:5-4:6: expression 'x' must have a field named 'bar', but its type 'bigint' doesn't
+error: ./test/datalog_tests/function.fail.dl:4.5-4.6: expression 'x' must have a field named 'bar', but its type 'bigint' doesn't
     x.bar // x is not a struct
     ^
 
-error: ./test/datalog_tests/function.fail.dl:3:41-5:1: Conversion between signed and unsigned bit vectors only supported across types of the same bit width. Try casting to signed<32> first.
+error: ./test/datalog_tests/function.fail.dl:3.41-5.1: Conversion between signed and unsigned bit vectors only supported across types of the same bit width. Try casting to signed<32> first.
 function cast(x: bit<32>): signed<64> = x as signed<64>
                                         ^
 
-error: ./test/datalog_tests/function.fail.dl:3:41-5:1: Conversion between signed and unsigned bit vectors only supported across types of the same bit width. Try casting to bit<32> first.
+error: ./test/datalog_tests/function.fail.dl:3.41-5.1: Conversion between signed and unsigned bit vectors only supported across types of the same bit width. Try casting to bit<32> first.
 function cast(x: signed<32>): bit<64> = x as bit<64>
                                         ^
 
-error: ./test/datalog_tests/function.fail.dl:3:37-5:1: Direct casts from bigint to bit<> are not supported; consider going through signed<>("./test/datalog_tests/function.fail.dl" (line 3, column 37),"./test/datalog_tests/function.fail.dl" (line 3, column 39))
+error: ./test/datalog_tests/function.fail.dl:3.37-5.1: Direct casts from bigint to bit<> are not supported; consider going through signed<>("./test/datalog_tests/function.fail.dl" (line 3, column 37),"./test/datalog_tests/function.fail.dl" (line 3, column 39))
 function cast(x: bigint): bit<64> = x as bit<64>
                                     ^
 
-error: ./test/datalog_tests/function.fail.dl:3:35-5:1: Cannot type-cast expression to bool.  Only numeric types can be cast to.
+error: ./test/datalog_tests/function.fail.dl:3.35-5.1: Cannot type-cast expression to bool.  Only numeric types can be cast to.
 function cast(x: bit<16>): bool = x as bool
                                   ^
 
@@ -54,23 +54,23 @@ Failed to parse input file: "./test/datalog_tests/function.fail.dl" (line 3, col
 unexpected "3"
 expecting "bit", "signed", "bigint", "double", "float", "string", "bool", "#", constructor name, type name, "'", "function", "|", "(" or ">"
 
-error: ./test/datalog_tests/function.fail.dl:3:37-5:1: There are no direct casts from floating point to integers; use the library functions int_from_*.double
+error: ./test/datalog_tests/function.fail.dl:3.37-5.1: There are no direct casts from floating point to integers; use the library functions int_from_*.double
 function cast(x: double): bit<32> = x as bit<32>
                                     ^
 
-error: ./test/datalog_tests/function.fail.dl:3:34-5:1: Cannot type-cast expression of type string.  The type-cast operator is only supported for numeric types.
+error: ./test/datalog_tests/function.fail.dl:3.34-5.1: Cannot type-cast expression of type string.  The type-cast operator is only supported for numeric types.
 function cast(x: string): bool = x as bool
                                  ^
 
-error: ./test/datalog_tests/function.fail.dl:6:5-7:1: "continue" outside of a loop
+error: ./test/datalog_tests/function.fail.dl:6.5-7.1: "continue" outside of a loop
     continue
     ^
 
-error: ./test/datalog_tests/function.fail.dl:8:9-8:18: Expression is not an l-value
+error: ./test/datalog_tests/function.fail.dl:8.9-8.18: Expression is not an l-value
         continue = true
         ^^^^^^^^^
 
-error: ./test/datalog_tests/function.fail.dl:6:12-7:1: Type mismatch:
+error: ./test/datalog_tests/function.fail.dl:6.12-7.1: Type mismatch:
 expected type: ()
 actual type: bool
 in
@@ -82,19 +82,19 @@ Failed to parse input file: "./test/datalog_tests/function.fail.dl" (line 9, col
 unexpected end of input
 expecting "," or "."
 
-error: ./test/datalog_tests/function.fail.dl:7:5-8:1: Upper bound of the slice exceeds argument width
+error: ./test/datalog_tests/function.fail.dl:7.5-8.1: Upper bound of the slice exceeds argument width
     x[31:0]
     ^
 
-error: ./test/datalog_tests/function.fail.dl:6:5-6:9: Expression is not an l-value
+error: ./test/datalog_tests/function.fail.dl:6.5-6.9: Expression is not an l-value
     x.0 = "bar";
     ^^^^
 
-error: ./test/datalog_tests/function.fail.dl:7:5-7:9: Expression is not an l-value
+error: ./test/datalog_tests/function.fail.dl:7.5-7.9: Expression is not an l-value
     x.0 = "foo";
     ^^^^
 
-error: ./test/datalog_tests/function.fail.dl:10:16-10:29: Type mismatch:
+error: ./test/datalog_tests/function.fail.dl:10.16-10.29: Type mismatch:
 expected type: bool
 actual type: ddlog_std::Option<bool>
 in
@@ -105,13 +105,13 @@ expression 'bool_identity'
   (Tagg{.col = bool_identity(any)})
                ^^^^^^^^^^^^^
 
-error: ./test/datalog_tests/function.fail.dl:5:1-6:1: Extern function 'foo' clashes with function declaration(s) at
-  ./test/datalog_tests/function.fail.dl:6:1-8:1
+error: ./test/datalog_tests/function.fail.dl:5.1-6.1: Extern function 'foo' clashes with function declaration(s) at
+  ./test/datalog_tests/function.fail.dl:6.1-8.1
 Only non-extern functions can be overloaded.
 extern function foo(x: u32): ()
 ^
 
-error: ./test/datalog_tests/function.fail.dl:6:5-10:1: Type mismatch:
+error: ./test/datalog_tests/function.fail.dl:6.5-10.1: Type mismatch:
 expected type: ddlog_std::Result<(string,string),string>
 actual type: ddlog_std::Option<'a35>
 in
@@ -122,33 +122,33 @@ expression '{(var components = ([One of [ddlog_std::split, internment::split]](n
     var components = name.split(" ");
     ^
 
-error: ./test/datalog_tests/function.fail.dl:13:5-13:7: Expression is not an l-value
+error: ./test/datalog_tests/function.fail.dl:13.5-13.7: Expression is not an l-value
     y = 0
     ^^
 
-error: ./test/datalog_tests/function.fail.dl:7:9-7:13: Expression is not an l-value
+error: ./test/datalog_tests/function.fail.dl:7.9-7.13: Expression is not an l-value
         val = y
         ^^^^
 
-error: ./test/datalog_tests/function.fail.dl:15:5-15:17: Expression is not an l-value
+error: ./test/datalog_tests/function.fail.dl:15.5-15.17: Expression is not an l-value
     interned.f1 = "bar"
     ^^^^^^^^^^^^
 
-error: ./test/datalog_tests/function.fail.dl:13:9-13:12: Expression is not an l-value
+error: ./test/datalog_tests/function.fail.dl:13.9-13.12: Expression is not an l-value
         vec.push(val)
         ^^^
 
-error: ./test/datalog_tests/function.fail.dl:13:10-13:13: Expression is not an l-value
+error: ./test/datalog_tests/function.fail.dl:13.10-13.13: Expression is not an l-value
     if ({vec.push(3); vec.len()} > 5) { () }
          ^^^
 
-error: ./test/datalog_tests/function.fail.dl:5:20-5:27: Multiple definitions of argument x at the following locations:
-  ./test/datalog_tests/function.fail.dl:5:20-5:27
-  ./test/datalog_tests/function.fail.dl:5:29-5:36
+error: ./test/datalog_tests/function.fail.dl:5.20-5.27: Multiple definitions of argument x at the following locations:
+  ./test/datalog_tests/function.fail.dl:5.20-5.27
+  ./test/datalog_tests/function.fail.dl:5.29-5.36
     var closure = |x: bool, x: bool|: u64 {0};
                    ^^^^^^^
 
-error: ./test/datalog_tests/function.fail.dl:6:16-6:17: Type mismatch:
+error: ./test/datalog_tests/function.fail.dl:6.16-6.17: Type mismatch:
 expected type: function( 'a2):'a0
 actual type: function( bit<16>, bit<16>):bit<16>
 in
@@ -156,7 +156,7 @@ expression 'a'
 function b() { a(0) }
                ^
 
-error: ./test/datalog_tests/function.fail.dl:6:16-6:17: Type mismatch:
+error: ./test/datalog_tests/function.fail.dl:6.16-6.17: Type mismatch:
 expected type: ()
 actual type: bit<16>
 in

--- a/test/datalog_tests/pattern.fail.ast.expected
+++ b/test/datalog_tests/pattern.fail.ast.expected
@@ -42,6 +42,6 @@ error: ./test/datalog_tests/pattern.fail.dl:6.12-6.13: Non-exhaustive match patt
     match (s) {
            ^
 
-Failed to parse input file: "./test/datalog_tests/pattern.fail.dl" (line 7, column 14):
+error: failed to parse input file: "./test/datalog_tests/pattern.fail.dl" (line 7, column 14):
 unexpected 'o'
 expecting operator

--- a/test/datalog_tests/pattern.fail.ast.expected
+++ b/test/datalog_tests/pattern.fail.ast.expected
@@ -1,44 +1,44 @@
-error: ./test/datalog_tests/pattern.fail.dl:7:12-7:13: Non-exhaustive match patterns
+error: ./test/datalog_tests/pattern.fail.dl:7.12-7.13: Non-exhaustive match patterns
     match (x) {
            ^
 
-error: ./test/datalog_tests/pattern.fail.dl:11:9-11:13: Unsatisfiable match pattern
+error: ./test/datalog_tests/pattern.fail.dl:11.9-11.13: Unsatisfiable match pattern
         C11 -> true,
         ^^^^
 
-error: ./test/datalog_tests/pattern.fail.dl:12:12-12:13: Non-exhaustive match patterns
+error: ./test/datalog_tests/pattern.fail.dl:12.12-12.13: Non-exhaustive match patterns
     match (x) {
            ^
 
-error: ./test/datalog_tests/pattern.fail.dl:15:9-15:25: Unsatisfiable match pattern
+error: ./test/datalog_tests/pattern.fail.dl:15.9-15.25: Unsatisfiable match pattern
         C22{(_, C11{})} -> true  // redundant
         ^^^^^^^^^^^^^^^^
 
-error: ./test/datalog_tests/pattern.fail.dl:16:9-16:25: Unsatisfiable match pattern
+error: ./test/datalog_tests/pattern.fail.dl:16.9-16.25: Unsatisfiable match pattern
         _               -> false
         ^^^^^^^^^^^^^^^^
 
-error: ./test/datalog_tests/pattern.fail.dl:6:12-6:13: Non-exhaustive match patterns
+error: ./test/datalog_tests/pattern.fail.dl:6.12-6.13: Non-exhaustive match patterns
     match (z) {
            ^
 
-error: ./test/datalog_tests/pattern.fail.dl:12:9-12:37: Unsatisfiable match pattern
+error: ./test/datalog_tests/pattern.fail.dl:12.9-12.37: Unsatisfiable match pattern
         (false, (_,(false, false))) -> true
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: ./test/datalog_tests/pattern.fail.dl:6:12-6:13: Non-exhaustive match patterns
+error: ./test/datalog_tests/pattern.fail.dl:6.12-6.13: Non-exhaustive match patterns
     match (z) {
            ^
 
-error: ./test/datalog_tests/pattern.fail.dl:12:12-12:13: Non-exhaustive match patterns
+error: ./test/datalog_tests/pattern.fail.dl:12.12-12.13: Non-exhaustive match patterns
     match (q) {
            ^
 
-error: ./test/datalog_tests/pattern.fail.dl:12:12-12:13: Non-exhaustive match patterns
+error: ./test/datalog_tests/pattern.fail.dl:12.12-12.13: Non-exhaustive match patterns
     match (q) {
            ^
 
-error: ./test/datalog_tests/pattern.fail.dl:6:12-6:13: Non-exhaustive match patterns
+error: ./test/datalog_tests/pattern.fail.dl:6.12-6.13: Non-exhaustive match patterns
     match (s) {
            ^
 

--- a/test/datalog_tests/rectype.fail.ast.expected
+++ b/test/datalog_tests/rectype.fail.ast.expected
@@ -1,21 +1,21 @@
-error: ./test/datalog_tests/rectype.fail.dl:3:1-5:1: Recursive alias types: t -> t
+error: ./test/datalog_tests/rectype.fail.dl:3.1-5.1: Recursive alias types: t -> t
 typedef t = t
 ^
 
-error: ./test/datalog_tests/rectype.fail.dl:3:1-5:1: Recursive alias types: t -> t
+error: ./test/datalog_tests/rectype.fail.dl:3.1-5.1: Recursive alias types: t -> t
 typedef t = ( t, t )
 ^
 
-error: ./test/datalog_tests/rectype.fail.dl:3:1-4:1: Recursive alias types: t -> t1 -> t
+error: ./test/datalog_tests/rectype.fail.dl:3.1-4.1: Recursive alias types: t -> t1 -> t
 typedef t = t1
 ^
 
-./test/datalog_tests/rectype.fail.dl:3:13-5:1: Unknown type 'undef'
+./test/datalog_tests/rectype.fail.dl:3.13-5.1: Unknown type 'undef'
 
 Failed to parse input file: "./test/datalog_tests/rectype.fail.dl" (line 4, column 13):
 unexpected "{"
 expecting "bit", "signed", "bigint", "double", "float", "string", "bool", "#", constructor name, type name, "'", "function", "|" or "("
 
-error: ./test/datalog_tests/rectype.fail.dl:5:1-6:1: Recursive alias types: TSeq2 -> TSeq2
+error: ./test/datalog_tests/rectype.fail.dl:5.1-6.1: Recursive alias types: TSeq2 -> TSeq2
 typedef TSeq2 = Option<(string, Ref<TSeq2>)>
 ^

--- a/test/datalog_tests/rectype.fail.ast.expected
+++ b/test/datalog_tests/rectype.fail.ast.expected
@@ -12,7 +12,7 @@ typedef t = t1
 
 error: ./test/datalog_tests/rectype.fail.dl:3.13-5.1: Unknown type 'undef'
 
-Failed to parse input file: "./test/datalog_tests/rectype.fail.dl" (line 4, column 13):
+error: failed to parse input file: "./test/datalog_tests/rectype.fail.dl" (line 4, column 13):
 unexpected "{"
 expecting "bit", "signed", "bigint", "double", "float", "string", "bool", "#", constructor name, type name, "'", "function", "|" or "("
 

--- a/test/datalog_tests/rectype.fail.ast.expected
+++ b/test/datalog_tests/rectype.fail.ast.expected
@@ -10,7 +10,7 @@ error: ./test/datalog_tests/rectype.fail.dl:3.1-4.1: Recursive alias types: t ->
 typedef t = t1
 ^
 
-./test/datalog_tests/rectype.fail.dl:3.13-5.1: Unknown type 'undef'
+error: ./test/datalog_tests/rectype.fail.dl:3.13-5.1: Unknown type 'undef'
 
 Failed to parse input file: "./test/datalog_tests/rectype.fail.dl" (line 4, column 13):
 unexpected "{"

--- a/test/datalog_tests/rules.fail.ast.expected
+++ b/test/datalog_tests/rules.fail.ast.expected
@@ -64,7 +64,7 @@ IntClosures(|x| {x = 10; x} ).
 
 ./test/datalog_tests/rules.fail.dl:10.29-10.43: 'group_by' operator can occur at most once in an expression. Previous occurrence: ("./test/datalog_tests/rules.fail.dl" (line 10, column 16),"./test/datalog_tests/rules.fail.dl" (line 10, column 17))
 
-./test/datalog_tests/rules.fail.dl:6.6-6.15: Unknown function 'group_by'
+error: ./test/datalog_tests/rules.fail.dl:6.6-6.15: Unknown function 'group_by'
     x.group_by(y)
      ^^^^^^^^^
 

--- a/test/datalog_tests/rules.fail.ast.expected
+++ b/test/datalog_tests/rules.fail.ast.expected
@@ -2,22 +2,22 @@ Failed to parse input file: "./test/datalog_tests/rules.fail.dl" (line 3, column
 unexpected ":"
 expecting letter or digit, "_", "::", "(" or "["
 
-./test/datalog_tests/rules.fail.dl:5:1-7:1: Multiple definitions of type R1 at the following locations:
-  ./test/datalog_tests/rules.fail.dl:5:1-7:1
-  ./test/datalog_tests/rules.fail.dl:7:1-9:1
+./test/datalog_tests/rules.fail.dl:5.1-7.1: Multiple definitions of type R1 at the following locations:
+  ./test/datalog_tests/rules.fail.dl:5.1-7.1
+  ./test/datalog_tests/rules.fail.dl:7.1-9.1
 
 
-error: ./test/datalog_tests/rules.fail.dl:10:1-11:1: Relation R3 is mutually recursive with R2 and therefore cannot appear negated in this rule.
+error: ./test/datalog_tests/rules.fail.dl:10.1-11.1: Relation R3 is mutually recursive with R2 and therefore cannot appear negated in this rule.
 Dependency cycle: R3 -> R2 -> R3
 R2(x) :- R1(x), not R3(x, "foo").
 ^
 
-error: ./test/datalog_tests/rules.fail.dl:9:1-11:1: Relation R2 is mutually recursive with R2 and therefore cannot appear negated in this rule.
+error: ./test/datalog_tests/rules.fail.dl:9.1-11.1: Relation R2 is mutually recursive with R2 and therefore cannot appear negated in this rule.
 Dependency cycle: R2 -> R2
 R2(x) :- R1(x), not R2(x).
 ^
 
-error: ./test/datalog_tests/rules.fail.dl:9:28-9:39: Type mismatch:
+error: ./test/datalog_tests/rules.fail.dl:9.28-9.39: Type mismatch:
 expected type: (string,string)
 actual type: string
 in
@@ -31,7 +31,7 @@ expression 'concat_ys'
     var s = Aggregate((x,z), concat_ys(y)).
                            ^^^^^^^^^^^
 
-error: ./test/datalog_tests/rules.fail.dl:9:28-9:39: Type mismatch:
+error: ./test/datalog_tests/rules.fail.dl:9.28-9.39: Type mismatch:
 expected type: string
 actual type: bigint
 in
@@ -48,35 +48,35 @@ expression 'concat_ys'
     var s = Aggregate((x,z), concat_ys(y)).
                            ^^^^^^^^^^^
 
-error: ./test/datalog_tests/rules.fail.dl:9:13-9:18: expression '(1 + 2)' of a numeric type appears in a context where type '()' is expected
+error: ./test/datalog_tests/rules.fail.dl:9.13-9.18: expression '(1 + 2)' of a numeric type appears in a context where type '()' is expected
     Inspect 1 + 2.
             ^^^^^
 
-error: ./test/datalog_tests/rules.fail.dl:10:19-10:28: ?-expressions are only allowed in the body of a function or closure
+error: ./test/datalog_tests/rules.fail.dl:10.19-10.28: ?-expressions are only allowed in the body of a function or closure
           var z = y.nth(5)?.
                   ^^^^^^^^^
 
-error: ./test/datalog_tests/rules.fail.dl:6:18-6:20: Expression is not an l-value
+error: ./test/datalog_tests/rules.fail.dl:6.18-6.20: Expression is not an l-value
 IntClosures(|x| {x = 10; x} ).
                  ^^
 
-./test/datalog_tests/rules.fail.dl:10:13-10:29: The 'group_by' operator must be invoked with two arguments, e.g., 'expr1.group_by(expr2)' or 'group_by(expr1, expr2)', but it is invoked with 3
+./test/datalog_tests/rules.fail.dl:10.13-10.29: The 'group_by' operator must be invoked with two arguments, e.g., 'expr1.group_by(expr2)' or 'group_by(expr1, expr2)', but it is invoked with 3
 
-./test/datalog_tests/rules.fail.dl:10:29-10:43: 'group_by' operator can occur at most once in an expression. Previous occurrence: ("./test/datalog_tests/rules.fail.dl" (line 10, column 16),"./test/datalog_tests/rules.fail.dl" (line 10, column 17))
+./test/datalog_tests/rules.fail.dl:10.29-10.43: 'group_by' operator can occur at most once in an expression. Previous occurrence: ("./test/datalog_tests/rules.fail.dl" (line 10, column 16),"./test/datalog_tests/rules.fail.dl" (line 10, column 17))
 
-./test/datalog_tests/rules.fail.dl:6:6-6:15: Unknown function 'group_by'
+./test/datalog_tests/rules.fail.dl:6.6-6.15: Unknown function 'group_by'
     x.group_by(y)
      ^^^^^^^^^
 
-error: ./test/datalog_tests/rules.fail.dl:10:26-10:31: Group-by expression must be a variable or a tuple of variables, e.g., 'group_by(x)' or 'group_by((x,y))'
+error: ./test/datalog_tests/rules.fail.dl:10.26-10.31: Group-by expression must be a variable or a tuple of variables, e.g., 'group_by(x)' or 'group_by((x,y))'
     var sz = ().group_by(x + y).size().
                          ^^^^^
 
-error: ./test/datalog_tests/rules.fail.dl:10:29-10:34: Group-by expression must be a variable or a tuple of variables, e.g., 'group_by(x)' or 'group_by((x,y))'
+error: ./test/datalog_tests/rules.fail.dl:10.29-10.34: Group-by expression must be a variable or a tuple of variables, e.g., 'group_by(x)' or 'group_by((x,y))'
     var sz = ().group_by((x,x + y)).size().
                             ^^^^^
 
-error: ./test/datalog_tests/rules.fail.dl:10:21-10:22: Type mismatch:
+error: ./test/datalog_tests/rules.fail.dl:10.21-10.22: Type mismatch:
 expected type: bit<64>
 actual type: ddlog_std::Option<ddlog_std::usize<>>
 in
@@ -84,38 +84,38 @@ variable 'x'
     var x = FlatMap(v).
                     ^
 
-error: ./test/datalog_tests/rules.fail.dl:10:5-10:11: Variable y already defined in this scope
+error: ./test/datalog_tests/rules.fail.dl:10.5-10.11: Variable y already defined in this scope
     var y = x.
     ^^^^^^
 
-error: ./test/datalog_tests/rules.fail.dl:10:21-10:22: Variable y already defined in this scope
+error: ./test/datalog_tests/rules.fail.dl:10.21-10.22: Variable y already defined in this scope
     var y = FlatMap(y).
                     ^
 
-error: ./test/datalog_tests/rules.fail.dl:10:23-10:31: Attempt to join stream relation 'S2' and the stream produced by the prefix of the rule before this literal. Stream joins are currently not supported.
+error: ./test/datalog_tests/rules.fail.dl:10.23-10.31: Attempt to join stream relation 'S2' and the stream produced by the prefix of the rule before this literal. Stream joins are currently not supported.
 S3(x, z) :- S1(x, y), S2(y, z).
                       ^^^^^^^^
 
-error: ./test/datalog_tests/rules.fail.dl:10:1-10:10: The body of the rule yields a stream relation, but relation 'S3' in the head of the rule is not declared as a stream.
+error: ./test/datalog_tests/rules.fail.dl:10.1-10.10: The body of the rule yields a stream relation, but relation 'S3' in the head of the rule is not declared as a stream.
 S3(x, z) :- S1(x, y), S2(y, z).
 ^^^^^^^^^
 
-error: ./test/datalog_tests/rules.fail.dl:10:1-10:10: Relation 'S3' in the head of the rule is declared as a stream, but the body of the rule computes a regular non-stream relation.
+error: ./test/datalog_tests/rules.fail.dl:10.1-10.10: Relation 'S3' in the head of the rule is declared as a stream, but the body of the rule computes a regular non-stream relation.
 S3(x, z) :- S1(x, y), S2(y, z).
 ^^^^^^^^^
 
-error: ./test/datalog_tests/rules.fail.dl:8:31-8:32: Illegal 'group_by' over a stream: only non-stream relations can be aggregated.
+error: ./test/datalog_tests/rules.fail.dl:8.31-8.32: Illegal 'group_by' over a stream: only non-stream relations can be aggregated.
 S2(y, z) :- S1(x, y), var z = x.group_by(y).
                               ^
 
-error: ./test/datalog_tests/rules.fail.dl:9:27-9:35: Unsupported antijoin. The prefix of the rule before this literal produces a stream. Antijoins with streams are currently not supported.
+error: ./test/datalog_tests/rules.fail.dl:9.27-9.35: Unsupported antijoin. The prefix of the rule before this literal produces a stream. Antijoins with streams are currently not supported.
 S3(x, y) :- S1(x, y), not S2(y, _).
                           ^^^^^^^^
 
-error: ./test/datalog_tests/rules.fail.dl:9:27-9:35: Attempt to negate a stream relation 'S2'.  This is currently not supported.
+error: ./test/datalog_tests/rules.fail.dl:9.27-9.35: Attempt to negate a stream relation 'S2'.  This is currently not supported.
 S3(x, y) :- S1(x, y), not S2(y, _).
                           ^^^^^^^^
 
-error: ./test/datalog_tests/rules.fail.dl:10:10-10:15: Stream 'S2' occurs inside a recursive fragment consisting of: [S2,S3]
+error: ./test/datalog_tests/rules.fail.dl:10.10-10.15: Stream 'S2' occurs inside a recursive fragment consisting of: [S2,S3]
 S3(x) :- S2(x).
          ^^^^^

--- a/test/datalog_tests/rules.fail.ast.expected
+++ b/test/datalog_tests/rules.fail.ast.expected
@@ -1,4 +1,4 @@
-Failed to parse input file: "./test/datalog_tests/rules.fail.dl" (line 3, column 18):
+error: failed to parse input file: "./test/datalog_tests/rules.fail.dl" (line 3, column 18):
 unexpected ":"
 expecting letter or digit, "_", "::", "(" or "["
 

--- a/test/datalog_tests/strings.fail.ast.expected
+++ b/test/datalog_tests/strings.fail.ast.expected
@@ -1,4 +1,4 @@
-Failed to parse input file: "./test/datalog_tests/strings.fail.dl" (line 5, column 28):
+error: failed to parse input file: "./test/datalog_tests/strings.fail.dl" (line 5, column 28):
 unexpected ";"
 expecting literal string
 "./test/datalog_tests/strings.fail.dl" (line 5, column 27):

--- a/test/datalog_tests/strings.fail.ast.expected
+++ b/test/datalog_tests/strings.fail.ast.expected
@@ -5,15 +5,15 @@ expecting literal string
 unexpected end of input
 expecting letter or digit, "_", operator, "+", "-" or "}"
 
-error: ./test/datalog_tests/strings.fail.dl:4:18-4:19: integer value '2' is used in a context where type 'string' is expected
+error: ./test/datalog_tests/strings.fail.dl:4.18-4.19: integer value '2' is used in a context where type 'string' is expected
     var b = "" > 2;
                  ^
 
-error: ./test/datalog_tests/strings.fail.dl:4:19-4:20: integer value '2' is used in a context where type 'string' is expected
+error: ./test/datalog_tests/strings.fail.dl:4.19-4.20: integer value '2' is used in a context where type 'string' is expected
     var c = "" != 2;
                   ^
 
-error: ./test/datalog_tests/strings.fail.dl:4:13-4:21: Type mismatch:
+error: ./test/datalog_tests/strings.fail.dl:4.13-4.21: Type mismatch:
 expected type: bool
 actual type: string
 in
@@ -21,14 +21,14 @@ expression '"string"'
     var s = "string";
             ^^^^^^^^
 
-error: ./test/datalog_tests/strings.fail.dl:7:18-7:19: Cannot find declaration of function 'to_string(Type1): string' needed to convert expression 'x' to string
+error: ./test/datalog_tests/strings.fail.dl:7.18-7.19: Cannot find declaration of function 'to_string(Type1): string' needed to convert expression 'x' to string
     var err = "${x}"; // don't know how to convert x to string
                  ^
 
-error: ./test/datalog_tests/strings.fail.dl:6:24-6:28: Unknown variable: str1
+error: ./test/datalog_tests/strings.fail.dl:6.24-6.28: Unknown variable: str1
     var err = "${str2++str1}"; // str1 is not declared in this scope
                        ^^^^
 
-error: ./test/datalog_tests/strings.fail.dl:16:52-16:53: Cannot find declaration of function 'to_string(serializable_t): string' needed to convert expression 'e' to string
+error: ./test/datalog_tests/strings.fail.dl:16.52-16.53: Cannot find declaration of function 'to_string(serializable_t): string' needed to convert expression 'e' to string
     var err = "a=${a}, b=${b}, c=${c}, d=${d}, e:${e}";
                                                    ^


### PR DESCRIPTION
This isn't right, because I couldn't figure out how to do the equivalent of "fprintf(stderr, ...); exit(1);" in Haskell, but it's a start.