### PR TITLE
Speedup hashing of interned objects.

### DIFF
--- a/test/datalog_tests/json_test.dump.expected
+++ b/test/datalog_tests/json_test.dump.expected
@@ -3,10 +3,10 @@ json_test::JsonTest{.description = "-100", .value = "{\"Ok\":{\"res\":-100}}"}
 json_test::JsonTest{.description = "100", .value = "{\"Ok\":{\"res\":100}}"}
 json_test::JsonTest{.description = "2.99792458e8", .value = "{\"Ok\":{\"res\":299792458.0}}"}
 json_test::JsonTest{.description = "[{\"b\":true}, {\"b\":false}, {\"b\":true}, {\"b\":false}]", .value = "{\"Ok\":{\"res\":[{\"b\":true},{\"b\":false},{\"b\":true},{\"b\":false}]}}"}
-json_test::JsonTest{.description = "get_by_ptr([])", .value = "{\"t\":\"foo\",\"nested\":{\"z\":[{\"@type\":\"t.V1\",\"b\":true},{\"@type\":\"t.V2\",\"b\":{\"f\":[{\"payload\":\"foo\",\"key\":100}]}},null,null,null,null,null,null,null,{\"q\":{\"f\":[{\"payload\":\"foo\",\"key\":100}]}},{\"b\":{\"f\":[{\"payload\":\"foo\",\"key\":100}]}}],\"x\":{\"foo\":\"bar\",\"b\":true},\"y\":{\"foo\":\"bar\",\"b\":true}},\"id\":\"1001001001\"}"}
+json_test::JsonTest{.description = "get_by_ptr([])", .value = "{\"t\":\"foo\",\"nested\":{\"y\":{\"b\":true,\"foo\":\"bar\"},\"z\":[{\"b\":true,\"@type\":\"t.V1\"},{\"b\":{\"f\":[{\"payload\":\"foo\",\"key\":100}]},\"@type\":\"t.V2\"},null,null,null,null,null,null,null,{\"q\":{\"f\":[{\"payload\":\"foo\",\"key\":100}]}},{\"b\":{\"f\":[{\"payload\":\"foo\",\"key\":100}]}}],\"x\":{\"b\":true,\"foo\":\"bar\"}},\"id\":\"1001001001\"}"}
 json_test::JsonTest{.description = "get_by_ptr(nested/z/10/b)", .value = "{\"f\":[{\"payload\":\"foo\",\"key\":100}]}"}
 json_test::JsonTest{.description = "get_by_ptr(nested/z/10/c)", .value = "null"}
-json_test::JsonTest{.description = "set_by_ptr test", .value = "{\"t\":\"foo\",\"nested\":{\"z\":[{\"@type\":\"t.V1\",\"b\":true},{\"@type\":\"t.V2\",\"b\":{\"f\":[{\"payload\":\"foo\",\"key\":100}]}},null,null,null,null,null,null,null,{\"q\":{\"f\":[{\"payload\":\"foo\",\"key\":100}]}},{\"b\":{\"f\":[{\"payload\":\"foo\",\"key\":100}]}}],\"x\":{\"foo\":\"bar\",\"b\":true},\"y\":{\"foo\":\"bar\",\"b\":true}},\"id\":\"1001001001\"}"}
+json_test::JsonTest{.description = "set_by_ptr test", .value = "{\"t\":\"foo\",\"nested\":{\"y\":{\"b\":true,\"foo\":\"bar\"},\"z\":[{\"b\":true,\"@type\":\"t.V1\"},{\"b\":{\"f\":[{\"payload\":\"foo\",\"key\":100}]},\"@type\":\"t.V2\"},null,null,null,null,null,null,null,{\"q\":{\"f\":[{\"payload\":\"foo\",\"key\":100}]}},{\"b\":{\"f\":[{\"payload\":\"foo\",\"key\":100}]}}],\"x\":{\"b\":true,\"foo\":\"bar\"}},\"id\":\"1001001001\"}"}
 json_test::JsonTest{.description = "true", .value = "{\"Ok\":{\"res\":true}}"}
 json_test::JsonTest{.description = "wrapped {\"@type\": \"t.V1\", \"b\": true}", .value = "{\"Ok\":{\"res\":{\"@type\":\"t.V1\",\"b\":true}}}"}
 json_test::JsonTest{.description = "wrapped {\"@type\": \"t.V2\", \"b\": false}", .value = "{\"Err\":{\"err\":\"missing field `u`\"}}"}
@@ -31,7 +31,7 @@ json_test::JsonTest{.description = "{\"x\": \"100000000000\"}", .value = "{\"Err
 json_test::JsonTest{.description = "{\"x\": \"x\", \"y\": \"-100000\"}", .value = "{\"Err\":{\"err\":\"invalid digit found in string at line 1 column 26\"}}"}
 json_test::JsonTest{.description = "{\"x\": \"x\", \"y\": \"100000\"}", .value = "{\"Ok\":{\"res\":{\"x\":\"x\",\"y\":\"100000\"}}}"}
 json_test::JsonTest{.description = "{}", .value = "{\"Ok\":{\"res\":{\"s\":null,\"i\":null,\"v\":null}}}"}
-json_test::JsonTestValue{.description = "wrapped {\"@type\": \"t.V1\", \"b\": true}", .value = "{\"Ok\":{\"res\":{\"@type\":\"t.V1\",\"b\":true}}}"}
+json_test::JsonTestValue{.description = "wrapped {\"@type\": \"t.V1\", \"b\": true}", .value = "{\"Ok\":{\"res\":{\"b\":true,\"@type\":\"t.V1\"}}}"}
 json_test::JsonTestValue{.description = "wrapped {\"@type\": \"t.V2\", \"b\": false}", .value = "{\"Err\":{\"err\":\"missing field `u`\"}}"}
-json_test::JsonTestValue{.description = "wrapped {\"@type\": \"t.V2\", \"u\": 100}", .value = "{\"Ok\":{\"res\":{\"u\":100,\"@type\":\"t.V2\"}}}"}
+json_test::JsonTestValue{.description = "wrapped {\"@type\": \"t.V2\", \"u\": 100}", .value = "{\"Ok\":{\"res\":{\"@type\":\"t.V2\",\"u\":100}}}"}
 json_test::TVariant1{.b = true}


### PR DESCRIPTION
We recently changed the implementation of `Hash` for interned objects to
hash the value of the object itself instead of hashing the pointer,
which is non-deterministic in some scenarios.  So obviously hashing
became much more expensive for interned types.  Of course the biggest
user of hashing is the internment library itself, as it hashes objects
in order to intern them.  So, interning an object whose fields are also
interned values became many times more expensive.  This for example
affected the performance of OVN in some scenarios.

To solve this, we change the way interned objects are hashed once again.
We already store a hash with each interned object, used to speedup
comparison operators by comparing by hash instead of by value.
Similarly, we now hash the interned object by hashing the stored hash
instead of hashing the object itself.  We also increase the stored hash
size to 64 bit.

Signed-off-by: Leonid Ryzhyk <lryzhyk@vmware.com>