### PR TITLE
Add Unit() to standard library and document its use.

### DIFF
--- a/doc/tutorial/tutorial.md
+++ b/doc/tutorial/tutorial.md
@@ -1262,6 +1262,48 @@ EndpointSanitization(endpoint, false) :-
     Blocklisted(endpoint).
 ```
 
+#### Unit
+
+The first clause in a rule must be positive, meaning that `not` may
+only appear as the second or later clause.  Occasionally, this is
+restrictive.  For example, suppose we want to create a relation
+`AnyBlocked` with a single row that is `true` if the `Blocklisted`
+relation defined above contains at least one row and `false` if it is
+empty.  The `true` case is easy:
+
+```
+relation AnyBlocked[bool]
+AnyBlocked[true] :- Blocklisted[_].
+```
+
+It is tempting to add the following to implement the `false` case, but
+the DDlog compiler will reject it with `Rule must start with a
+positive literal`:
+
+```
+AnyBlocked[false] :- not Blocklisted[_].    // This will not compile
+```
+
+To avoid the problem, we can start the rule with an artificial
+relation that has a single row.  Although we could define our own, the
+DDlog library has `Unit` in `util.dl` that is defined this way:
+
+```
+relation Unit()
+Unit().
+```
+
+We can use `Unit` to finish the definition of `AnyBlocked`.  The final
+definition looks like this:
+
+```
+import unit
+
+relation AnyBlocked[bool]
+AnyBlocked[true] :- Blocklisted[_].
+AnyBlocked[false] :- Unit(), not Blocklisted[_].
+```
+
 #### Assignments in rules
 
 We can directly use assignments in rules:

--- a/lib/unit.dl
+++ b/lib/unit.dl
@@ -1,0 +1,5 @@
+/* Unit
+ *
+ * Dummy relation with one empty row, useful for antijoins. */
+relation Unit()
+Unit().


### PR DESCRIPTION
This add Unit to a new library file unit.dl.  I did try to add it to
ddlog_std.dl, instead, so that it would always be available.  This
works fine with the compiler, but whenever DDlog code actually tries
to use Unit in that case, the generated Rust fails to build with:

```
2547 error[E0308]: mismatched types
    --> types/ddlog_std/ddlog_std.rs:2548:122
     |
2548 | ...                   __f},
     |                       ^^^ expected enum `std::option::Option`, found enum `Option`
     |
     = note: expected fn pointer `fn(differential_datalog::ddval::DDValue) -> std::option::Option<(differential_datalog::ddval::DDValue, differential_datalog::ddval::DDValue)>`
                   found fn item `fn(differential_datalog::ddval::DDValue) -> Option<(differential_datalog::ddval::DDValue, differential_datalog::ddval::DDValue)> {__Arng_ddlog_std_Unit_0::{{closure}}#0::__f}`
error[E0308]: mismatched types
    --> types/ddlog_std/ddlog_std.rs:2543:126
     |
2540 |   ...                   afun: {fn __f(__v: DDValue) -> Option<(DDValue,DDValue)>
     |                                                        ------------------------- expected `Option<(differential_datalog::ddval::DDValue, differential_datalog::ddval::DDValue)>` because of return type
...
2543 | / ...                       match <Unit>::from_ddvalue(__v) {
2544 | | ...                           _ => Some((()).into_ddvalue()),
2545 | | ...                           _ => None
2546 | | ...                       }.map(|x|(x,__cloned))
     | |________________________________________________^ expected enum `Option`, found enum `std::option::Option`
     |
     = note: expected enum `Option<(differential_datalog::ddval::DDValue, differential_datalog::ddval::DDValue)>`
                found enum `std::option::Option<(differential_datalog::ddval::DDValue, differential_datalog::ddval::DDValue)>`
```