### PR TITLE
Improved handling of iteration in the compiler.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,50 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Language improvements
+
+- Enable pattern matching in `for` loops and `FlatMap`. One can now write:
+    ```
+    for ((k,v) in map) {}
+    ```
+    instead of
+    ```
+    for ((kv in map) { var k = kv.0}
+    ```
+    and
+    ```
+    (var x, var y) = FlatMap(expr)
+    ```
+    instead of:
+    ```
+    var xy = FlatMap(expr),
+    var x = xy.0
+    ```
+
+- Remove the hardwired knowledge about iterable types from the compiler.
+  Until now the compiler only knew how to iterate over `Vec`, `Set`,
+  `Map`, `Group`, and `TinySet` types.  Instead we now allow the programmer
+  to label any extern type as iterable, meaning that it implements `iter()`
+  and `into_iter()` methods, that return Rust iterators using one of two
+  attributes:
+  ```
+  #[iterate_by_ref=iter:<type>]
+  ```
+  or
+  ```
+  #[iterate_by_val=iter:<type>]
+  ```
+  where `type` is the type yielded by the `next()` method of the iterator
+  The former indicates that the `iter()` method returns a by-reference
+  iterator, the latter indicates that `iter()` returns a by-value
+  iterator.
+
+  As a side effect of this change, the compiler no longer distinguishes
+  maps from other cotnainers that over 2-tuples.  Therefore maps are
+  represented as lists of tuples in the Flatbuf-based Java API.
+
 ## [0.36.0] - Feb 7, 2021
 
 ### API changes

--- a/doc/java_api.md
+++ b/doc/java_api.md
@@ -422,5 +422,5 @@ the same table.
 | Struct: `S<t1,..,tN>`  | `S__t1..__tnWriter`                  | `S__t1..__tnReader`      |
 | `Vec<T>`               | `List<T_w>`                          | `List<T_r>`              |
 | `Set<T>`               | `List<T_w>`                          | `List<T_r>`              |
-| `Map<K,V>`             | `Map<K_w,V_w>`                       | `Map<K_r,V_r>`           |
+| `Map<K,V>`             | `List<Tuple2__K_w__V_w>`             | `Map<Tuple2__K_r__V_r>`  |
 | `Ref<T>`               | `T_w`                                | `T_r`                    |

