### PR TITLE
Switched to triomphe for DDValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Changes
+
+- Made all reference counting (internal and through `ddlog_std::Ref`) use reference counters without weak counts
+  in an effort to reduce memory usage
+
 ## [0.40.2] - May 11, 2021
 
 ### Libraries
@@ -15,7 +22,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Bug fix
 
 - Segfault in the Java API in `transactionCommitDumpChanges`.
-
 
 ## [0.40.1] - May 7, 2021
 

--- a/lib/ddlog_rt.rs
+++ b/lib/ddlog_rt.rs
@@ -297,7 +297,7 @@ impl<Args: 'static + Clone, Output: 'static + Clone + Default> Default
             f: {
                 fn __f<A, O: Default>(args: A, captured: &()) -> O {
                     O::default()
-                };
+                }
                 __f
             },
         })
@@ -401,7 +401,8 @@ mod tests {
                                 )
                             })
                             .collect()
-                    };
+                    }
+
                     __f
                 },
             };
@@ -417,7 +418,8 @@ mod tests {
                         unsafe { &*args.0 },
                         unsafe { &*args.1 }
                     )]
-                };
+                }
+
                 __f
             },
         };

--- a/lib/ddlog_std.rs
+++ b/lib/ddlog_std.rs
@@ -43,9 +43,10 @@ use std::{
     option::Option as StdOption,
     result::Result as StdResult,
     slice, str,
-    sync::Arc,
+    sync::Arc as StdArc,
     vec::{self, Vec as StdVec},
 };
+use triomphe::Arc;
 
 const XX_SEED1: u64 = 0x23b691a751d0e108;
 const XX_SEED2: u64 = 0x20b09801dce5ff84;
@@ -1107,7 +1108,7 @@ pub fn hash128<T: Hash>(x: &T) -> u128 {
     ((w1 as u128) << 64) | (w2 as u128)
 }
 
-pub type ProjectFunc<X> = Arc<dyn Fn(&DDValue) -> X + Send + Sync>;
+pub type ProjectFunc<X> = StdArc<dyn Fn(&DDValue) -> X + Send + Sync>;
 
 /*
  * Group type (returned by the `group_by` operator).

--- a/lib/ddlog_std.toml
+++ b/lib/ddlog_std.toml
@@ -1,0 +1,2 @@
+[dependencies.triomphe]
+version = "0.1.3"

--- a/rust/template/Cargo.toml
+++ b/rust/template/Cargo.toml
@@ -33,6 +33,7 @@ serde = { version = "1.0", features = ["derive"] }
 erased-serde = "0.3"
 crossbeam-channel = "0.5.0"
 enum-primitive-derive = "0.2.1"
+triomphe = "0.1.3"
 
 # FlatBuffers dependency enabled by the `flatbuf` feature.
 # flatbuffers crate version must be in sync with the flatc compiler and Java

--- a/rust/template/differential_datalog/Cargo.toml
+++ b/rust/template/differential_datalog/Cargo.toml
@@ -27,6 +27,7 @@ sequence_trie = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 erased-serde = "0.3"
 crossbeam-channel = "0.5.0"
+triomphe = "0.1.2"
 
 [dev-dependencies]
 byteorder = "1.4.2"

--- a/rust/template/differential_datalog/src/program/config.rs
+++ b/rust/template/differential_datalog/src/program/config.rs
@@ -7,10 +7,11 @@ use crate::{
 use differential_dataflow::Config as DDFlowConfig;
 use std::{
     env,
-    sync::{atomic::AtomicBool, Arc, Mutex},
+    sync::{atomic::AtomicBool, Mutex},
     thread::{self, JoinHandle},
 };
 use timely::Config as TimelyConfig;
+use triomphe::Arc;
 
 /// The configuration for a DDlog program
 #[derive(Debug, Clone, Copy)]

--- a/rust/template/differential_datalog/src/program/worker.rs
+++ b/rust/template/differential_datalog/src/program/worker.rs
@@ -49,6 +49,7 @@ use timely::{
     progress::frontier::AntichainRef,
     worker::Worker,
 };
+use triomphe::Arc as ThinArc;
 
 // Handles to objects involved in managing the progress of the dataflow.
 struct SessionData {
@@ -904,9 +905,9 @@ fn render_scc<'a>(
 #[derive(Debug, Clone)]
 pub struct ProfilingData {
     /// Whether CPU profiling is enabled
-    cpu_enabled: Arc<AtomicBool>,
+    cpu_enabled: ThinArc<AtomicBool>,
     /// Whether timely profiling is enabled
-    timely_enabled: Arc<AtomicBool>,
+    timely_enabled: ThinArc<AtomicBool>,
     /// The channel used to send profiling data to the profiling thread
     data_channel: Sender<ProfMsg>,
 }
@@ -914,8 +915,8 @@ pub struct ProfilingData {
 impl ProfilingData {
     /// Create a new profiling instance
     pub const fn new(
-        cpu_enabled: Arc<AtomicBool>,
-        timely_enabled: Arc<AtomicBool>,
+        cpu_enabled: ThinArc<AtomicBool>,
+        timely_enabled: ThinArc<AtomicBool>,
         data_channel: Sender<ProfMsg>,
     ) -> Self {
         Self {


### PR DESCRIPTION
Triomphe doesn't allow weak references (which we don't use) so this lowers the overhead of `DDValue`s somewhat. Should have a decent memory boost, my benches also showed a nice little perf boost

```
twitter-micro/1 thread/150000 records
time:   [330.47 ms 332.58 ms 334.66 ms]
change: [-7.9898% -7.0025% -5.9926%] (p = 0.00 < 0.05)

twitter-micro/4 threads/200000 records
time:   [213.30 ms 214.84 ms 216.31 ms]
change: [-8.7423% -7.1495% -5.5009%] (p = 0.00 < 0.05)

twitter-micro/3 threads/200000 records
time:   [222.58 ms 224.66 ms 226.83 ms]
change: [-10.161% -8.6242% -7.1023%] (p = 0.00 < 0.05)

twitter-micro/2 threads/200000 records
time:   [287.95 ms 289.78 ms 292.07 ms]
change: [-9.8372% -8.5416% -7.1336%] (p = 0.00 < 0.05)

twitter-micro/1 thread/200000 records
time:   [440.43 ms 443.72 ms 447.15 ms]
change: [-8.0105% -6.7065% -5.2675%] (p = 0.00 < 0.05)

twitter-macro/4 threads/10000000 samples
time:   [150.55 s 162.49 s 173.91 s]
change: [-20.019% -11.893% -4.1555%] (p = 0.02 < 0.05)
```