### PR TITLE
Loosen function type

### DIFF
--- a/rust/template/differential_datalog/Cargo.toml
+++ b/rust/template/differential_datalog/Cargo.toml
@@ -27,6 +27,7 @@ sequence_trie = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 erased-serde = "0.3"
 crossbeam-channel = "0.5.0"
+dyn-clone = "1.0"
 
 [dev-dependencies]
 byteorder = "1.4.2"

--- a/rust/template/differential_datalog/src/dataflow/filter_map.rs
+++ b/rust/template/differential_datalog/src/dataflow/filter_map.rs
@@ -4,8 +4,6 @@ use timely::{
     Data,
 };
 
-pub type FilterMapFunc<D, D2> = std::sync::Arc<dyn Fn(D) -> Option<D2>>;
-
 pub trait FilterMap<D, D2> {
     type Output;
 

--- a/rust/template/differential_datalog/src/dataflow/filter_map.rs
+++ b/rust/template/differential_datalog/src/dataflow/filter_map.rs
@@ -12,7 +12,6 @@ pub trait FilterMap<D, D2> {
     fn filter_map<L>(&self, logic: L) -> Self::Output
     where
         L: FnMut(D) -> Option<D2> + 'static,
-    // fn filter_map(&self, logic: FilterMapFunc<D, D2>) -> Self::Output
     {
         self.filter_map_named("FilterMap", logic)
     }
@@ -20,7 +19,6 @@ pub trait FilterMap<D, D2> {
     fn filter_map_named<L>(&self, name: &str, logic: L) -> Self::Output
     where
         L: FnMut(D) -> Option<D2> + 'static;
-    // fn filter_map_named(&self, name: &str, logic: FilterMapFunc<D, D2>) -> Self::Output;
 }
 
 impl<S, D, D2> FilterMap<D, D2> for Stream<S, D>
@@ -34,7 +32,6 @@ where
     fn filter_map_named<L>(&self, name: &str, mut logic: L) -> Self::Output
     where
         L: FnMut(D) -> Option<D2> + 'static,
-    // fn filter_map_named(&self, name: &str, logic: FilterMapFunc<D, D2>) -> Self::Output
     {
         let mut buffer = Vec::new();
 
@@ -64,7 +61,6 @@ where
     fn filter_map_named<L>(&self, name: &str, mut logic: L) -> Self::Output
     where
         L: FnMut(D) -> Option<D2> + 'static,
-    // fn filter_map_named(&self, name: &str, logic: FilterMapFunc<D, D2>) -> Self::Output
     {
         self.inner
             .filter_map_named(name, move |(data, time, diff)| {

--- a/rust/template/differential_datalog/src/dataflow/filter_map.rs
+++ b/rust/template/differential_datalog/src/dataflow/filter_map.rs
@@ -9,18 +9,18 @@ pub type FilterMapFunc<D, D2> = std::sync::Arc<dyn Fn(D) -> Option<D2>>;
 pub trait FilterMap<D, D2> {
     type Output;
 
-    // fn filter_map<L>(&self, logic: L) -> Self::Output
-    // where
-    //     L: FnMut(D) -> Option<D2> + 'static,
-    fn filter_map(&self, logic: FilterMapFunc<D, D2>) -> Self::Output
+    fn filter_map<L>(&self, logic: L) -> Self::Output
+    where
+        L: FnMut(D) -> Option<D2> + 'static,
+    // fn filter_map(&self, logic: FilterMapFunc<D, D2>) -> Self::Output
     {
         self.filter_map_named("FilterMap", logic)
     }
 
-    // fn filter_map_named<L>(&self, name: &str, logic: L) -> Self::Output
-    // where
-    //     L: FnMut(D) -> Option<D2> + 'static;
-    fn filter_map_named(&self, name: &str, logic: FilterMapFunc<D, D2>) -> Self::Output;
+    fn filter_map_named<L>(&self, name: &str, logic: L) -> Self::Output
+    where
+        L: FnMut(D) -> Option<D2> + 'static;
+    // fn filter_map_named(&self, name: &str, logic: FilterMapFunc<D, D2>) -> Self::Output;
 }
 
 impl<S, D, D2> FilterMap<D, D2> for Stream<S, D>
@@ -31,10 +31,10 @@ where
 {
     type Output = Stream<S, D2>;
 
-    // fn filter_map_named<L>(&self, name: &str, mut logic: L) -> Self::Output
-    // where
-    //     L: FnMut(D) -> Option<D2> + 'static,
-    fn filter_map_named(&self, name: &str, logic: FilterMapFunc<D, D2>) -> Self::Output
+    fn filter_map_named<L>(&self, name: &str, mut logic: L) -> Self::Output
+    where
+        L: FnMut(D) -> Option<D2> + 'static,
+    // fn filter_map_named(&self, name: &str, logic: FilterMapFunc<D, D2>) -> Self::Output
     {
         let mut buffer = Vec::new();
 
@@ -61,17 +61,15 @@ where
 {
     type Output = Collection<S, D2, R>;
 
-    // fn filter_map_named<L>(&self, name: &str, mut logic: L) -> Self::Output
-    // where
-    //     L: FnMut(D) -> Option<D2> + 'static,
-    fn filter_map_named(&self, name: &str, logic: FilterMapFunc<D, D2>) -> Self::Output
+    fn filter_map_named<L>(&self, name: &str, mut logic: L) -> Self::Output
+    where
+        L: FnMut(D) -> Option<D2> + 'static,
+    // fn filter_map_named(&self, name: &str, logic: FilterMapFunc<D, D2>) -> Self::Output
     {
         self.inner
-            .filter_map_named(name, 
-                std::sync::Arc::new(move |(data, time, diff)| {
-                    logic(data).map(|data| (data, time, diff))
-                })
-            )
+            .filter_map_named(name, move |(data, time, diff)| {
+                logic(data).map(|data| (data, time, diff))
+            })
             .as_collection()
     }
 }

--- a/rust/template/differential_datalog_test/lib.rs
+++ b/rust/template/differential_datalog_test/lib.rs
@@ -294,7 +294,7 @@ fn test_two_relations(nthreads: usize) {
                 rel: 1,
                 xform: Some(XFormCollection::Inspect {
                     description: Cow::from("Inspect"),
-                    ifun: ifun as InspectFunc,
+                    ifun: Box::new(ifun),
                     next: Box::new(None),
                 }),
             }],
@@ -401,7 +401,7 @@ fn test_semijoin(nthreads: usize) {
             rules: Vec::new(),
             arrangements: vec![Arrangement::Set {
                 name: Cow::from("arrange2.0"),
-                fmfun: fmfun1 as FilterMapFunc,
+                fmfun: Box::new(fmfun1),
                 distinct: false,
             }],
             change_cb: Some(Arc::new(move |_, v, w| set_update("T2", &relset2, v, w))),
@@ -432,12 +432,12 @@ fn test_semijoin(nthreads: usize) {
                 rel: 1,
                 xform: Some(XFormCollection::Arrange {
                     description: Cow::from("arrange by .0"),
-                    afun: afun1 as ArrangeFunc,
+                    afun: Box::new(afun1),
                     next: Box::new(XFormArrangement::Semijoin {
                         description: Cow::from("1.semijoin (2,0)"),
                         ffun: None,
                         arrangement: (2, 0),
-                        jfun: jfun as SemijoinFunc,
+                        jfun: Box::new(jfun),
                         next: Box::new(None),
                     }),
                 }),
@@ -521,7 +521,7 @@ fn test_join(nthreads: usize) {
             arrangements: vec![Arrangement::Map {
                 name: Cow::from("arrange2.0"),
                 // afun: afun1 as ArrangeFunc,
-                afun: Arc::new(afun1),
+                afun: Box::new(afun1),
                 queryable: true,
             }],
             change_cb: Some(Arc::new(move |_, v, w| set_update("T2", &relset2, v, w))),
@@ -552,12 +552,12 @@ fn test_join(nthreads: usize) {
                 rel: 1,
                 xform: Some(XFormCollection::Arrange {
                     description: Cow::from("arrange by .0"),
-                    afun: afun1 as ArrangeFunc,
+                    afun: Box::new(afun1),
                     next: Box::new(XFormArrangement::Join {
                         description: Cow::from("1.semijoin (2,0)"),
                         ffun: None,
                         arrangement: (2, 0),
-                        jfun: Arc::new(jfun),
+                        jfun: Box::new(jfun),
                         next: Box::new(None),
                     }),
                 }),
@@ -682,12 +682,12 @@ fn test_streamjoin(nthreads: usize) {
                 Arrangement::Map {
                     name: Cow::from("arrange1.0"),
                     // afun: afun1 as ArrangeFunc,
-                    afun: Arc::new(afun1),
+                    afun: Box::new(afun1),
                     queryable: false,
                 },
                 Arrangement::Set {
                     name: Cow::from("arrange1.1"),
-                    fmfun: safun1 as FilterMapFunc,
+                    fmfun: Box::new(safun1),
                     distinct: false,
                 },
             ],
@@ -779,13 +779,13 @@ fn test_streamjoin(nthreads: usize) {
                 rel: 1,
                 xform: Some(XFormCollection::Arrange {
                     description: Cow::from("arrange by .0"),
-                    afun: afun1 as ArrangeFunc,
+                    afun: Box::new(afun1),
                     next: Box::new(XFormArrangement::StreamJoin {
                         description: Cow::from("1.streamjoin (2)"),
                         ffun: None,
                         rel: 2,
-                        kfun: kfun as KeyFunc,
-                        jfun: jfun as ValJoinFunc,
+                        kfun: Box::new(kfun),
+                        jfun: Box::new(jfun),
                         next: Box::new(None),
                     }),
                 }),
@@ -810,9 +810,9 @@ fn test_streamjoin(nthreads: usize) {
                 rel: 2,
                 xform: Some(XFormCollection::StreamJoin {
                     description: Cow::from("2.streamjoin (1)"),
-                    afun: afun1,
+                    afun: Box::new(afun1),
                     arrangement: (1, 0),
-                    jfun: jfun2 as ValJoinFunc,
+                    jfun: Box::new(jfun2),
                     next: Box::new(None),
                 }),
             }],
@@ -836,13 +836,13 @@ fn test_streamjoin(nthreads: usize) {
                 rel: 1,
                 xform: Some(XFormCollection::Arrange {
                     description: Cow::from("arrange by .0"),
-                    afun: afun1 as ArrangeFunc,
+                    afun: Box::new(afun1),
                     next: Box::new(XFormArrangement::StreamSemijoin {
                         description: Cow::from("1.streamsemijoin (2)"),
                         ffun: None,
                         rel: 2,
-                        kfun: kfun as KeyFunc,
-                        jfun: sjfun as StreamSemijoinFunc,
+                        kfun: Box::new(kfun),
+                        jfun: Box::new(sjfun),
                         next: Box::new(None),
                     }),
                 }),
@@ -867,9 +867,9 @@ fn test_streamjoin(nthreads: usize) {
                 rel: 2,
                 xform: Some(XFormCollection::StreamSemijoin {
                     description: Cow::from("2.streamsemijoin (1)"),
-                    afun: afun1,
+                    afun: Box::new(afun1),
                     arrangement: (1, 1),
-                    jfun: sjfun2 as StreamSemijoinFunc,
+                    jfun: Box::new(sjfun2),
                     next: Box::new(None),
                 }),
             }],
@@ -983,13 +983,13 @@ fn test_antijoin(nthreads: usize) {
                 rel: 2,
                 xform: Some(XFormCollection::Map {
                     description: Cow::from("map by .0"),
-                    mfun: Arc::new(mfun),
+                    mfun: Box::new(mfun),
                     next: Box::new(None),
                 }),
             }],
             arrangements: vec![Arrangement::Set {
                 name: Cow::from("arrange2.1"),
-                fmfun: fmnull_fun as FilterMapFunc,
+                fmfun: Box::new(fmnull_fun),
                 distinct: true,
             }],
             change_cb: Some(Arc::new(move |_, v, w| set_update("T21", &relset21, v, w))),
@@ -1011,7 +1011,7 @@ fn test_antijoin(nthreads: usize) {
                 rel: 1,
                 xform: Some(XFormCollection::Arrange {
                     description: Cow::from("arrange by .0"),
-                    afun: afun1 as ArrangeFunc,
+                    afun: Box::new(afun1),
                     next: Box::new(XFormArrangement::Antijoin {
                         description: Cow::from("1.antijoin (21,0)"),
                         ffun: None,
@@ -1159,16 +1159,16 @@ fn test_map(nthreads: usize) {
                 rel: 1,
                 xform: Some(XFormCollection::Map {
                     description: Cow::from("map x2"),
-                    mfun: Arc::new(mfun),
+                    mfun: Box::new(mfun),
                     next: Box::new(Some(XFormCollection::Filter {
                         description: Cow::from("filter >10"),
-                        ffun: ffun as FilterFunc,
+                        ffun: Box::new(ffun),
                         next: Box::new(Some(XFormCollection::FilterMap {
                             description: Cow::from("filter >12 map x2"),
-                            fmfun: fmfun as FilterMapFunc,
+                            fmfun: Box::new(fmfun),
                             next: Box::new(Some(XFormCollection::FlatMap {
                                 description: Cow::from("flat-map >12 [-x,-2x]"),
-                                fmfun: flatmapfun as FlatMapFunc,
+                                fmfun: Box::new(flatmapfun),
                                 next: Box::new(None),
                             })),
                         })),
@@ -1194,11 +1194,11 @@ fn test_map(nthreads: usize) {
                 rel: 2,
                 xform: Some(XFormCollection::Arrange {
                     description: Cow::from("arrange by ()"),
-                    afun: gfun3 as ArrangeFunc,
+                    afun: Box::new(gfun3),
                     next: Box::new(XFormArrangement::Aggregate {
                         description: Cow::from("2.aggregate"),
                         ffun: None,
-                        aggfun: agfun3 as AggFunc,
+                        aggfun: Box::new(agfun3),
                         next: Box::new(None),
                     }),
                 }),
@@ -1223,11 +1223,11 @@ fn test_map(nthreads: usize) {
                 rel: 2,
                 xform: Some(XFormCollection::Arrange {
                     description: Cow::from("arrange by self"),
-                    afun: gfun4 as ArrangeFunc,
+                    afun: Box::new(gfun4),
                     next: Box::new(XFormArrangement::Aggregate {
                         description: Cow::from("2.aggregate"),
                         ffun: None,
-                        aggfun: agfun4 as AggFunc,
+                        aggfun: Box::new(agfun4),
                         next: Box::new(None),
                     }),
                 }),
@@ -1395,10 +1395,10 @@ fn test_delayed(nthreads: usize) {
                     description: Cow::from("T1.stream_xform"),
                     xform: Box::new(Some(XFormCollection::Arrange {
                         description: Cow::from("T1.stream_arrange"),
-                        afun: afun1,
+                        afun: Box::new(afun1),
                         next: Box::new(XFormArrangement::FilterMap {
                             description: Cow::from("T5 :-"),
-                            fmfun: fmfun1,
+                            fmfun: Box::new(fmfun1),
                             next: Box::new(None),
                         }),
                     })),
@@ -1533,7 +1533,7 @@ fn test_recursion(nthreads: usize) {
             arrangements: vec![Arrangement::Map {
                 name: Cow::from("arrange_by_parent"),
                 // afun: arrange_by_fst as ArrangeFunc,
-                afun: Arc::new(arrange_by_fst),
+                afun: Box::new(arrange_by_fst),
                 queryable: false,
             }],
             change_cb: Some(Arc::new(move |_, v, w| {
@@ -1565,7 +1565,7 @@ fn test_recursion(nthreads: usize) {
                         description: Cow::from("(2,2).join (1,0)"),
                         ffun: None,
                         arrangement: (1, 0),
-                        jfun: Arc::new(jfun),
+                        jfun: Box::new(jfun),
                         next: Box::new(None),
                     },
                 },
@@ -1574,18 +1574,18 @@ fn test_recursion(nthreads: usize) {
                 Arrangement::Map {
                     name: Cow::from("arrange_by_ancestor"),
                     // afun: arrange_by_fst as ArrangeFunc,
-                    afun: Arc::new(arrange_by_fst),
+                    afun: Box::new(arrange_by_fst),
                     queryable: false,
                 },
                 Arrangement::Set {
                     name: Cow::from("arrange_by_self"),
-                    fmfun: fmnull_fun as FilterMapFunc,
+                    fmfun: Box::new(fmnull_fun),
                     distinct: true,
                 },
                 Arrangement::Map {
                     name: Cow::from("arrange_by_snd"),
                     // afun: arrange_by_snd as ArrangeFunc,
-                    afun: Arc::new(arrange_by_snd),
+                    afun: Box::new(arrange_by_snd),
                     queryable: false,
                 },
             ],
@@ -1618,24 +1618,24 @@ fn test_recursion(nthreads: usize) {
                     description: Cow::from("(2,0).join (2,0)"),
                     ffun: None,
                     arrangement: (2, 0),
-                    jfun: Arc::new(jfun2),
+                    jfun: Box::new(jfun2),
                     next: Box::new(Some(XFormCollection::Arrange {
                         description: Cow::from("arrange by self"),
-                        afun: anti_arrange1 as ArrangeFunc,
+                        afun: Box::new(anti_arrange1),
                         next: Box::new(XFormArrangement::Antijoin {
                             description: Cow::from("(2,0).antijoin (2,1)"),
                             ffun: None,
                             arrangement: (2, 1),
                             next: Box::new(Some(XFormCollection::Arrange {
                                 description: Cow::from("arrange by .1"),
-                                afun: anti_arrange2 as ArrangeFunc,
+                                afun: Box::new(anti_arrange2),
                                 next: Box::new(XFormArrangement::Antijoin {
                                     description: Cow::from("...join (2,1)"),
                                     ffun: None,
                                     arrangement: (2, 1),
                                     next: Box::new(Some(XFormCollection::Filter {
                                         description: Cow::from("filter .0 != .1"),
-                                        ffun: ffun as FilterFunc,
+                                        ffun: Box::new(ffun),
                                         next: Box::new(None),
                                     })),
                                 }),

--- a/rust/template/differential_datalog_test/lib.rs
+++ b/rust/template/differential_datalog_test/lib.rs
@@ -520,7 +520,8 @@ fn test_join(nthreads: usize) {
             rules: Vec::new(),
             arrangements: vec![Arrangement::Map {
                 name: Cow::from("arrange2.0"),
-                afun: afun1 as ArrangeFunc,
+                // afun: afun1 as ArrangeFunc,
+                afun: Arc::new(afun1),
                 queryable: true,
             }],
             change_cb: Some(Arc::new(move |_, v, w| set_update("T2", &relset2, v, w))),
@@ -556,7 +557,7 @@ fn test_join(nthreads: usize) {
                         description: Cow::from("1.semijoin (2,0)"),
                         ffun: None,
                         arrangement: (2, 0),
-                        jfun: jfun as JoinFunc,
+                        jfun: Arc::new(jfun),
                         next: Box::new(None),
                     }),
                 }),
@@ -680,7 +681,8 @@ fn test_streamjoin(nthreads: usize) {
             arrangements: vec![
                 Arrangement::Map {
                     name: Cow::from("arrange1.0"),
-                    afun: afun1 as ArrangeFunc,
+                    // afun: afun1 as ArrangeFunc,
+                    afun: Arc::new(afun1),
                     queryable: false,
                 },
                 Arrangement::Set {
@@ -981,7 +983,7 @@ fn test_antijoin(nthreads: usize) {
                 rel: 2,
                 xform: Some(XFormCollection::Map {
                     description: Cow::from("map by .0"),
-                    mfun: mfun as MapFunc,
+                    mfun: Arc::new(mfun),
                     next: Box::new(None),
                 }),
             }],
@@ -1157,7 +1159,7 @@ fn test_map(nthreads: usize) {
                 rel: 1,
                 xform: Some(XFormCollection::Map {
                     description: Cow::from("map x2"),
-                    mfun: mfun as MapFunc,
+                    mfun: Arc::new(mfun),
                     next: Box::new(Some(XFormCollection::Filter {
                         description: Cow::from("filter >10"),
                         ffun: ffun as FilterFunc,
@@ -1530,7 +1532,8 @@ fn test_recursion(nthreads: usize) {
             rules: Vec::new(),
             arrangements: vec![Arrangement::Map {
                 name: Cow::from("arrange_by_parent"),
-                afun: arrange_by_fst as ArrangeFunc,
+                // afun: arrange_by_fst as ArrangeFunc,
+                afun: Arc::new(arrange_by_fst),
                 queryable: false,
             }],
             change_cb: Some(Arc::new(move |_, v, w| {
@@ -1562,7 +1565,7 @@ fn test_recursion(nthreads: usize) {
                         description: Cow::from("(2,2).join (1,0)"),
                         ffun: None,
                         arrangement: (1, 0),
-                        jfun: jfun as JoinFunc,
+                        jfun: Arc::new(jfun),
                         next: Box::new(None),
                     },
                 },
@@ -1570,7 +1573,8 @@ fn test_recursion(nthreads: usize) {
             arrangements: vec![
                 Arrangement::Map {
                     name: Cow::from("arrange_by_ancestor"),
-                    afun: arrange_by_fst as ArrangeFunc,
+                    // afun: arrange_by_fst as ArrangeFunc,
+                    afun: Arc::new(arrange_by_fst),
                     queryable: false,
                 },
                 Arrangement::Set {
@@ -1580,7 +1584,8 @@ fn test_recursion(nthreads: usize) {
                 },
                 Arrangement::Map {
                     name: Cow::from("arrange_by_snd"),
-                    afun: arrange_by_snd as ArrangeFunc,
+                    // afun: arrange_by_snd as ArrangeFunc,
+                    afun: Arc::new(arrange_by_snd),
                     queryable: false,
                 },
             ],
@@ -1613,7 +1618,7 @@ fn test_recursion(nthreads: usize) {
                     description: Cow::from("(2,0).join (2,0)"),
                     ffun: None,
                     arrangement: (2, 0),
-                    jfun: jfun2 as JoinFunc,
+                    jfun: Arc::new(jfun2),
                     next: Box::new(Some(XFormCollection::Arrange {
                         description: Cow::from("arrange by self"),
                         afun: anti_arrange1 as ArrangeFunc,


### PR DESCRIPTION
This is an incomplete PR for #983 to loosen the restriction on function types. For now I only changed four function types `FilterMapFunc`, `FilterFunc`, `JoinFunc`, `ArrangeFunc` for a review and will add another commit to change the rest of the function types if you guys think everything is good without breaking anything.