--- a/doc/tutorial/tutorial.md
+++ b/doc/tutorial/tutorial.md
@@ -1481,11 +1481,11 @@ containing item name, vendor, and price:
 function best_vendor_string(g: Group<string, (string, bit<64>)>): string
 {
     var min_vendor = "";
-    var min_price: bit<64> = 'hffffffffffffffff;
-    for (vendor_price in g) {
-        if (vendor_price.1 < min_price) {
-            min_vendor = vendor_price.0;
-            min_price = vendor_price.1
+    var min_price = 'hffffffffffffffff;
+    for ((vendor, price) in g) {
+        if (price < min_price) {
+            min_vendor = vendor;
+            min_price = price;
         }
     };
     "Best deal for ${group_key(g)}: ${min_vendor}, $${min_price}"
@@ -3058,6 +3058,38 @@ function returns a reference in Rust:
 ```
 #[return_by_ref]
 extern function deref(x: Ref<'A>): 'A
+```
+
+### `#[iterate_by_ref]` and `#[iterate_by_val]`
+
+These attributes apply to extern types only and tell the compiler that the given
+type is **iterable**.  Iterable types can be iterated over in a for-loop and
+flattened by `FlatMap`.  The syntax for these attributes is:
+
+```
+#[iterate_by_ref=iter:<type>]
+```
+
+```
+#[iterate_by_val=iter:<type>]
+```
+
+Both variants tell the DDlog compiler that the Rust type that the extern type
+declaration binds to implements the `iter()` method, which returns a type that
+implements the Rust `Iterator` trait, and that the `next()` method of the
+resulting iterator returns values of type `<type>`.  The first form indicates
+that the iterator returns the contents of the collection by reference, while
+the second form indicates that the iterator returns elements in the collection
+by value.
+
+Here are two examples from `ddlog_std.dl`:
+
+```
+#[iterate_by_ref=iter:'A]
+extern type Vec<'A>
+
+#[iterate_by_val=iter:('K,'V)]
+extern type Map<'K,'V>
 ```
 
 ### `#[deserialize_from_array=func()]`

--- a/doc/tutorial/tutorial.md
+++ b/doc/tutorial/tutorial.md
@@ -3011,6 +3011,18 @@ to optimize data structures layout:
 extern type IObj<'A>
 ```
 
+### `#[dyn_alloc]`
+
+This attribute is applicable to `extern type` declarations.  It tells the
+compiler that the type allocates its storage dynamically on the heap.  Rust
+knows the size of the stack-allocated portion of such types statically and
+allows using them as part of recursive typedefs.
+
+```
+#[dyn_alloc]
+extern type Set<'A>
+```
+
 ### `#[custom_serde]`
 
 Tells DDlog not to generate `Serialize` and `Deserialize` implementations for a type.

--- a/java/test_flatbuf1/Test.java
+++ b/java/test_flatbuf1/Test.java
@@ -57,11 +57,11 @@ public class Test {
     }
 
     private String printQI(QIReader v) {
-        Map<Long,String> vs = v.m();
+        List<Tuple2__bit_32___stringReader> vs = v.m();
         ArrayList<String> vs_strs = new ArrayList<String>(vs.size());
-        for (Map.Entry<Long,String> entry : vs.entrySet()) {
-            vs_strs.add(entry.getKey() + "=>\"" + entry.getValue() + "\"");
-        }
+        vs.forEach((t) -> {
+            vs_strs.add(t.a0() + "=>\"" + t.a1() + "\"");
+        });
         return "QI{{" + String.join(", ", vs_strs) + "}}";
     }
 
@@ -117,19 +117,15 @@ public class Test {
         }
     }
 
-    private String printZI5(Map<String, ManyReader> v) {
-        ArrayList<String> strings = new ArrayList<String>(v.size());
-        for (Map.Entry<String, ManyReader> e: v.entrySet()) {
-            strings.add("\"" + e.getKey() + "\"=>" + printMany(e.getValue()));
-        }
+    private String printZI5(List<Tuple2__string__ManyReader> vs) {
+        ArrayList<String> strings = new ArrayList<String>(vs.size());
+        vs.forEach((t) -> strings.add("\"" + t.a0() + "\"=>" + printMany(t.a1())));
         return "{" + String.join(", ", strings) + "}";
     }
 
-    private String printZI11(Map<ManyReader, String> v) {
-        ArrayList<String> strings = new ArrayList<String>(v.size());
-        for (Map.Entry<ManyReader, String> e: v.entrySet()) {
-            strings.add(printMany(e.getKey()) + "=>\"" + e.getValue() + "\"");
-        }
+    private String printZI11(List<Tuple2__Many__stringReader> vs) {
+        ArrayList<String> strings = new ArrayList<String>(vs.size());
+        vs.forEach((t) -> strings.add(printMany(t.a0()) + "=>\"" + t.a1() + "\""));
         return "{" + String.join(", ", strings) + "}";
     }
 
@@ -427,7 +423,7 @@ public class Test {
             }
             // output relation OZI5[Map<string, Many>]
             case typesTestRelation.OZI5: {
-                fb_file.println("From " + relid + " " + command.kind() + " " + printZI5((Map<String, ManyReader>)command.value()));
+                fb_file.println("From " + relid + " " + command.kind() + " " + printZI5((List<Tuple2__string__ManyReader>)command.value()));
                 break;
             }
             // output relation OZI6[Option<string>]
@@ -461,7 +457,7 @@ public class Test {
             }
             // output relation OZI11[Map<Many, string>]
             case typesTestRelation.OZI11: {
-                fb_file.println("From " + relid + " " + command.kind() + " " + printZI11((Map<ManyReader,String>)command.value()));
+                fb_file.println("From " + relid + " " + command.kind() + " " + printZI11((List<Tuple2__Many__stringReader>)command.value()));
                 break;
             }
             // output relation OZI12[(string, bigint, Vec<bigint>, (bit<16>, Many))]
@@ -612,9 +608,9 @@ public class Test {
             builder.insert_PI5(pi);
         }
         {
-            Map<Long, String> map = new HashMap<Long, String>();
-            map.put(Long.valueOf(2), "here");
-            map.put(Long.valueOf(3), "there");
+            ArrayList<Tuple2__bit_32___stringWriter> map = new ArrayList<Tuple2__bit_32___stringWriter>();
+            map.add(builder.create_Tuple2__bit_32___string(2, "here"));
+            map.add(builder.create_Tuple2__bit_32___string(3, "there"));
             builder.insert_QI(map);
         }
         builder.insert_RI(2);
@@ -677,9 +673,9 @@ public class Test {
             builder.insert_ZI4(strings);
         }
         {
-            Map<String, ManyWriter> map = new HashMap<String, ManyWriter>();
-            map.put("key1", builder.create_B(false));
-            map.put("key2", builder.create_A("val2"));
+            ArrayList<Tuple2__string__ManyWriter> map = new ArrayList<Tuple2__string__ManyWriter>();
+            map.add(builder.create_Tuple2__string__Many("key1", builder.create_B(false)));
+            map.add(builder.create_Tuple2__string__Many("key2", builder.create_A("val2")));
             builder.insert_ZI5(map);
         }
         builder.insert_ZI6_ddlog_std_Some("ZI6");
@@ -690,11 +686,11 @@ public class Test {
         builder.insert_ZI9(100);
         builder.insert_ZI10("Ref<IString>");
         {
-            Map<ManyWriter, String> map = new HashMap<ManyWriter, String>();
+            ArrayList<Tuple2__Many__stringWriter> map = new ArrayList<Tuple2__Many__stringWriter>();
             //map.put(builder.create_B(false), "v1");
             // Cannot add more than one record, since the map is printed in
             // non-deterministic order, so the diff fails.
-            map.put(builder.create_A("val2"), "v2");
+            map.add(builder.create_Tuple2__Many__string(builder.create_A("val2"), "v2"));
             builder.insert_ZI11(map);
         }
         {
@@ -1103,12 +1099,16 @@ public class Test {
 
         query_file.println("Query QI_by_m[(2=>\"here\", 3=>\"there\"]:");
         {
-            Map<Long, String> map = new HashMap<Long, String>();
-            map.put(Long.valueOf(2), "here");
-            map.put(Long.valueOf(3), "there");
-            typesTestQuery.queryQI_by_m(this.api, map, v -> {
-                query_file.println(printQI(v));
-            });
+            typesTestQuery.queryQI_by_m(this.api,
+                bldr -> {
+                    ArrayList<Tuple2__bit_32___stringWriter> map = new ArrayList<Tuple2__bit_32___stringWriter>();
+                    map.add(bldr.create_Tuple2__bit_32___string(Long.valueOf(2), "here"));
+                    map.add(bldr.create_Tuple2__bit_32___string(Long.valueOf(3), "there"));
+                    return map;
+                },
+                v -> {
+                    query_file.println(printQI(v));
+                });
         }
 
         query_file.println("Query RI_by_refm[2]:");
@@ -1274,9 +1274,9 @@ public class Test {
         query_file.println("Query ZI5_by_self[...]:");
         typesTestQuery.queryZI5_by_self(this.api,
                 bldr -> {
-                    Map<String, ManyWriter> map = new HashMap<String, ManyWriter>();
-                    map.put("key1", bldr.create_B(false));
-                    map.put("key2", bldr.create_A("val2"));
+                    ArrayList<Tuple2__string__ManyWriter> map = new ArrayList<Tuple2__string__ManyWriter>();
+                    map.add(bldr.create_Tuple2__string__Many("key1", bldr.create_B(false)));
+                    map.add(bldr.create_Tuple2__string__Many("key2", bldr.create_A("val2")));
                     return map;
                 },
                 v -> { query_file.println(printZI5(v)); });
@@ -1322,8 +1322,8 @@ public class Test {
         query_file.println("Query ZI11_by_self[\"val2\"=>\"v2\"]:");
         typesTestQuery.queryZI11_by_self(this.api,
                 bldr -> {
-                    Map<ManyWriter, String> map = new HashMap<ManyWriter, String>();
-                    map.put(bldr.create_A("val2"), "v2");
+                    ArrayList<Tuple2__Many__stringWriter> map = new ArrayList<Tuple2__Many__stringWriter>();
+                    map.add(bldr.create_Tuple2__Many__string(bldr.create_A("val2"), "v2"));
                     return map;
                 },
                 v -> { query_file.println(printZI11(v)); });

--- a/lib/ddlog_std.dl
+++ b/lib/ddlog_std.dl
@@ -558,6 +558,7 @@ function max(g: Group<'K, 'V>): 'V {
 /*
  * Vec
  */
+#[dyn_alloc]
 extern type Vec<'A>
 
 extern function vec_empty(): Vec<'A>
@@ -667,6 +668,7 @@ function update_nth(v: mut Vec<'X>, idx: usize, value: 'X): bool {
  * Map
  */
 
+#[dyn_alloc]
 extern type Map<'K,'V>
 
 extern function map_empty(): Map<'K, 'V>
@@ -713,6 +715,7 @@ function keys(m: Map<'K, 'V>): Vec<'K> {
  * Set
  */
 
+#[dyn_alloc]
 extern type Set<'A>
 
 extern function set_singleton(x: 'X): Set<'X>

--- a/lib/ddlog_std.dl
+++ b/lib/ddlog_std.dl
@@ -435,6 +435,7 @@ extern function hash128(x: 'X): bit<128>
  * represents a non-empty list of objects.
  * `'K` is the type of group key, and `'V` is the type of value in the group.
  */
+#[iterate_by_val=iter:'V]
 extern type Group<'K,'V>
 
 /* Extracts group key.
@@ -559,6 +560,7 @@ function max(g: Group<'K, 'V>): 'V {
  * Vec
  */
 #[dyn_alloc]
+#[iterate_by_ref=iter:'A]
 extern type Vec<'A>
 
 extern function vec_empty(): Vec<'A>
@@ -669,6 +671,7 @@ function update_nth(v: mut Vec<'X>, idx: usize, value: 'X): bool {
  */
 
 #[dyn_alloc]
+#[iterate_by_val=iter:('K,'V)]
 extern type Map<'K,'V>
 
 extern function map_empty(): Map<'K, 'V>
@@ -716,6 +719,7 @@ function keys(m: Map<'K, 'V>): Vec<'K> {
  */
 
 #[dyn_alloc]
+#[iterate_by_ref=iter:'A]
 extern type Set<'A>
 
 extern function set_singleton(x: 'X): Set<'X>

--- a/lib/tinyset.dl
+++ b/lib/tinyset.dl
@@ -5,6 +5,7 @@
  * copying (e.g., 8, 16, 32, or 64-bit integers). */
 
 #[dyn_alloc]
+#[iterate_by_val=iter:'X]
 extern type Set64<'X>
 
 extern function size(s: Set64<'X>): bit<64>

--- a/lib/tinyset.dl
+++ b/lib/tinyset.dl
@@ -4,6 +4,7 @@
  * `Set64`, which is a set of values that fit in 64 bits and can be cloned by
  * copying (e.g., 8, 16, 32, or 64-bit integers). */
 
+#[dyn_alloc]
 extern type Set64<'X>
 
 extern function size(s: Set64<'X>): bit<64>

--- a/src/Language/DifferentialDatalog/Attribute.hs
+++ b/src/Language/DifferentialDatalog/Attribute.hs
@@ -1,5 +1,5 @@
 {-
-Copyright (c) 2021 VMware, Inc.
+Copyright (c) 2020-2021 VMware, Inc.
 SPDX-License-Identifier: MIT
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -37,6 +37,8 @@ import Language.DifferentialDatalog.Pos
 import Language.DifferentialDatalog.Syntax
 import {-# SOURCE #-} Language.DifferentialDatalog.Type
 import {-# SOURCE #-} Language.DifferentialDatalog.Function
+import {-# SOURCE #-} Language.DifferentialDatalog.Validate
+import Language.DifferentialDatalog.Rust
 import Language.DifferentialDatalog.Error
 
 progValidateAttributes :: (MonadError String me) => DatalogProgram -> me ()
@@ -56,43 +58,50 @@ typedefValidateAttrs d tdef@TypeDef{..} = do
     _ <- tdefCheckDynAllocAttr d tdef
     _ <- tdefCheckAliasAttr d tdef
     _ <- checkRustAttrs d tdefAttrs
+    _ <- tdefCheckIterableAttr d tdef
     maybe (return ()) (typeValidateAttrs d) tdefType
     return ()
 
 typedefValidateAttr :: (MonadError String me) => DatalogProgram -> TypeDef -> Attribute -> me ()
-typedefValidateAttr d TypeDef{..} attr = do
+typedefValidateAttr d tdef@TypeDef{..} attr = do
     case name attr of
          "size" -> do
-            check d (isNothing tdefType) (pos attr)
+            check d (tdefIsExtern tdef) (pos attr)
                 $ "Only extern types can have a 'size' attribute."
          "rust" -> do
-            check d (isJust tdefType) (pos attr)
+            check d (not $ tdefIsExtern tdef) (pos attr)
                 $ "Extern types cannot have a 'rust' attribute."
          "custom_serde" -> do
-            check d (isJust tdefType) (pos attr)
+            check d (not $ tdefIsExtern tdef) (pos attr)
                 $ "Extern types cannot have a 'custom_serde' attribute."
             let t = fromJust tdefType
             check d (isStruct d t) (pos attr)
                 $ "'custom_serde' attribute cannot be applied to type aliases."
          "custom_from_record" -> do
-            check d (isJust tdefType) (pos attr)
+            check d (not $ tdefIsExtern tdef) (pos attr)
                 $ "Extern types cannot have a 'custom_from_record' attribute."
             let t = fromJust tdefType
             check d (isStruct d t) (pos attr)
                 $ "'custom_from_record' attribute cannot be applied to type aliases."
          "shared_ref" -> do
-            check d (isNothing tdefType) (pos attr)
+            check d (tdefIsExtern tdef) (pos attr)
                 $ "'sharef_ref' attribute is only applicable to extern types."
             check d (length tdefArgs == 1) (pos attr)
                 $ "Types annotated with 'shared_ref' must have exactly one type argument, e.g., \"Ref<'T>\"."
          "dyn_alloc" -> do
-            check d (isNothing tdefType) (pos attr)
+            check d (tdefIsExtern tdef) (pos attr)
                 $ "'dyn_alloc' attribute is only applicable to extern types."
          "alias" -> do
              case tdefType of
                   Just TUser{} -> err d (pos attr) "The 'alias' attribute does not apply to struct types."
                   Nothing -> err d (pos attr) "The 'alias' attribute does not apply to extern types."
                   _ -> return ()
+         "iterate_by_ref" -> do
+            check d (tdefIsExtern tdef) (pos attr)
+                $ "Only extern types can have a 'iterate_by_ref' attribute."
+         "iterate_by_val" -> do
+            check d (tdefIsExtern tdef) (pos attr)
+                $ "Only extern types can have a 'iterate_by_val' attribute."
          n -> err d (pos attr) $ "Unknown attribute " ++ n
 
 typeValidateAttrs :: (MonadError String me) => DatalogProgram -> Type -> me ()
@@ -311,3 +320,39 @@ funcGetReturnByRefAttr d f =
     case checkReturnByRefAttr d f of
          Left e -> error e
          Right return_by_ref -> return_by_ref
+
+{- 'iterate_by_val', 'iterate_by_ref' attributes: Tell DDlog that the type can be iterated over and thus
+   can be used in a for-loop or a 'FlatMap' operator.  The first form indicates tha the 'iter()' method
+   returns a by-value iterator, the second form indicates that 'iter()' returns a by-reference iterator. -}
+tdefCheckIterableAttr :: (MonadError String me) => DatalogProgram -> TypeDef -> me (Maybe (Type, EKind))
+tdefCheckIterableAttr d TypeDef{..} = do
+    by_ref <- case find ((== "iterate_by_ref") . name) tdefAttrs of
+                   Nothing   -> return Nothing
+                   Just attr -> case attrVal attr of
+                                     E (ETyped _ (E EVar{..}) t) -> do
+                                         typeValidate d tdefArgs t
+                                         return $ Just t
+                                     _ -> err d (pos $ attrVal attr)
+                                                $ "The 'iterate_by_ref' attribute must have the following syntax: '#[iterate_by_ref=iter:<type>]', " ++
+                                                  "where <type> is the type of each element when iterating over the collection of type '" ++ tdefName ++ "'"
+    by_val <- case find ((== "iterate_by_val") . name) tdefAttrs of
+                   Nothing   -> return Nothing
+                   Just attr -> case attrVal attr of
+                                     E (ETyped _ (E EVar{..}) t) -> do
+                                         check d (isNothing by_ref) (pos attr) $ "Conflicting attributes 'iterate_by_val' and 'iterate_by_ref' specified for type '" ++ tdefName ++ "'"
+                                         typeValidate d tdefArgs t
+                                         return $ Just t
+                                     _ -> err d (pos $ attrVal attr)
+                                                $ "The 'iterate_by_val' attribute must have the following syntax: '#[iterate_by_val=iter:<type>]', " ++
+                                                  "where <type> is the type of each element when iterating over the collection of type '" ++ tdefName ++ "'"
+    case (by_ref, by_val) of
+         (Nothing, Nothing) -> return Nothing
+         (Just t, Nothing)  -> return $ Just (t, EReference)
+         (Nothing, Just t)  -> return $ Just (t, EVal)
+         _                  -> error "tdefCheckIterableAttr: unreachable"
+
+tdefGetIterableAttr :: DatalogProgram -> TypeDef -> Maybe (Type, EKind)
+tdefGetIterableAttr d tdef =
+    case tdefCheckIterableAttr d tdef of
+         Left e  -> error e
+         Right b -> b

--- a/src/Language/DifferentialDatalog/DatalogProgram.hs
+++ b/src/Language/DifferentialDatalog/DatalogProgram.hs
@@ -117,7 +117,8 @@ rhsExprMapCtxM fun r rhsidx a@RHSGroupBy{} = do
     return a{rhsGroupBy = g, rhsProject = e}
 rhsExprMapCtxM fun r rhsidx m@RHSFlatMap{}   = do
     e <- exprFoldCtxM fun (CtxRuleRFlatMap r rhsidx) (rhsMapExpr m)
-    return m{rhsMapExpr = e}
+    vs <- exprFoldCtxM fun (CtxRuleRFlatMapVars r rhsidx) (rhsVars m)
+    return m{rhsVars = vs, rhsMapExpr = e}
 rhsExprMapCtxM fun r rhsidx i@RHSInspect{}   = do
     e <- exprFoldCtxM fun (CtxRuleRInspect r rhsidx) (rhsInspectExpr i)
     return i{rhsInspectExpr = e}

--- a/src/Language/DifferentialDatalog/ECtx.hs
+++ b/src/Language/DifferentialDatalog/ECtx.hs
@@ -1,5 +1,5 @@
 {-
-Copyright (c) 2018-2020 VMware, Inc.
+Copyright (c) 2018-2021 VMware, Inc.
 SPDX-License-Identifier: MIT
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -29,6 +29,7 @@ Description: Helper functions for manipulating expression contexts.
  -}
 module Language.DifferentialDatalog.ECtx(
      ctxAncestors,
+     ctxLocalAncestors,
      ctxIsRuleL,
      ctxInRuleL,
      ctxIsMatchPat,
@@ -44,6 +45,8 @@ module Language.DifferentialDatalog.ECtx(
      ctxIsRuleRCond,
      ctxInRuleRHSPositivePattern,
      ctxInRuleRHSPattern,
+     ctxIsRuleRFlatMapVars,
+     ctxInRuleRFlatMapVars,
      ctxIsIndex,
      ctxInIndex,
      ctxIsFunc,
@@ -54,6 +57,8 @@ module Language.DifferentialDatalog.ECtx(
      ctxInFuncOrClosure,
      ctxIsForLoopBody,
      ctxInForLoopBody,
+     ctxIsForLoopVars,
+     ctxInForLoopVars,
      ctxStripTypeAnnotations)
 where
 
@@ -198,7 +203,25 @@ ctxIsForLoopBody _            = False
 ctxInForLoopBody :: ECtx -> Bool
 ctxInForLoopBody ctx = any ctxIsForLoopBody $ ctxLocalAncestors ctx
 
+ctxIsForLoopVars :: ECtx -> Bool
+ctxIsForLoopVars CtxForVars{} = True
+ctxIsForLoopVars _            = False
+
+-- | The context is located in the for-loop variable pattern.
+ctxInForLoopVars :: ECtx -> Bool
+ctxInForLoopVars ctx = any ctxIsForLoopVars $ ctxLocalAncestors ctx
+
+ctxIsRuleRFlatMapVars :: ECtx -> Bool
+ctxIsRuleRFlatMapVars CtxRuleRFlatMapVars{} = True
+ctxIsRuleRFlatMapVars _                     = False
+
+-- | The context is located in the lhs of a FlatMap operator.
+ctxInRuleRFlatMapVars :: ECtx -> Bool
+ctxInRuleRFlatMapVars ctx = any ctxIsRuleRFlatMapVars $ ctxAncestors ctx
+
 -- | Find the first parent that is not a type annotation.
 ctxStripTypeAnnotations :: ECtx -> ECtx
 ctxStripTypeAnnotations CtxTyped{..} = ctxStripTypeAnnotations ctxPar
 ctxStripTypeAnnotations ctx          = ctx
+
+

--- a/src/Language/DifferentialDatalog/Rust.hs
+++ b/src/Language/DifferentialDatalog/Rust.hs
@@ -1,0 +1,82 @@
+{-
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-}
+
+{-# LANGUAGE RecordWildCards, FlexibleContexts, LambdaCase, TupleSections, OverloadedStrings, TemplateHaskell, QuasiQuotes, ImplicitParams, NamedFieldPuns #-}
+
+{- |
+Module     : Rust
+Description: Rust language definitions used in the DDlog compiler.
+-}
+
+module Language.DifferentialDatalog.Rust where
+
+import Prelude hiding((<>))
+import Text.PrettyPrint
+
+import Language.DifferentialDatalog.Syntax
+
+-- Rust expression kind
+data EKind = EVal         -- normal value
+           | ELVal        -- l-value that can be written to or moved
+           | EReference   -- reference (mutable or immutable)
+           | ENoReturn    -- expression does not return (e.g., break, continue, or return).
+           deriving (Eq, Show)
+
+-- convert any expression into reference
+ref :: (Doc, EKind, ENode) -> Doc
+ref (x, EReference, _)  = x
+ref (x, ENoReturn, _)   = x
+ref (x, _, _)           = parens $ "&" <> x
+
+-- dereference expression if it is a reference; leave it alone
+-- otherwise
+deref :: (Doc, EKind, ENode) -> Doc
+deref (x, EReference, _) = parens $ "*" <> x
+deref (x, _, _)          = x
+
+-- convert any expression into mutable reference
+mutref :: (Doc, EKind, ENode) -> Doc
+mutref (x, EReference, _)  = x
+mutref (x, ENoReturn, _)   = x
+mutref (x, _, _)           = parens $ "&mut" <+> x
+
+-- convert any expression to EVal by cloning it if necessary
+val :: (Doc, EKind, ENode) -> Doc
+val (x, EVal, _)        = x
+val (x, ENoReturn, _)   = x
+val (x, EReference, _)  = cloneRef x
+val (x, _, _)           = x <> ".clone()"
+
+-- convert expression to l-value
+lval :: (Doc, EKind, ENode) -> Doc
+lval (x, ELVal, _)      = x
+-- this can only be mutable reference in a valid program
+lval (x, EReference, _) = parens $ "*" <> x
+lval (x, EVal, _)       = error $ "Compile.lval: cannot convert value to l-value: " ++ show x
+lval (x, ENoReturn, _)  = error $ "Compile.lval: cannot convert expression to l-value: " ++ show x
+
+-- When calling `clone()` on a reference, Rust occasionally decides to clone
+-- the reference instead of the referenced object.  This function makes sure to
+-- dereference it first.
+cloneRef :: Doc -> Doc
+cloneRef r = "(*" <> r <> ").clone()"

--- a/src/Language/DifferentialDatalog/Type.hs-boot
+++ b/src/Language/DifferentialDatalog/Type.hs-boot
@@ -29,14 +29,11 @@ typeConsTree :: Type -> ConsTree
 exprType :: DatalogProgram -> ECtx -> Expr -> Type
 exprType' :: DatalogProgram -> ECtx -> Expr -> Type
 exprType'' :: DatalogProgram -> ECtx -> Expr -> Type
-sET_TYPES :: [String]
 gROUP_TYPE :: String
 ePOCH_TYPE :: String
 iTERATION_TYPE :: String
 nESTED_TS_TYPE :: String
 wEIGHT_TYPE :: String
-checkIterable :: (MonadError String me, WithType a) => String -> Pos -> DatalogProgram -> a -> me ()
-typeIterType :: DatalogProgram -> Type -> (Type, Bool)
 exprNodeType :: DatalogProgram -> ECtx -> ExprNode Type -> Type
 isBool :: (WithType a) => DatalogProgram -> a -> Bool
 isBit :: (WithType a) => DatalogProgram -> a -> Bool

--- a/src/Language/DifferentialDatalog/Unification.hs
+++ b/src/Language/DifferentialDatalog/Unification.hs
@@ -44,6 +44,7 @@ module Language.DifferentialDatalog.Unification(
     teDeref,
     teIsConstant,
     teExpandAliases,
+    teSubstTypeArgs,
     typeToTExpr,
     Predicate(..),
     solve)
@@ -433,7 +434,7 @@ teSubstTypeArgs _     t                = t
 
 -- Convert type to a type expression, replacing type arguments ('A, 'B, ...)
 -- with type constants 'TETArg "A", TETArg "B", ...'.  For example, when
--- generating type inference in the body of a function, we treat its type
+-- performing type inference in the body of a function, we treat its type
 -- arguments as constants.  Inferred types for variables and expressions inside
 -- the body of the function may depend on these constants.
 typeToTExpr :: (?d::DatalogProgram) => Type -> TExpr

--- a/src/Language/DifferentialDatalog/Validate.hs-boot
+++ b/src/Language/DifferentialDatalog/Validate.hs-boot
@@ -1,0 +1,8 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+module Language.DifferentialDatalog.Validate where
+
+import Control.Monad.Except
+import Language.DifferentialDatalog.Syntax
+
+typeValidate :: (MonadError String me) => DatalogProgram -> [String] -> Type -> me ()

--- a/src/Language/DifferentialDatalog/Var.hs-boot
+++ b/src/Language/DifferentialDatalog/Var.hs-boot
@@ -7,13 +7,11 @@ import Language.DifferentialDatalog.Syntax
 import Language.DifferentialDatalog.PP
 
 data Var = ExprVar {varCtx::ECtx, varExpr::ENode}
-         | ForVar {varCtx::ECtx, varExpr::ENode}
          | BindingVar {varCtx::ECtx, varExpr::ENode}
          | ArgVar {varFunc::Function, varArgIndex::Int, varName::String}
          | ClosureArgVar {varCtx::ECtx, varExpr::ENode, varArgIndex::Int}
          | KeyVar {varRel::Relation}
          | IdxVar {varIndex::Index, varArgIndex::Int, varName::String}
-         | FlatMapVar {varRule::Rule, varRhsIdx::Int}
          | GroupVar {varRule::Rule, varRhsIdx::Int}
          | WeightVar
          | TSVar Rule

--- a/test/datalog_tests/function.fail.ast.expected
+++ b/test/datalog_tests/function.fail.ast.expected
@@ -18,11 +18,11 @@ error: ./test/datalog_tests/function.fail.dl:6.13-7.1: Access to guarded field '
     var b = a.x
             ^
 
-error: ./test/datalog_tests/function.fail.dl:6.5-6.17: Type constructor in the left-hand side of an assignment is only allowed for types with one constructor,  but "ddlog_std::Option" has multiple constructors
+error: ./test/datalog_tests/function.fail.dl:6.5-6.17: Type constructor in the left-hand side of an assignment is only allowed for types with one constructor,  but 'ddlog_std::Option' has multiple constructors
     Some{var s} = x
     ^^^^^^^^^^^^
 
-error: ./test/datalog_tests/function.fail.dl:8.16-8.27: Type constructor in the left-hand side of an assignment is only allowed for types with one constructor,  but "ddlog_std::Option" has multiple constructors
+error: ./test/datalog_tests/function.fail.dl:8.16-8.27: Type constructor in the left-hand side of an assignment is only allowed for types with one constructor,  but 'ddlog_std::Option' has multiple constructors
     T{.field = Some{var s}} = x
                ^^^^^^^^^^^
 
@@ -42,7 +42,7 @@ error: ./test/datalog_tests/function.fail.dl:3.41-5.1: Conversion between signed
 function cast(x: signed<32>): bit<64> = x as bit<64>
                                         ^
 
-error: ./test/datalog_tests/function.fail.dl:3.37-5.1: Direct casts from bigint to bit<> are not supported; consider going through signed<>("./test/datalog_tests/function.fail.dl" (line 3, column 37),"./test/datalog_tests/function.fail.dl" (line 3, column 39))
+error: ./test/datalog_tests/function.fail.dl:3.37-5.1: Direct casts from 'bigint' to 'bit<>' are not supported; consider going through 'signed<>'("./test/datalog_tests/function.fail.dl" (line 3, column 37),"./test/datalog_tests/function.fail.dl" (line 3, column 39))
 function cast(x: bigint): bit<64> = x as bit<64>
                                     ^
 
@@ -54,11 +54,11 @@ error: failed to parse input file: "./test/datalog_tests/function.fail.dl" (line
 unexpected "3"
 expecting "bit", "signed", "bigint", "double", "float", "string", "bool", "#", constructor name, type name, "'", "function", "|", "(" or ">"
 
-error: ./test/datalog_tests/function.fail.dl:3.37-5.1: There are no direct casts from floating point to integers; use the library functions int_from_*.double
+error: ./test/datalog_tests/function.fail.dl:3.37-5.1: There are no direct casts from floating point to integers; use the library functions 'int_from_*'.double
 function cast(x: double): bit<32> = x as bit<32>
                                     ^
 
-error: ./test/datalog_tests/function.fail.dl:3.34-5.1: Cannot type-cast expression of type string.  The type-cast operator is only supported for numeric types.
+error: ./test/datalog_tests/function.fail.dl:3.34-5.1: Cannot type-cast expression of type 'string'.  The type-cast operator is only supported for numeric types.
 function cast(x: string): bool = x as bool
                                  ^
 

--- a/test/datalog_tests/rules.fail.ast.expected
+++ b/test/datalog_tests/rules.fail.ast.expected
@@ -76,21 +76,21 @@ error: ./test/datalog_tests/rules.fail.dl:10.29-10.34: Group-by expression must 
     var sz = ().group_by((x,x + y)).size().
                             ^^^^^
 
-error: ./test/datalog_tests/rules.fail.dl:10.21-10.22: Type mismatch:
+error: ./test/datalog_tests/rules.fail.dl:10.5-10.11: Type mismatch:
 expected type: bit<64>
 actual type: ddlog_std::Option<ddlog_std::usize<>>
 in
-variable 'x'
+expression 'var x'
     var x = FlatMap(v).
-                    ^
+    ^^^^^^
 
-error: ./test/datalog_tests/rules.fail.dl:10.5-10.11: Variable y already defined in this scope
+error: ./test/datalog_tests/rules.fail.dl:10.5-10.11: Variable 'y' already defined in this scope
     var y = x.
     ^^^^^^
 
-error: ./test/datalog_tests/rules.fail.dl:10.21-10.22: Variable y already defined in this scope
+error: ./test/datalog_tests/rules.fail.dl:10.5-10.11: Variable 'y' already defined in this scope
     var y = FlatMap(y).
-                    ^
+    ^^^^^^
 
 error: ./test/datalog_tests/rules.fail.dl:10.23-10.31: Attempt to join stream relation 'S2' and the stream produced by the prefix of the rule before this literal. Stream joins are currently not supported.
 S3(x, z) :- S1(x, y), S2(y, z).

--- a/test/datalog_tests/simple2.dl
+++ b/test/datalog_tests/simple2.dl
@@ -471,3 +471,129 @@ FlatGroup(x) :-
     GroupThis(x, y),
     var g = x.group_by(y),
     var x = FlatMap(g).
+
+/*
+ * for-loop patterns
+ */
+
+typedef ForStruct1<'T> = ForStruct1 {
+    f1: 'T,
+    f2: istring
+}
+
+typedef ForStruct2 = ForStruct2 {
+    f1: (bool, double),
+    f2: ForStruct1<(usize, usize)>
+}
+
+function testMap(): Map<(usize, string), ForStruct2> {
+    [ (1, "1") -> ForStruct2{ .f1 = (true, 1.0), .f2 = ForStruct1{ .f1 = (1, 1), .f2 = i"foo"}}
+    , (2, "2") -> ForStruct2{ .f1 = (false, 2.0), .f2 = ForStruct1{ .f1 = (2, 2), .f2 = i"bar"}}
+    , (3, "3") -> ForStruct2{ .f1 = (false, 4.0), .f2 = ForStruct1{ .f1 = (3, 3), .f2 = i"buzz"}}
+    ]
+}
+
+output relation ForTests(id: usize, result: string)
+
+ForTests(1, {
+    var res = "";
+    for ((k, v) in testMap()) {
+        res = res ++ k.1
+    };
+    res
+}).
+
+ForTests(2, {
+    var res = "";
+    for (((_, k), v) in testMap()) {
+        res = res ++ k
+    };
+    res
+}).
+
+ForTests(3, {
+    var res = "";
+    for (((_, _), ForStruct2{.f2 = ForStruct1{_,s}}) in testMap()) {
+        res = "${res} ${s}"
+    };
+    res
+}).
+
+ForTests(4, {
+    var res = "";
+    for (((_, s1), ForStruct2{.f2 = ForStruct1{_,s2}}) in testMap()) {
+        res = "${res} ${s1}:${s2}"
+    };
+    res
+}).
+
+function testSet1(): Set<ForStruct2> {
+    [ ForStruct2{ .f1 = (true, 1.0), .f2 = ForStruct1{ .f1 = (1, 1), .f2 = i"foo"}} ].to_set()
+}
+
+function testSet2(): Set<ForStruct2> {
+    [ ForStruct2{ .f1 = (false, 2.0), .f2 = ForStruct1{ .f1 = (2, 2), .f2 = i"bar"}}
+    , ForStruct2{ .f1 = (false, 4.0), .f2 = ForStruct1{ .f1 = (3, 3), .f2 = i"buzz"}}
+    ].to_set()
+}
+
+function testVec(): Vec<ForStruct1<Set<ForStruct2>>> {
+    [ ForStruct1{ .f1 = testSet1(), .f2 = i"foo"}
+    , ForStruct1{ .f1 = testSet2(), .f2 = i"bar"}
+    , ForStruct1{ .f1 = testSet2(), .f2 = i"buzz"}
+    ]
+}
+
+ForTests(5, {
+    var res = "";
+    for (ForStruct1{_,s2} in testVec()) {
+        res = "${res}${s2}"
+    };
+    res
+}).
+
+ForTests(6, {
+    var res = "";
+    for (ForStruct1{set,f2} in testVec()) {
+        res = "${res} ${f2}";
+        for (ForStruct2{.f2 = ForStruct1{_,s2}} in set) {
+            res = "${res}${s2}"
+        }
+    };
+    res
+}).
+
+/*
+ * FlatMap patterns
+ */
+
+output relation FlatMapTests(id: usize, result: string)
+
+relation FMapMaps(map: Map<(usize, string), ForStruct2>)
+
+FMapMaps(testMap()).
+
+FlatMapTests(1, k.1) :-
+    FMapMaps(map),
+    (var k, var v) = FlatMap(map).
+
+FlatMapTests(2, k) :-
+    FMapMaps(map),
+    ((_, var k), var v) = FlatMap(map).
+
+FlatMapTests(3, s.ival()) :-
+    FMapMaps(map),
+    ((_, _), ForStruct2{.f2 = ForStruct1{_, var s}}) = FlatMap(map).
+
+FlatMapTests(4, "${s1}:${s2}") :-
+    FMapMaps(map),
+    ((_, var s1), ForStruct2{.f2 = ForStruct1{_, var s2}}) = FlatMap(map).
+
+FlatMapTests(5, "${s2}") :-
+    FMapMaps(),
+    ForStruct1{_, var s2} = FlatMap(testVec()).
+
+FlatMapTests(6, "${f2} ${s2}") :-
+    FMapMaps(),
+    ForStruct1{var set, var f2} = FlatMap(testVec()),
+    ForStruct2{.f2 = ForStruct1{_, var s2}} = FlatMap(set).

--- a/test/datalog_tests/simple2.dump.expected
+++ b/test/datalog_tests/simple2.dump.expected
@@ -15,6 +15,34 @@ Fib{.x = 3, .f = 2}: +1
 Fib{.x = 4, .f = 3}: +1
 Fib{.x = 10, .f = 55}: +1
 Fib{.x = 20, .f = 6765}: +1
+FlatMapTests:
+FlatMapTests{.id = 1, .result = "1"}: +1
+FlatMapTests{.id = 1, .result = "2"}: +1
+FlatMapTests{.id = 1, .result = "3"}: +1
+FlatMapTests{.id = 2, .result = "1"}: +1
+FlatMapTests{.id = 2, .result = "2"}: +1
+FlatMapTests{.id = 2, .result = "3"}: +1
+FlatMapTests{.id = 3, .result = "bar"}: +1
+FlatMapTests{.id = 3, .result = "buzz"}: +1
+FlatMapTests{.id = 3, .result = "foo"}: +1
+FlatMapTests{.id = 4, .result = "1:foo"}: +1
+FlatMapTests{.id = 4, .result = "2:bar"}: +1
+FlatMapTests{.id = 4, .result = "3:buzz"}: +1
+FlatMapTests{.id = 5, .result = "bar"}: +1
+FlatMapTests{.id = 5, .result = "buzz"}: +1
+FlatMapTests{.id = 5, .result = "foo"}: +1
+FlatMapTests{.id = 6, .result = "bar bar"}: +1
+FlatMapTests{.id = 6, .result = "bar buzz"}: +1
+FlatMapTests{.id = 6, .result = "buzz bar"}: +1
+FlatMapTests{.id = 6, .result = "buzz buzz"}: +1
+FlatMapTests{.id = 6, .result = "foo foo"}: +1
+ForTests:
+ForTests{.id = 1, .result = "123"}: +1
+ForTests{.id = 2, .result = "123"}: +1
+ForTests{.id = 3, .result = " foo bar buzz"}: +1
+ForTests{.id = 4, .result = " 1:foo 2:bar 3:buzz"}: +1
+ForTests{.id = 5, .result = "foobarbuzz"}: +1
+ForTests{.id = 6, .result = " foofoo barbarbuzz buzzbarbuzz"}: +1
 FuncTest:
 FuncTest{.x = "foo"}: +1
 MapOfMaps:

--- a/test/datalog_tests/tutorial.dl
+++ b/test/datalog_tests/tutorial.dl
@@ -338,10 +338,10 @@ function best_vendor_string(g: Group<string, (string, u64)>): string
 {
     var min_vendor = "";
     var min_price = 'hffffffffffffffff;
-    for (vendor_price in g) {
-        if (vendor_price.1 < min_price) {
-            min_vendor = vendor_price.0;
-            min_price = vendor_price.1;
+    for ((vendor, price) in g) {
+        if (price < min_price) {
+            min_vendor = vendor;
+            min_price = price;
         }
     };
     "Best deal for ${group_key(g)}: ${min_vendor}, $${min_price}"


### PR DESCRIPTION
Introduce the `#[dyn_alloc]` attribute (see commit message for detail).

 This PR also improves the handling of iteration in a couple of ways.
    
- First, it enables pattern matching in `for` loops and `FlatMap` (#784).  One
  can now write:
        ```
        for ((k,v) in map) {}
        ```
        instead of
        ```
        for ((kv in map) { var k = kv.0}
        ```
        and
        ```
        (var x, var y) = FlatMap(expr)
        ```
        instead of:
        ```
        var xy = FlatMap(expr),
        var x = xy.0
        ```
      In general, the pattern can contain constructor names, tuples,
      placeholders, and variable declarations.  The pattern must be
      irrefutable, i.e., any constructor name used in the pattern must be
      the unique constructor for the given type.

- Second, we remove the hardwired knowledge about iterable types from
      the compiler.  Until now the compiler only knew how to iterate over
      `Vec`, `Set`, `Map`, `Group`, and `TinySet` types.  Instead we now
      allow the programmer to label any extern type as iterable, meaning
      that it implements `iter()` and `into_iter()` methods, that return
      Rust iterators using one of two attributes:
      ```
      #[iterate_by_ref=iter:<type>]
      ```
      or
      ```
      #[iterate_by_val=iter:<type>]
      ```
      where `type` is the type yielded by the `next()` method of the iterator
      The former indicates that the `iter()` method returns a by-reference
      iterator, the latter indicates that `iter()` returns a by-value
      iterator.
    
    Example:

     ```
     #[iterate_by_val=iter:('K,'V)]
     extern type Map<'K,'V>
     ```
    
     This feature will enable us to introduce new container types, e.g.,
     immutable sets and maps in the future.
    
     Unfortunately, it introduces one, hopefully minor, usability
     regression.  Since we can no longer distinguish a map from any other
     container whose iterator is a 2-tuple, we cannot reliably convert
     DDlog maps to/from Java maps in the FlatBuf-based API.  They must
     therefore be passed around as arrays of key-value tuples and converted
     to/from Java maps by the client.
    
Future todos:
- Support pattern matching in closure arguments and the LHS of `group_by` clauses.
- Should refutable patterns be supported for `FlatMap`?  This would have
  the effect of filtering the flattened collection.
