### PR TITLE
Strip array subtype in Presto -> H2 compiler

### DIFF
--- a/sql/src/main/java/com/vmware/ddlog/TranslateCreateTableDialect.java
+++ b/sql/src/main/java/com/vmware/ddlog/TranslateCreateTableDialect.java
@@ -28,7 +28,7 @@ class TranslateCreateTableDialect extends AstVisitor<String, String> {
 
                 // We need to strip the array subtype for H2
                 final Pattern arrayType = Pattern.compile("ARRAY\\((.+)\\)");
-                Matcher m = arrayType.matcher(cd.getType());
+                Matcher m = arrayType.matcher(h2Type);
                 if (m.find()) {
                     h2Type = "array";
                 }

--- a/sql/src/test/java/ddlog/JooqProviderTest.java
+++ b/sql/src/test/java/ddlog/JooqProviderTest.java
@@ -67,10 +67,13 @@ public class JooqProviderTest {
         String s1 = "create table hosts (id varchar(36) with (primary_key = true), capacity integer, up boolean)";
         String v2 = "create view hostsv as select distinct * from hosts";
         String v1 = "create view good_hosts as select distinct * from hosts where capacity < 10";
+        String checkArrayParse = "create table junk (testCol integer array)";
+
         List<String> ddl = new ArrayList<>();
         ddl.add(s1);
         ddl.add(v2);
         ddl.add(v1);
+        ddl.add(checkArrayParse);
         compileAndLoad(ddl);
         final DDlogAPI dDlogAPI = new DDlogAPI(1, false);
 


### PR DESCRIPTION
H2 SQL doesn't like subtypes for the ARRAY column type.
In order for the JooqConnection to accept the result of this translator, we need to strip subtypes from Presto ARRAY(*) column types.

Signed-off-by: Amy Tai <amy.tai.2009@gmail.com>