### PR TITLE
Added Clone bounds to IntoRecord and Mutator derives

### DIFF
--- a/rust/template/ddlog_derive/src/from_record.rs
+++ b/rust/template/ddlog_derive/src/from_record.rs
@@ -21,9 +21,9 @@ pub fn from_record_inner(input: DeriveInput) -> Result<TokenStream> {
     let generics = add_trait_bounds(
         input.generics,
         vec![
-            parse_quote!(differential_datalog::record::FromRecord),
-            parse_quote!(Sized),
-            parse_quote!(std::default::Default),
+            parse_quote!(::differential_datalog::record::FromRecord),
+            parse_quote!(::core::marker::Sized),
+            parse_quote!(::core::default::Default),
             parse_quote!(serde::de::DeserializeOwned),
         ],
     );
@@ -78,7 +78,7 @@ fn from_record_struct(
 
             // Call `FromRecord::from_record()` directly on each field
             quote! {
-                #field_ident: <#field_type as differential_datalog::record::FromRecord>::from_record(&args[#idx])?,
+                #field_ident: <#field_type as ::differential_datalog::record::FromRecord>::from_record(&args[#idx])?,
             }
         })
         .collect();
@@ -104,7 +104,7 @@ fn from_record_struct(
 
             // Call `FromRecord::from_record()` directly on each field
             Ok(quote! {
-                #field_ident: differential_datalog::record::arg_extract::<#field_type>(args, #field_record_name)?,
+                #field_ident: ::differential_datalog::record::arg_extract::<#field_type>(args, #field_record_name)?,
             })
         })
         .collect::<Result<TokenStream>>()?;
