### PR TITLE
Parens around complex Boolean expressions.

### DIFF
--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -2363,7 +2363,7 @@ mkFFun :: (?cfg::Config, ?specname::String, ?statics::CrateStatics, ?crate_graph
 mkFFun _ Rule{} [] = "None"
 mkFFun d rl@Rule{..} input_filters =
    let open = openAtom d vALUE_VAR rl 0 (rhsAtom $ ruleRHS !! 0) ("return false")
-       checks = hsep $ punctuate " &&"
+       checks = parens $ vcat $ punctuate " &&"
                 $ map (\i -> mkExpr d (CtxRuleRCond rl i) (rhsExpr $ ruleRHS !! i) EVal) input_filters
    in "Some({fn __f(" <> vALUE_VAR <> ": &DDValue) -> bool" $$
       (braces' $ open $$ checks)                             $$


### PR DESCRIPTION
Rust likes to see parens around complex Boolean expressions
(e.g., ones that contain subexpressions in curly braces).  We failed to
add such parens in one code path.