### PR TITLE
Timezone support

### DIFF
--- a/lib/allocate.dl
+++ b/lib/allocate.dl
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 /* Allocate a unique identifier in the range `min_val..max_val` for each element in `toallocate`.
  * `allocated` stores already allocated ids that must not be re-used.
  *

--- a/lib/allocate.rs
+++ b/lib/allocate.rs
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 use std::cmp;
 use std::collections::BTreeSet;
 use std::ops;

--- a/lib/base64.dl
+++ b/lib/base64.dl
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 // Decodes a base64 encoding; if the input is not a valid encoding it
 // produces an error describing the problem.
 extern function decode(s: string): Result<Vec<u8>, string>

--- a/lib/base64.rs
+++ b/lib/base64.rs
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 use base64::decode as b64decode;
 use base64::encode as b64encode;
 use base64::DecodeError as b64DecodeError;

--- a/lib/ddlog_bigint.dl
+++ b/lib/ddlog_bigint.dl
@@ -1,4 +1,27 @@
-/* Implementation of dynamically sized signed and unsigned integers that back 
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+/* Implementation of dynamically sized signed and unsigned integers that back
  * DDlog's `bigint`, as well as `bit<>` types wider that 128 bits.  This module
  * does not have any DDlog declarations; see `ddlog_bigint.rs` for the list of
  * Rust declarations exported by this module. */

