### PR TITLE
GitHash issue when building from sources

### DIFF
--- a/src/Language/DifferentialDatalog/Version.hs
+++ b/src/Language/DifferentialDatalog/Version.hs
@@ -29,10 +29,19 @@ module Language.DifferentialDatalog.Version (
 where
 
 import GitHash
+import Data.List
 
 -- Keep this in sync with the binary release version on github
 dDLOG_VERSION :: String
 dDLOG_VERSION = "v0.40.2"
 
+gitInfoCwdTry :: Either String GitInfo
+gitInfoCwdTry = $$tGitInfoCwdTry
+
 gitHash :: String
-gitHash = giHash $$tGitInfoCwd
+gitHash =
+    case gitInfoCwdTry of
+        Left err -> case isInfixOf "GHEGitRunFailed" err of
+            True -> "built from sources"
+            False -> error "gitHash error - failed to obtain GitInfo"
+        Right gitInfo -> giHash gitInfo


### PR DESCRIPTION
This is a fix for issue #966 

Sources downloaded from release page are not a git repository; thus, they don't have ".git" folder inside. This causes "stack build" to fail as it tries to obtain last commit hash using GitHash. This PR fixes this bug:
1) if this is a git repository, then last commit hash will be obtained
2) if this is not a git repo (such a tarball with sources downloaded from release page) then last commit hash will be replaced with "built from sources" string
3) if other error will happen in GitHash then "gitHash error - failed to obtain GitInfo" error will be printed when will try to call "ddlog -v". Note, however, that does not abort build and I think that ddlog may still work except when try to obtain its version.

However, it fixes the bug of failing build from sources though other exceptions in GitHash may need to be handled better.