### PR TITLE
Convert string literals to lazy statics.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Optimizations
+
+- Compile string literals into lazy static to avoid dynamic allocation every
+  time a string literal is used.
+
+### Bug fixes
+
+- Bug fixes in the SQL-to-DDlog compiler
+
 ## [0.43.0] - Jul 25, 2021
 
 ### Bug fixes

--- a/src/Language/DifferentialDatalog/Expr.hs
+++ b/src/Language/DifferentialDatalog/Expr.hs
@@ -536,6 +536,7 @@ exprIsStatic d ctx e@(E EApply{}) =
     null (exprFreeVars d ctx e) &&
     (not $ exprIsPolymorphic d ctx e) &&
     exprIsPure d ctx e
+exprIsStatic _ _ (E EString{}) = True
 exprIsStatic _ _ _ = False
 
 -- | Transform types referenced in the expression


### PR DESCRIPTION
Since we map DDlog's `string` type to Rust's `String`, the
straightforward translation of string literals instantiates a `String`
every time the literal is evaluated: `String::from("foo")`.  This
involves a dynamic memory allocation, which is highly inefficient.  The
right thing to do in this case is to use `&'static str` and insert
conversions to/from `String` only where necessary.  Unfortunately, this
requires a significant compiler refactoring: we'd have to introduce the
notion that `T` and `&T` can be represented as different Rust types and
inject type conversions where necessary.

We implement a much simpler but slightly less efficient optimization that
simply converts string literals into lazy statics, so that memory
allocation is only performed once.

Signed-off-by: Leonid Ryzhyk <lryzhyk@vmware.com>