--- a/lib/ddlog_bigint.flatbuf.rs
+++ b/lib/ddlog_bigint.flatbuf.rs
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 impl<'a> FromFlatBuffer<fb::__BigInt<'a>> for ddlog_bigint::Int {
     fn from_flatbuf(fb: fb::__BigInt<'a>) -> std::result::Result<ddlog_bigint::Int, String> {
         let bytes = fb.bytes().ok_or_else(|| {

--- a/lib/ddlog_bigint.rs
+++ b/lib/ddlog_bigint.rs
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 use abomonation::Abomonation;
 use num::bigint::BigInt;
 use num::bigint::BigUint;

--- a/lib/ddlog_log.dl
+++ b/lib/ddlog_log.dl
@@ -1,2 +1,25 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 /* This module does not have any DDlog declarations; see `ddlog_log.rs`
  * for the list of Rust declarations exported by this module. */

--- a/lib/ddlog_log.h
+++ b/lib/ddlog_log.h
@@ -1,4 +1,27 @@
 /*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+/*
  * C prototypes for the logging API (see `log.dl`, `log.rs`)
  */
 

--- a/lib/ddlog_log.rs
+++ b/lib/ddlog_log.rs
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 /* Logging Configuration API, (detailed documentation in `ddlog_log.h`) */
 
 use once_cell::sync::Lazy;

--- a/lib/ddlog_rt.dl
+++ b/lib/ddlog_rt.dl
@@ -1,3 +1,26 @@
-/* Rust types, functions and traits imported by every DDlog module, including 
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+/* Rust types, functions and traits imported by every DDlog module, including
  * `ddlog_std`.  This module does not have any DDlog declarations; see
  * `ddlog_rt.rs` for the list of Rust declarations exported by this module. */

--- a/lib/ddlog_rt.flatbuf.rs
+++ b/lib/ddlog_rt.flatbuf.rs
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 impl<'a, Args, Output> FromFlatBuffer<&'a str> for Box<dyn ddlog_rt::Closure<Args, Output>>
 where
     Args: 'static + Clone,

--- a/lib/ddlog_rt.rs
+++ b/lib/ddlog_rt.rs
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 use std::cmp::Ordering;
 use std::fmt::Debug;
 use std::fmt::Display;

--- a/lib/ddlog_std.dl
+++ b/lib/ddlog_std.dl
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 /* Description: DDlog "standard library" automatically imported into every module */
 
 import ddlog_rt

--- a/lib/ddlog_std.flatbuf.rs
+++ b/lib/ddlog_std.flatbuf.rs
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 impl<T, FB> FromFlatBuffer<FB> for ddlog_std::Ref<T>
 where
     T: FromFlatBuffer<FB>,

--- a/lib/ddlog_std.rs
+++ b/lib/ddlog_std.rs
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 use abomonation::Abomonation;
 /// Rust implementation of DDlog standard library functions and types.
 use differential_datalog::record::{arg_extract, Record};

--- a/lib/debug.dl
+++ b/lib/debug.dl
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 /* Description: DDlog debugging library contains functions that emit events to
  * an external debugger tool.
  */

--- a/lib/debug.rs
+++ b/lib/debug.rs
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 use std::fmt;
 use std::fs::OpenOptions;
 use std::io::Write;

--- a/lib/fp.dl
+++ b/lib/fp.dl
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 // Library with operations on floating point values (float and double)
 // All float operations have suffix _f, and all double operations have suffix _d
 

--- a/lib/fp.rs
+++ b/lib/fp.rs
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 use ddlog_bigint::*;
 use num::bigint::BigInt;
 use num::traits::FromPrimitive;

--- a/lib/graph.dl
+++ b/lib/graph.dl
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 /* Functions and transformers for use in graph processing */
 
 /* Compute strongly connected components of a directed graph:

--- a/lib/graph.rs
+++ b/lib/graph.rs
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 /* Functions and transformers for use in graph processing */
 
 use differential_dataflow::algorithms::graphs::propagate;

--- a/lib/group.dl
+++ b/lib/group.dl
@@ -1,4 +1,27 @@
 /*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+/*
  * Functions for working with groups (see basic group operations defined in
  * `ddlog_std.dl`).
  */

--- a/lib/hashset.dl
+++ b/lib/hashset.dl
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 /* Immutable hash sets.
  * This module contains bindings for the `HashSet` type
  * from the `im` crate. */

--- a/lib/hashset.flatbuf.rs
+++ b/lib/hashset.flatbuf.rs
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 impl<'a, T, F> FromFlatBuffer<fbrt::Vector<'a, F>> for typedefs::hashset::HashSet<T>
 where
     T: Hash + Eq + Clone + FromFlatBuffer<F::Inner>,

--- a/lib/hashset.rs
+++ b/lib/hashset.rs
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 use ddlog_rt::Closure;
 use ddlog_std::{option2std, tuple2, Group, Option as DDOption, Vec as DDVec};
 

--- a/lib/intern.dl
+++ b/lib/intern.dl
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 /* Object interning library.
  * Generates a unique ID for an object, which can be converted back to the original value.
  *

--- a/lib/intern.flatbuf.rs
+++ b/lib/intern.flatbuf.rs
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 impl<'a> FromFlatBuffer<&'a str> for types__intern::IString {
     fn from_flatbuf(fb: &'a str) -> Result<Self, String> {
         Ok(types__intern::string_intern(&String::from_flatbuf(fb)?))

--- a/lib/intern.rs
+++ b/lib/intern.rs
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 use differential_datalog::record::{self, Record};
 use fxhash::FxBuildHasher;
 use lasso::{Capacity, Key, Spur, ThreadedRodeo};

--- a/lib/internment.dl
+++ b/lib/internment.dl
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 /* Object interning library based on the `internment` crate.
  *
  * This library is automatically imported by all DDlog programs.

--- a/lib/internment.flatbuf.rs
+++ b/lib/internment.flatbuf.rs
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 impl<A, FB> FromFlatBuffer<FB> for internment::Intern<A>
 where
     A: Eq + std::hash::Hash + Send + Sync + 'static,

--- a/lib/internment.rs
+++ b/lib/internment.rs
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 use ddlog_std::Vec as DDlogVec;
 use differential_datalog::record::{self, Record};
 use internment::ArcIntern;

--- a/lib/json.dl
+++ b/lib/json.dl
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 /* JSON parsing/serialization library.
  *
  * Functions in this library are bindings for functions in

--- a/lib/json.rs
+++ b/lib/json.rs
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 use ordered_float::OrderedFloat;
 use serde::de::DeserializeOwned;
 use std::result::Result;

--- a/lib/log.dl
+++ b/lib/log.dl
@@ -1,4 +1,27 @@
 /*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+/*
  * Logging API.
  *
  * This API has two facets.  First, it provides the `log()` function that can

--- a/lib/log.rs
+++ b/lib/log.rs
@@ -1,1 +1,24 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 pub use ddlog_log::log;

--- a/lib/log4j.dl
+++ b/lib/log4j.dl
@@ -1,4 +1,27 @@
 /*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+/*
  * Convenience functions for using the logging API with log4j.
  */
 

--- a/lib/map.dl
+++ b/lib/map.dl
@@ -1,4 +1,27 @@
 /*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+/*
  * Functions for working with maps (see basic map operations defined in
  * `ddlog_std.dl`).
  */

--- a/lib/map.rs
+++ b/lib/map.rs
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 use ddlog_rt::Closure;
 
 pub fn map_map_in_place<K: Ord, V>(

--- a/lib/net/ipaddr.dl
+++ b/lib/net/ipaddr.dl
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 /* An IP address, either IPv4 or IPv6.
  *
  * This enum can contain either an Ipv4Addr or an Ipv6Addr, see their respective

--- a/lib/net/ipv4.dl
+++ b/lib/net/ipv4.dl
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 /* An IPv4 address.
  *
  * IPv4 addresses are defined as 32-bit integers in IETF RFC 791. They are
@@ -71,7 +94,7 @@ extern function ipv4_is_unspecified(addr: Ipv4Addr): bool
 /* Returns true if this is a loopback address (127.0.0.0/8).
  *
  * This property is defined by IETF RFC 1122.
- */ 
+ */
 extern function ipv4_is_loopback(addr: Ipv4Addr): bool
 
 /* Returns true if this is a private address.

--- a/lib/net/ipv4.rs
+++ b/lib/net/ipv4.rs
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 use differential_datalog::record::Record;
 use serde::de::Deserializer;
 use serde::ser::Serializer;

--- a/lib/net/ipv6.dl
+++ b/lib/net/ipv6.dl
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 /* An IPv6 address.
  *
  * IPv6 addresses are defined as 128-bit integers in IETF RFC 4291. They are

--- a/lib/net/ipv6.rs
+++ b/lib/net/ipv6.rs
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 use differential_datalog::record::Record;
 use serde::de::Deserializer;
 use serde::ser::Serializer;

--- a/lib/ovsdb.dl
+++ b/lib/ovsdb.dl
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 import uuid
 
 typedef integer      = bit<64>
@@ -47,4 +70,3 @@ extern function group2set_remove_sentinel(g: Group<'K, uuid_or_string_t>): Set<u
 // A sentinel value is added to an empty map before `FlatMap` to ensure that `FlatMap`
 // generates at least one entry.  It must be filtered out in a subsequent `Aggregate`.
 extern function group2map_remove_sentinel(g: Group<'K1, ('K2, uuid_or_string_t)>): Map<'K2, uuid_or_string_t>
-

--- a/lib/ovsdb.rs
+++ b/lib/ovsdb.rs
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 use std::iter::FromIterator;
 
 use ddlog_rt::Val;

--- a/lib/print.dl
+++ b/lib/print.dl
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 // These functions are useful for debugging.
 // print can be inserted in imperative code,
 // while printTrue can be inserted on the RHS of rules

--- a/lib/print.rs
+++ b/lib/print.rs
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 use std::fmt::Debug;
 
 pub fn print(msg: &String) {

--- a/lib/regex.dl
+++ b/lib/regex.dl
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 /* Bindings for the Rust regular expressions library.
  *
  * See regex crate documentation for description of the regex syntax supported

--- a/lib/regex.rs
+++ b/lib/regex.rs
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 use ddlog_std::{Option as DDlogOption, Result as DDlogResult, Vec as DDlogVec};
 use differential_datalog::record::{CollectionKind, Record};
 use regex::{Error as RegexError, Regex as InnerRegex, RegexSet as InnerRegexSet};

--- a/lib/set.dl
+++ b/lib/set.dl
@@ -1,4 +1,27 @@
 /*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+/*
  * Functions for working with sets (see basic set operations defined in
  * `ddlog_std.dl`).
  */

--- a/lib/set.rs
+++ b/lib/set.rs
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 use ddlog_rt::Closure;
 
 pub fn set_arg_min<A: Ord + Clone, B: Ord>(

--- a/lib/souffle_lib.dl
+++ b/lib/souffle_lib.dl
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 // Library of Souffle functions
 
 import intern

--- a/lib/souffle_types.dl
+++ b/lib/souffle_types.dl
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 // Library of Souffle types
 
 import intern

--- a/lib/time.dl
+++ b/lib/time.dl
@@ -155,9 +155,7 @@ Modifier	Description
 %0?	        Uses zeroes as a padding. (e.g. %e =  9, %0e = 09)
 */
 
-/// Convert the time to a string using a default format.
 extern function time2string(t: Time): string
-
 function to_string(t: Time): string {
     time2string(t)
 }
@@ -169,8 +167,9 @@ function to_time(s: string): Result<Time, string> {
 }
 
 /// Format the Time using the provided string.
-extern function time_format(t: Time, format: string): string
-function format(t: Time, format: string): string {
+/// Conversion can fail when the format string is incorrect
+extern function time_format(t: Time, format: string): Result<string, string>
+function format(t: Time, format: string): Result<string, string> {
     time_format(t, format)
 }
 
@@ -227,8 +226,9 @@ extern function from_julian_day(julian_day: signed<64>): Date
 extern function date_parse(s: string, format: string): Result<Date, string>
 
 /// format the Date using the specified format string
-extern function date_format(date: Date, format: string): string
-function format(date: Date, format: string): string {
+/// Formatting can fail if the format string is incorrect.
+extern function date_format(date: Date, format: string): Result<string, string>
+function format(date: Date, format: string): Result<string, string> {
     date_format(date, format)
 }
 
@@ -271,8 +271,9 @@ function to_datetime(s: string): Result<DateTime, string> {
 }
 
 /// format the DateTime using the specified format string
-extern function datetime_format(d: DateTime, format: string): string
-function format(d: DateTime, format: string): string {
+/// Formatting can fail if the format string is incorrect.
+extern function datetime_format(d: DateTime, format: string): Result<string, string>
+function format(d: DateTime, format: string): Result<string, string> {
     datetime_format(d, format)
 }
 
@@ -281,6 +282,9 @@ extern function datetime_from_unix_timestamp(timestamp: signed<64>): DateTime
 
 ///////////////////////////////////////////////////
 // Timezone handling, based on chrono
+// Chrono has a separate Timezone trait, but we do not
+// expose it, since it is never really useful without
+// a DateTime.
 
 /// An object representing a datetime with a timezone
 extern type TzDateTime
@@ -290,14 +294,14 @@ extern function utc_timezone(dt: DateTime): TzDateTime
 
 /// Convert a DateTime to a TzDateTime in a timezone with a specified
 /// offset in seconds to the east from UTC.
-extern function offset_timezone(eastOffsetInSeconds: signed<32>, dt: DateTime): TzDateTime
+extern function offset_timezone(dt: DateTime, eastOffsetInSeconds: signed<32>): TzDateTime
 /// Changes the associated time zone. This does not change the actual DateTime (but will change the string representation).
-extern function change_offset(eastOffsetInSeconds: signed<32>, dt: TzDateTime): TzDateTime
+extern function change_offset(dt: TzDateTime, eastOffsetInSeconds: signed<32>): TzDateTime
 /// Get the DateTime without a timezone in the UTC timezone
 extern function utc_datetime(dt: TzDateTime): DateTime
 
-extern function tz_datetime_format(td: TzDateTime, format: string): string
-function format(td: TzDateTime, format: string): string {
+extern function tz_datetime_format(td: TzDateTime, format: string): Result<string, string>
+function format(td: TzDateTime, format: string): Result<string, string> {
    tz_datetime_format(td, format)
 }
 extern function tzDateTime2string(td: TzDateTime): string

--- a/lib/time.dl
+++ b/lib/time.dl
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 /// Library supporting dates, times, and date-times
 /// Based on the chrono crate
 /// https://github.com/chronotope/chrono
@@ -147,6 +170,9 @@ function to_time(s: string): Result<Time, string> {
 
 /// Format the Time using the provided string.
 extern function time_format(t: Time, format: string): string
+function format(t: Time, format: string): string {
+    time_format(t, format)
+}
 
 /// Attempt to parse a Time using the provided format string.
 extern function time_parse(s: string, format: string): Result<Time, string>
@@ -202,6 +228,9 @@ extern function date_parse(s: string, format: string): Result<Date, string>
 
 /// format the Date using the specified format string
 extern function date_format(date: Date, format: string): string
+function format(date: Date, format: string): string {
+    date_format(date, format)
+}
 
 /// Convert the date to a string using a default format.
 extern function date2string(t: Date): string
@@ -243,6 +272,9 @@ function to_datetime(s: string): Result<DateTime, string> {
 
 /// format the DateTime using the specified format string
 extern function datetime_format(d: DateTime, format: string): string
+function format(d: DateTime, format: string): string {
+    datetime_format(d, format)
+}
 
 /// Create a DateTime from a given unix timestamp
 extern function datetime_from_unix_timestamp(timestamp: signed<64>): DateTime
@@ -255,3 +287,33 @@ extern type TzDateTime
 
 /// Convert a DateTime to a TzDateTime in the UTC timezone
 extern function utc_timezone(dt: DateTime): TzDateTime
+
+/// Convert a DateTime to a TzDateTime in a timezone with a specified
+/// offset in seconds to the east from UTC.
+extern function offset_timezone(eastOffsetInSeconds: signed<32>, dt: DateTime): TzDateTime
+/// Changes the associated time zone. This does not change the actual DateTime (but will change the string representation).
+extern function change_offset(eastOffsetInSeconds: signed<32>, dt: TzDateTime): TzDateTime
+/// Get the DateTime without a timezone in the UTC timezone
+extern function utc_datetime(dt: TzDateTime): DateTime
+
+extern function tz_datetime_format(td: TzDateTime, format: string): string
+function format(td: TzDateTime, format: string): string {
+   tz_datetime_format(td, format)
+}
+extern function tzDateTime2string(td: TzDateTime): string
+/// Returns an RFC 2822 date and time string such as Tue, 1 Jul 2003 10:52:37 +0200.
+extern function to_rfc2822(td: TzDateTime): string
+/// Returns an RFC 3339 and ISO 8601 date and time string such as 1996-12-19T16:39:57-08:00.
+extern function to_rfc3339(td: TzDateTime): string
+
+/// Parse a TzDateTime using the specified string format
+extern function tz_datetime_parse(s: string, format: string): Result<TzDateTime, string>
+/// Parses an RFC 3339 and ISO 8601 date and time string such as 1996-12-19T16:39:57-08:00
+extern function tz_datetime_parse_from_rfc3339(s: string): Result<TzDateTime, string>
+/// Parses an RFC 2822 date and time string such as Tue, 1 Jul 2003 10:52:37 +0200
+extern function tz_datetime_parse_from_rfc2822(s: string): Result<TzDateTime, string>
+extern function time(dt: TzDateTime): Time
+
+function to_string(dt: TzDateTime): string {
+    tzDateTime2string(dt)
+}

--- a/lib/time.dl
+++ b/lib/time.dl
@@ -1,6 +1,6 @@
 /// Library supporting dates, times, and date-times
-/// This parallels closely the Rust time crate
-/// https://time-rs.github.io/time/time/struct.Time.html
+/// Based on the chrono crate
+/// https://github.com/chronotope/chrono
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 /// The clock time within a given date. Nanosecond precision.
@@ -8,6 +8,9 @@
 /// made to handle leap seconds (either positive or negative).
 /// When comparing two Times, they are assumed to be in the same
 /// calendar date.
+/// ATTENTION: This module only contains deterministic function.
+/// Since DDlog programs are supposed to be deterministic, there are no
+/// functions such as today(), now()
 
 extern type Time
 
@@ -44,47 +47,90 @@ extern function microsecond(t: Time): bit<32>
 /// Get the nanoseconds within the second.  The returned value will always be in the range 0..1000000000.
 extern function nanosecond(t: Time): bit<32>
 
-// Here is a list of the format specifiers:
-// Spec	Replaced by                                                             Example
-// %a	Abbreviated weekday name                                                Thu
-// %A	Full weekday name	                                                Thursday
-// %b	Abbreviated month name	                                                Aug
-// %B	Full month name	                                                        August
-// %c	Date and time representation, equivalent to %a %b %-d %-H:%M:%S %-Y	Thu Aug 23 14:55:02 2001
-// %C	Year divided by 100 and truncated to integer (00-99)	                20
-// %d	Day of the month, zero-padded (01-31)	                                23
-// %D	Short MM/DD/YY date, equivalent to %-m/%d/%y	                        8/23/01
-// %F	Short YYYY-MM-DD date, equivalent to %-Y-%m-%d	                        2001-08-23
-// %g	Week-based year, last two digits (00-99)	                        01
-// %G	Week-based year	                                                        2001
-// %H	Hour in 24h format (00-23)	                                        14
-// %I	Hour in 12h format (01-12)	                                        02
-// %j	Day of the year (001-366)	                                        235
-// %m	Month as a decimal number (01-12)	                                08
-// %M	Minute (00-59)	                                                        55
-// %N	Subsecond nanoseconds. Always 9 digits	                                012345678
-// %p	am or pm designation	                                                pm
-// %P	AM or PM designation	                                                PM
-// %r	12-hour clock time, equivalent to %-I:%M:%S %p	                        2:55:02 pm
-// %R	24-hour HH:MM time, equivalent to %-H:%M	                        14:55
-// %S	Second (00-59)	                                                        02
-// %T	24-hour clock time with seconds, equivalent to %-H:%M:%S	        14:55:02
-// %u	ISO 8601 weekday as number with Monday as 1 (1-7)	                4
-// %U	Week number with the first Sunday as the start of week one (00-53)	33
-// %V	ISO 8601 week number (01-53)	                                        34
-// %w	Weekday as a decimal number with Sunday as 0 (0-6)	                4
-// %W	Week number with the first Monday as the start of week one (00-53)	34
-// %y	Year, last two digits (00-99)	                                        01
-// %Y	Full year, including + if >= 10,000	                                2001
-// %z	ISO 8601 offset from UTC in timezone (+HHMM)	                        +0100
-// %%	Literal %	                                                        %
+// Here is a list of the format specifiers, which can be used for both parsing and formatting.
+// This is based on the strftime format specification.
+// https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html
+/*
+Spec.	Example	Description
+                        DATE SPECIFIERS:
+%Y	2001	        The full proleptic Gregorian year, zero-padded to 4 digits.
+%C	20	        The proleptic Gregorian year divided by 100, zero-padded to 2 digits.
+%y	01	        The proleptic Gregorian year modulo 100, zero-padded to 2 digits.
 
-// All specifiers that are strictly numerical have modifiers for formatting.
-// Adding a modifier to a non-supporting specifier is a no-op.
-// Modifier	     Behavior	         Example
-// - (dash)	     No padding	         %-d => 5
-// _ (underscore)    Pad with spaces	 %_d =>  5
-// 0	             Pad with zeros	 %0d => 05
+%m	07		Month number (01--12), zero-padded to 2 digits.
+%b	Jul		Abbreviated month name. Always 3 letters.
+%B	July		Full month name. Also accepts corresponding abbreviation in parsing.
+%h	Jul		Same as %b.
+
+%d	08		Day number (01--31), zero-padded to 2 digits.
+%e	 8		Same as %d but space-padded. Same as %_d.
+
+%a	Sun		Abbreviated weekday name. Always 3 letters.
+%A	Sunday		Full weekday name. Also accepts corresponding abbreviation in parsing.
+%w	0		Sunday = 0, Monday = 1, ..., Saturday = 6.
+%u	7		Monday = 1, Tuesday = 2, ..., Sunday = 7. (ISO 8601)
+
+%U	28		Week number starting with Sunday (00--53), zero-padded to 2 digits.
+%W	27		Same as %U, but week 1 starts with the first Monday in that year instead.
+
+%G	2001		Same as %Y but uses the year number in ISO 8601 week date.
+%g	01		Same as %y but uses the year number in ISO 8601 week date.
+%V	27		Same as %U but uses the week number in ISO 8601 week date (01--53).
+
+%j	189		Day of the year (001--366), zero-padded to 3 digits.
+
+%D	07/08/01	Month-day-year format. Same as %m/%d/%y.
+%x	07/08/01	Locale's date representation (e.g., 12/31/99).
+%F	2001-07-08	Year-month-day format (ISO 8601). Same as %Y-%m-%d.
+%v	8-Jul-2001	Day-month-year format. Same as %e-%b-%Y.
+
+		TIME SPECIFIERS:
+%H	00		Hour number (00--23), zero-padded to 2 digits.
+%k	 0		Same as %H but space-padded. Same as %_H.
+%I	12		Hour number in 12-hour clocks (01--12), zero-padded to 2 digits.
+%l	12		Same as %I but space-padded. Same as %_I.
+
+%P	am		am or pm in 12-hour clocks.
+%p	AM		AM or PM in 12-hour clocks.
+
+%M	34		Minute number (00--59), zero-padded to 2 digits.
+%S	60		Second number (00--60), zero-padded to 2 digits.
+%f	026490000	The fractional seconds (in nanoseconds) since last whole second.
+%.f	.026490	        Similar to .%f but left-aligned. These all consume the leading dot.
+%.3f	.026    	Similar to .%f but left-aligned but fixed to a length of 3.
+%.6f	.026490	        Similar to .%f but left-aligned but fixed to a length of 6.
+%.9f	.026490000	Similar to .%f but left-aligned but fixed to a length of 9.
+%3f	026	        Similar to %.3f but without the leading dot.
+%6f	026490	        Similar to %.6f but without the leading dot.
+%9f	026490000	Similar to %.9f but without the leading dot.
+
+%R	00:34	        Hour-minute format. Same as %H:%M.
+%T	00:34:60	Hour-minute-second format. Same as %H:%M:%S.
+%X	00:34:60	Locale's time representation (e.g., 23:13:48).
+%r	12:34:60 AM	Hour-minute-second format in 12-hour clocks. Same as %I:%M:%S %p.
+
+		TIME ZONE SPECIFIERS:
+%Z	ACST	     Local time zone name. Skips all non-whitespace characters during parsing.
+%z	+0930	     Offset from the local time to UTC (with UTC being +0000).
+%:z	+09:30	     Same as %z but with a colon.
+%#z	+09	     Parsing only: Same as %z but allows minutes to be missing or present.
+
+		DATE & TIME SPECIFIERS:
+%c	Sun Jul  8 00:34:60 2001                Locale's date and time (e.g., Thu Mar 3 23:05:25 2005).
+%+	2001-07-08T00:34:60.026490+09:30	ISO 8601 / RFC 3339 date & time format.
+%s	994518299	                        UNIX timestamp, the number of seconds since 1970-01-01 00:00 UTC.
+
+		SPECIAL SPECIFIERS:
+%t		Literal tab (\t).
+%n		Literal newline (\n).
+%%		Literal percent sign.
+
+It is possible to override the default padding behavior of numeric specifiers %?. This is not allowed for other specifiers and will result in the BAD_FORMAT error.
+Modifier	Description
+%-?	        Suppresses any padding including spaces and zeroes. (e.g. %j = 012, %-j = 12)
+%_?	        Uses spaces as a padding. (e.g. %j = 012, %_j =  12)
+%0?	        Uses zeroes as a padding. (e.g. %e =  9, %0e = 09)
+*/
 
 /// Convert the time to a string using a default format.
 extern function time2string(t: Time): string
@@ -136,12 +182,6 @@ extern function ordinal(date: Date): bit<16>
 /// Get the ISO week number.  The returned value will always be in the range 1..=53.
 extern function week(date: Date): bit<8>
 
-/// Get the week number where week 1 begins on the first Sunday.  The returned value will always be in the range 0..=53.
-extern function sunday_based_week(date: Date): bit<8>
-
-/// Get the week number where week 1 begins on the first Monday.  The returned value will always be in the range 0..=53.
-extern function monday_based_week(date: Date): bit<8>
-
 /// Get the weekday.
 extern function weekday(date: Date): Weekday
 
@@ -183,6 +223,7 @@ typedef Weekday = Monday
                 | Saturday
                 | Sunday
 
+// This is really a local date + time, without timezone information
 typedef DateTime = DateTime { date: Date, time: Time }
 
 /// Parse a string into a DateTime using the specified format
@@ -205,3 +246,12 @@ extern function datetime_format(d: DateTime, format: string): string
 
 /// Create a DateTime from a given unix timestamp
 extern function datetime_from_unix_timestamp(timestamp: signed<64>): DateTime
+
+///////////////////////////////////////////////////
+// Timezone handling, based on chrono
+
+/// An object representing a datetime with a timezone
+extern type TzDateTime
+
+/// Convert a DateTime to a TzDateTime in the UTC timezone
+extern function utc_timezone(dt: DateTime): TzDateTime

--- a/lib/time.rs
+++ b/lib/time.rs
@@ -1,103 +1,108 @@
 use differential_datalog::record;
 use std::fmt::Display;
+use chrono::{Timelike, Datelike, TimeZone, NaiveDateTime, FixedOffset};
 
 //////////////////////////// Time //////////////////////////////////
 #[derive(Eq, Ord, Clone, Hash, PartialEq, PartialOrd, Serialize, Deserialize, Debug)]
 pub struct TimeWrapper {
-    val: ::time::Time,
+    val: ::chrono::NaiveTime,
 }
 pub type Time = TimeWrapper;
 
 impl Default for TimeWrapper {
     fn default() -> Self {
-        let mid = ::time::Time::midnight();
+        let mid = ::chrono::NaiveTime::from_hms(0, 0, 0);
         TimeWrapper { val: mid }
     }
 }
 
-pub fn res2std_time_wrap<E: Display>(
-    r: ::std::result::Result<::time::Time, E>,
+pub fn time_option_to_result(
+    r: Option<::chrono::NaiveTime>,
 ) -> ddlog_std::Result<Time, String> {
     match (r) {
-        Ok(res) => {
-            let t = TimeWrapper { val: res };
-            ddlog_std::Result::Ok { res: t }
-        }
-        Err(e) => ddlog_std::Result::Err {
-            err: format!("{}", e),
+        Some(res) => {
+            ddlog_std::Result::Ok { res: TimeWrapper { val: res } }
+        },
+        None => ddlog_std::Result::Err {
+            err: "illegal time value".to_string()
         },
     }
 }
 
 pub fn try_from_hms(h: &u8, m: &u8, s: &u8) -> ddlog_std::Result<Time, String> {
-    res2std_time_wrap(::time::Time::try_from_hms(*h, *m, *s))
+    time_option_to_result(::chrono::NaiveTime::from_hms_opt(*h as u32, *m as u32, *s as u32))
 }
 
 pub fn try_from_hms_milli(h: &u8, m: &u8, s: &u8, ms: &u16) -> ddlog_std::Result<Time, String> {
-    res2std_time_wrap(::time::Time::try_from_hms_milli(*h, *m, *s, *ms))
+    time_option_to_result(::chrono::NaiveTime::from_hms_milli_opt(*h as u32, *m as u32, *s as u32, *ms as u32))
 }
 
 pub fn try_from_hms_micro(h: &u8, m: &u8, s: &u8, mc: &u32) -> ddlog_std::Result<Time, String> {
-    res2std_time_wrap(::time::Time::try_from_hms_micro(*h, *m, *s, *mc))
+    time_option_to_result(::chrono::NaiveTime::from_hms_micro_opt(*h as u32, *m as u32, *s as u32, *mc as u32))
 }
 
 pub fn try_from_hms_nano(h: &u8, m: &u8, s: &u8, mc: &u32) -> ddlog_std::Result<Time, String> {
-    res2std_time_wrap(::time::Time::try_from_hms_nano(*h, *m, *s, *mc))
+    time_option_to_result(::chrono::NaiveTime::from_hms_nano_opt(*h as u32, *m as u32, *s as u32, *mc as u32))
 }
 
 pub fn hour(t: &Time) -> u8 {
-    ::time::Time::hour(t.val)
+    t.val.hour() as u8
 }
 
 pub fn minute(t: &Time) -> u8 {
-    ::time::Time::minute(t.val)
+    t.val.minute() as u8
 }
 
 pub fn second(t: &Time) -> u8 {
-    ::time::Time::second(t.val)
+    t.val.second() as u8
 }
 
 pub fn millisecond(t: &Time) -> u16 {
-    ::time::Time::millisecond(t.val)
+    (t.val.nanosecond() / 1_000_000) as u16
 }
 
 pub fn microsecond(t: &Time) -> u32 {
-    ::time::Time::microsecond(t.val)
+    t.val.nanosecond() / 1_000
 }
 
 pub fn nanosecond(t: &Time) -> u32 {
-    ::time::Time::nanosecond(t.val)
+    t.val.nanosecond()
 }
 
-const default_time_format: &str = "%T.%N";
-
-pub fn time2string(t: &Time) -> String {
-    t.val.format(default_time_format)
-}
-
-pub fn string2time(s: &String) -> ddlog_std::Result<Time, String> {
-    res2std_time_wrap(::time::Time::parse(s, default_time_format))
-}
+const default_time_format: &str = "%T.%f";
 
 pub fn midnight() -> Time {
     TimeWrapper {
-        val: ::time::Time::midnight(),
+        val: ::chrono::NaiveTime::from_hms(0, 0, 0),
     }
 }
 
 pub fn time_parse(s: &String, format: &String) -> ddlog_std::Result<Time, String> {
-    res2std_time_wrap(::time::Time::parse(s, format))
+    match (::chrono::NaiveTime::parse_from_str(s, format)) {
+        Ok(t) => ddlog_std::Result::Ok { res: TimeWrapper { val: t }},
+        Err(e) => ddlog_std::Result::Err {
+            err: format!("{}", e)
+        },
+    }
 }
 
 pub fn time_format(t: &Time, format: &String) -> String {
-    t.val.format(format)
+    t.val.format(format).to_string()
+}
+
+pub fn time2string(t: &Time) -> String {
+    time_format(t, &default_time_format.to_string())
+}
+
+pub fn string2time(s: &String) -> ddlog_std::Result<Time, String> {
+    time_parse(s, &default_time_format.to_string())
 }
 
 impl FromRecord for Time {
     fn from_record(val: &record::Record) -> ::std::result::Result<Self, String> {
         match (val) {
-            record::Record::String(s) => match (::time::Time::parse(s, default_time_format)) {
-                Ok(s) => Ok(TimeWrapper { val: s }),
+            record::Record::String(s) => match (::chrono::NaiveTime::parse_from_str(s, &default_time_format.to_string())) {
+                Ok(t) => Ok(TimeWrapper { val: t }),
                 Err(e) => Err(format!("{}", e)),
             },
             _ => Err(String::from("Unexpected type")),
@@ -122,60 +127,59 @@ impl record::Mutator<Time> for record::Record {
 
 #[derive(Eq, Ord, Clone, Hash, PartialEq, PartialOrd, Serialize, Deserialize, Debug)]
 pub struct DateWrapper {
-    val: ::time::Date,
+    val: ::chrono::NaiveDate,
 }
 pub type Date = DateWrapper;
 
 impl Default for DateWrapper {
     fn default() -> Self {
-        let mid = ::time::Date::try_from_ymd(0, 0, 0).unwrap();
+        let mid = ::chrono::NaiveDate::from_ymd(0, 1, 1);
         DateWrapper { val: mid }
     }
 }
 
-pub fn res2std_date_wrap<E: Display>(
-    r: ::std::result::Result<::time::Date, E>,
+pub fn date_option_to_result(
+    r: Option<::chrono::NaiveDate>,
 ) -> ddlog_std::Result<Date, String> {
     match (r) {
-        Ok(res) => {
-            let t = DateWrapper { val: res };
-            ddlog_std::Result::Ok { res: t }
-        }
-        Err(e) => ddlog_std::Result::Err {
-            err: format!("{}", e),
+        Some(d) => {
+            ddlog_std::Result::Ok { res: DateWrapper { val: d }}
+        },
+        None => ddlog_std::Result::Err {
+            err: "Invalid date".to_string(),
         },
     }
 }
 
 pub fn try_from_ymd(year: &i32, month: &u8, day: &u8) -> ddlog_std::Result<Date, String> {
-    res2std_date_wrap(::time::Date::try_from_ymd(*year, *month, *day))
+    date_option_to_result(::chrono::NaiveDate::from_ymd_opt(*year, *month as u32, *day as u32))
 }
 
 pub fn try_from_yo(year: &i32, ordinal: &u16) -> ddlog_std::Result<Date, String> {
-    res2std_date_wrap(::time::Date::try_from_yo(*year, *ordinal))
+    date_option_to_result(::chrono::NaiveDate::from_yo_opt(*year, *ordinal as u32))
 }
 
-fn convert_weekday_from_ddlog(weekday: &Weekday) -> ::time::Weekday {
+fn convert_weekday_from_ddlog(weekday: &Weekday) -> ::chrono::Weekday {
     match (*weekday) {
-        Weekday::Monday => ::time::Weekday::Monday,
-        Weekday::Tuesday => ::time::Weekday::Tuesday,
-        Weekday::Wednesday => ::time::Weekday::Wednesday,
-        Weekday::Thursday => ::time::Weekday::Thursday,
-        Weekday::Friday => ::time::Weekday::Friday,
-        Weekday::Saturday => ::time::Weekday::Saturday,
-        Weekday::Sunday => ::time::Weekday::Sunday,
+        Weekday::Monday => ::chrono::Weekday::Mon,
+        Weekday::Tuesday => ::chrono::Weekday::Tue,
+        Weekday::Wednesday => ::chrono::Weekday::Wed,
+        Weekday::Thursday => ::chrono::Weekday::Thu,
+        Weekday::Friday => ::chrono::Weekday::Fri,
+        Weekday::Saturday => ::chrono::Weekday::Sat,
+        Weekday::Sunday => ::chrono::Weekday::Sun,
     }
 }
 
-fn convert_weekday_to_ddlog(weekday: ::time::Weekday) -> Weekday {
+fn convert_weekday_to_ddlog(weekday: ::chrono::Weekday) -> Weekday {
     match (weekday) {
-        ::time::Weekday::Monday => Weekday::Monday,
-        ::time::Weekday::Tuesday => Weekday::Tuesday,
-        ::time::Weekday::Wednesday => Weekday::Wednesday,
-        ::time::Weekday::Thursday => Weekday::Thursday,
-        ::time::Weekday::Friday => Weekday::Friday,
-        ::time::Weekday::Saturday => Weekday::Saturday,
-        ::time::Weekday::Sunday => Weekday::Sunday,
+        ::chrono::Weekday::Mon => Weekday::Monday,
+        ::chrono::Weekday::Tue => Weekday::Tuesday,
+        ::chrono::Weekday::Wed => Weekday::Wednesday,
+        ::chrono::Weekday::Thu => Weekday::Thursday,
+        ::chrono::Weekday::Fri => Weekday::Friday,
+        ::chrono::Weekday::Sat => Weekday::Saturday,
+        ::chrono::Weekday::Sun => Weekday::Sunday,
     }
 }
 
@@ -184,65 +188,65 @@ pub fn try_from_iso_ywd(
     week: &u8,
     weekday: &Weekday,
 ) -> ddlog_std::Result<Date, String> {
-    res2std_date_wrap(::time::Date::try_from_iso_ywd(
+    date_option_to_result(::chrono::NaiveDate::from_isoywd_opt(
         *year,
-        *week,
+        *week as u32,
         convert_weekday_from_ddlog(weekday),
     ))
 }
 
 pub fn year(date: &Date) -> i32 {
-    ::time::Date::year((*date).val)
+    date.val.year()
 }
 
 pub fn month(date: &Date) -> u8 {
-    ::time::Date::month((*date).val)
+    date.val.month() as u8
 }
 
 pub fn day(date: &Date) -> u8 {
-    ::time::Date::day((*date).val)
+    date.val.day() as u8
 }
 
 pub fn ordinal(date: &Date) -> u16 {
-    ::time::Date::ordinal((*date).val)
+    date.val.ordinal() as u16
 }
 
 pub fn week(date: &Date) -> u8 {
-    ::time::Date::week((*date).val)
-}
-
-pub fn sunday_based_week(date: &Date) -> u8 {
-    ::time::Date::sunday_based_week((*date).val)
-}
-
-pub fn monday_based_week(date: &Date) -> u8 {
-    ::time::Date::monday_based_week((*date).val)
+    date.val.iso_week().week() as u8
 }
 
 pub fn weekday(date: &Date) -> Weekday {
-    convert_weekday_to_ddlog(::time::Date::weekday((*date).val))
+    convert_weekday_to_ddlog(date.val.weekday())
+}
+
+pub fn naivedate_to_timedate(date: ::chrono::NaiveDate) -> ::time::Date {
+    ::time::Date::try_from_ymd(date.year(), date.month() as u8, date.day() as u8).unwrap()
+}
+
+pub fn timedate_to_naivedate(date: ::time::Date) -> ::chrono::NaiveDate {
+    ::chrono::NaiveDate::from_ymd(date.year(), date.month().into(), date.day().into())
 }
 
 pub fn next_day(date: &Date) -> Date {
     DateWrapper {
-        val: ::time::Date::next_day((*date).val),
+        val: timedate_to_naivedate(naivedate_to_timedate(date.val).next_day()),
     }
 }
 
 pub fn previous_day(date: &Date) -> Date {
     DateWrapper {
-        val: ::time::Date::previous_day((*date).val),
+        val: timedate_to_naivedate(naivedate_to_timedate(date.val).previous_day()),
     }
-}
-
-pub fn julian_day(date: &Date) -> i64 {
-    ::time::Date::julian_day((*date).val)
 }
 
 pub fn from_julian_day(julian_day: &i64) -> Date {
     DateWrapper {
-        val: ::time::Date::from_julian_day(*julian_day),
+        val: timedate_to_naivedate(::time::Date::from_julian_day(*julian_day))
     }
+}
+
+pub fn julian_day(date: &Date) -> i64 {
+    ::time::Date::julian_day(naivedate_to_timedate(date.val))
 }
 
 const default_date_format: &str = "%Y-%m-%d";
@@ -250,8 +254,8 @@ const default_date_format: &str = "%Y-%m-%d";
 impl FromRecord for Date {
     fn from_record(val: &record::Record) -> ::std::result::Result<Self, String> {
         match (val) {
-            record::Record::String(s) => match (::time::Date::parse(s, default_date_format)) {
-                Ok(s) => Ok(DateWrapper { val: s }),
+            record::Record::String(s) => match (::chrono::NaiveDate::parse_from_str(s, default_date_format)) {
+                Ok(d) => Ok(DateWrapper { val: d }),
                 Err(e) => Err(format!("{}", e)),
             },
             _ => Err(String::from("Unexpected type")),
@@ -259,20 +263,27 @@ impl FromRecord for Date {
     }
 }
 
-pub fn date2string(t: &Date) -> String {
-    t.val.format(default_date_format)
-}
-
 pub fn date_format(d: &Date, format: &String) -> String {
-    d.val.format(format)
+    d.val.format(format).to_string()
 }
 
-pub fn string2date(s: &String) -> ddlog_std::Result<Date, String> {
-    res2std_date_wrap(::time::Date::parse(s, default_date_format))
+pub fn date2string(t: &Date) -> String {
+    date_format(t, &default_date_format.to_string())
 }
 
 pub fn date_parse(s: &String, format: &String) -> ddlog_std::Result<Date, String> {
-    res2std_date_wrap(::time::Date::parse(s, format))
+    match (::chrono::NaiveDate::parse_from_str(s, &default_date_format.to_string())) {
+        Ok(d) => ddlog_std::Result::Ok {
+            res: DateWrapper { val: d }
+        },
+        Err(e) => ddlog_std::Result::Err {
+            err: format!("{}", e)
+        },
+    }
+}
+
+pub fn string2date(s: &String) -> ddlog_std::Result<Date, String> {
+    date_parse(s, &default_date_format.to_string())
 }
 
 impl IntoRecord for Date {
@@ -293,7 +304,7 @@ impl record::Mutator<Date> for record::Record {
 const defaultDateTimeFormat: &str = "%Y-%m-%dT%T";
 
 pub fn datetime_parse(s: &String, format: &String) -> ddlog_std::Result<DateTime, String> {
-    let prim = ::time::PrimitiveDateTime::parse(s, format);
+    let prim = ::chrono::NaiveDateTime::parse_from_str(s, format);
     match (prim) {
         Ok(res) => {
             let dt = DateTime {
@@ -302,15 +313,15 @@ pub fn datetime_parse(s: &String, format: &String) -> ddlog_std::Result<DateTime
             };
             ddlog_std::Result::Ok { res: dt }
         }
-        Err(m) => ddlog_std::Result::Err {
-            err: format!("{}", m),
+        Err(e) => ddlog_std::Result::Err {
+            err: format!("{}", e),
         },
     }
 }
 
 pub fn dateTime2string(d: &DateTime) -> String {
-    let prim = ::time::PrimitiveDateTime::new((*d).date.val, (*d).time.val);
-    prim.format(defaultDateTimeFormat)
+    let prim = ::chrono::NaiveDateTime::new((*d).date.val, (*d).time.val);
+    prim.format(defaultDateTimeFormat).to_string()
 }
 
 pub fn string2datetime(s: &String) -> ddlog_std::Result<DateTime, String> {
@@ -318,14 +329,34 @@ pub fn string2datetime(s: &String) -> ddlog_std::Result<DateTime, String> {
 }
 
 pub fn datetime_format(d: &DateTime, format: &String) -> String {
-    let dt = ::time::PrimitiveDateTime::new((*d).date.val, (*d).time.val);
-    dt.format(format)
+    let dt = ::chrono::NaiveDateTime::new((*d).date.val, (*d).time.val);
+    dt.format(format).to_string()
 }
 
 pub fn datetime_from_unix_timestamp(timestamp: &i64) -> DateTime {
-    let odt = ::time::OffsetDateTime::from_unix_timestamp(*timestamp);
+    let odt = ::chrono::NaiveDateTime::from_timestamp(*timestamp, 0);
     DateTime {
         date: DateWrapper { val: odt.date() },
         time: TimeWrapper { val: odt.time() },
     }
+}
+
+//////////////////////////////////////////// Timezone ////////////////////////////////////
+
+pub fn datetime_to_naivedatetime(dt: DateTime) -> NaiveDateTime {
+    NaiveDateTime::new(dt.date.val, dt.time.val)
+}
+
+pub fn utc() -> FixedOffset {
+    FixedOffset::east(0)
+}
+
+#[derive(Eq, Ord, Clone, Hash, PartialEq, PartialOrd, Serialize, Deserialize, Debug)]
+pub struct TzDateTime {
+    // We only use FixedOffset, since it is the most general timezone offset
+    val: ::chrono::DateTime<::chrono::FixedOffset>,
+}
+
+pub fn utc_timezone(dt: DateTime) -> TzDateTime {
+    TzDateTime { val: utc().from_utc_datetime(&datetime_to_naivedatetime(dt)) }
 }

--- a/lib/time.rs
+++ b/lib/time.rs
@@ -21,7 +21,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-use std::panic;
 use chrono::{Datelike, FixedOffset, NaiveDateTime, TimeZone, Timelike};
 use differential_datalog::record;
 use std::fmt::Write;

--- a/lib/time.rs
+++ b/lib/time.rs
@@ -1,6 +1,6 @@
+use chrono::{Timelike, Datelike, TimeZone, NaiveDateTime, FixedOffset};
 use differential_datalog::record;
 use std::fmt::Display;
-use chrono::{Timelike, Datelike, TimeZone, NaiveDateTime, FixedOffset};
 
 //////////////////////////// Time //////////////////////////////////
 #[derive(Eq, Ord, Clone, Hash, PartialEq, PartialOrd, Serialize, Deserialize, Debug)]
@@ -16,33 +16,39 @@ impl Default for TimeWrapper {
     }
 }
 
-pub fn time_option_to_result(
-    r: Option<::chrono::NaiveTime>,
-) -> ddlog_std::Result<Time, String> {
+pub fn time_option_to_result(r: Option<::chrono::NaiveTime>) -> ddlog_std::Result<Time, String> {
     match (r) {
-        Some(res) => {
-            ddlog_std::Result::Ok { res: TimeWrapper { val: res } }
+        Some(res) => ddlog_std::Result::Ok {
+            res: TimeWrapper { val: res }
         },
         None => ddlog_std::Result::Err {
-            err: "illegal time value".to_string()
+            err: "illegal time value".to_string(),
         },
     }
 }
 
 pub fn try_from_hms(h: &u8, m: &u8, s: &u8) -> ddlog_std::Result<Time, String> {
-    time_option_to_result(::chrono::NaiveTime::from_hms_opt(*h as u32, *m as u32, *s as u32))
+    time_option_to_result(::chrono::NaiveTime::from_hms_opt(
+        *h as u32, *m as u32, *s as u32,
+    ))
 }
 
 pub fn try_from_hms_milli(h: &u8, m: &u8, s: &u8, ms: &u16) -> ddlog_std::Result<Time, String> {
-    time_option_to_result(::chrono::NaiveTime::from_hms_milli_opt(*h as u32, *m as u32, *s as u32, *ms as u32))
+    time_option_to_result(::chrono::NaiveTime::from_hms_milli_opt(
+        *h as u32, *m as u32, *s as u32, *ms as u32,
+    ))
 }
 
 pub fn try_from_hms_micro(h: &u8, m: &u8, s: &u8, mc: &u32) -> ddlog_std::Result<Time, String> {
-    time_option_to_result(::chrono::NaiveTime::from_hms_micro_opt(*h as u32, *m as u32, *s as u32, *mc as u32))
+    time_option_to_result(::chrono::NaiveTime::from_hms_micro_opt(
+        *h as u32, *m as u32, *s as u32, *mc as u32,
+    ))
 }
 
 pub fn try_from_hms_nano(h: &u8, m: &u8, s: &u8, mc: &u32) -> ddlog_std::Result<Time, String> {
-    time_option_to_result(::chrono::NaiveTime::from_hms_nano_opt(*h as u32, *m as u32, *s as u32, *mc as u32))
+    time_option_to_result(::chrono::NaiveTime::from_hms_nano_opt(
+        *h as u32, *m as u32, *s as u32, *mc as u32,
+    ))
 }
 
 pub fn hour(t: &Time) -> u8 {
@@ -79,9 +85,11 @@ pub fn midnight() -> Time {
 
 pub fn time_parse(s: &String, format: &String) -> ddlog_std::Result<Time, String> {
     match (::chrono::NaiveTime::parse_from_str(s, format)) {
-        Ok(t) => ddlog_std::Result::Ok { res: TimeWrapper { val: t }},
+        Ok(t) => ddlog_std::Result::Ok {
+            res: TimeWrapper { val: t }
+        },
         Err(e) => ddlog_std::Result::Err {
-            err: format!("{}", e)
+            err: format!("{}", e),
         },
     }
 }
@@ -101,10 +109,12 @@ pub fn string2time(s: &String) -> ddlog_std::Result<Time, String> {
 impl FromRecord for Time {
     fn from_record(val: &record::Record) -> ::std::result::Result<Self, String> {
         match (val) {
-            record::Record::String(s) => match (::chrono::NaiveTime::parse_from_str(s, &default_time_format.to_string())) {
-                Ok(t) => Ok(TimeWrapper { val: t }),
-                Err(e) => Err(format!("{}", e)),
-            },
+            record::Record::String(s) => {
+                match (::chrono::NaiveTime::parse_from_str(s, &default_time_format.to_string())) {
+                    Ok(t) => Ok(TimeWrapper { val: t }),
+                    Err(e) => Err(format!("{}", e)),
+                }
+            }
             _ => Err(String::from("Unexpected type")),
         }
     }
@@ -138,12 +148,10 @@ impl Default for DateWrapper {
     }
 }
 
-pub fn date_option_to_result(
-    r: Option<::chrono::NaiveDate>,
-) -> ddlog_std::Result<Date, String> {
+pub fn date_option_to_result(r: Option<::chrono::NaiveDate>) -> ddlog_std::Result<Date, String> {
     match (r) {
-        Some(d) => {
-            ddlog_std::Result::Ok { res: DateWrapper { val: d }}
+        Some(d) => ddlog_std::Result::Ok {
+            res: DateWrapper { val: d },
         },
         None => ddlog_std::Result::Err {
             err: "Invalid date".to_string(),
@@ -241,7 +249,7 @@ pub fn previous_day(date: &Date) -> Date {
 
 pub fn from_julian_day(julian_day: &i64) -> Date {
     DateWrapper {
-        val: timedate_to_naivedate(::time::Date::from_julian_day(*julian_day))
+        val: timedate_to_naivedate(::time::Date::from_julian_day(*julian_day)),
     }
 }
 
@@ -254,10 +262,12 @@ const default_date_format: &str = "%Y-%m-%d";
 impl FromRecord for Date {
     fn from_record(val: &record::Record) -> ::std::result::Result<Self, String> {
         match (val) {
-            record::Record::String(s) => match (::chrono::NaiveDate::parse_from_str(s, default_date_format)) {
-                Ok(d) => Ok(DateWrapper { val: d }),
-                Err(e) => Err(format!("{}", e)),
-            },
+            record::Record::String(s) => {
+                match (::chrono::NaiveDate::parse_from_str(s, default_date_format)) {
+                    Ok(d) => Ok(DateWrapper { val: d }),
+                    Err(e) => Err(format!("{}", e)),
+                }
+            }
             _ => Err(String::from("Unexpected type")),
         }
     }
@@ -274,10 +284,10 @@ pub fn date2string(t: &Date) -> String {
 pub fn date_parse(s: &String, format: &String) -> ddlog_std::Result<Date, String> {
     match (::chrono::NaiveDate::parse_from_str(s, &default_date_format.to_string())) {
         Ok(d) => ddlog_std::Result::Ok {
-            res: DateWrapper { val: d }
+            res: DateWrapper { val: d },
         },
         Err(e) => ddlog_std::Result::Err {
-            err: format!("{}", e)
+            err: format!("{}", e),
         },
     }
 }
@@ -358,5 +368,7 @@ pub struct TzDateTime {
 }
 
 pub fn utc_timezone(dt: DateTime) -> TzDateTime {
-    TzDateTime { val: utc().from_utc_datetime(&datetime_to_naivedatetime(dt)) }
+    TzDateTime {
+        val: utc().from_utc_datetime(&datetime_to_naivedatetime(dt)),
+    }
 }

--- a/lib/time.rs
+++ b/lib/time.rs
@@ -118,12 +118,13 @@ pub fn time_parse(s: &String, format: &String) -> ddlog_std::Result<Time, String
     }
 }
 
-pub fn result_from_delayed_format<'a>(d: chrono::format::DelayedFormat<chrono::format::strftime::StrftimeItems<'a>>, format: &String) -> ddlog_std::Result<String, String> {
+pub fn result_from_delayed_format<'a>(
+    d: chrono::format::DelayedFormat<chrono::format::strftime::StrftimeItems<'a>>,
+    format: &String,
+) -> ddlog_std::Result<String, String> {
     let mut buffer = String::new();
     match write!(&mut buffer, "{}", d) {
-        Ok(t) => ddlog_std::Result::Ok {
-            res: buffer,
-        },
+        Ok(t) => ddlog_std::Result::Ok { res: buffer },
         Err(_) => ddlog_std::Result::Err {
             err: format!("Error in format string '{}'", format),
         },

--- a/lib/time.rs
+++ b/lib/time.rs
@@ -1,4 +1,4 @@
-use chrono::{Timelike, Datelike, TimeZone, NaiveDateTime, FixedOffset};
+use chrono::{Datelike, FixedOffset, NaiveDateTime, TimeZone, Timelike};
 use differential_datalog::record;
 use std::fmt::Display;
 
@@ -19,7 +19,7 @@ impl Default for TimeWrapper {
 pub fn time_option_to_result(r: Option<::chrono::NaiveTime>) -> ddlog_std::Result<Time, String> {
     match (r) {
         Some(res) => ddlog_std::Result::Ok {
-            res: TimeWrapper { val: res }
+            res: TimeWrapper { val: res },
         },
         None => ddlog_std::Result::Err {
             err: "illegal time value".to_string(),
@@ -160,7 +160,11 @@ pub fn date_option_to_result(r: Option<::chrono::NaiveDate>) -> ddlog_std::Resul
 }
 
 pub fn try_from_ymd(year: &i32, month: &u8, day: &u8) -> ddlog_std::Result<Date, String> {
-    date_option_to_result(::chrono::NaiveDate::from_ymd_opt(*year, *month as u32, *day as u32))
+    date_option_to_result(::chrono::NaiveDate::from_ymd_opt(
+        *year,
+        *month as u32,
+        *day as u32,
+    ))
 }
 
 pub fn try_from_yo(year: &i32, ordinal: &u16) -> ddlog_std::Result<Date, String> {

--- a/lib/time.toml
+++ b/lib/time.toml
@@ -1,0 +1,3 @@
+[dependencies.chrono]
+version = "0.4"
+features = ["serde"]

--- a/lib/tinyset.dl
+++ b/lib/tinyset.dl
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 /* `tinyset` (https://docs.rs/tinyset/0.2.2/tinyset/) is a Rust crate that
  * implements several space-efficient sparse collections.  This library is a
  * wrapper around `tinyset` that so far only supports one of these types --

--- a/lib/tinyset.flatbuf.rs
+++ b/lib/tinyset.flatbuf.rs
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 use types__tinyset::*;
 
 impl<'a, T, F> FromFlatBuffer<fbrt::Vector<'a, F>> for Set64<T>

--- a/lib/tinyset.rs
+++ b/lib/tinyset.rs
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 use differential_datalog::record::*;
 use serde;
 use std::cmp;

--- a/lib/url.dl
+++ b/lib/url.dl
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 /* Bindings for the Rust URL library.
  */
 

--- a/lib/url.rs
+++ b/lib/url.rs
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 use differential_datalog::record;
 
 #[derive(Eq, Ord, Clone, Hash, PartialEq, PartialOrd, Serialize, Deserialize, Debug)]

--- a/lib/uuid.dl
+++ b/lib/uuid.dl
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 /* Universally Unique Identified (UUID) library.
  *
  * Functions in this library are bindings for functions in
@@ -8,7 +31,7 @@ extern type Uuid
 
 typedef Error = string
 
-/* The nil UUID is special form of UUID that is specified to have all 128 bits 
+/* The nil UUID is special form of UUID that is specified to have all 128 bits
  * set to zero, as defined in IETF RFC 4122 Section 4.1.7. */
 extern function nil(): Uuid
 

--- a/lib/uuid.rs
+++ b/lib/uuid.rs
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 use differential_datalog::record::Record;
 use serde::de::Deserializer;
 use serde::ser::Serializer;

--- a/lib/vec.dl
+++ b/lib/vec.dl
@@ -1,4 +1,27 @@
 /*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+/*
  * Functions for working with vectors (see basic vector operations defined in
  * `ddlog_std.dl`).
  */

--- a/lib/vec.rs
+++ b/lib/vec.rs
@@ -1,3 +1,26 @@
+/*
+Copyright (c) 2021 VMware, Inc.
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 use ddlog_rt::Closure;
 
 pub fn vec_sort_by<A, B: Ord>(v: &mut ddlog_std::Vec<A>, f: &Box<dyn Closure<*const A, B>>) {

--- a/rust/template/Cargo.toml
+++ b/rust/template/Cargo.toml
@@ -17,6 +17,7 @@ c_api = ["differential_datalog/c_api"]
 [dependencies]
 abomonation = "0.7"
 time = { version = "0.2", features = ["serde"] }
+chrono = { version = "0.4", features = ["serde"] }
 ordered-float = { version = "2.0.0", features = ["serde"] }
 cpuprofiler = { version = "0.0", optional = true }
 #differential-dataflow = "0.11.0"

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -713,7 +713,7 @@ simplifyDifferentiation d =
                else return a)
         S.empty
 
-compileLib :: (?cfg::Config, ?specname::String, ?crate_graph::CrateGraph, ?modules::M.Map ModuleName DatalogModule) 
+compileLib :: (?cfg::Config, ?specname::String, ?crate_graph::CrateGraph, ?modules::M.Map ModuleName DatalogModule)
     => DatalogProgram -> M.Map String String -> M.Map ModuleName (Doc, Doc, Doc) -> (M.Map FilePath Doc, Doc)
 compileLib d d3log_rel_map rs_code =
     (crates, main_lib)
@@ -778,6 +778,7 @@ mkCargoToml rs_code crate crate_id =
            "once_cell = \"1.4.1\""                                                         $$
            "libc = \"0.2\""                                                                $$
            "time = { version = \"0.2\", features = [\"serde\"] }"                          $$
+           "chrono = { version = \"0.4\", features = [\"serde\"] }"                        $$
            "serde_json = \"1.0\""                                                          $$
            "serde = { version = \"1.0\", features = [\"derive\"] }"                        $$
            "num = \"0.3\""                                                                 $$

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -778,7 +778,6 @@ mkCargoToml rs_code crate crate_id =
            "once_cell = \"1.4.1\""                                                         $$
            "libc = \"0.2\""                                                                $$
            "time = { version = \"0.2\", features = [\"serde\"] }"                          $$
-           "chrono = { version = \"0.4\", features = [\"serde\"] }"                        $$
            "serde_json = \"1.0\""                                                          $$
            "serde = { version = \"1.0\", features = [\"derive\"] }"                        $$
            "num = \"0.3\""                                                                 $$

--- a/test/datalog_tests/time_test.dl
+++ b/test/datalog_tests/time_test.dl
@@ -87,6 +87,13 @@ function someDateTimeFormat(): string {
 input relation DTITest(d: DateTime)
 output relation DTTest(s: string, t: Result<DateTime, string>)
 
+function get_datetime(r: Result<TzDateTime, string>): Result<DateTime, string> {
+     match (r) {
+         Ok{dt} -> Ok{utc_datetime(dt)},
+         Err{e} -> Err{e}
+     }
+}
+
 DTTest(to_string(d), Ok{d}) :- DTITest(d).
 DTTest("string2datetime(\"2020-10-10T10:20:30\")", string2datetime("2020-10-10T10:20:30")).
 DTTest("string2datetime(to_string(${someDateTime()}))",
@@ -98,5 +105,36 @@ DTTest("datetime_parse(\"2020/10/10T10:20:30\", \"%Y-%m-%dT%H:%M:%S\")",
 DTTest("datetime_parse(datetime_format(${someDateTime()}, ${someDateTimeFormat()}), ${someDateTimeFormat()})",
         datetime_parse(datetime_format(someDateTime(), someDateTimeFormat()), someDateTimeFormat())).
 DTTest("datetime_from_unix_timestamp(10000000)", Ok{datetime_from_unix_timestamp(10000000)}).
+DTTest("datetime_parse(\"Wed Mar 05 07:45:30 MST 2025\", \"%a %b %d %H:%M:%S %Z %Y\")",
+        datetime_parse("Wed Mar 05 07:45:30 MST 2025", "%a %b %d %H:%M:%S %Z %Y")).
+DTTest("get_datetime(tz_datetime_parse_from_rfc2822(\"Tue, 1 Jul 2003 10:52:37 GMT\"))",
+        get_datetime(tz_datetime_parse_from_rfc2822("Tue, 1 Jul 2003 10:52:37 GMT"))).
 
 //////////////////////////////////////////////////
+
+input relation DTZITest(d: TzDateTime)
+output relation DTZTest(s: string, t: Result<TzDateTime, string>)
+
+function utc(r: Result<DateTime, string>): Result<TzDateTime, string> {
+     match (r) {
+         Ok{dt} -> Ok{utc_timezone(dt)},
+         Err{e} -> Err{e}
+     }
+}
+
+DTZTest(to_string(d), Ok{d}) :- DTZITest(d).
+DTZTest("utc(string2datetime(\"2020-10-10T10:20:30\"))", utc(string2datetime("2020-10-10T10:20:30"))).
+DTZTest("tz_datetime_parse(\"2020-10-10T10:20:30 +02:00\", \"%Y-%m-%dT%H:%M:%S %z\")",
+        tz_datetime_parse("2020-10-10T10:20:30 +02:00", "%Y-%m-%dT%H:%M:%S %z")).
+DTZTest("tz_datetime_parse(\"2020/10/10T10:20:30 -02:00\", \"%Y/%m/%dT%H:%M:%S %z\")",
+        tz_datetime_parse("2020/10/10T10:20:30 -03:00", "%Y/%m/%dT%H:%M:%S %z")).
+DTZTest("tz_datetime_parse_from_rfc3339(\"2020-10-10T10:20:30-03:00\")",
+        tz_datetime_parse_from_rfc3339("2020-10-10T10:20:30-03:00")).
+DTZTest("tz_datetime_parse_from_rfc2822(\"Tue, 1 Jul 2003 10:52:37 +0200\")",
+        tz_datetime_parse_from_rfc2822("Tue, 1 Jul 2003 10:52:37 +0200")).
+DTZTest("tz_datetime_parse_from_rfc2822(\"Tue, 1 Jul 2003 10:52:37 GMT\")",
+        tz_datetime_parse_from_rfc2822("Tue, 1 Jul 2003 10:52:37 GMT")).
+// The following actually gives an error, since the %Z format cannot infer a timezone reliably
+// So this cannot extract a date with a timezone, only a DateTime
+DTZTest("tz_datetime_parse(\"Wed Mar 05 07:45:30 MST 2025\", \"%a %b %d %H:%M:%S %Z %Y\")",
+         tz_datetime_parse("Wed Mar 05 07:45:30 MST 2025", "%a %b %d %H:%M:%S %Z %Y")).

--- a/test/datalog_tests/time_test.dl
+++ b/test/datalog_tests/time_test.dl
@@ -14,7 +14,7 @@ TTest("try_from_hms(8'd0, 8'd60, 8'd0)", try_from_hms(8'd0, 8'd60, 8'd0)).
 TTest("Ok(midnight())", Ok{midnight()}: Result<Time, string>).
 TTest("time_parse(\"10:10\", \"%T\")", time_parse("10:10", "%T")).
 TTest("time_parse(\"10:10:10\", \"%T\")", time_parse("10:10:10", "%T")).
-TTest("time_parse(\"10:10:10.102030405\", \"%T.%N\")", time_parse("10:10:10.102030405", "%T.%N")).
+TTest("time_parse(\"10:10:10.102030405\", \"%T.%f\")", time_parse("10:10:10.102030405", "%T.%f")).
 TTest("string2time(to_string(result_unwrap_or_default(try_from_hms(8'd10, 8'd10, 8'd10))))",
        try_from_hms(8'd10, 8'd10, 8'd10).unwrap_or_default().to_string().to_time()).
 TTest("string2time(to_string(result_unwrap_or_default(try_from_hms_milli(8'd10, 8'd10, 8'd10, 16'd10))))",
@@ -74,8 +74,6 @@ Extract("month(${someDate()})", month(someDate()) as bit<32>).
 Extract("day(${someDate()})", day(someDate()) as bit<32>).
 Extract("ordinal(${someDate()})", ordinal(someDate()) as bit<32>).
 Extract("week(${someDate()})", week(someDate()) as bit<32>).
-Extract("sunday_based_week(${someDate()})", sunday_based_week(someDate()) as bit<32>).
-Extract("monday_based_week(${someDate()})", monday_based_week(someDate()) as bit<32>).
 
 //////////////////////////////////////////////
 
@@ -100,3 +98,5 @@ DTTest("datetime_parse(\"2020/10/10T10:20:30\", \"%Y-%m-%dT%H:%M:%S\")",
 DTTest("datetime_parse(datetime_format(${someDateTime()}, ${someDateTimeFormat()}), ${someDateTimeFormat()})",
         datetime_parse(datetime_format(someDateTime(), someDateTimeFormat()), someDateTimeFormat())).
 DTTest("datetime_from_unix_timestamp(10000000)", Ok{datetime_from_unix_timestamp(10000000)}).
+
+//////////////////////////////////////////////////

--- a/test/datalog_tests/time_test.dl
+++ b/test/datalog_tests/time_test.dl
@@ -3,6 +3,13 @@ import time
 input relation TITest(t: Time)
 output relation TTest(s: string, t: Result<Time, string>)
 
+function result_or_error(r: Result<string, string>): string {
+    match (r) {
+        Ok{s} -> s,
+        Err{e} -> e
+    }
+}
+
 TTest(t.to_string(), Ok{t}) :- TITest(t).
 TTest("try_from_hms(8'd10, 8'd10, 8'd10)", try_from_hms(8'd10, 8'd10, 8'd10)).
 TTest("try_from_hms_milli(8'd10, 8'd10, 8'd10, 16'd10)", try_from_hms_milli(8'd10, 8'd10, 8'd10, 16'd10)).
@@ -23,8 +30,15 @@ TTest("string2time(to_string(result_unwrap_or_default(try_from_hms_micro(8'd10, 
        string2time(to_string(result_unwrap_or_default(try_from_hms_micro(8'd10, 8'd10, 8'd10, 32'd10))))).
 TTest("string2time(to_string(result_unwrap_or_default(try_from_hms_nano(8'd10, 8'd10, 8'd10, 32'd10))))",
        string2time(to_string(result_unwrap_or_default(try_from_hms_nano(8'd10, 8'd10, 8'd10, 32'd10))))).
-TTest("time_parse(time_format(${someTime()}, ${someTimeFormat()}), ${someTimeFormat()})",
-       time_parse(time_format(someTime(), someTimeFormat()), someTimeFormat())).
+TTest("time_parse(time_format(${someTime()}, ${someTimeFormat()}).unwrap_or_default(), ${someTimeFormat()})",
+       time_parse(time_format(someTime(), someTimeFormat()).unwrap_or_default(), someTimeFormat())).
+// Check that default value is ok
+TTest("try_from_hms(100, 0, 0).unwrap_or_default()", Ok{try_from_hms(100, 0, 0).unwrap_or_default()}).
+// This test checks that an incorrect format does not cause a panic
+TTest(time_format(someTime(), "%incorrectformat").result_or_error(), Ok{someTime()}).
+// Test to_string
+TTest("${someTime()}", Ok{someTime()}).
+TTest("SomeTime: ${someTzDateTime().time()}", Ok{someTzDateTime().time()}).
 
 function someTime(): Time {
    result_unwrap_or_default( try_from_hms_nano(10, 11, 12, 103104105) )
@@ -66,8 +80,14 @@ DTest("string2date(to_string(someDate()))",
 DTest("Ok{next_day(${someDate()})}", Ok{next_day(someDate())}).
 DTest("Ok{previous_day(${someDate()})}", Ok{previous_day(someDate())}).
 DTest("Ok{from_julian_day(2000000)}", Ok{from_julian_day(2000000)}).
-DTest("date_parse(date_format(${someDate()}, ${someDateFormat()}), ${someDateFormat()})",
-       date_parse(date_format(someDate(), someDateFormat()), someDateFormat())).
+DTest("date_parse(date_format(${someDate()}, ${someDateFormat()}).result_or_error(), ${someDateFormat()})",
+       date_parse(date_format(someDate(), someDateFormat()).result_or_error(), someDateFormat())).
+// Check that default value is ok
+DTest("try_from_yd(0, 0, 0).unwrap_or_default()", Ok{try_from_ymd(0, 0, 0).unwrap_or_default()}).
+// This test checks that an incorrect format does not cause a panic
+DTest(date_format(someDate(), "%incorrectformat").result_or_error(), Ok{someDate()}).
+// Test to_string
+DTest("${someDate()}", Ok{someDate()}).
 
 Extract("year(${someDate()})", year(someDate()) as bit<32>).
 Extract("month(${someDate()})", month(someDate()) as bit<32>).
@@ -102,13 +122,21 @@ DTTest("datetime_parse(\"2020-10-10T10:20:30\", \"%Y-%m-%dT%H:%M:%S\")",
         datetime_parse("2020-10-10T10:20:30", "%Y-%m-%dT%H:%M:%S")).
 DTTest("datetime_parse(\"2020/10/10T10:20:30\", \"%Y-%m-%dT%H:%M:%S\")",
         datetime_parse("2020/10/10T10:20:30", "%Y-%m-%dT%H:%M:%S")).
-DTTest("datetime_parse(datetime_format(${someDateTime()}, ${someDateTimeFormat()}), ${someDateTimeFormat()})",
-        datetime_parse(datetime_format(someDateTime(), someDateTimeFormat()), someDateTimeFormat())).
+DTTest("datetime_parse(datetime_format(${someDateTime()}, ${someDateTimeFormat()}).result_or_error(), ${someDateTimeFormat()})",
+        datetime_parse(datetime_format(someDateTime(), someDateTimeFormat()).result_or_error(), someDateTimeFormat())).
 DTTest("datetime_from_unix_timestamp(10000000)", Ok{datetime_from_unix_timestamp(10000000)}).
 DTTest("datetime_parse(\"Wed Mar 05 07:45:30 MST 2025\", \"%a %b %d %H:%M:%S %Z %Y\")",
         datetime_parse("Wed Mar 05 07:45:30 MST 2025", "%a %b %d %H:%M:%S %Z %Y")).
 DTTest("get_datetime(tz_datetime_parse_from_rfc2822(\"Tue, 1 Jul 2003 10:52:37 GMT\"))",
         get_datetime(tz_datetime_parse_from_rfc2822("Tue, 1 Jul 2003 10:52:37 GMT"))).
+// Check that default value is ok
+DTTest("\"\".string2datetime().unwrap_or_default()", Ok{"".string2datetime().unwrap_or_default()}).
+// This test checks that an incorrect format does not cause a panic
+DTTest(datetime_format(someDateTime(), "%incorrectformat").result_or_error(), Ok{someDateTime()}).
+// Test to_string
+DTTest("${someDateTime()}", Ok{someDateTime()}).
+DTTest("Extract date ${someTzDateTime().utc_datetime()}", Ok{someTzDateTime().utc_datetime()}).
+DTTest("Extract shifted ${someTzDateTime().change_offset(-1000).utc_datetime()}", Ok{someTzDateTime().change_offset(-1000).utc_datetime()}).
 
 //////////////////////////////////////////////////
 
@@ -122,8 +150,12 @@ function utc(r: Result<DateTime, string>): Result<TzDateTime, string> {
      }
 }
 
+function someTzDateTime(): TzDateTime {
+     someDateTime().utc_timezone()
+}
+
 DTZTest(to_string(d), Ok{d}) :- DTZITest(d).
-DTZTest("utc(string2datetime(\"2020-10-10T10:20:30\"))", utc(string2datetime("2020-10-10T10:20:30"))).
+DTZTest("string2datetime(\"2020-10-10T10:20:30\").utc()", string2datetime("2020-10-10T10:20:30").utc()).
 DTZTest("tz_datetime_parse(\"2020-10-10T10:20:30 +02:00\", \"%Y-%m-%dT%H:%M:%S %z\")",
         tz_datetime_parse("2020-10-10T10:20:30 +02:00", "%Y-%m-%dT%H:%M:%S %z")).
 DTZTest("tz_datetime_parse(\"2020/10/10T10:20:30 -02:00\", \"%Y/%m/%dT%H:%M:%S %z\")",
@@ -138,3 +170,11 @@ DTZTest("tz_datetime_parse_from_rfc2822(\"Tue, 1 Jul 2003 10:52:37 GMT\")",
 // So this cannot extract a date with a timezone, only a DateTime
 DTZTest("tz_datetime_parse(\"Wed Mar 05 07:45:30 MST 2025\", \"%a %b %d %H:%M:%S %Z %Y\")",
          tz_datetime_parse("Wed Mar 05 07:45:30 MST 2025", "%a %b %d %H:%M:%S %Z %Y")).
+// This test checks that an incorrect format does not cause a panic
+DTZTest(tz_datetime_format(someTzDateTime(), "%incorrectformat").result_or_error(), Ok{someTzDateTime()}).
+// Test to_string
+DTZTest("${someTzDateTime()}", Ok{someTzDateTime()}).
+// Check that default value is ok
+DTZTest("\"\".tz_datetime_parse_from_rfc2822().unwrap_or_default()", Ok{"".tz_datetime_parse_from_rfc2822().unwrap_or_default()}).
+DTZTest("RFC 2822: ${someTzDateTime().to_rfc2822()}", Ok{someTzDateTime()}).
+DTZTest("RFC 3339: ${someTzDateTime().to_rfc3339()}", Ok{someTzDateTime()}).

--- a/test/datalog_tests/time_test.dump.expected
+++ b/test/datalog_tests/time_test.dump.expected
@@ -1,28 +1,41 @@
 DTTest:
+DTTest{.s = "\"\".string2datetime().unwrap_or_default()", .t = ddlog_std::Ok{.res = time::DateTime{.date = "0000-01-01", .time = "00:00:00.000000000"}}}: +1
+DTTest{.s = "2020-04-14T10:11:12", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.103104105"}}}: +1
+DTTest{.s = "Error in format string '%incorrectformat'", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.103104105"}}}: +1
+DTTest{.s = "Extract date 2020-04-14T10:11:12", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.103104105"}}}: +1
+DTTest{.s = "Extract shifted 2020-04-14T10:11:12", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.103104105"}}}: +1
 DTTest{.s = "datetime_from_unix_timestamp(10000000)", .t = ddlog_std::Ok{.res = time::DateTime{.date = "1970-04-26", .time = "17:46:40.000000000"}}}: +1
 DTTest{.s = "datetime_parse(\"2020-10-10T10:20:30\", \"%Y-%m-%dT%H:%M:%S\")", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-10-10", .time = "10:20:30.000000000"}}}: +1
 DTTest{.s = "datetime_parse(\"2020/10/10T10:20:30\", \"%Y-%m-%dT%H:%M:%S\")", .t = ddlog_std::Err{.err = "input contains invalid characters"}}: +1
 DTTest{.s = "datetime_parse(\"Wed Mar 05 07:45:30 MST 2025\", \"%a %b %d %H:%M:%S %Z %Y\")", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2025-03-05", .time = "07:45:30.000000000"}}}: +1
-DTTest{.s = "datetime_parse(datetime_format(2020-04-14T10:11:12, %Y-%m-%dT%H::%M), %Y-%m-%dT%H::%M)", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:00.000000000"}}}: +1
+DTTest{.s = "datetime_parse(datetime_format(2020-04-14T10:11:12, %Y-%m-%dT%H::%M).result_or_error(), %Y-%m-%dT%H::%M)", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:00.000000000"}}}: +1
 DTTest{.s = "get_datetime(tz_datetime_parse_from_rfc2822(\"Tue, 1 Jul 2003 10:52:37 GMT\"))", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2003-07-01", .time = "10:52:37.000000000"}}}: +1
 DTTest{.s = "string2datetime(\"2020-10-10T10:20:30\")", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-10-10", .time = "10:20:30.000000000"}}}: +1
 DTTest{.s = "string2datetime(to_string(2020-04-14T10:11:12))", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.000000000"}}}: +1
 DTZTest:
+DTZTest{.s = "\"\".tz_datetime_parse_from_rfc2822().unwrap_or_default()", .t = ddlog_std::Ok{.res = "0000-01-01T00:00:00+00:00"}}: +1
+DTZTest{.s = "2020-04-14T10:11:12.103104105+00:00", .t = ddlog_std::Ok{.res = "2020-04-14T10:11:12.103104105+00:00"}}: +1
+DTZTest{.s = "Error in format string '%incorrectformat'", .t = ddlog_std::Ok{.res = "2020-04-14T10:11:12.103104105+00:00"}}: +1
+DTZTest{.s = "RFC 2822: Tue, 14 Apr 2020 10:11:12 +0000", .t = ddlog_std::Ok{.res = "2020-04-14T10:11:12.103104105+00:00"}}: +1
+DTZTest{.s = "RFC 3339: 2020-04-14T10:11:12.103104105+00:00", .t = ddlog_std::Ok{.res = "2020-04-14T10:11:12.103104105+00:00"}}: +1
+DTZTest{.s = "string2datetime(\"2020-10-10T10:20:30\").utc()", .t = ddlog_std::Ok{.res = "2020-10-10T10:20:30+00:00"}}: +1
 DTZTest{.s = "tz_datetime_parse(\"2020-10-10T10:20:30 +02:00\", \"%Y-%m-%dT%H:%M:%S %z\")", .t = ddlog_std::Ok{.res = "2020-10-10T10:20:30+02:00"}}: +1
 DTZTest{.s = "tz_datetime_parse(\"2020/10/10T10:20:30 -02:00\", \"%Y/%m/%dT%H:%M:%S %z\")", .t = ddlog_std::Ok{.res = "2020-10-10T10:20:30-03:00"}}: +1
 DTZTest{.s = "tz_datetime_parse(\"Wed Mar 05 07:45:30 MST 2025\", \"%a %b %d %H:%M:%S %Z %Y\")", .t = ddlog_std::Err{.err = "input is not enough for unique date and time"}}: +1
 DTZTest{.s = "tz_datetime_parse_from_rfc2822(\"Tue, 1 Jul 2003 10:52:37 +0200\")", .t = ddlog_std::Ok{.res = "2003-07-01T10:52:37+02:00"}}: +1
 DTZTest{.s = "tz_datetime_parse_from_rfc2822(\"Tue, 1 Jul 2003 10:52:37 GMT\")", .t = ddlog_std::Ok{.res = "2003-07-01T10:52:37+00:00"}}: +1
 DTZTest{.s = "tz_datetime_parse_from_rfc3339(\"2020-10-10T10:20:30-03:00\")", .t = ddlog_std::Ok{.res = "2020-10-10T10:20:30-03:00"}}: +1
-DTZTest{.s = "utc(string2datetime(\"2020-10-10T10:20:30\"))", .t = ddlog_std::Ok{.res = "2020-10-10T10:20:30+00:00"}}: +1
 DTest:
+DTest{.s = "2020-04-14", .t = ddlog_std::Ok{.res = "2020-04-14"}}: +1
+DTest{.s = "Error in format string '%incorrectformat'", .t = ddlog_std::Ok{.res = "2020-04-14"}}: +1
 DTest{.s = "Ok{from_julian_day(2000000)}", .t = ddlog_std::Ok{.res = "0763-09-18"}}: +1
 DTest{.s = "Ok{next_day(2020-04-14)}", .t = ddlog_std::Ok{.res = "2020-04-15"}}: +1
 DTest{.s = "Ok{previous_day(2020-04-14)}", .t = ddlog_std::Ok{.res = "2020-04-13"}}: +1
-DTest{.s = "date_parse(\"2020/04/14\", \"%Y/%m/%d\")", .t = ddlog_std::Err{.err = "input contains invalid characters"}}: +1
-DTest{.s = "date_parse(date_format(2020-04-14, %Y-%m-%dT), %Y-%m-%dT)", .t = ddlog_std::Err{.err = "trailing input"}}: +1
+DTest{.s = "date_parse(\"2020/04/14\", \"%Y/%m/%d\")", .t = ddlog_std::Ok{.res = "2020-04-14"}}: +1
+DTest{.s = "date_parse(date_format(2020-04-14, %Y-%m-%dT).result_or_error(), %Y-%m-%dT)", .t = ddlog_std::Ok{.res = "2020-04-14"}}: +1
 DTest{.s = "string2date(to_string(someDate()))", .t = ddlog_std::Ok{.res = "2020-04-14"}}: +1
 DTest{.s = "try_from_iso_ywd(32'sd2020, 8'd4, Monday)", .t = ddlog_std::Ok{.res = "2020-01-20"}}: +1
+DTest{.s = "try_from_yd(0, 0, 0).unwrap_or_default()", .t = ddlog_std::Ok{.res = "0000-01-01"}}: +1
 DTest{.s = "try_from_ymd(32'sd2020, 8'd0, 8'd14)", .t = ddlog_std::Err{.err = "Invalid date"}}: +1
 DTest{.s = "try_from_ymd(32'sd2020, 8'd04, 8'd14)", .t = ddlog_std::Ok{.res = "2020-04-14"}}: +1
 DTest{.s = "try_from_ymd(32'sd2020, 8'd13, 8'd14)", .t = ddlog_std::Err{.err = "Invalid date"}}: +1
@@ -41,7 +54,10 @@ Extract{.s = "second(10:11:12.103104105)", .v = 12}: +1
 Extract{.s = "week(2020-04-14)", .v = 16}: +1
 Extract{.s = "year(2020-04-14)", .v = 2020}: +1
 TTest:
+TTest{.s = "10:11:12.103104105", .t = ddlog_std::Ok{.res = "10:11:12.103104105"}}: +1
+TTest{.s = "Error in format string '%incorrectformat'", .t = ddlog_std::Ok{.res = "10:11:12.103104105"}}: +1
 TTest{.s = "Ok(midnight())", .t = ddlog_std::Ok{.res = "00:00:00.000000000"}}: +1
+TTest{.s = "SomeTime: 10:11:12.103104105", .t = ddlog_std::Ok{.res = "10:11:12.103104105"}}: +1
 TTest{.s = "string2time(to_string(result_unwrap_or_default(try_from_hms(8'd10, 8'd10, 8'd10))))", .t = ddlog_std::Ok{.res = "10:10:10.000000000"}}: +1
 TTest{.s = "string2time(to_string(result_unwrap_or_default(try_from_hms_micro(8'd10, 8'd10, 8'd10, 32'd10))))", .t = ddlog_std::Ok{.res = "10:10:10.000010000"}}: +1
 TTest{.s = "string2time(to_string(result_unwrap_or_default(try_from_hms_milli(8'd10, 8'd10, 8'd10, 16'd10))))", .t = ddlog_std::Ok{.res = "10:10:10.010000000"}}: +1
@@ -49,7 +65,8 @@ TTest{.s = "string2time(to_string(result_unwrap_or_default(try_from_hms_nano(8'd
 TTest{.s = "time_parse(\"10:10\", \"%T\")", .t = ddlog_std::Err{.err = "premature end of input"}}: +1
 TTest{.s = "time_parse(\"10:10:10\", \"%T\")", .t = ddlog_std::Ok{.res = "10:10:10.000000000"}}: +1
 TTest{.s = "time_parse(\"10:10:10.102030405\", \"%T.%f\")", .t = ddlog_std::Ok{.res = "10:10:10.102030405"}}: +1
-TTest{.s = "time_parse(time_format(10:11:12.103104105, %H::%M::%S), %H::%M::%S)", .t = ddlog_std::Ok{.res = "10:11:12.000000000"}}: +1
+TTest{.s = "time_parse(time_format(10:11:12.103104105, %H::%M::%S).unwrap_or_default(), %H::%M::%S)", .t = ddlog_std::Ok{.res = "10:11:12.000000000"}}: +1
+TTest{.s = "try_from_hms(100, 0, 0).unwrap_or_default()", .t = ddlog_std::Ok{.res = "00:00:00.000000000"}}: +1
 TTest{.s = "try_from_hms(8'd0, 8'd60, 8'd0)", .t = ddlog_std::Err{.err = "illegal time value"}}: +1
 TTest{.s = "try_from_hms(8'd10, 8'd10, 8'd10)", .t = ddlog_std::Ok{.res = "10:10:10.000000000"}}: +1
 TTest{.s = "try_from_hms(8'd23, 8'd0, 8'd0)", .t = ddlog_std::Ok{.res = "23:00:00.000000000"}}: +1
@@ -58,7 +75,10 @@ TTest{.s = "try_from_hms_micro(8'd10, 8'd10, 8'd10, 32'd10)", .t = ddlog_std::Ok
 TTest{.s = "try_from_hms_milli(8'd10, 8'd10, 8'd10, 16'd10)", .t = ddlog_std::Ok{.res = "10:10:10.010000000"}}: +1
 TTest{.s = "try_from_hms_nano(8'd10, 8'd10, 8'd10, 32'd10)", .t = ddlog_std::Ok{.res = "10:10:10.000000010"}}: +1
 TTest{.s = "10:11:12.000000000", .t = ddlog_std::Ok{.res = "10:11:12.000000000"}}
+TTest{.s = "10:11:12.103104105", .t = ddlog_std::Ok{.res = "10:11:12.103104105"}}
+TTest{.s = "Error in format string '%incorrectformat'", .t = ddlog_std::Ok{.res = "10:11:12.103104105"}}
 TTest{.s = "Ok(midnight())", .t = ddlog_std::Ok{.res = "00:00:00.000000000"}}
+TTest{.s = "SomeTime: 10:11:12.103104105", .t = ddlog_std::Ok{.res = "10:11:12.103104105"}}
 TTest{.s = "string2time(to_string(result_unwrap_or_default(try_from_hms(8'd10, 8'd10, 8'd10))))", .t = ddlog_std::Ok{.res = "10:10:10.000000000"}}
 TTest{.s = "string2time(to_string(result_unwrap_or_default(try_from_hms_micro(8'd10, 8'd10, 8'd10, 32'd10))))", .t = ddlog_std::Ok{.res = "10:10:10.000010000"}}
 TTest{.s = "string2time(to_string(result_unwrap_or_default(try_from_hms_milli(8'd10, 8'd10, 8'd10, 16'd10))))", .t = ddlog_std::Ok{.res = "10:10:10.010000000"}}
@@ -66,7 +86,8 @@ TTest{.s = "string2time(to_string(result_unwrap_or_default(try_from_hms_nano(8'd
 TTest{.s = "time_parse(\"10:10\", \"%T\")", .t = ddlog_std::Err{.err = "premature end of input"}}
 TTest{.s = "time_parse(\"10:10:10\", \"%T\")", .t = ddlog_std::Ok{.res = "10:10:10.000000000"}}
 TTest{.s = "time_parse(\"10:10:10.102030405\", \"%T.%f\")", .t = ddlog_std::Ok{.res = "10:10:10.102030405"}}
-TTest{.s = "time_parse(time_format(10:11:12.103104105, %H::%M::%S), %H::%M::%S)", .t = ddlog_std::Ok{.res = "10:11:12.000000000"}}
+TTest{.s = "time_parse(time_format(10:11:12.103104105, %H::%M::%S).unwrap_or_default(), %H::%M::%S)", .t = ddlog_std::Ok{.res = "10:11:12.000000000"}}
+TTest{.s = "try_from_hms(100, 0, 0).unwrap_or_default()", .t = ddlog_std::Ok{.res = "00:00:00.000000000"}}
 TTest{.s = "try_from_hms(8'd0, 8'd60, 8'd0)", .t = ddlog_std::Err{.err = "illegal time value"}}
 TTest{.s = "try_from_hms(8'd10, 8'd10, 8'd10)", .t = ddlog_std::Ok{.res = "10:10:10.000000000"}}
 TTest{.s = "try_from_hms(8'd23, 8'd0, 8'd0)", .t = ddlog_std::Ok{.res = "23:00:00.000000000"}}
@@ -86,24 +107,32 @@ Extract{.s = "second(10:11:12.103104105)", .v = 12}
 Extract{.s = "week(2020-04-14)", .v = 16}
 Extract{.s = "year(2020-04-14)", .v = 2020}
 DTest{.s = "2010-10-15", .t = ddlog_std::Ok{.res = "2010-10-15"}}
+DTest{.s = "2020-04-14", .t = ddlog_std::Ok{.res = "2020-04-14"}}
+DTest{.s = "Error in format string '%incorrectformat'", .t = ddlog_std::Ok{.res = "2020-04-14"}}
 DTest{.s = "Ok{from_julian_day(2000000)}", .t = ddlog_std::Ok{.res = "0763-09-18"}}
 DTest{.s = "Ok{next_day(2020-04-14)}", .t = ddlog_std::Ok{.res = "2020-04-15"}}
 DTest{.s = "Ok{previous_day(2020-04-14)}", .t = ddlog_std::Ok{.res = "2020-04-13"}}
-DTest{.s = "date_parse(\"2020/04/14\", \"%Y/%m/%d\")", .t = ddlog_std::Err{.err = "input contains invalid characters"}}
-DTest{.s = "date_parse(date_format(2020-04-14, %Y-%m-%dT), %Y-%m-%dT)", .t = ddlog_std::Err{.err = "trailing input"}}
+DTest{.s = "date_parse(\"2020/04/14\", \"%Y/%m/%d\")", .t = ddlog_std::Ok{.res = "2020-04-14"}}
+DTest{.s = "date_parse(date_format(2020-04-14, %Y-%m-%dT).result_or_error(), %Y-%m-%dT)", .t = ddlog_std::Ok{.res = "2020-04-14"}}
 DTest{.s = "string2date(to_string(someDate()))", .t = ddlog_std::Ok{.res = "2020-04-14"}}
 DTest{.s = "try_from_iso_ywd(32'sd2020, 8'd4, Monday)", .t = ddlog_std::Ok{.res = "2020-01-20"}}
+DTest{.s = "try_from_yd(0, 0, 0).unwrap_or_default()", .t = ddlog_std::Ok{.res = "0000-01-01"}}
 DTest{.s = "try_from_ymd(32'sd2020, 8'd0, 8'd14)", .t = ddlog_std::Err{.err = "Invalid date"}}
 DTest{.s = "try_from_ymd(32'sd2020, 8'd04, 8'd14)", .t = ddlog_std::Ok{.res = "2020-04-14"}}
 DTest{.s = "try_from_ymd(32'sd2020, 8'd13, 8'd14)", .t = ddlog_std::Err{.err = "Invalid date"}}
 DTest{.s = "try_from_yo(32'sd2020, 16'd100)", .t = ddlog_std::Ok{.res = "2020-04-09"}}
 DTest{.s = "try_from_yo(32'sd2020, 16'd367)", .t = ddlog_std::Err{.err = "Invalid date"}}
+DTTest{.s = "\"\".string2datetime().unwrap_or_default()", .t = ddlog_std::Ok{.res = time::DateTime{.date = "0000-01-01", .time = "00:00:00.000000000"}}}
 DTTest{.s = "2010-10-15T10:11:12", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2010-10-15", .time = "10:11:12.000000000"}}}
+DTTest{.s = "2020-04-14T10:11:12", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.103104105"}}}
+DTTest{.s = "Error in format string '%incorrectformat'", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.103104105"}}}
+DTTest{.s = "Extract date 2020-04-14T10:11:12", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.103104105"}}}
+DTTest{.s = "Extract shifted 2020-04-14T10:11:12", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.103104105"}}}
 DTTest{.s = "datetime_from_unix_timestamp(10000000)", .t = ddlog_std::Ok{.res = time::DateTime{.date = "1970-04-26", .time = "17:46:40.000000000"}}}
 DTTest{.s = "datetime_parse(\"2020-10-10T10:20:30\", \"%Y-%m-%dT%H:%M:%S\")", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-10-10", .time = "10:20:30.000000000"}}}
 DTTest{.s = "datetime_parse(\"2020/10/10T10:20:30\", \"%Y-%m-%dT%H:%M:%S\")", .t = ddlog_std::Err{.err = "input contains invalid characters"}}
 DTTest{.s = "datetime_parse(\"Wed Mar 05 07:45:30 MST 2025\", \"%a %b %d %H:%M:%S %Z %Y\")", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2025-03-05", .time = "07:45:30.000000000"}}}
-DTTest{.s = "datetime_parse(datetime_format(2020-04-14T10:11:12, %Y-%m-%dT%H::%M), %Y-%m-%dT%H::%M)", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:00.000000000"}}}
+DTTest{.s = "datetime_parse(datetime_format(2020-04-14T10:11:12, %Y-%m-%dT%H::%M).result_or_error(), %Y-%m-%dT%H::%M)", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:00.000000000"}}}
 DTTest{.s = "get_datetime(tz_datetime_parse_from_rfc2822(\"Tue, 1 Jul 2003 10:52:37 GMT\"))", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2003-07-01", .time = "10:52:37.000000000"}}}
 DTTest{.s = "string2datetime(\"2020-10-10T10:20:30\")", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-10-10", .time = "10:20:30.000000000"}}}
 DTTest{.s = "string2datetime(to_string(2020-04-14T10:11:12))", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.000000000"}}}

--- a/test/datalog_tests/time_test.dump.expected
+++ b/test/datalog_tests/time_test.dump.expected
@@ -1,7 +1,7 @@
 DTTest:
 DTTest{.s = "datetime_from_unix_timestamp(10000000)", .t = ddlog_std::Ok{.res = time::DateTime{.date = "1970-04-26", .time = "17:46:40.000000000"}}}: +1
 DTTest{.s = "datetime_parse(\"2020-10-10T10:20:30\", \"%Y-%m-%dT%H:%M:%S\")", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-10-10", .time = "10:20:30.000000000"}}}: +1
-DTTest{.s = "datetime_parse(\"2020/10/10T10:20:30\", \"%Y-%m-%dT%H:%M:%S\")", .t = ddlog_std::Err{.err = "expected character `-`, found `/`"}}: +1
+DTTest{.s = "datetime_parse(\"2020/10/10T10:20:30\", \"%Y-%m-%dT%H:%M:%S\")", .t = ddlog_std::Err{.err = "input contains invalid characters"}}: +1
 DTTest{.s = "datetime_parse(datetime_format(2020-04-14T10:11:12, %Y-%m-%dT%H::%M), %Y-%m-%dT%H::%M)", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:00.000000000"}}}: +1
 DTTest{.s = "string2datetime(\"2020-10-10T10:20:30\")", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-10-10", .time = "10:20:30.000000000"}}}: +1
 DTTest{.s = "string2datetime(to_string(2020-04-14T10:11:12))", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.000000000"}}}: +1
@@ -9,60 +9,58 @@ DTest:
 DTest{.s = "Ok{from_julian_day(2000000)}", .t = ddlog_std::Ok{.res = "0763-09-18"}}: +1
 DTest{.s = "Ok{next_day(2020-04-14)}", .t = ddlog_std::Ok{.res = "2020-04-15"}}: +1
 DTest{.s = "Ok{previous_day(2020-04-14)}", .t = ddlog_std::Ok{.res = "2020-04-13"}}: +1
-DTest{.s = "date_parse(\"2020/04/14\", \"%Y/%m/%d\")", .t = ddlog_std::Ok{.res = "2020-04-14"}}: +1
-DTest{.s = "date_parse(date_format(2020-04-14, %Y-%m-%dT), %Y-%m-%dT)", .t = ddlog_std::Ok{.res = "2020-04-14"}}: +1
+DTest{.s = "date_parse(\"2020/04/14\", \"%Y/%m/%d\")", .t = ddlog_std::Err{.err = "input contains invalid characters"}}: +1
+DTest{.s = "date_parse(date_format(2020-04-14, %Y-%m-%dT), %Y-%m-%dT)", .t = ddlog_std::Err{.err = "trailing input"}}: +1
 DTest{.s = "string2date(to_string(someDate()))", .t = ddlog_std::Ok{.res = "2020-04-14"}}: +1
 DTest{.s = "try_from_iso_ywd(32'sd2020, 8'd4, Monday)", .t = ddlog_std::Ok{.res = "2020-01-20"}}: +1
-DTest{.s = "try_from_ymd(32'sd2020, 8'd0, 8'd14)", .t = ddlog_std::Err{.err = "month must be in the range 1..=12"}}: +1
+DTest{.s = "try_from_ymd(32'sd2020, 8'd0, 8'd14)", .t = ddlog_std::Err{.err = "Invalid date"}}: +1
 DTest{.s = "try_from_ymd(32'sd2020, 8'd04, 8'd14)", .t = ddlog_std::Ok{.res = "2020-04-14"}}: +1
-DTest{.s = "try_from_ymd(32'sd2020, 8'd13, 8'd14)", .t = ddlog_std::Err{.err = "month must be in the range 1..=12"}}: +1
+DTest{.s = "try_from_ymd(32'sd2020, 8'd13, 8'd14)", .t = ddlog_std::Err{.err = "Invalid date"}}: +1
 DTest{.s = "try_from_yo(32'sd2020, 16'd100)", .t = ddlog_std::Ok{.res = "2020-04-09"}}: +1
-DTest{.s = "try_from_yo(32'sd2020, 16'd367)", .t = ddlog_std::Err{.err = "ordinal must be in the range 1..=366, given values of other parameters"}}: +1
+DTest{.s = "try_from_yo(32'sd2020, 16'd367)", .t = ddlog_std::Err{.err = "Invalid date"}}: +1
 Extract:
 Extract{.s = "day(2020-04-14)", .v = 14}: +1
 Extract{.s = "hour(10:11:12.103104105)", .v = 10}: +1
 Extract{.s = "microsecond(10:11:12.103104105)", .v = 103104}: +1
 Extract{.s = "millisecond(10:11:12.103104105)", .v = 103}: +1
 Extract{.s = "minute(10:11:12.103104105)", .v = 11}: +1
-Extract{.s = "monday_based_week(2020-04-14)", .v = 15}: +1
 Extract{.s = "month(2020-04-14)", .v = 4}: +1
 Extract{.s = "nanosecond(10:11:12.103104105)", .v = 103104105}: +1
 Extract{.s = "ordinal(2020-04-14)", .v = 105}: +1
 Extract{.s = "second(10:11:12.103104105)", .v = 12}: +1
-Extract{.s = "sunday_based_week(2020-04-14)", .v = 15}: +1
 Extract{.s = "week(2020-04-14)", .v = 16}: +1
 Extract{.s = "year(2020-04-14)", .v = 2020}: +1
 TTest:
-TTest{.s = "Ok(midnight())", .t = ddlog_std::Ok{.res = "0:00:00.000000000"}}: +1
+TTest{.s = "Ok(midnight())", .t = ddlog_std::Ok{.res = "00:00:00.000000000"}}: +1
 TTest{.s = "string2time(to_string(result_unwrap_or_default(try_from_hms(8'd10, 8'd10, 8'd10))))", .t = ddlog_std::Ok{.res = "10:10:10.000000000"}}: +1
 TTest{.s = "string2time(to_string(result_unwrap_or_default(try_from_hms_micro(8'd10, 8'd10, 8'd10, 32'd10))))", .t = ddlog_std::Ok{.res = "10:10:10.000010000"}}: +1
 TTest{.s = "string2time(to_string(result_unwrap_or_default(try_from_hms_milli(8'd10, 8'd10, 8'd10, 16'd10))))", .t = ddlog_std::Ok{.res = "10:10:10.010000000"}}: +1
 TTest{.s = "string2time(to_string(result_unwrap_or_default(try_from_hms_nano(8'd10, 8'd10, 8'd10, 32'd10))))", .t = ddlog_std::Ok{.res = "10:10:10.000000010"}}: +1
-TTest{.s = "time_parse(\"10:10\", \"%T\")", .t = ddlog_std::Err{.err = "unexpected end of string"}}: +1
+TTest{.s = "time_parse(\"10:10\", \"%T\")", .t = ddlog_std::Err{.err = "premature end of input"}}: +1
 TTest{.s = "time_parse(\"10:10:10\", \"%T\")", .t = ddlog_std::Ok{.res = "10:10:10.000000000"}}: +1
-TTest{.s = "time_parse(\"10:10:10.102030405\", \"%T.%N\")", .t = ddlog_std::Ok{.res = "10:10:10.102030405"}}: +1
+TTest{.s = "time_parse(\"10:10:10.102030405\", \"%T.%f\")", .t = ddlog_std::Ok{.res = "10:10:10.102030405"}}: +1
 TTest{.s = "time_parse(time_format(10:11:12.103104105, %H::%M::%S), %H::%M::%S)", .t = ddlog_std::Ok{.res = "10:11:12.000000000"}}: +1
-TTest{.s = "try_from_hms(8'd0, 8'd60, 8'd0)", .t = ddlog_std::Err{.err = "minute must be in the range 0..=59"}}: +1
+TTest{.s = "try_from_hms(8'd0, 8'd60, 8'd0)", .t = ddlog_std::Err{.err = "illegal time value"}}: +1
 TTest{.s = "try_from_hms(8'd10, 8'd10, 8'd10)", .t = ddlog_std::Ok{.res = "10:10:10.000000000"}}: +1
 TTest{.s = "try_from_hms(8'd23, 8'd0, 8'd0)", .t = ddlog_std::Ok{.res = "23:00:00.000000000"}}: +1
-TTest{.s = "try_from_hms(8'd24, 8'd0, 8'd0)", .t = ddlog_std::Err{.err = "hour must be in the range 0..=23"}}: +1
+TTest{.s = "try_from_hms(8'd24, 8'd0, 8'd0)", .t = ddlog_std::Err{.err = "illegal time value"}}: +1
 TTest{.s = "try_from_hms_micro(8'd10, 8'd10, 8'd10, 32'd10)", .t = ddlog_std::Ok{.res = "10:10:10.000010000"}}: +1
 TTest{.s = "try_from_hms_milli(8'd10, 8'd10, 8'd10, 16'd10)", .t = ddlog_std::Ok{.res = "10:10:10.010000000"}}: +1
 TTest{.s = "try_from_hms_nano(8'd10, 8'd10, 8'd10, 32'd10)", .t = ddlog_std::Ok{.res = "10:10:10.000000010"}}: +1
 TTest{.s = "10:11:12.000000000", .t = ddlog_std::Ok{.res = "10:11:12.000000000"}}
-TTest{.s = "Ok(midnight())", .t = ddlog_std::Ok{.res = "0:00:00.000000000"}}
+TTest{.s = "Ok(midnight())", .t = ddlog_std::Ok{.res = "00:00:00.000000000"}}
 TTest{.s = "string2time(to_string(result_unwrap_or_default(try_from_hms(8'd10, 8'd10, 8'd10))))", .t = ddlog_std::Ok{.res = "10:10:10.000000000"}}
 TTest{.s = "string2time(to_string(result_unwrap_or_default(try_from_hms_micro(8'd10, 8'd10, 8'd10, 32'd10))))", .t = ddlog_std::Ok{.res = "10:10:10.000010000"}}
 TTest{.s = "string2time(to_string(result_unwrap_or_default(try_from_hms_milli(8'd10, 8'd10, 8'd10, 16'd10))))", .t = ddlog_std::Ok{.res = "10:10:10.010000000"}}
 TTest{.s = "string2time(to_string(result_unwrap_or_default(try_from_hms_nano(8'd10, 8'd10, 8'd10, 32'd10))))", .t = ddlog_std::Ok{.res = "10:10:10.000000010"}}
-TTest{.s = "time_parse(\"10:10\", \"%T\")", .t = ddlog_std::Err{.err = "unexpected end of string"}}
+TTest{.s = "time_parse(\"10:10\", \"%T\")", .t = ddlog_std::Err{.err = "premature end of input"}}
 TTest{.s = "time_parse(\"10:10:10\", \"%T\")", .t = ddlog_std::Ok{.res = "10:10:10.000000000"}}
-TTest{.s = "time_parse(\"10:10:10.102030405\", \"%T.%N\")", .t = ddlog_std::Ok{.res = "10:10:10.102030405"}}
+TTest{.s = "time_parse(\"10:10:10.102030405\", \"%T.%f\")", .t = ddlog_std::Ok{.res = "10:10:10.102030405"}}
 TTest{.s = "time_parse(time_format(10:11:12.103104105, %H::%M::%S), %H::%M::%S)", .t = ddlog_std::Ok{.res = "10:11:12.000000000"}}
-TTest{.s = "try_from_hms(8'd0, 8'd60, 8'd0)", .t = ddlog_std::Err{.err = "minute must be in the range 0..=59"}}
+TTest{.s = "try_from_hms(8'd0, 8'd60, 8'd0)", .t = ddlog_std::Err{.err = "illegal time value"}}
 TTest{.s = "try_from_hms(8'd10, 8'd10, 8'd10)", .t = ddlog_std::Ok{.res = "10:10:10.000000000"}}
 TTest{.s = "try_from_hms(8'd23, 8'd0, 8'd0)", .t = ddlog_std::Ok{.res = "23:00:00.000000000"}}
-TTest{.s = "try_from_hms(8'd24, 8'd0, 8'd0)", .t = ddlog_std::Err{.err = "hour must be in the range 0..=23"}}
+TTest{.s = "try_from_hms(8'd24, 8'd0, 8'd0)", .t = ddlog_std::Err{.err = "illegal time value"}}
 TTest{.s = "try_from_hms_micro(8'd10, 8'd10, 8'd10, 32'd10)", .t = ddlog_std::Ok{.res = "10:10:10.000010000"}}
 TTest{.s = "try_from_hms_milli(8'd10, 8'd10, 8'd10, 16'd10)", .t = ddlog_std::Ok{.res = "10:10:10.010000000"}}
 TTest{.s = "try_from_hms_nano(8'd10, 8'd10, 8'd10, 32'd10)", .t = ddlog_std::Ok{.res = "10:10:10.000000010"}}
@@ -71,31 +69,29 @@ Extract{.s = "hour(10:11:12.103104105)", .v = 10}
 Extract{.s = "microsecond(10:11:12.103104105)", .v = 103104}
 Extract{.s = "millisecond(10:11:12.103104105)", .v = 103}
 Extract{.s = "minute(10:11:12.103104105)", .v = 11}
-Extract{.s = "monday_based_week(2020-04-14)", .v = 15}
 Extract{.s = "month(2020-04-14)", .v = 4}
 Extract{.s = "nanosecond(10:11:12.103104105)", .v = 103104105}
 Extract{.s = "ordinal(2020-04-14)", .v = 105}
 Extract{.s = "second(10:11:12.103104105)", .v = 12}
-Extract{.s = "sunday_based_week(2020-04-14)", .v = 15}
 Extract{.s = "week(2020-04-14)", .v = 16}
 Extract{.s = "year(2020-04-14)", .v = 2020}
 DTest{.s = "2010-10-15", .t = ddlog_std::Ok{.res = "2010-10-15"}}
 DTest{.s = "Ok{from_julian_day(2000000)}", .t = ddlog_std::Ok{.res = "0763-09-18"}}
 DTest{.s = "Ok{next_day(2020-04-14)}", .t = ddlog_std::Ok{.res = "2020-04-15"}}
 DTest{.s = "Ok{previous_day(2020-04-14)}", .t = ddlog_std::Ok{.res = "2020-04-13"}}
-DTest{.s = "date_parse(\"2020/04/14\", \"%Y/%m/%d\")", .t = ddlog_std::Ok{.res = "2020-04-14"}}
-DTest{.s = "date_parse(date_format(2020-04-14, %Y-%m-%dT), %Y-%m-%dT)", .t = ddlog_std::Ok{.res = "2020-04-14"}}
+DTest{.s = "date_parse(\"2020/04/14\", \"%Y/%m/%d\")", .t = ddlog_std::Err{.err = "input contains invalid characters"}}
+DTest{.s = "date_parse(date_format(2020-04-14, %Y-%m-%dT), %Y-%m-%dT)", .t = ddlog_std::Err{.err = "trailing input"}}
 DTest{.s = "string2date(to_string(someDate()))", .t = ddlog_std::Ok{.res = "2020-04-14"}}
 DTest{.s = "try_from_iso_ywd(32'sd2020, 8'd4, Monday)", .t = ddlog_std::Ok{.res = "2020-01-20"}}
-DTest{.s = "try_from_ymd(32'sd2020, 8'd0, 8'd14)", .t = ddlog_std::Err{.err = "month must be in the range 1..=12"}}
+DTest{.s = "try_from_ymd(32'sd2020, 8'd0, 8'd14)", .t = ddlog_std::Err{.err = "Invalid date"}}
 DTest{.s = "try_from_ymd(32'sd2020, 8'd04, 8'd14)", .t = ddlog_std::Ok{.res = "2020-04-14"}}
-DTest{.s = "try_from_ymd(32'sd2020, 8'd13, 8'd14)", .t = ddlog_std::Err{.err = "month must be in the range 1..=12"}}
+DTest{.s = "try_from_ymd(32'sd2020, 8'd13, 8'd14)", .t = ddlog_std::Err{.err = "Invalid date"}}
 DTest{.s = "try_from_yo(32'sd2020, 16'd100)", .t = ddlog_std::Ok{.res = "2020-04-09"}}
-DTest{.s = "try_from_yo(32'sd2020, 16'd367)", .t = ddlog_std::Err{.err = "ordinal must be in the range 1..=366, given values of other parameters"}}
+DTest{.s = "try_from_yo(32'sd2020, 16'd367)", .t = ddlog_std::Err{.err = "Invalid date"}}
 DTTest{.s = "2010-10-15T10:11:12", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2010-10-15", .time = "10:11:12.000000000"}}}
 DTTest{.s = "datetime_from_unix_timestamp(10000000)", .t = ddlog_std::Ok{.res = time::DateTime{.date = "1970-04-26", .time = "17:46:40.000000000"}}}
 DTTest{.s = "datetime_parse(\"2020-10-10T10:20:30\", \"%Y-%m-%dT%H:%M:%S\")", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-10-10", .time = "10:20:30.000000000"}}}
-DTTest{.s = "datetime_parse(\"2020/10/10T10:20:30\", \"%Y-%m-%dT%H:%M:%S\")", .t = ddlog_std::Err{.err = "expected character `-`, found `/`"}}
+DTTest{.s = "datetime_parse(\"2020/10/10T10:20:30\", \"%Y-%m-%dT%H:%M:%S\")", .t = ddlog_std::Err{.err = "input contains invalid characters"}}
 DTTest{.s = "datetime_parse(datetime_format(2020-04-14T10:11:12, %Y-%m-%dT%H::%M), %Y-%m-%dT%H::%M)", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:00.000000000"}}}
 DTTest{.s = "string2datetime(\"2020-10-10T10:20:30\")", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-10-10", .time = "10:20:30.000000000"}}}
 DTTest{.s = "string2datetime(to_string(2020-04-14T10:11:12))", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.000000000"}}}

--- a/test/datalog_tests/time_test.dump.expected
+++ b/test/datalog_tests/time_test.dump.expected
@@ -2,9 +2,19 @@ DTTest:
 DTTest{.s = "datetime_from_unix_timestamp(10000000)", .t = ddlog_std::Ok{.res = time::DateTime{.date = "1970-04-26", .time = "17:46:40.000000000"}}}: +1
 DTTest{.s = "datetime_parse(\"2020-10-10T10:20:30\", \"%Y-%m-%dT%H:%M:%S\")", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-10-10", .time = "10:20:30.000000000"}}}: +1
 DTTest{.s = "datetime_parse(\"2020/10/10T10:20:30\", \"%Y-%m-%dT%H:%M:%S\")", .t = ddlog_std::Err{.err = "input contains invalid characters"}}: +1
+DTTest{.s = "datetime_parse(\"Wed Mar 05 07:45:30 MST 2025\", \"%a %b %d %H:%M:%S %Z %Y\")", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2025-03-05", .time = "07:45:30.000000000"}}}: +1
 DTTest{.s = "datetime_parse(datetime_format(2020-04-14T10:11:12, %Y-%m-%dT%H::%M), %Y-%m-%dT%H::%M)", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:00.000000000"}}}: +1
+DTTest{.s = "get_datetime(tz_datetime_parse_from_rfc2822(\"Tue, 1 Jul 2003 10:52:37 GMT\"))", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2003-07-01", .time = "10:52:37.000000000"}}}: +1
 DTTest{.s = "string2datetime(\"2020-10-10T10:20:30\")", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-10-10", .time = "10:20:30.000000000"}}}: +1
 DTTest{.s = "string2datetime(to_string(2020-04-14T10:11:12))", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.000000000"}}}: +1
+DTZTest:
+DTZTest{.s = "tz_datetime_parse(\"2020-10-10T10:20:30 +02:00\", \"%Y-%m-%dT%H:%M:%S %z\")", .t = ddlog_std::Ok{.res = "2020-10-10T10:20:30+02:00"}}: +1
+DTZTest{.s = "tz_datetime_parse(\"2020/10/10T10:20:30 -02:00\", \"%Y/%m/%dT%H:%M:%S %z\")", .t = ddlog_std::Ok{.res = "2020-10-10T10:20:30-03:00"}}: +1
+DTZTest{.s = "tz_datetime_parse(\"Wed Mar 05 07:45:30 MST 2025\", \"%a %b %d %H:%M:%S %Z %Y\")", .t = ddlog_std::Err{.err = "input is not enough for unique date and time"}}: +1
+DTZTest{.s = "tz_datetime_parse_from_rfc2822(\"Tue, 1 Jul 2003 10:52:37 +0200\")", .t = ddlog_std::Ok{.res = "2003-07-01T10:52:37+02:00"}}: +1
+DTZTest{.s = "tz_datetime_parse_from_rfc2822(\"Tue, 1 Jul 2003 10:52:37 GMT\")", .t = ddlog_std::Ok{.res = "2003-07-01T10:52:37+00:00"}}: +1
+DTZTest{.s = "tz_datetime_parse_from_rfc3339(\"2020-10-10T10:20:30-03:00\")", .t = ddlog_std::Ok{.res = "2020-10-10T10:20:30-03:00"}}: +1
+DTZTest{.s = "utc(string2datetime(\"2020-10-10T10:20:30\"))", .t = ddlog_std::Ok{.res = "2020-10-10T10:20:30+00:00"}}: +1
 DTest:
 DTest{.s = "Ok{from_julian_day(2000000)}", .t = ddlog_std::Ok{.res = "0763-09-18"}}: +1
 DTest{.s = "Ok{next_day(2020-04-14)}", .t = ddlog_std::Ok{.res = "2020-04-15"}}: +1
@@ -92,6 +102,8 @@ DTTest{.s = "2010-10-15T10:11:12", .t = ddlog_std::Ok{.res = time::DateTime{.dat
 DTTest{.s = "datetime_from_unix_timestamp(10000000)", .t = ddlog_std::Ok{.res = time::DateTime{.date = "1970-04-26", .time = "17:46:40.000000000"}}}
 DTTest{.s = "datetime_parse(\"2020-10-10T10:20:30\", \"%Y-%m-%dT%H:%M:%S\")", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-10-10", .time = "10:20:30.000000000"}}}
 DTTest{.s = "datetime_parse(\"2020/10/10T10:20:30\", \"%Y-%m-%dT%H:%M:%S\")", .t = ddlog_std::Err{.err = "input contains invalid characters"}}
+DTTest{.s = "datetime_parse(\"Wed Mar 05 07:45:30 MST 2025\", \"%a %b %d %H:%M:%S %Z %Y\")", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2025-03-05", .time = "07:45:30.000000000"}}}
 DTTest{.s = "datetime_parse(datetime_format(2020-04-14T10:11:12, %Y-%m-%dT%H::%M), %Y-%m-%dT%H::%M)", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:00.000000000"}}}
+DTTest{.s = "get_datetime(tz_datetime_parse_from_rfc2822(\"Tue, 1 Jul 2003 10:52:37 GMT\"))", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2003-07-01", .time = "10:52:37.000000000"}}}
 DTTest{.s = "string2datetime(\"2020-10-10T10:20:30\")", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-10-10", .time = "10:20:30.000000000"}}}
 DTTest{.s = "string2datetime(to_string(2020-04-14T10:11:12))", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.000000000"}}}


### PR DESCRIPTION
I have also realized that no library files had copyright.
The previous implementation of time was based on a Rust crate called time, which used non-standard format specifiers and did not support time zones. So the implementation has been rewritten based on the chrono crate which uses C strftime format. However, the names of the functions were not changed, to prevent client breakage. The old library gave better error messages on malformed times.