### PR TITLE
Optimize code generation for `match` expressions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Optimizations
+
+- Optimize code generation for `match` and `?` expressions.
+- Optimize code generation for interpolated strings.
+
 ## [0.45.0] - Aug 15, 2021
 
 ### Optimizations

--- a/test/datalog_tests/simple3.dl
+++ b/test/datalog_tests/simple3.dl
@@ -214,3 +214,79 @@ typedef Thosts = Thosts{id:Option<string>, capacity:Option<signed<64>>, up:Optio
 input relation Rhosts[Thosts] primary key (row) (row.id)
 output relation Rhostsv[Thosts]
 Rhostsv[v0] :- Rhosts[v],var v0 = v.
+
+
+/**********************************************************/
+
+// Test code generation for `match` expressions.
+
+function test_match0() {
+    var x = Ok{Some{"foo"}};
+    var y = match (x) {
+        Err{e: string} -> e,
+        Ok{Some{s}} -> {
+            s // returned by reference.
+        },
+        _ -> return
+    }
+}
+
+
+function test_match1() {
+    var x = Ok{Some{"foo"}};
+    var y = match (x) {
+        Err{e: string} -> e,
+        Ok{Some{s}} -> {
+            var ss = s++s;
+            match (ss) {
+                "foofoo" -> ss, // returned by reference
+                _        -> s
+            } // returned by-value
+        },
+        _ -> return
+    }
+}
+
+function test_match2() {
+    var v: Result<string, string> = Ok{"100"};
+    var y = match (v) {
+        Ok{s} -> {
+            match (parse_dec_u64(s)) {
+                Some{x} -> x, // returned by-value, because match expression produces an owned value that cannot be leaked.
+                _ -> return
+            }
+        },
+        _ -> return
+    }
+}
+
+
+function test_match3() {
+    var x = Ok{Some{"foo"}};
+    var y = match (x) {
+        Err{e: string} -> e,
+        Ok{Some{s}} -> {
+            var ss = s++s;
+            match (ref_new(ss++ss).deref()) {
+                "foofoo" -> ss, // returned by reference
+                x        -> x
+            } // returned by-value
+        },
+        _ -> return
+    }
+}
+
+function test_match4() {
+    var x = Ok{Some{"foo"}};
+    var y = match (x) {
+        Err{e: string} -> e,
+        Ok{Some{s}} -> {
+            var ss = s++s;
+            match ((ss++ss).intern().ival()) {
+                "foofoo" -> ss, // returned by reference
+                x        -> x
+            } // returned by-value
+        },
+        _ -> return
+    }
+}


### PR DESCRIPTION
This was motivated by the following code generated for expressions of
the form `x?.field`:

```
match x {
        ddlog_std::Option::None{} => return (ddlog_std::Option::None{}),
        ddlog_std::Option::Some{x: ref __x} => (*__x).clone()
    }.field.clone()
```

which clones the entire `x`, which is potentially a large struct, just
to extract one field.

The optimization eliminates the clone and instead returns the result of
the `match` expression by reference.  This is only valid if all match
cases are the match expression are references:

```
match x {
        ddlog_std::Option::None{} => return (ddlog_std::Option::None{}),
        ddlog_std::Option::Some{x: ref __x} => __x
    }.field.clone()
```

Signed-off-by: Leonid Ryzhyk <lryzhyk@vmware.com>