### PR TITLE
Fix segfault in the Java API.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+
+## [Unreleased]
+
+### Bug fix
+
+- Segfault in the Java API in `transactionCommitDumpChanges`.
+
 ## [0.40.2] - May 10, 2021
 
 ### Libraries

--- a/java/ddlogapi.c
+++ b/java/ddlogapi.c
@@ -299,7 +299,9 @@ JNIEXPORT void JNICALL Java_ddlogapi_DDlogAPI_ddlog_1transaction_1commit_1dump_1
 
     ddlog_delta *delta = ddlog_transaction_commit_dump_changes((ddlog_prog)handle);
     if (delta == NULL) {
+        free(cbinfo);
         throwDDlogException(env, NULL);
+        return;
     };
     ddlog_delta_enumerate(delta, commit_dump_callback, (uintptr_t)cbinfo);
     ddlog_free_delta(delta);


### PR DESCRIPTION
A missing `return` in `ddlog_1transaction_1commit_1dump_1changes` caused
the method to access invalid memory locations on the error path.

Fixes #967.