### PR TITLE
c_api.rs: Remove spurious assertion.

### DIFF
--- a/rust/template/src/api/c_api.rs
+++ b/rust/template/src/api/c_api.rs
@@ -832,7 +832,6 @@ pub unsafe extern "C" fn ddlog_delta_enumerate(
     if let Some(f) = cb {
         for (table_id, table_data) in (&*delta).as_ref().iter() {
             for (val, weight) in table_data.iter() {
-                assert!(*weight == 1 || *weight == -1);
                 f(
                     cb_arg,
                     *table_id as libc::size_t,


### PR DESCRIPTION
An assertion in c_api.rs was checking that the weight of each record in
a delta is +1 or -1.  This invariant no longer holds: streams and
multisets can have arbitrary multiplicities.