### PR TITLE
ddlog-sql: `not null` column annotation gets lost dialect translation

### DIFF
--- a/sql/src/main/java/com/vmware/ddlog/TranslateCreateTableDialect.java
+++ b/sql/src/main/java/com/vmware/ddlog/TranslateCreateTableDialect.java
@@ -47,7 +47,7 @@ class TranslateCreateTableDialect extends AstVisitor<String, String> {
                     throw new RuntimeException(String.format("Unsupported properties %s in sql: %s",
                             cd.getProperties(), sql));
                 }
-                columnsToCreate.add(String.format("%s %s", cd.getName().getValue(), h2Type));
+                columnsToCreate.add(String.format("%s %s %s", cd.getName().getValue(), h2Type, cd.isNullable() ? "" : "not null"));
             }
         }
 

--- a/sql/src/test/java/ddlog/JooqProviderTest.java
+++ b/sql/src/test/java/ddlog/JooqProviderTest.java
@@ -68,12 +68,15 @@ public class JooqProviderTest {
         String v2 = "create view hostsv as select distinct * from hosts";
         String v1 = "create view good_hosts as select distinct * from hosts where capacity < 10";
         String checkArrayParse = "create table junk (testCol integer array)";
+        String checkNotNullColumns = "create table not_null (test_col1 integer not null, test_col2 varchar(36) not null)";
 
         List<String> ddl = new ArrayList<>();
         ddl.add(s1);
         ddl.add(v2);
         ddl.add(v1);
         ddl.add(checkArrayParse);
+        ddl.add(checkNotNullColumns);
+
         compileAndLoad(ddl);
         final DDlogAPI dDlogAPI = new DDlogAPI(1, false);
 
@@ -329,6 +332,19 @@ public class JooqProviderTest {
         }
     }
 
+    /*
+     * Test we can insert into columns with `not null` annotations.
+     */
+    @Test
+    public void testNotNullColumns() {
+        // Without bindings
+        create.execute("insert into not_null values (5, 'test_string')");
+
+        // With bindings
+        create.insertInto(table("not_null"))
+                .values(1, "herp")
+                .execute();
+    }
 
     public static void compileAndLoad(final List<String> ddl) throws IOException, DDlogException {
         final Translator t = new Translator(null);


### PR DESCRIPTION
`not null` column annotation gets lost in Presto -> H2 translation. This causes any insertions into a column with `not null` to fail on the DDlog side, because the types are not the same (DDlog expects a type T without an option, but the JooqProvider will end up generating a DDlog `Option<T>` object for a record).

Signed-off-by: Amy Tai <amy.tai.2009@gmail.com>