@@ -114,14 +114,14 @@ fn from_record_struct(
         impl #impl_generics differential_datalog::record::FromRecord for #struct_ident #type_generics #where_clause {
             fn from_record(record: &differential_datalog::record::Record) -> std::result::Result<Self, std::string::String> {
                 match record {
-                    differential_datalog::record::Record::PosStruct(constructor, args) => {
+                    ::differential_datalog::record::Record::PosStruct(constructor, args) => {
                         match constructor.as_ref() {
                             #struct_record_name if args.len() == #num_fields => {
-                                std::result::Result::Ok(Self { #positional_fields })
+                                ::core::result::Result::Ok(Self { #positional_fields })
                             },
 
                             error => {
-                                std::result::Result::Err(std::format!(
+                                ::core::result::Result::Err(::std::format!(
                                     "unknown constructor {} of type '{}' in {:?}",
                                     error, #struct_record_name, *record,
                                 ))
@@ -132,11 +132,11 @@ fn from_record_struct(
                     differential_datalog::record::Record::NamedStruct(constructor, args) => {
                         match constructor.as_ref() {
                             #struct_record_name => {
-                                std::result::Result::Ok(Self { #named_fields })
+                                ::core::result::Result::Ok(Self { #named_fields })
                             },
 
                             error => {
-                                std::result::Result::Err(std::format!(
+                                ::core::result::Result::Err(::std::format!(
                                     "unknown constructor {} of type '{}' in {:?}",
                                     error, #struct_record_name, *record,
                                 ))
@@ -148,12 +148,12 @@ fn from_record_struct(
                         if format == "json" {
                             serde_json::from_str(serialized.as_str()).map_err(|error| format!("{}", error))
                         } else {
-                            std::result::Result::Err(std::format!("unsupported serialization format '{}'", format))
+                            ::core::result::Result::Err(::std::format!("unsupported serialization format '{}'", format))
                         }
                     },
 
                     error => {
-                        std::result::Result::Err(std::format!("not a struct {:?}", *error))
+                        ::core::result::Result::Err(::std::format!("not a struct {:?}", *error))
                     },
                 }
             }
@@ -202,7 +202,7 @@ fn from_record_enum(
 
                     // Call `FromRecord::from_record()` directly on each field
                     quote! {
-                        #field_ident: <#field_type as differential_datalog::record::FromRecord>::from_record(&args[#idx])?,
+                        #field_ident: <#field_type as ::differential_datalog::record::FromRecord>::from_record(&args[#idx])?,
                     }
                 })
                 .collect();
@@ -210,7 +210,7 @@ fn from_record_enum(
             // Generate the code for each match arm individually
             Ok(quote! {
                 #variant_record_name if args.len() == #num_fields => {
-                    std::result::Result::Ok(Self::#variant_ident { #positional_fields })
+                    ::core::result::Result::Ok(Self::#variant_ident { #positional_fields })
                 },
             })
         })
@@ -249,7 +249,7 @@ fn from_record_enum(
 
                     // Call `FromRecord::from_record()` directly on each field
                     Ok(quote! {
-                        #field_ident: differential_datalog::record::arg_extract::<#field_type>(args, #field_record_name)?,
+                        #field_ident: ::differential_datalog::record::arg_extract::<#field_type>(args, #field_record_name)?,
                     })
                 })
                 .collect::<Result<TokenStream>>()?;
@@ -257,7 +257,7 @@ fn from_record_enum(
             // Generate the code for each match arm individually
             Ok(quote! {
                 #variant_record_name if args.len() == #num_fields => {
-                    std::result::Result::Ok(Self::#variant_ident { #named_fields })
+                    ::core::result::Result::Ok(Self::#variant_ident { #named_fields })
                 },
             })
         })
@@ -265,15 +265,15 @@ fn from_record_enum(
 
     Ok(quote! {
         #[automatically_derived]
-        impl #impl_generics differential_datalog::record::FromRecord for #enum_ident #type_generics #where_clause {
-            fn from_record(record: &differential_datalog::record::Record) -> std::result::Result<Self, std::string::String> {
+        impl #impl_generics ::differential_datalog::record::FromRecord for #enum_ident #type_generics #where_clause {
+            fn from_record(record: &::differential_datalog::record::Record) -> ::core::result::Result<Self, ::std::string::String> {
                 match record {
-                    differential_datalog::record::Record::PosStruct(constructor, args) => {
+                    ::differential_datalog::record::Record::PosStruct(constructor, args) => {
                         match constructor.as_ref() {
                             #positional_variants
 
                             error => {
-                                std::result::Result::Err(std::format!(
+                                ::core::result::Result::Err(::std::format!(
                                     "unknown constructor {} of type '{}' in {:?}",
                                     error, #enum_record_name, *record,
                                 ))
@@ -281,12 +281,12 @@ fn from_record_enum(
                         }
                     },
 
-                    differential_datalog::record::Record::NamedStruct(constructor, args) => {
+                    ::differential_datalog::record::Record::NamedStruct(constructor, args) => {
                         match constructor.as_ref() {
                             #named_variants
 
                             error => {
-                                std::result::Result::Err(std::format!(
+                                ::core::result::Result::Err(::std::format!(
                                     "unknown constructor {} of type '{}' in {:?}",
                                     error, #enum_record_name, *record,
                                 ))
@@ -294,16 +294,16 @@ fn from_record_enum(
                         }
                     },
 
-                    differential_datalog::record::Record::Serialized(format, serialized) => {
+                    ::differential_datalog::record::Record::Serialized(format, serialized) => {
                         if format == "json" {
                             serde_json::from_str(serialized.as_str()).map_err(|error| format!("{}", error))
                         } else {
-                            std::result::Result::Err(std::format!("unsupported serialization format '{}'", format))
+                            ::core::result::Result::Err(::std::format!("unsupported serialization format '{}'", format))
                         }
                     },
 
                     error => {
-                        std::result::Result::Err(std::format!("not a struct {:?}", *error))
+                        ::core::result::Result::Err(::std::format!("not a struct {:?}", *error))
                     }
                 }
             }

--- a/rust/template/ddlog_derive/src/into_record.rs
+++ b/rust/template/ddlog_derive/src/into_record.rs
@@ -19,7 +19,10 @@ pub fn into_record_inner(input: DeriveInput) -> Result<TokenStream> {
     // Add the required trait bounds
     let generics = add_trait_bounds(
         input.generics,
-        vec![parse_quote!(differential_datalog::record::IntoRecord)],
+        vec![
+            parse_quote!(::differential_datalog::record::IntoRecord),
+            parse_quote!(::core::clone::Clone),
+        ],
     );
     let generics = generics.split_for_impl();
 
@@ -84,8 +87,8 @@ fn into_record_struct(
 
     Ok(quote! {
         #[automatically_derived]
-        impl #impl_generics differential_datalog::record::IntoRecord for #struct_ident #type_generics #where_clause {
-            fn into_record(self) -> differential_datalog::record::Record {
+        impl #impl_generics ::differential_datalog::record::IntoRecord for #struct_ident #type_generics #where_clause {
+            fn into_record(self) -> ::differential_datalog::record::Record {
                 #guard
                 #generated_record
             }
@@ -149,8 +152,8 @@ fn into_record_enum(
 
     Ok(quote! {
         #[automatically_derived]
-        impl #impl_generics differential_datalog::record::IntoRecord for #enum_ident #type_generics #where_clause {
-            fn into_record(self) -> differential_datalog::record::Record {
+        impl #impl_generics ::differential_datalog::record::IntoRecord for #enum_ident #type_generics #where_clause {
+            fn into_record(self) -> ::differential_datalog::record::Record {
                 match self {
                     #generated_variants
                 }
@@ -181,8 +184,8 @@ fn named_struct_record<'a>(
 
         Ok(quote! {
             (
-                std::borrow::Cow::Borrowed(#element_record_name),
-                <#element_type as differential_datalog::record::IntoRecord>::into_record(#element_ident),
+                ::std::borrow::Cow::Borrowed(#element_record_name),
+                <#element_type as ::differential_datalog::record::IntoRecord>::into_record(#element_ident),
             ),
         })
     })
@@ -190,7 +193,7 @@ fn named_struct_record<'a>(
 
     let record = quote! {
         differential_datalog::record::Record::NamedStruct(
-            std::borrow::Cow::Borrowed(#record_name),
+            ::std::borrow::Cow::Borrowed(#record_name),
             vec![#elements],
         )
     };
@@ -230,13 +233,13 @@ fn tuple_struct_record<'a>(
         let element_type = &element.ty;
 
         quote! {
-            <#element_type as differential_datalog::record::IntoRecord>::into_record(#index),
+            <#element_type as ::differential_datalog::record::IntoRecord>::into_record(#index),
         }
     });
 
     let record = quote! {
-        differential_datalog::record::Record::PosStruct(
-            std::borrow::Cow::Borrowed(#record_name),
+        ::differential_datalog::record::Record::PosStruct(
+            ::std::borrow::Cow::Borrowed(#record_name),
             vec![#( #element_records )*],
         )
     };
@@ -246,9 +249,9 @@ fn tuple_struct_record<'a>(
 
 fn unit_struct_record(record_name: &str) -> TokenStream {
     quote! {
-        differential_datalog::record::Record::NamedStruct(
-            std::borrow::Cow::Borrowed(#record_name),
-            std::vec::Vec::new(),
+        ::differential_datalog::record::Record::NamedStruct(
+            ::std::borrow::Cow::Borrowed(#record_name),
+            ::std::vec::Vec::new(),
         )
     }
 }

--- a/rust/template/ddlog_derive/tests/ui/pass/clone_ref.rs
+++ b/rust/template/ddlog_derive/tests/ui/pass/clone_ref.rs
@@ -1,0 +1,74 @@
+use ddlog_derive::{FromRecord, IntoRecord, Mutator};
+use serde::{de::Deserializer, ser::Serializer, Deserialize, Serialize};
+use std::sync::Arc;
+
+#[derive(
+    Eq,
+    Ord,
+    Clone,
+    Hash,
+    PartialEq,
+    PartialOrd,
+    IntoRecord,
+    Mutator,
+    Serialize,
+    Deserialize,
+    FromRecord,
+)]
+#[ddlog(rename = "List")]
+pub enum List<N> {
+    #[ddlog(rename = "List")]
+    List { node: N, nxt: ListNxt<N> },
+    #[ddlog(rename = "EMPTY")]
+    EMPTY,
+}
+
+impl<T> Default for List<T> {
+    fn default() -> Self {
+        Self::EMPTY
+    }
+}
+
+#[derive(
+    Eq,
+    Ord,
+    Clone,
+    Hash,
+    PartialEq,
+    PartialOrd,
+    IntoRecord,
+    Mutator,
+    Serialize,
+    Deserialize,
+    FromRecord,
+    Default,
+)]
+#[ddlog(rename = "ListNxt")]
+pub struct ListNxt<N> {
+    nxt: Ref<List<N>>,
+}
+
+#[derive(Eq, Ord, Clone, Hash, PartialEq, PartialOrd, IntoRecord, Mutator, FromRecord, Default)]
+pub struct Ref<T> {
+    inner: Arc<T>,
+}
+
+impl<'a, T> Deserialize<'a> for Ref<T> {
+    fn deserialize<D>(_deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'a>,
+    {
+        unimplemented!()
+    }
+}
+
+impl<T> Serialize for Ref<T> {
+    fn serialize<S>(&self, _serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        unimplemented!()
+    }
+}
+
+fn main() {}

--- a/rust/template/differential_datalog/src/record/mod.rs
+++ b/rust/template/differential_datalog/src/record/mod.rs
@@ -8,16 +8,21 @@ use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
 use std::{
     borrow::Cow,
+    cell::{Cell, RefCell},
     collections::{btree_map, BTreeMap, BTreeSet},
     fmt::{self, Write},
     iter::FromIterator,
-    str, vec,
+    rc::Rc,
+    str,
+    sync::Arc as StdArc,
+    vec,
 };
 #[cfg(feature = "c_api")]
 use std::{
     ffi::{CStr, CString},
     ptr, slice,
 };
+use triomphe::Arc;
 
 pub type Name = Cow<'static, str>;
 
@@ -731,7 +736,7 @@ impl Mutator<String> for Record {
 impl<T: FromRecord> FromRecord for vec::Vec<T> {
     fn from_record(val: &Record) -> Result<Self, String> {
         match val {
-            Record::Array(_, args) => Result::from_iter(args.iter().map(|x| T::from_record(x))),
+            Record::Array(_, args) => args.iter().map(T::from_record).collect(),
             v => {
                 T::from_record(v).map(|x| vec![x])
                 //Err(format!("not an array {:?}", *v))
@@ -822,6 +827,170 @@ impl<T: FromRecord + Ord> Mutator<BTreeSet<T>> for Record {
                 set.insert(v);
             }
         }
+        Ok(())
+    }
+}
+
+impl<T> FromRecord for Arc<T>
+where
+    T: FromRecord,
+{
+    fn from_record(val: &Record) -> Result<Self, String> {
+        T::from_record(val).map(Arc::new)
+    }
+}
+
+impl<T> FromRecord for StdArc<T>
+where
+    T: FromRecord,
+{
+    fn from_record(val: &Record) -> Result<Self, String> {
+        T::from_record(val).map(StdArc::new)
+    }
+}
+
+impl<T> FromRecord for Rc<T>
+where
+    T: FromRecord,
+{
+    fn from_record(val: &Record) -> Result<Self, String> {
+        T::from_record(val).map(Rc::new)
+    }
+}
+
+impl<T> FromRecord for Cell<T>
+where
+    T: FromRecord,
+{
+    fn from_record(val: &Record) -> Result<Self, String> {
+        T::from_record(val).map(Cell::new)
+    }
+}
+
+impl<T> FromRecord for RefCell<T>
+where
+    T: FromRecord,
+{
+    fn from_record(val: &Record) -> Result<Self, String> {
+        T::from_record(val).map(RefCell::new)
+    }
+}
+
+impl<T> IntoRecord for Arc<T>
+where
+    T: IntoRecord + Clone,
+{
+    fn into_record(self) -> Record {
+        Arc::try_unwrap(self)
+            .unwrap_or_else(|this| T::clone(&*this))
+            .into_record()
+    }
+}
+
+impl<T> IntoRecord for StdArc<T>
+where
+    T: IntoRecord + Clone,
+{
+    fn into_record(self) -> Record {
+        StdArc::try_unwrap(self)
+            .unwrap_or_else(|this| T::clone(&*this))
+            .into_record()
+    }
+}
+
+impl<T> IntoRecord for Rc<T>
+where
+    T: IntoRecord + Clone,
+{
+    fn into_record(self) -> Record {
+        Rc::try_unwrap(self)
+            .unwrap_or_else(|this| T::clone(&*this))
+            .into_record()
+    }
+}
+
+impl<T> IntoRecord for Cell<T>
+where
+    T: IntoRecord,
+{
+    fn into_record(self) -> Record {
+        Cell::into_inner(self).into_record()
+    }
+}
+
+impl<T> IntoRecord for RefCell<T>
+where
+    T: IntoRecord,
+{
+    fn into_record(self) -> Record {
+        RefCell::into_inner(self).into_record()
+    }
+}
+
+impl<T> Mutator<Arc<T>> for Record
+where
+    T: Clone,
+    Record: Mutator<T>,
+{
+    fn mutate(&self, this: &mut Arc<T>) -> Result<(), String> {
+        let mut value = Arc::try_unwrap(this.clone()).unwrap_or_else(|this| T::clone(&*this));
+        self.mutate(&mut value)?;
+        *this = Arc::new(value);
+
+        Ok(())
+    }
+}
+
+impl<T> Mutator<StdArc<T>> for Record
+where
+    T: Clone,
+    Record: Mutator<T>,
+{
+    fn mutate(&self, this: &mut StdArc<T>) -> Result<(), String> {
+        let mut value = StdArc::try_unwrap(this.clone()).unwrap_or_else(|this| T::clone(&*this));
+        self.mutate(&mut value)?;
+        *this = StdArc::new(value);
+
+        Ok(())
+    }
+}
+
+impl<T> Mutator<Rc<T>> for Record
+where
+    T: Clone,
+    Record: Mutator<T>,
+{
+    fn mutate(&self, this: &mut Rc<T>) -> Result<(), String> {
+        let mut value = Rc::try_unwrap(this.clone()).unwrap_or_else(|this| T::clone(&*this));
+        self.mutate(&mut value)?;
+        *this = Rc::new(value);
+
+        Ok(())
+    }
+}
+
+impl<T> Mutator<Cell<T>> for Record
+where
+    T: Copy,
+    Record: Mutator<T>,
+{
+    fn mutate(&self, cell: &mut Cell<T>) -> Result<(), String> {
+        let mut value = cell.get();
+        self.mutate(&mut value)?;
+        cell.set(value);
+
+        Ok(())
+    }
+}
+
+impl<T> Mutator<RefCell<T>> for Record
+where
+    Record: Mutator<T>,
+{
+    fn mutate(&self, cell: &mut RefCell<T>) -> Result<(), String> {
+        let mut value = cell.borrow_mut();
+        self.mutate(&mut value)?;
+
         Ok(())
     }
 }

--- a/test/datalog_tests/simple2.dat
+++ b/test/datalog_tests/simple2.dat
@@ -115,3 +115,11 @@ start;
 insert DataForSingletonTest(100),
 
 commit dump_changes;
+
+start;
+
+insert InList(        Lst{1,
+              ListNxt{Lst{2,
+              ListNxt{Lst{3,
+              ListNxt{EMPTY}}}}}});
+commit dump_changes;

--- a/test/datalog_tests/simple2.dl
+++ b/test/datalog_tests/simple2.dl
@@ -614,3 +614,26 @@ SingletonTest("${v}") :- var v = 5.
  */
 #[original="original_name"]
 input relation Renamed()
+
+
+/*
+ * Test IntoRecord/FromRecord implementations for `Ref<'T>`, where
+ * 'T is a type argument (see issue #1017).
+ */
+
+typedef LinkedList<'N> = Lst { node: 'N, nxt: ListNxt<'N> } | EMPTY
+typedef ListNxt<'N> = ListNxt { nxt: Ref<LinkedList<'N>> }
+
+function map(l: LinkedList<'T1>, f: (function ('T1) : 'T2)): LinkedList<'T2> {
+    match (l) {
+        EMPTY -> EMPTY,
+        Lst{n, ListNxt{nxt}} -> Lst{f(n), ListNxt{ref_new(nxt.deref().map(f))}}
+    }
+}
+
+input relation InList(l: LinkedList<usize>)
+output relation OutList(l: LinkedList<string>)
+
+OutList(out_list) :-
+    InList(in_list),
+    var out_list = in_list.map(|x| "${x}").

--- a/test/datalog_tests/simple2.dump.expected
+++ b/test/datalog_tests/simple2.dump.expected
@@ -204,3 +204,5 @@ FlatGroup{.x = 111}: +1
 FlatGroup{.x = 222}: +1
 SingletonTest:
 SingletonTest{.s = "DataForSingletonTest is empty"}: -1
+OutList:
+OutList{.l = Lst{.node = "1", .nxt = ListNxt{.nxt = Lst{.node = "2", .nxt = ListNxt{.nxt = Lst{.node = "3", .nxt = ListNxt{.nxt = EMPTY{}}}}}}}}: +1


### PR DESCRIPTION
* Adds `Clone` bounds into the derived `IntoRecord` and `Mutator` derives
  * Adds a regression test to the derive suite for #1017
* Implements `IntoRecord`, `FromRecord` and `Mutator` for `std::sync::Arc`, `triomphe::Arc`, `std::rc::Rc`, `std::cell::Cell` and `std::cell::RecCell`

Fixes #1017