### PR TITLE
`#[by_val]` attribute for function arguments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Optimizations
+
+- Introduce [`#[by_val]`](https://github.com/vmware/differential-datalog/blob/master/doc/tutorial/tutorial.md#by_val)
+  attribute to pass function arguments by value.
+- Use the new attribute to optimize a bunch of library functions.  This should
+  not break any existing DDlog code, but it will affect Rust code that calls
+  DDlog libraries directly.
+
 ## [0.44.0] - Aug 12, 2021
 
 ### Optimizations

--- a/lib/allocate.dl
+++ b/lib/allocate.dl
@@ -33,7 +33,7 @@ SOFTWARE.
  */
 extern function allocate(
     allocated: Set<'N>,
-    toallocate: Vec<'B>,
+    #[by_val] toallocate: Vec<'B>,
     min_val: 'N,
     max_val: 'N): Vec<('B, 'N)>
 
@@ -50,7 +50,7 @@ extern function allocate(
  */
 extern function allocate_with_hint(
     allocated: Set<'N>,
-    toallocate: Vec<('B, Option<'N>)>,
+    #[by_val] toallocate: Vec<('B, Option<'N>)>,
     min_val: 'N,
     max_val: 'N): Vec<('B, 'N)>
 
@@ -66,7 +66,7 @@ extern function allocate_with_hint(
  */
 extern function allocate_opt(
     allocated: Set<'N>,
-    toallocate: Vec<'B>,
+    #[by_val] toallocate: Vec<'B>,
     min_val: 'N,
     max_val: 'N): Vec<('B, Option<'N>)>
 

--- a/lib/allocate.rs
+++ b/lib/allocate.rs
@@ -25,9 +25,9 @@ use std::cmp;
 use std::collections::BTreeSet;
 use std::ops;
 
-pub fn allocate<B: Ord + Clone, N: num::Num + ops::Add + cmp::Ord + Copy>(
+pub fn allocate<B: Ord, N: num::Num + ops::Add + cmp::Ord + Copy>(
     allocated: &ddlog_std::Set<N>,
-    toallocate: &ddlog_std::Vec<B>,
+    toallocate: ddlog_std::Vec<B>,
     min_val: &N,
     max_val: &N,
 ) -> ddlog_std::Vec<ddlog_std::tuple2<B, N>> {
@@ -42,7 +42,7 @@ pub fn allocate<B: Ord + Clone, N: num::Num + ops::Add + cmp::Ord + Copy>(
     };
     let mut offset = N::zero();
     let mut res = ddlog_std::Vec::new();
-    for b in toallocate.iter() {
+    for b in toallocate.into_iter() {
         loop {
             next = if next == *max_val {
                 *min_val
@@ -57,7 +57,7 @@ pub fn allocate<B: Ord + Clone, N: num::Num + ops::Add + cmp::Ord + Copy>(
                 offset = offset + N::one();
                 continue;
             } else {
-                res.push(ddlog_std::tuple2((*b).clone(), next));
+                res.push(ddlog_std::tuple2(b, next));
                 if offset == range {
                     return res;
                 };
@@ -69,9 +69,9 @@ pub fn allocate<B: Ord + Clone, N: num::Num + ops::Add + cmp::Ord + Copy>(
     return res;
 }
 
-pub fn allocate_with_hint<B: Ord + Clone, N: num::Num + ops::Add + cmp::Ord + Copy>(
+pub fn allocate_with_hint<B: Ord, N: num::Num + ops::Add + cmp::Ord + Copy>(
     allocated: &ddlog_std::Set<N>,
-    toallocate: &ddlog_std::Vec<ddlog_std::tuple2<B, ddlog_std::Option<N>>>,
+    toallocate: ddlog_std::Vec<ddlog_std::tuple2<B, ddlog_std::Option<N>>>,
     min_val: &N,
     max_val: &N,
 ) -> ddlog_std::Vec<ddlog_std::tuple2<B, N>> {
@@ -86,11 +86,11 @@ pub fn allocate_with_hint<B: Ord + Clone, N: num::Num + ops::Add + cmp::Ord + Co
         next = *min_val;
     };
     let mut res = ddlog_std::Vec::new();
-    for ddlog_std::tuple2(b, hint) in toallocate.iter() {
+    for ddlog_std::tuple2(b, hint) in toallocate.into_iter() {
         let mut offset = N::zero();
         next = match hint {
             ddlog_std::Option::None => next,
-            ddlog_std::Option::Some { x: h } => *h,
+            ddlog_std::Option::Some { x: h } => h,
         };
         loop {
             if allocated.x.contains(&next) || new_allocations.contains(&next) {
@@ -105,7 +105,7 @@ pub fn allocate_with_hint<B: Ord + Clone, N: num::Num + ops::Add + cmp::Ord + Co
                 };
                 continue;
             } else {
-                res.push(ddlog_std::tuple2((*b).clone(), next));
+                res.push(ddlog_std::tuple2(b, next));
                 new_allocations.insert(next);
                 if offset == range {
                     return res;
@@ -122,9 +122,9 @@ pub fn allocate_with_hint<B: Ord + Clone, N: num::Num + ops::Add + cmp::Ord + Co
     return res;
 }
 
-pub fn allocate_opt<B: Ord + Clone, N: num::Num + ops::Add + cmp::Ord + Copy>(
+pub fn allocate_opt<B: Ord, N: num::Num + ops::Add + cmp::Ord + Copy>(
     allocated: &ddlog_std::Set<N>,
-    toallocate: &ddlog_std::Vec<B>,
+    toallocate: ddlog_std::Vec<B>,
     min_val: &N,
     max_val: &N,
 ) -> ddlog_std::Vec<ddlog_std::tuple2<B, ddlog_std::Option<N>>> {
@@ -142,10 +142,10 @@ pub fn allocate_opt<B: Ord + Clone, N: num::Num + ops::Add + cmp::Ord + Copy>(
     // Signal that address space has been exhausted, but iteration must continue to
     // assign `None` to all remaining items.
     let mut exhausted = false;
-    for b in toallocate.iter() {
+    for b in toallocate.into_iter() {
         loop {
             if exhausted {
-                res.push(ddlog_std::tuple2((*b).clone(), ddlog_std::Option::None));
+                res.push(ddlog_std::tuple2(b, ddlog_std::Option::None));
                 break;
             };
             if offset == range {
@@ -161,10 +161,7 @@ pub fn allocate_opt<B: Ord + Clone, N: num::Num + ops::Add + cmp::Ord + Copy>(
             if allocated.x.contains(&next) {
                 continue;
             } else {
-                res.push(ddlog_std::tuple2(
-                    (*b).clone(),
-                    ddlog_std::Option::Some { x: next },
-                ));
+                res.push(ddlog_std::tuple2(b, ddlog_std::Option::Some { x: next }));
                 break;
             }
         }

--- a/lib/ddlog_std.dl
+++ b/lib/ddlog_std.dl
@@ -88,7 +88,7 @@ function to_string(ts: DDNestedTS): string {
 #[shared_ref]
 extern type Ref<'A>
 
-extern function ref_new(x: 'A): Ref<'A>
+extern function ref_new(#[by_val] x: 'A): Ref<'A>
 
 #[return_by_ref]
 extern function deref(x: Ref<'A>): 'A
@@ -197,7 +197,7 @@ function unwrap_or(x: Option<'A>, def: 'A): 'A = {
 /* Returns the default value for the given type if `opt` is
  * `None`.
  */
-function unwrap_or_default(opt: Option<'A>): 'A {
+function unwrap_or_default(#[by_val] opt: Option<'A>): 'A {
     option_unwrap_or_default(opt)
 }
 
@@ -281,7 +281,7 @@ function unwrap_or(res: Result<'V,'E>, def: 'V): 'V = {
 /* Returns the default value for the given type if `res` is
  * an error.
  */
-function unwrap_or_default(res: Result<'V,'E>): 'V {
+function unwrap_or_default(#[by_val] res: Result<'V,'E>): 'V {
     result_unwrap_or_default(res)
 }
 
@@ -610,13 +610,13 @@ extern type Vec<'A>
 extern function vec_empty(): Vec<'A>
 extern function vec_with_length(len: usize, x: 'A): Vec<'A>
 extern function vec_with_capacity(len: usize): Vec<'A>
-extern function vec_singleton(x: 'X): Vec<'X>
+extern function vec_singleton(#[by_val] x: 'X): Vec<'X>
 
 function len(v: Vec<'X>): usize {
     vec_len(v)
 }
 
-function push(v: mut Vec<'X>, x: 'X) {
+function push(v: mut Vec<'X>, #[by_val] x: 'X) {
     vec_push(v, x)
 }
 
@@ -628,7 +628,7 @@ function append(v: mut Vec<'X>, other: Vec<'X>) {
     vec_append(v, other)
 }
 
-function push_imm(v: Vec<'X>, x: 'X): Vec<'X> {
+function push_imm(v: Vec<'X>, #[by_val] x: 'X): Vec<'X> {
     vec_push_imm(v, x)
 }
 
@@ -644,7 +644,7 @@ function nth(v: Vec<'X>, n: usize): Option<'X> {
     vec_nth(v, n)
 }
 
-function to_set(s: Vec<'A>): Set<'A> {
+function to_set(#[by_val] s: Vec<'A>): Set<'A> {
     vec_to_set(s)
 }
 
@@ -652,22 +652,16 @@ function sort(v: mut Vec<'X>) {
     vec_sort(v)
 }
 
-function sort_imm(v: Vec<'X>): Vec<'X> {
+function sort_imm(#[by_val] v: Vec<'X>): Vec<'X> {
     vec_sort_imm(v)
 }
 
-function zip(v1: Vec<'X>, v2: Vec<'Y>): Vec<('X, 'Y)> {
+function zip(#[by_val] v1: Vec<'X>, #[by_val] v2: Vec<'Y>): Vec<('X, 'Y)> {
     vec_zip(v1, v2)
 }
 
-function unzip(v: Vec<('X, 'Y)>): (Vec<'X>, Vec<'Y>) {
-    var v1 = vec_with_capacity(v.len());
-    var v2 = vec_with_capacity(v.len());
-    for (val in v) {
-        v1.push(val.0);
-        v2.push(val.1);
-    };
-    (v1, v2)
+function unzip(#[by_val] v: Vec<('X, 'Y)>): (Vec<'X>, Vec<'Y>) {
+    vec_unzip(v)
 }
 
 /* Reverse vector in-place. */
@@ -719,7 +713,7 @@ function swap_nth(v: mut Vec<'X>, idx: usize, value: mut 'X): bool {
 /* Set value at index `idx` to `value`.
  * If `idx` exceeds the size of the vector (in which case the vector remains unmodified).
  * Returns true if update happened and false otherwise. */
-function update_nth(v: mut Vec<'X>, idx: usize, value: 'X): bool {
+function update_nth(v: mut Vec<'X>, idx: usize, #[by_val] value: 'X): bool {
     vec_update_nth(v, idx, value)
 }
 
@@ -732,13 +726,13 @@ function update_nth(v: mut Vec<'X>, idx: usize, value: 'X): bool {
 extern type Map<'K,'V>
 
 extern function map_empty(): Map<'K, 'V>
-extern function map_singleton(k: 'K, v: 'V): Map<'K, 'V>
+extern function map_singleton(#[by_val] k: 'K, #[by_val] v: 'V): Map<'K, 'V>
 
 function size(m: Map<'K, 'V>): usize {
     map_size(m)
 }
 
-function insert(m: mut Map<'K,'V>, k: 'K, v: 'V) {
+function insert(m: mut Map<'K,'V>, #[by_val] k: 'K, #[by_val] v: 'V) {
     map_insert(m, k, v)
 }
 
@@ -746,7 +740,7 @@ function remove(m: mut Map<'K,'V>, k: 'K): Option<'V> {
     map_remove(m, k)
 }
 
-function insert_imm(m: Map<'K,'V>, k: 'K, v: 'V): Map<'K,'V> {
+function insert_imm(#[by_val] m: Map<'K,'V>, #[by_val] k: 'K, #[by_val] v: 'V): Map<'K,'V> {
     map_insert_imm(m, k, v)
 }
 
@@ -763,7 +757,7 @@ function is_empty(m: Map<'K,'V>): bool {
 }
 
 /// If a key is present in both maps keep the one from m2
-function union(m1: Map<'K, 'V>, m2: Map<'K,'V>): Map<'K, 'V> {
+function union(#[by_val] m1: Map<'K, 'V>, #[by_val] m2: Map<'K,'V>): Map<'K, 'V> {
     map_union(m1, m2)
 }
 
@@ -791,18 +785,18 @@ function nth_value(m: Map<'K, 'V>, n: usize): Option<'V> {
 #[iterate_by_ref=iter:'A]
 extern type Set<'A>
 
-extern function set_singleton(x: 'X): Set<'X>
+extern function set_singleton(#[by_val] x: 'X): Set<'X>
 extern function set_empty(): Set<'X>
 
 function size(s: Set<'X>): usize {
     set_size(s)
 }
 
-function insert(s: mut Set<'X>, v: 'X) {
+function insert(s: mut Set<'X>, #[by_val] v: 'X) {
     set_insert(s, v)
 }
 
-function insert_imm(s: Set<'X>, v: 'X): Set<'X> {
+function insert_imm(#[by_val] s: Set<'X>, #[by_val] v: 'X): Set<'X> {
     set_insert_imm(s, v)
 }
 
@@ -859,8 +853,8 @@ extern function htons(x: bit<16>): bit<16>
  * these functions outside of this module is discouraged.
  */
 
-extern function option_unwrap_or_default(opt: Option<'A>): 'A
-extern function result_unwrap_or_default(res: Result<'V,'E>): 'V
+extern function option_unwrap_or_default(#[by_val] opt: Option<'A>): 'A
+extern function result_unwrap_or_default(#[by_val] res: Result<'V,'E>): 'V
 
 extern function string_contains(s1: string, s2: string): bool
 extern function string_join(strings: Vec<string>, sep: string): string
@@ -879,45 +873,46 @@ extern function string_to_uppercase(s: string): string
 extern function string_reverse(s: string): string
 
 extern function vec_len(v: Vec<'X>): usize
-extern function vec_push(v: mut Vec<'X>, x: 'X)
+extern function vec_push(v: mut Vec<'X>, #[by_val] x: 'X)
 extern function vec_pop(v: mut Vec<'X>): Option<'X>
 extern function vec_append(v: mut Vec<'X>, other: Vec<'X>)
-extern function vec_push_imm(v: Vec<'X>, x: 'X): Vec<'X>
+extern function vec_push_imm(v: Vec<'X>, #[by_val] x: 'X): Vec<'X>
 extern function vec_contains(v: Vec<'X>, x: 'X): bool
 extern function vec_is_empty(v: Vec<'X>): bool
 extern function vec_nth(v: Vec<'X>, n: usize): Option<'X>
-extern function vec_to_set(s: Vec<'A>): Set<'A>
+extern function vec_to_set(#[by_val] s: Vec<'A>): Set<'A>
 extern function vec_sort(v: mut Vec<'X>)
-extern function vec_sort_imm(v: Vec<'X>): Vec<'X>
+extern function vec_sort_imm(#[by_val] v: Vec<'X>): Vec<'X>
 extern function vec_resize(v: mut Vec<'X>, new_len: usize, value: 'X)
 extern function vec_truncate(v: mut Vec<'X>, len: usize)
 extern function vec_swap_nth(v: mut Vec<'X>, idx: usize, value: mut 'X): bool
-extern function vec_update_nth(v: mut Vec<'X>, idx: usize, value: 'X): bool
-extern function vec_zip(v1: Vec<'X>, v2: Vec<'Y>): Vec<('X, 'Y)>
+extern function vec_update_nth(v: mut Vec<'X>, idx: usize, #[by_val] value: 'X): bool
+extern function vec_zip(#[by_val] v1: Vec<'X>, #[by_val] v2: Vec<'Y>): Vec<('X, 'Y)>
+extern function vec_unzip(#[by_val] v: Vec<('X, 'Y)>): (Vec<'X>, Vec<'Y>)
 extern function vec_reverse(v: mut Vec<'X>)
 
 extern function map_size(m: Map<'K, 'V>): usize
-extern function map_insert(m: mut Map<'K,'V>, k: 'K, v: 'V)
+extern function map_insert(m: mut Map<'K,'V>, #[by_val] k: 'K, #[by_val] v: 'V)
 extern function map_remove(m: mut Map<'K,'V>, k: 'K): Option<'V>
-extern function map_insert_imm(m: Map<'K,'V>, k: 'K, v: 'V): Map<'K,'V>
+extern function map_insert_imm(#[by_val] m: Map<'K,'V>, #[by_val] k: 'K, #[by_val] v: 'V): Map<'K,'V>
 extern function map_get(m: Map<'K,'V>, k:'K): Option<'V>
 extern function map_contains_key(m: Map<'K,'V>, k: 'K): bool
 extern function map_is_empty(m: Map<'K,'V>): bool
 extern function map_nth_key(m: Map<'K, 'V>, n: usize): Option<'K>
 extern function map_nth_value(m: Map<'K, 'V>, n: usize): Option<'V>
-extern function map_union(m1: Map<'K, 'V>, m2: Map<'K,'V>): Map<'K, 'V>
+extern function map_union(#[by_val] m1: Map<'K, 'V>, #[by_val] m2: Map<'K,'V>): Map<'K, 'V>
 extern function map_keys(m: Map<'K, 'V>): Vec<'K>
 extern function map_values(m: Map<'K, 'V>): Vec<'V>
 
 extern function set_size(s: Set<'X>): usize
-extern function set_insert(s: mut Set<'X>, v: 'X)
-extern function set_insert_imm(s: Set<'X>, v: 'X): Set<'X>
+extern function set_insert(s: mut Set<'X>, #[by_val] v: 'X)
+extern function set_insert_imm(#[by_val] s: Set<'X>, #[by_val] v: 'X): Set<'X>
 extern function set_contains(s: Set<'X>, v: 'X): bool
 extern function set_is_empty(s: Set<'X>): bool
 extern function set_nth(s: Set<'X>, n: usize): Option<'X>
-extern function set_to_vec(s: Set<'A>): Vec<'A>
-extern function set_union(s1: Set<'X>, s2: Set<'X>): Set<'X>
-extern function set_unions(sets: Vec<Set<'X>>): Set<'X>
+extern function set_to_vec(#[by_val] s: Set<'A>): Vec<'A>
+extern function set_union(#[by_val] s1: Set<'X>, #[by_val] s2: Set<'X>): Set<'X>
+extern function set_unions(#[by_val] sets: Vec<Set<'X>>): Set<'X>
 extern function set_intersection(s1: Set<'X>, s2: Set<'X>): Set<'X>
 extern function set_difference(s1: Set<'X>, s2: Set<'X>): Set<'X>
 

--- a/lib/internment.dl
+++ b/lib/internment.dl
@@ -43,7 +43,7 @@ typedef istring = Intern<string>
 
 /* Intern a value.
  */
-extern function intern(s: 'A): Intern<'A>
+extern function intern(#[by_val] s: 'A): Intern<'A>
 
 /* Extract an interned value.
  */

--- a/lib/internment.rs
+++ b/lib/internment.rs
@@ -215,18 +215,18 @@ where
     fn mutate(&self, value: &mut Intern<T>) -> Result<(), String> {
         let mut mutated = ival(value).clone();
         self.mutate(&mut mutated)?;
-        *value = intern(&mutated);
+        *value = intern(mutated);
 
         Ok(())
     }
 }
 
 /// Create a new interned value
-pub fn intern<T>(value: &T) -> Intern<T>
+pub fn intern<T>(value: T) -> Intern<T>
 where
-    T: Eq + Hash + Send + Sync + Clone + 'static,
+    T: Eq + Hash + Send + Sync + 'static,
 {
-    Intern::new(value.clone())
+    Intern::new(value)
 }
 
 /// Get the inner value of an interned value

--- a/lib/json.dl
+++ b/lib/json.dl
@@ -51,17 +51,17 @@ extern function to_json_string(x: 'T): Result<string, string>
  * structure expected by 'T, for example if 'T is a struct type but the input
  * contains something other than a JSON map.
  */
-function from_json_value(json_val: JsonValue): Result<'T, string> {
+function from_json_value(#[by_val] json_val: JsonValue): Result<'T, string> {
     _from_json_value(json_val)
 }
 
-extern function _from_json_value(json_val: JsonValue): Result<'T, string>
+extern function _from_json_value(#[by_val] json_val: JsonValue): Result<'T, string>
 
 /* Serialize the given data structure as a JsonValue.
  *
  * Serialization can fail if 'T contains a map with non-string keys.
  */
-extern function to_json_value(x: 'T): Result<JsonValue, string>
+extern function to_json_value(#[by_val] x: 'T): Result<JsonValue, string>
 
 /* Represents any valid JSON value.
  */

--- a/lib/json.rs
+++ b/lib/json.rs
@@ -37,14 +37,12 @@ pub fn to_json_string<T: serde::Serialize>(x: &T) -> ddlog_std::Result<String, S
     res2std(serde_json::to_string(x))
 }
 
-pub fn _from_json_value<T: DeserializeOwned>(val: &JsonValue) -> ddlog_std::Result<T, String> {
-    res2std(serde_json::from_value(serde_json::value::Value::from(
-        val.clone(),
-    )))
+pub fn _from_json_value<T: DeserializeOwned>(val: JsonValue) -> ddlog_std::Result<T, String> {
+    res2std(serde_json::from_value(serde_json::value::Value::from(val)))
 }
 
-pub fn to_json_value<T: serde::Serialize>(x: &T) -> ddlog_std::Result<JsonValue, String> {
-    res2std(serde_json::to_value(x.clone()).map(JsonValue::from))
+pub fn to_json_value<T: serde::Serialize>(x: T) -> ddlog_std::Result<JsonValue, String> {
+    res2std(serde_json::to_value(x).map(JsonValue::from))
 }
 
 pub struct ValueWrapper(serde_json::value::Value);
@@ -103,7 +101,7 @@ impl From<serde_json::value::Value> for JsonValue {
                 n: JsonNum::from(n),
             },
             serde_json::value::Value::String(s) => JsonValue::JsonString {
-                s: internment::intern(&s),
+                s: internment::intern(s),
             },
             serde_json::value::Value::Array(a) => {
                 let v: Vec<JsonValue> = a.into_iter().map(|v| JsonValue::from(v)).collect();
@@ -113,7 +111,7 @@ impl From<serde_json::value::Value> for JsonValue {
             }
             serde_json::value::Value::Object(o) => JsonValue::JsonObject {
                 o: o.into_iter()
-                    .map(|(k, v)| (internment::intern(&k), JsonValue::from(v)))
+                    .map(|(k, v)| (internment::intern(k), JsonValue::from(v)))
                     .collect(),
             },
         }

--- a/lib/tinyset.dl
+++ b/lib/tinyset.dl
@@ -35,11 +35,11 @@ extern function size(s: Set64<'X>): bit<64>
 extern function empty(): Set64<'X>
 extern function singleton(x: 'X): Set64<'X>
 extern function insert(s: mut Set64<'X>, v: 'X): ()
-extern function insert_imm(s: Set64<'X>, v: 'X): Set64<'X>
+extern function insert_imm(#[by_val] s: Set64<'X>, #[by_val] v: 'X): Set64<'X>
 extern function contains(s: Set64<'X>, v: 'X): bool
 extern function is_empty(s: Set64<'X>): bool
 extern function nth(s: Set64<'X>, n: bit<64>): Option<bit<64>>
-extern function union(s1: Set64<'X>, s2: Set64<'X>): Set64<'X>
+extern function union(#[by_val] s1: Set64<'X>, s2: Set64<'X>): Set64<'X>
 extern function unions(sets: Vec<Set64<'X>>): Set64<'X>
 extern function intersection(s1: Set64<'X>, s2: Set64<'X>): Set64<'X>
 extern function difference(s1: Set64<'X>, s2: Set64<'X>): Set64<'X>

--- a/lib/tinyset.rs
+++ b/lib/tinyset.rs
@@ -241,10 +241,9 @@ pub fn insert<X: u64set::Fits64 + Clone>(s: &mut Set64<X>, v: &X) {
     s.x.insert((*v).clone());
 }
 
-pub fn insert_imm<X: u64set::Fits64 + Clone>(s: &Set64<X>, v: &X) -> Set64<X> {
-    let mut s2 = s.clone();
-    s2.insert((*v).clone());
-    s2
+pub fn insert_imm<X: u64set::Fits64>(mut s: Set64<X>, v: X) -> Set64<X> {
+    s.insert(v);
+    s
 }
 
 pub fn contains<X: u64set::Fits64>(s: &Set64<X>, v: &X) -> bool {
@@ -265,9 +264,10 @@ pub fn set2vec<X: u64set::Fits64 + Ord + Clone>(s: &Set64<X>) -> ddlog_std::Vec<
     ddlog_std::Vec::from(v)
 }
 
-pub fn union<X: u64set::Fits64 + Clone>(s1: &Set64<X>, s2: &Set64<X>) -> Set64<X> {
-    let s = s1.x.clone();
-    Set64 { x: s.bitor(&s2.x) }
+pub fn union<X: u64set::Fits64>(mut s1: Set64<X>, s2: &Set64<X>) -> Set64<X> {
+    Set64 {
+        x: s1.x.bitor(&s2.x),
+    }
 }
 
 pub fn unions<X: u64set::Fits64 + Clone>(sets: &ddlog_std::Vec<Set64<X>>) -> Set64<X> {
@@ -324,7 +324,7 @@ pub fn group_setref_unions<K, V: u64set::Fits64 + Ord + Clone>(
     if ddlog_std::group_count(g) == 1 {
         ddlog_std::group_first(g)
     } else {
-        let mut res = ddlog_std::ref_new(&Set64 {
+        let mut res = ddlog_std::ref_new(Set64 {
             x: u64set::Set64::new(),
         });
         {

--- a/src/Language/DifferentialDatalog/Parse.hs
+++ b/src/Language/DifferentialDatalog/Parse.hs
@@ -309,7 +309,7 @@ func = (Function nopos [] <$  (try $ reserved "extern" *> reserved "function")
                          <*> (option (TTuple nopos []) (colon *> typeSpecSimple))
                          <*> (Just <$> ((reservedOp "=" *> expr) <|> (braces eseq))))
 
-farg = withPos $ (FuncArg nopos) <$> varIdent <*> (colon *> atype)
+farg = withPos $ (FuncArg nopos) <$> attributes <*> varIdent <*> (colon *> atype)
 atype = withPos $ ArgType nopos <$> (option False (True <$ reserved "mut")) <*> typeSpecSimple
 
 transformer = (Transformer nopos True <$  (reserved "extern" *> reserved "transformer")

--- a/src/Language/DifferentialDatalog/Syntax.hs
+++ b/src/Language/DifferentialDatalog/Syntax.hs
@@ -126,6 +126,7 @@ module Language.DifferentialDatalog.Syntax (
         FuncArg(..),
         argMut,
         Function(..),
+        funcIsExtern,
         funcMutArgs,
         funcImmutArgs,
         funcShowProto,
@@ -1060,16 +1061,17 @@ eTry e              = E $ ETry      nopos e
 eClosure ts r e     = E $ EClosure  nopos ts r e
 eFunc f             = E $ EFunc     nopos [f]
 
-data FuncArg = FuncArg { argPos  :: Pos
-                       , argName :: String
-                       , argType :: ArgType
+data FuncArg = FuncArg { argPos   :: Pos
+                       , argAttrs :: [Attribute]
+                       , argName  :: String
+                       , argType  :: ArgType
                        }
 
 instance Eq FuncArg where
-    (==) (FuncArg _ n1 t1) (FuncArg _ n2 t2) = (n1, t1) == (n2, t2)
+    (==) (FuncArg _ a1 n1 t1) (FuncArg _ a2 n2 t2) = (a1, n1, t1) == (a2, n2, t2)
 
 instance Ord FuncArg where
-    compare (FuncArg _ n1 t1) (FuncArg _ n2 t2) = compare (n1, t1) (n2, t2)
+    compare (FuncArg _ a1 n1 t1) (FuncArg _ a2 n2 t2) = compare (a1, n1, t1) (a2, n2, t2)
 
 instance WithPos FuncArg where
     pos = argPos
@@ -1080,7 +1082,7 @@ instance WithName FuncArg where
     setName a n = a { argName = n }
 
 instance PP FuncArg where
-    pp FuncArg{..} = pp argName <> ":" <+> pp argType
+    pp FuncArg{..} = ppAttributes argAttrs <+> pp argName <> ":" <+> pp argType
 
 argMut :: FuncArg -> Bool
 argMut = atypeMut . argType
@@ -1092,6 +1094,9 @@ data Function = Function { funcPos   :: Pos
                          , funcType  :: Type
                          , funcDef   :: Maybe Expr
                          }
+
+funcIsExtern :: Function -> Bool
+funcIsExtern f = isNothing $ funcDef f
 
 funcMutArgs :: Function -> [FuncArg]
 funcMutArgs f = filter argMut $ funcArgs f

--- a/src/Language/DifferentialDatalog/Var.hs
+++ b/src/Language/DifferentialDatalog/Var.hs
@@ -25,7 +25,8 @@ SOFTWARE.
 module Language.DifferentialDatalog.Var(
     Var(..),
     VLocator,
-    varLocator)
+    varLocator,
+    varKind)
 where
 
 import Data.Maybe
@@ -34,8 +35,10 @@ import Text.PrettyPrint
 import Language.DifferentialDatalog.Name
 import Language.DifferentialDatalog.Pos
 import Language.DifferentialDatalog.PP
+import Language.DifferentialDatalog.Attribute
 import Language.DifferentialDatalog.Syntax
 import Language.DifferentialDatalog.Expr
+import Language.DifferentialDatalog.Rust
 
 -- Uniquely identifies a variable declaration in a DDlog program.
 data Var = -- Variable declared in an expression ('var v').
@@ -108,3 +111,9 @@ varLocator GroupVar{..}         = VLocator  [6, varRhsIdx]
 varLocator WeightVar            = VLocator  [7]
 varLocator TSVar{}              = VLocator  [8]
 
+-- Generally, DDlog variables are compiled to Rust references.  An exception are
+-- function arguments annotated with '#[by_val]'.
+varKind :: DatalogProgram -> Var -> EKind
+varKind d ArgVar{..} | argGetByValAttr d (funcArgs varFunc !! varArgIndex)
+                     = EVal
+varKind _ _          = EReference


### PR DESCRIPTION
This feature was motivated by a large program where the `malloc_freq`
profile showed a large number of allocations happening inside
`internment::intern()`, which creates an owned copy of its argument.
This is often unnecessary as the caller may have an owned copy that they
could just pass to the function.

The `#[by_val]` attribute tells DDlog to pass the argument by value:

```
extern function intern(#[by_val] s: 'A): Intern<'A>
```

Here is the Rust implementation:

```
pub fn intern<T>(value: T) -> Intern<T>
where
    T: Eq + Hash + Send + Sync + 'static,
{
    Intern::new(value)
}
```

Note that the argument has type `T`, not `&T`, so we don't need to clone
it in the body of the function.

The `#[by_val]` attribute is also applicable to non-extern functions; however it
can break things, since the DDlog compiler does not currently have the
infrastructure to precisely track the ownership of values in Rust.
In practice, this attribute should only be used in polymorphic functions that are
one-line wrappers around non-polymorphic extern functions:

```
// Pass arguments by value all the way to Rust.
function insert(m: mut Map<'K,'V>, #[by_val] k: 'K, #[by_val] v: 'V) {
    map_insert(m, k, v)
}

extern function map_insert(m: mut Map<'K,'V>, #[by_val] k: 'K, #[by_val] v: 'V)
```

This commit implements support for `#[by_val]` in the compiler and uses
it to optmize a bunch of library functions.

It should not break any existing DDlog code, but it may break Rust
programs that call DDlog library functions from Rust.

Signed-off-by: Leonid Ryzhyk <lryzhyk@vmware.com>