### PR TITLE
Speedup JsonValue serialization.

### DIFF
--- a/lib/ddlog_std.rs
+++ b/lib/ddlog_std.rs
@@ -907,6 +907,10 @@ impl<K: Ord, V> Map<K, V> {
         Map { x: BTreeMap::new() }
     }
 
+    pub fn len(&self) -> usize {
+        self.x.len()
+    }
+
     pub fn insert(&mut self, k: K, v: V) {
         self.x.insert(k, v);
     }
@@ -988,7 +992,7 @@ impl<K: Debug + Ord, V: Debug> Debug for Map<K, V> {
 }
 
 pub fn map_size<K: Ord, V>(m: &Map<K, V>) -> std_usize {
-    m.x.len() as std_usize
+    m.len() as std_usize
 }
 
 pub fn map_empty<K: Ord + Clone, V: Clone>() -> Map<K, V> {

--- a/lib/json.dl
+++ b/lib/json.dl
@@ -65,7 +65,7 @@ extern function to_json_value(#[by_val] x: 'T): Result<JsonValue, string>
 
 /* Represents any valid JSON value.
  */
-#[rust="serde(from = \"ValueWrapper\", into = \"ValueWrapper\")"]
+#[custom_serde]
 typedef JsonValue = // Represents a JSON null value.
                     JsonNull
                   | // Represents a JSON boolean.

--- a/lib/tinyset.rs
+++ b/lib/tinyset.rs
@@ -264,7 +264,7 @@ pub fn set2vec<X: u64set::Fits64 + Ord + Clone>(s: &Set64<X>) -> ddlog_std::Vec<
     ddlog_std::Vec::from(v)
 }
 
-pub fn union<X: u64set::Fits64>(mut s1: Set64<X>, s2: &Set64<X>) -> Set64<X> {
+pub fn union<X: u64set::Fits64>(s1: Set64<X>, s2: &Set64<X>) -> Set64<X> {
     Set64 {
         x: s1.x.bitor(&s2.x),
     }

--- a/test/datalog_tests/json_test.dump.expected
+++ b/test/datalog_tests/json_test.dump.expected
@@ -3,10 +3,10 @@ json_test::JsonTest{.description = "-100", .value = "{\"Ok\":{\"res\":-100}}"}
 json_test::JsonTest{.description = "100", .value = "{\"Ok\":{\"res\":100}}"}
 json_test::JsonTest{.description = "2.99792458e8", .value = "{\"Ok\":{\"res\":299792458.0}}"}
 json_test::JsonTest{.description = "[{\"b\":true}, {\"b\":false}, {\"b\":true}, {\"b\":false}]", .value = "{\"Ok\":{\"res\":[{\"b\":true},{\"b\":false},{\"b\":true},{\"b\":false}]}}"}
-json_test::JsonTest{.description = "get_by_ptr([])", .value = "{\"id\":\"1001001001\",\"nested\":{\"x\":{\"b\":true,\"foo\":\"bar\"},\"y\":{\"b\":true,\"foo\":\"bar\"},\"z\":[{\"@type\":\"t.V1\",\"b\":true},{\"@type\":\"t.V2\",\"b\":{\"f\":[{\"key\":100,\"payload\":\"foo\"}]}},null,null,null,null,null,null,null,{\"q\":{\"f\":[{\"key\":100,\"payload\":\"foo\"}]}},{\"b\":{\"f\":[{\"key\":100,\"payload\":\"foo\"}]}}]},\"t\":\"foo\"}"}
-json_test::JsonTest{.description = "get_by_ptr(nested/z/10/b)", .value = "{\"f\":[{\"key\":100,\"payload\":\"foo\"}]}"}
+json_test::JsonTest{.description = "get_by_ptr([])", .value = "{\"t\":\"foo\",\"nested\":{\"z\":[{\"@type\":\"t.V1\",\"b\":true},{\"@type\":\"t.V2\",\"b\":{\"f\":[{\"payload\":\"foo\",\"key\":100}]}},null,null,null,null,null,null,null,{\"q\":{\"f\":[{\"payload\":\"foo\",\"key\":100}]}},{\"b\":{\"f\":[{\"payload\":\"foo\",\"key\":100}]}}],\"x\":{\"foo\":\"bar\",\"b\":true},\"y\":{\"foo\":\"bar\",\"b\":true}},\"id\":\"1001001001\"}"}
+json_test::JsonTest{.description = "get_by_ptr(nested/z/10/b)", .value = "{\"f\":[{\"payload\":\"foo\",\"key\":100}]}"}
 json_test::JsonTest{.description = "get_by_ptr(nested/z/10/c)", .value = "null"}
-json_test::JsonTest{.description = "set_by_ptr test", .value = "{\"id\":\"1001001001\",\"nested\":{\"x\":{\"b\":true,\"foo\":\"bar\"},\"y\":{\"b\":true,\"foo\":\"bar\"},\"z\":[{\"@type\":\"t.V1\",\"b\":true},{\"@type\":\"t.V2\",\"b\":{\"f\":[{\"key\":100,\"payload\":\"foo\"}]}},null,null,null,null,null,null,null,{\"q\":{\"f\":[{\"key\":100,\"payload\":\"foo\"}]}},{\"b\":{\"f\":[{\"key\":100,\"payload\":\"foo\"}]}}]},\"t\":\"foo\"}"}
+json_test::JsonTest{.description = "set_by_ptr test", .value = "{\"t\":\"foo\",\"nested\":{\"z\":[{\"@type\":\"t.V1\",\"b\":true},{\"@type\":\"t.V2\",\"b\":{\"f\":[{\"payload\":\"foo\",\"key\":100}]}},null,null,null,null,null,null,null,{\"q\":{\"f\":[{\"payload\":\"foo\",\"key\":100}]}},{\"b\":{\"f\":[{\"payload\":\"foo\",\"key\":100}]}}],\"x\":{\"foo\":\"bar\",\"b\":true},\"y\":{\"foo\":\"bar\",\"b\":true}},\"id\":\"1001001001\"}"}
 json_test::JsonTest{.description = "true", .value = "{\"Ok\":{\"res\":true}}"}
 json_test::JsonTest{.description = "wrapped {\"@type\": \"t.V1\", \"b\": true}", .value = "{\"Ok\":{\"res\":{\"@type\":\"t.V1\",\"b\":true}}}"}
 json_test::JsonTest{.description = "wrapped {\"@type\": \"t.V2\", \"b\": false}", .value = "{\"Err\":{\"err\":\"missing field `u`\"}}"}
@@ -33,5 +33,5 @@ json_test::JsonTest{.description = "{\"x\": \"x\", \"y\": \"100000\"}", .value =
 json_test::JsonTest{.description = "{}", .value = "{\"Ok\":{\"res\":{\"s\":null,\"i\":null,\"v\":null}}}"}
 json_test::JsonTestValue{.description = "wrapped {\"@type\": \"t.V1\", \"b\": true}", .value = "{\"Ok\":{\"res\":{\"@type\":\"t.V1\",\"b\":true}}}"}
 json_test::JsonTestValue{.description = "wrapped {\"@type\": \"t.V2\", \"b\": false}", .value = "{\"Err\":{\"err\":\"missing field `u`\"}}"}
-json_test::JsonTestValue{.description = "wrapped {\"@type\": \"t.V2\", \"u\": 100}", .value = "{\"Ok\":{\"res\":{\"@type\":\"t.V2\",\"u\":100}}}"}
+json_test::JsonTestValue{.description = "wrapped {\"@type\": \"t.V2\", \"u\": 100}", .value = "{\"Ok\":{\"res\":{\"u\":100,\"@type\":\"t.V2\"}}}"}
 json_test::TVariant1{.b = true}


### PR DESCRIPTION
`JsonValue` is the type we use to represent dynamically typed JSON in
DDlog.  We used to serialize it by converting to `serde::json::Value`
and serializing that.  This conversion is expensive and unnecessary, so
we implement `Serialize` for `JsonValue` natively instead.  We should
do the same for deserialize, but this is much more work, so we leave it
for when we really need it in the future.

One side effect of this change is that keys in JSON maps, which are
`istring`'s, are serialized in a deterministic, but unpredictable order,
instead of alphabetical order.

Signed-off-by: Leonid Ryzhyk <lryzhyk@vmware.com>