### PR TITLE
Expose DDValue type to DDlog programs.

### DIFF
--- a/lib/ddlog_log.rs
+++ b/lib/ddlog_log.rs
@@ -57,7 +57,7 @@ static LOG_CONFIG: Lazy<sync::RwLock<LogConfig>> =
 #[allow(clippy::ptr_arg, clippy::trivially_copy_pass_by_ref)]
 pub fn log(module: &i32, level: &i32, msg: &String) {
     let cfg = LOG_CONFIG.read().unwrap();
-    if let Some((cb, current_level)) = cfg.mod_callbacks.get(&module) {
+    if let Some((cb, current_level)) = cfg.mod_callbacks.get(module) {
         if *level <= *current_level {
             cb(*level, msg.as_str());
         }

--- a/lib/ddlog_std.dl
+++ b/lib/ddlog_std.dl
@@ -82,6 +82,28 @@ function to_string(ts: DDNestedTS): string {
 }
 
 /*
+ * Type-erased representation of any DDlog value.  Allows storing
+ * instances of different types, unknown at compile time, in the same
+ * relation.
+ *
+ * Any value can be converted to `Any`.  Conversely A `Any` can be
+ * converted back to the strongly typed representation.
+ *
+ * Note: `Any` relies on Rust's TypeId mechanism to order instances
+ * with different underlying types.  As a result, the ordering may
+ * differ across Rust compiler releases.
+ */
+extern type Any
+
+/* Convert arbitrary DDlog type to Any. */
+extern function to_any(#[by_val] x: 'T): Any
+
+/* Convert `Any` back to an instance of type `'T`.
+ * Returns `None` if `value` stores an instance of a
+ * different type. */
+extern function from_any(#[by_val] value: Any): Option<'T>
+
+/*
  * Ref
  */
 #[size=8]

--- a/lib/ddlog_std.rs
+++ b/lib/ddlog_std.rs
@@ -22,6 +22,7 @@ SOFTWARE.
 */
 
 use abomonation::Abomonation;
+pub use differential_datalog::ddval::{Any, DDValue};
 /// Rust implementation of DDlog standard library functions and types.
 use differential_datalog::record::{arg_extract, Record};
 use differential_datalog::triomphe::Arc;
@@ -53,6 +54,16 @@ const XX_SEED2: u64 = 0x20b09801dce5ff84;
 
 pub fn default<T: Default>() -> T {
     T::default()
+}
+
+// Any
+
+pub fn to_any<T: DDValConvert>(x: T) -> Any {
+    Any::new(x.into_ddvalue())
+}
+
+pub fn from_any<T: 'static + DDValConvert>(value: Any) -> Option<T> {
+    <Option<T>>::from(T::try_from_ddvalue(DDValue::from(value)))
 }
 
 // Result

--- a/rust/template/Cargo.toml
+++ b/rust/template/Cargo.toml
@@ -33,6 +33,7 @@ erased-serde = "0.3"
 crossbeam-channel = "0.5.0"
 enum-primitive-derive = "0.2.1"
 triomphe = "0.1.3"
+phf = { version = "0.10.0", features = ["macros"] }
 
 # FlatBuffers dependency enabled by the `flatbuf` feature.
 # flatbuffers crate version must be in sync with the flatc compiler and Java

--- a/rust/template/cmd_parser/lib.rs
+++ b/rust/template/cmd_parser/lib.rs
@@ -58,11 +58,11 @@ where
                     }
                     Err(ReadlineError::Eof) => {
                         println!("CTRL-D");
-                        save_history(&rl);
+                        save_history(rl);
                         return Ok(());
                     }
                     Err(err) => {
-                        save_history(&rl);
+                        save_history(rl);
                         return Err(format!("Readline failure: {}", err));
                     }
                 }

--- a/rust/template/differential_datalog/src/api/c_api.rs
+++ b/rust/template/differential_datalog/src/api/c_api.rs
@@ -77,7 +77,7 @@ impl ddlog_log_destination {
         Ok(match self.mode {
             ddlog_log_mode::ddlog_log_disabled => None,
             ddlog_log_mode::ddlog_log_to_socket => Some(LoggingDestination::Socket {
-                sockaddr: SocketAddr::from_str(&address.as_ref().ok_or_else(|| {
+                sockaddr: SocketAddr::from_str(address.as_ref().ok_or_else(|| {
                     "ddlog_log_to_socket requires socket address in address_str".to_string()
                 })?)
                 .map_err(|e| {

--- a/rust/template/differential_datalog/src/ddlog.rs
+++ b/rust/template/differential_datalog/src/ddlog.rs
@@ -13,7 +13,7 @@ use std::ops::Deref;
 use std::sync::Arc as StdArc;
 use triomphe::Arc;
 
-use crate::ddval::DDValue;
+use crate::ddval::{Any, DDValue};
 use crate::program::RelId;
 use crate::program::Update;
 use crate::program::{ArrId, IdxId};
@@ -411,4 +411,13 @@ pub trait DDlog: DDlogDynamic {
 
     /// Dump all values in an index.
     fn dump_index(&self, index: IdxId) -> Result<BTreeSet<DDValue>, String>;
+}
+
+pub type AnyDeserializeFunc =
+    fn(&mut dyn erased_serde::Deserializer) -> Result<Any, erased_serde::Error>;
+
+/// Given an input relation id, returns a function that deserializes the record
+/// type of this relation.
+pub trait AnyDeserialize {
+    fn get_deserialize(&self, relid: RelId) -> Option<AnyDeserializeFunc>;
 }

--- a/rust/template/differential_datalog/src/ddval/any.rs
+++ b/rust/template/differential_datalog/src/ddval/any.rs
@@ -1,0 +1,165 @@
+//! `Any` is a wrapper around `DDValue` that makes it safe to use
+//! outside of the DDlog runtime by providing safe implementations
+//! of `Ord` ans `Eq` traits, which work even if their arguments
+//! wrap different types.
+
+use crate::{
+    ddval::DDValue,
+    program::RelId,
+    record::{FromRecord, IntoRecord, Mutator, Record},
+    AnyDeserialize, AnyDeserializeFunc,
+};
+
+use std::{
+    cmp::Ordering,
+    fmt,
+    fmt::{Debug, Formatter},
+    hash::{Hash, Hasher},
+    ops::{Deref, DerefMut},
+    option::Option,
+    result::Result,
+};
+
+use serde::{
+    de::{DeserializeSeed, Error},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
+
+#[derive(Default, Clone)]
+pub struct Any(DDValue);
+
+impl Hash for Any {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.deref().hash(state)
+    }
+}
+
+impl Any {
+    pub fn new(val: DDValue) -> Self {
+        Any(val)
+    }
+}
+
+impl From<DDValue> for Any {
+    fn from(val: DDValue) -> Self {
+        Any::new(val)
+    }
+}
+
+impl From<Any> for DDValue {
+    fn from(any: Any) -> Self {
+        any.0
+    }
+}
+
+impl Deref for Any {
+    type Target = DDValue;
+
+    fn deref(&self) -> &DDValue {
+        &self.0
+    }
+}
+
+impl DerefMut for Any {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl Debug for Any {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        Debug::fmt(self.deref(), f)
+    }
+}
+
+impl IntoRecord for Any {
+    fn into_record(self) -> Record {
+        self.0.into_record()
+    }
+}
+
+impl FromRecord for Any {
+    fn from_record(val: &Record) -> Result<Self, String> {
+        DDValue::from_record(val).map(Self::new)
+    }
+}
+
+impl Mutator<Any> for Record {
+    fn mutate(&self, v: &mut Any) -> Result<(), String> {
+        self.mutate(v.deref_mut())
+    }
+}
+
+impl Eq for Any {}
+
+impl PartialEq for Any {
+    fn eq(&self, other: &Self) -> bool {
+        self.safe_eq(other)
+    }
+}
+
+impl PartialOrd for Any {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.safe_cmp(&*other))
+    }
+}
+
+impl Ord for Any {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.safe_cmp(&*other)
+    }
+}
+
+impl Serialize for Any {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.deref().serialize(serializer)
+    }
+}
+
+// This implementation always fails, as we cannot deserialize `Any`
+// without knowing the actual type.
+impl<'de> Deserialize<'de> for Any {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        DDValue::deserialize(deserializer).map(Self::new)
+    }
+}
+
+/// A `DeserializeSeed` implementation for `Any` that wraps an instance
+/// of `AnyDeserializeFunc`.
+/// This can be used to construct `Deserialize` implementations for more
+/// complex types that contain fields of type `Any`.
+pub struct AnyDeserializeSeed(AnyDeserializeFunc);
+
+impl AnyDeserializeSeed {
+    pub fn new(func: AnyDeserializeFunc) -> Self {
+        AnyDeserializeSeed(func)
+    }
+
+    pub fn from_relid<D>(ddlog: &D, relid: RelId) -> Option<Self>
+    where
+        D: AnyDeserialize + ?Sized,
+    {
+        ddlog.get_deserialize(relid).map(AnyDeserializeSeed::new)
+    }
+}
+
+impl<'de> DeserializeSeed<'de> for AnyDeserializeSeed {
+    type Value = Any;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Any, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        (self.0)(&mut <dyn erased_serde::Deserializer>::erase(deserializer))
+            .map_err(D::Error::custom)
+    }
+}

--- a/rust/template/differential_datalog/src/ddval/ddval_convert.rs
+++ b/rust/template/differential_datalog/src/ddval/ddval_convert.rs
@@ -308,3 +308,9 @@ where
         }
     };
 }
+
+impl Default for DDValue {
+    fn default() -> Self {
+        ().into_ddvalue()
+    }
+}

--- a/rust/template/differential_datalog/src/ddval/mod.rs
+++ b/rust/template/differential_datalog/src/ddval/mod.rs
@@ -53,8 +53,10 @@
 
 #[macro_use]
 mod ddval_convert;
+mod any;
 mod ddvalue;
 
+pub use any::{Any, AnyDeserializeSeed};
 pub use ddval_convert::DDValConvert;
 pub use ddvalue::DDValue;
 

--- a/rust/template/differential_datalog/src/lib.rs
+++ b/rust/template/differential_datalog/src/lib.rs
@@ -28,8 +28,8 @@ mod test_record;
 
 pub use callback::Callback;
 pub use ddlog::{
-    D3log, D3logLocalizer, D3logLocationId, DDlog, DDlogDump, DDlogDynamic, DDlogInventory,
-    DDlogProfiling,
+    AnyDeserialize, AnyDeserializeFunc, D3log, D3logLocalizer, D3logLocationId, DDlog, DDlogDump,
+    DDlogDynamic, DDlogInventory, DDlogProfiling,
 };
 pub use replay::CommandRecorder;
 pub use triomphe;

--- a/rust/template/differential_datalog/src/profile.rs
+++ b/rust/template/differential_datalog/src/profile.rs
@@ -179,7 +179,7 @@ impl Profile {
                             let context = context.as_ref().expect(
                                 "Operates events should always have valid context attached",
                             );
-                            self.handle_operates(&o, context);
+                            self.handle_operates(o, context);
                         }
                         event => {
                             if *profile_timely {
@@ -189,7 +189,7 @@ impl Profile {
                                     stats.handle_event(
                                         *duration,
                                         *id,
-                                        &event,
+                                        event,
                                         &self.op_address,
                                         &self.short_names,
                                     );

--- a/rust/template/differential_datalog/src/program/mod.rs
+++ b/rust/template/differential_datalog/src/program/mod.rs
@@ -436,14 +436,14 @@ pub enum XFormArrangement {
 impl XFormArrangement {
     pub fn description(&self) -> &str {
         match self {
-            XFormArrangement::FlatMap { description, .. } => &description,
-            XFormArrangement::FilterMap { description, .. } => &description,
-            XFormArrangement::Aggregate { description, .. } => &description,
-            XFormArrangement::Join { description, .. } => &description,
-            XFormArrangement::Semijoin { description, .. } => &description,
-            XFormArrangement::Antijoin { description, .. } => &description,
-            XFormArrangement::StreamJoin { description, .. } => &description,
-            XFormArrangement::StreamSemijoin { description, .. } => &description,
+            XFormArrangement::FlatMap { description, .. } => description,
+            XFormArrangement::FilterMap { description, .. } => description,
+            XFormArrangement::Aggregate { description, .. } => description,
+            XFormArrangement::Join { description, .. } => description,
+            XFormArrangement::Semijoin { description, .. } => description,
+            XFormArrangement::Antijoin { description, .. } => description,
+            XFormArrangement::StreamJoin { description, .. } => description,
+            XFormArrangement::StreamSemijoin { description, .. } => description,
         }
     }
 
@@ -618,16 +618,16 @@ pub enum XFormCollection {
 impl XFormCollection {
     pub fn description(&self) -> &str {
         match self {
-            XFormCollection::Arrange { description, .. } => &description,
-            XFormCollection::Differentiate { description, .. } => &description,
-            XFormCollection::Map { description, .. } => &description,
-            XFormCollection::FlatMap { description, .. } => &description,
-            XFormCollection::Filter { description, .. } => &description,
-            XFormCollection::FilterMap { description, .. } => &description,
-            XFormCollection::Inspect { description, .. } => &description,
-            XFormCollection::StreamJoin { description, .. } => &description,
-            XFormCollection::StreamSemijoin { description, .. } => &description,
-            XFormCollection::StreamXForm { description, .. } => &description,
+            XFormCollection::Arrange { description, .. } => description,
+            XFormCollection::Differentiate { description, .. } => description,
+            XFormCollection::Map { description, .. } => description,
+            XFormCollection::FlatMap { description, .. } => description,
+            XFormCollection::Filter { description, .. } => description,
+            XFormCollection::FilterMap { description, .. } => description,
+            XFormCollection::Inspect { description, .. } => description,
+            XFormCollection::StreamJoin { description, .. } => description,
+            XFormCollection::StreamSemijoin { description, .. } => description,
+            XFormCollection::StreamXForm { description, .. } => description,
         }
     }
 
@@ -1138,7 +1138,7 @@ impl Program {
     fn get_delayed_relation(&self, relid: RelId) -> Option<&DelayedRelation> {
         for drel in &self.delayed_rels {
             if drel.id == relid {
-                return Some(&drel);
+                return Some(drel);
             }
         }
         None
@@ -1283,7 +1283,7 @@ impl Program {
                 afun,
                 ref next,
             } => {
-                let arr = with_prof_context(&description, || col.flat_map(afun).arrange_by_key());
+                let arr = with_prof_context(description, || col.flat_map(afun).arrange_by_key());
                 Self::xform_arrangement(&arr, &*next, arrangements, lookup_collection)
             }
             XFormCollection::Differentiate {
@@ -1295,7 +1295,7 @@ impl Program {
                     <dyn Any>::downcast_ref::<<S::Timestamp as Timestamp>::Summary>(&(1 as TS))
                         .expect("Differentiate operator used in recursive context");
 
-                let diff = with_prof_context(&description, || {
+                let diff = with_prof_context(description, || {
                     col.concat(
                         &col.delay(move |t| one.results_in(t).expect("Integer overflow in Differentiate: maximal number of transactions exceeded")).negate())
                 });
@@ -1307,7 +1307,7 @@ impl Program {
                 mfun,
                 ref next,
             } => {
-                let mapped = with_prof_context(&description, || col.map(mfun));
+                let mapped = with_prof_context(description, || col.map(mfun));
                 Self::xform_collection(mapped, &*next, arrangements, lookup_collection)
             }
             XFormCollection::FlatMap {
@@ -1315,7 +1315,7 @@ impl Program {
                 fmfun,
                 ref next,
             } => {
-                let flattened = with_prof_context(&description, || {
+                let flattened = with_prof_context(description, || {
                     col.flat_map(move |x| fmfun(x).into_iter().flatten())
                 });
                 Self::xform_collection(flattened, &*next, arrangements, lookup_collection)
@@ -1325,7 +1325,7 @@ impl Program {
                 ffun,
                 ref next,
             } => {
-                let filtered = with_prof_context(&description, || col.filter(ffun));
+                let filtered = with_prof_context(description, || col.filter(ffun));
                 Self::xform_collection(filtered, &*next, arrangements, lookup_collection)
             }
             XFormCollection::FilterMap {
@@ -1333,7 +1333,7 @@ impl Program {
                 fmfun,
                 ref next,
             } => {
-                let flattened = with_prof_context(&description, || col.flat_map(fmfun));
+                let flattened = with_prof_context(description, || col.flat_map(fmfun));
                 Self::xform_collection(flattened, &*next, arrangements, lookup_collection)
             }
             XFormCollection::Inspect {
@@ -1341,7 +1341,7 @@ impl Program {
                 ifun,
                 ref next,
             } => {
-                let inspect = with_prof_context(&description, || {
+                let inspect = with_prof_context(description, || {
                     col.inspect(move |(v, ts, w)| ifun(v, ts.to_tuple_ts(), *w))
                 });
                 Self::xform_collection(inspect, &*next, arrangements, lookup_collection)
@@ -1353,7 +1353,7 @@ impl Program {
                 jfun,
                 ref next,
             } => {
-                let join = with_prof_context(&description, || {
+                let join = with_prof_context(description, || {
                     // arrange input collection
                     let collection_with_keys = col.flat_map(afun);
                     let arr = match arrangements.lookup_arr(arrangement) {
@@ -1386,7 +1386,7 @@ impl Program {
                 jfun,
                 ref next,
             } => {
-                let join = with_prof_context(&description, || {
+                let join = with_prof_context(description, || {
                     // arrange input collection
                     let collection_with_keys = col.flat_map(afun);
                     let arr = match arrangements.lookup_arr(arrangement) {
@@ -1499,7 +1499,7 @@ impl Program {
                 afun,
                 ref next,
             } => {
-                let arr = with_prof_context(&description, || col.flat_map(afun).arrange_by_key());
+                let arr = with_prof_context(description, || col.flat_map(afun).arrange_by_key());
                 Self::xform_arrangement(&arr, &*next, arrangements, lookup_collection)
             }
             XFormCollection::Differentiate {
@@ -1511,7 +1511,7 @@ impl Program {
                     <dyn Any>::downcast_ref::<<S::Timestamp as Timestamp>::Summary>(&(1 as TS))
                         .expect("Differentiate operator used in recursive context");
 
-                let diff = with_prof_context(&description, || {
+                let diff = with_prof_context(description, || {
                     col.concat(
                         &col.delay(move |t| one.results_in(t).expect("Integer overflow in Differentiate: maximal number of transactions exceeded")).negate())
                 });
@@ -1523,7 +1523,7 @@ impl Program {
                 mfun,
                 ref next,
             } => {
-                let mapped = with_prof_context(&description, || col.map(mfun));
+                let mapped = with_prof_context(description, || col.map(mfun));
                 Self::streamless_xform_collection(mapped, &*next, arrangements, lookup_collection)
             }
             XFormCollection::FlatMap {
@@ -1531,7 +1531,7 @@ impl Program {
                 fmfun,
                 ref next,
             } => {
-                let flattened = with_prof_context(&description, || {
+                let flattened = with_prof_context(description, || {
                     col.flat_map(move |x| fmfun(x).into_iter().flatten())
                 });
                 Self::streamless_xform_collection(
@@ -1546,7 +1546,7 @@ impl Program {
                 ffun,
                 ref next,
             } => {
-                let filtered = with_prof_context(&description, || col.filter(ffun));
+                let filtered = with_prof_context(description, || col.filter(ffun));
                 Self::streamless_xform_collection(filtered, &*next, arrangements, lookup_collection)
             }
             XFormCollection::FilterMap {
@@ -1554,7 +1554,7 @@ impl Program {
                 fmfun,
                 ref next,
             } => {
-                let flattened = with_prof_context(&description, || col.flat_map(fmfun));
+                let flattened = with_prof_context(description, || col.flat_map(fmfun));
                 Self::streamless_xform_collection(
                     flattened,
                     &*next,
@@ -1567,7 +1567,7 @@ impl Program {
                 ifun,
                 ref next,
             } => {
-                let inspect = with_prof_context(&description, || {
+                let inspect = with_prof_context(description, || {
                     col.inspect(move |(v, ts, w)| ifun(v, ts.to_tuple_ts(), *w))
                 });
                 Self::streamless_xform_collection(inspect, &*next, arrangements, lookup_collection)
@@ -1579,7 +1579,7 @@ impl Program {
                 jfun,
                 ref next,
             } => {
-                let join = with_prof_context(&description, || {
+                let join = with_prof_context(description, || {
                     // arrange input collection
                     let collection_with_keys = col.flat_map(afun);
                     let arr = match arrangements.lookup_arr(arrangement) {
@@ -1612,7 +1612,7 @@ impl Program {
                 jfun,
                 ref next,
             } => {
-                let join = with_prof_context(&description, || {
+                let join = with_prof_context(description, || {
                     // arrange input collection
                     let collection_with_keys = col.flat_map(afun);
                     let arr = match arrangements.lookup_arr(arrangement) {
@@ -1669,7 +1669,7 @@ impl Program {
                 ref description,
                 fmfun,
                 ref next,
-            } => with_prof_context(&description, || {
+            } => with_prof_context(description, || {
                 Self::streamless_xform_collection(
                     arr.flat_map_ref(move |_, v| match fmfun(v.clone()) {
                         Some(iter) => iter,
@@ -1684,7 +1684,7 @@ impl Program {
                 ref description,
                 fmfun,
                 ref next,
-            } => with_prof_context(&description, || {
+            } => with_prof_context(description, || {
                 Self::streamless_xform_collection(
                     arr.flat_map_ref(move |_, v| fmfun(v.clone())),
                     &*next,
@@ -1698,7 +1698,7 @@ impl Program {
                 aggfun,
                 ref next,
             } => {
-                let col = with_prof_context(&description, || {
+                let col = with_prof_context(description, || {
                     ffun.map_or_else(
                         || {
                             arr.reduce(move |key, src, dst| {
@@ -1729,7 +1729,7 @@ impl Program {
                 ref next,
             } => match arrangements.lookup_arr(arrangement) {
                 ArrangementFlavor::Local(DataflowArrangement::Map(arranged)) => {
-                    let col = with_prof_context(&description, || {
+                    let col = with_prof_context(description, || {
                         ffun.map_or_else(
                             || arr.join_core(&arranged, jfun),
                             |f| arr.filter(move |_, v| f(v)).join_core(&arranged, jfun),
@@ -1738,7 +1738,7 @@ impl Program {
                     Self::streamless_xform_collection(col, &*next, arrangements, lookup_collection)
                 }
                 ArrangementFlavor::Foreign(DataflowArrangement::Map(arranged)) => {
-                    let col = with_prof_context(&description, || {
+                    let col = with_prof_context(description, || {
                         ffun.map_or_else(
                             || arr.join_core(&arranged, jfun),
                             |f| arr.filter(move |_, v| f(v)).join_core(&arranged, jfun),
@@ -1757,7 +1757,7 @@ impl Program {
                 ref next,
             } => match arrangements.lookup_arr(arrangement) {
                 ArrangementFlavor::Local(DataflowArrangement::Set(arranged)) => {
-                    let col = with_prof_context(&description, || {
+                    let col = with_prof_context(description, || {
                         ffun.map_or_else(
                             || arr.join_core(&arranged, jfun),
                             |f| arr.filter(move |_, v| f(v)).join_core(&arranged, jfun),
@@ -1766,7 +1766,7 @@ impl Program {
                     Self::streamless_xform_collection(col, &*next, arrangements, lookup_collection)
                 }
                 ArrangementFlavor::Foreign(DataflowArrangement::Set(arranged)) => {
-                    let col = with_prof_context(&description, || {
+                    let col = with_prof_context(description, || {
                         ffun.map_or_else(
                             || arr.join_core(&arranged, jfun),
                             |f| arr.filter(move |_, v| f(v)).join_core(&arranged, jfun),
@@ -1783,9 +1783,9 @@ impl Program {
                 ref next,
             } => match arrangements.lookup_arr(arrangement) {
                 ArrangementFlavor::Local(DataflowArrangement::Set(arranged)) => {
-                    let col = with_prof_context(&description, || {
+                    let col = with_prof_context(description, || {
                         ffun.map_or_else(
-                            || antijoin_arranged(&arr, &arranged).map(|(_, v)| v),
+                            || antijoin_arranged(arr, &arranged).map(|(_, v)| v),
                             |f| {
                                 antijoin_arranged(&arr.filter(move |_, v| f(v)), &arranged)
                                     .map(|(_, v)| v)
@@ -1795,9 +1795,9 @@ impl Program {
                     Self::streamless_xform_collection(col, &*next, arrangements, lookup_collection)
                 }
                 ArrangementFlavor::Foreign(DataflowArrangement::Set(arranged)) => {
-                    let col = with_prof_context(&description, || {
+                    let col = with_prof_context(description, || {
                         ffun.map_or_else(
-                            || antijoin_arranged(&arr, &arranged).map(|(_, v)| v),
+                            || antijoin_arranged(arr, &arranged).map(|(_, v)| v),
                             |f| {
                                 antijoin_arranged(&arr.filter(move |_, v| f(v)), &arranged)
                                     .map(|(_, v)| v)
@@ -1816,7 +1816,7 @@ impl Program {
                 jfun,
                 ref next,
             } => {
-                let col = with_prof_context(&description, || {
+                let col = with_prof_context(description, || {
                     // Map `rel` into `(key, value)` pairs, filtering out
                     // records where `kfun` returns `None`.
                     // FIXME: The key will need to be cloned below.  To avoid
@@ -1868,7 +1868,7 @@ impl Program {
                 jfun,
                 ref next,
             } => {
-                let col = with_prof_context(&description, || {
+                let col = with_prof_context(description, || {
                     // Extract join key from `rel`, filtering out
                     // FIXME: The key will need to be cloned below.  To avoid
                     // this overhead, we need a version of `lookup_map` that
@@ -2401,7 +2401,7 @@ impl RunningProgram {
                 new
             }
             Update::DeleteValue { v, .. } => {
-                let present = s.remove(&v);
+                let present = s.remove(v);
                 if present {
                     Self::delta_dec(ds, v);
                 }
@@ -2532,7 +2532,7 @@ impl RunningProgram {
                     m.mutate(new)?;
                     Self::delta_dec(ds, &old);
                     updates.push(Update::DeleteValue { relid, v: old });
-                    Self::delta_inc(ds, &new);
+                    Self::delta_inc(ds, new);
                     updates.push(Update::Insert {
                         relid,
                         v: new.clone(),

--- a/rust/template/differential_datalog/src/program/worker.rs
+++ b/rust/template/differential_datalog/src/program/worker.rs
@@ -776,7 +776,7 @@ fn render_relation<S>(
         with_prof_context(arrangement.name(), || {
             arrangements.insert(
                 (relation.id, arr_id),
-                arrangement.build_arrangement_root(&render_context, &collection),
+                arrangement.build_arrangement_root(render_context, &collection),
             )
         });
     }

--- a/rust/template/differential_datalog/src/render/arrange_by.rs
+++ b/rust/template/differential_datalog/src/render/arrange_by.rs
@@ -105,7 +105,7 @@ impl<'a> ArrangeBy<'a> {
             }
 
             ArrangementKind::Map { value_function } => {
-                self.render_map(&collection, value_function, &arrangement_name)
+                self.render_map(collection, value_function, &arrangement_name)
             }
         }
     }
@@ -185,7 +185,7 @@ impl<'a> ArrangeBy<'a> {
             }
 
             ArrangementKind::Map { value_function } => {
-                self.render_map(&collection, value_function, &arrangement_name)
+                self.render_map(collection, value_function, &arrangement_name)
             }
         }
     }
@@ -242,7 +242,7 @@ impl<'a> ArrangeBy<'a> {
                 });
 
                 let arranged =
-                    keyed.arrange_named::<OrdKeySpine<_, _, _, Offset>>(&arrangement_name);
+                    keyed.arrange_named::<OrdKeySpine<_, _, _, Offset>>(arrangement_name);
 
                 Err(Arrangement::Set(arranged))
             }

--- a/rust/template/differential_datalog/src/replay.rs
+++ b/rust/template/differential_datalog/src/replay.rs
@@ -154,25 +154,25 @@ where
         match upd {
             UpdCmd::Insert(rel, record) => record_insert(
                 writer,
-                Self::relident2name(inventory, rel).unwrap_or(&"???"),
+                Self::relident2name(inventory, rel).unwrap_or("???"),
                 record,
             ),
             UpdCmd::InsertOrUpdate(rel, record) => record_insert_or_update(
                 writer,
-                Self::relident2name(inventory, rel).unwrap_or(&"???"),
+                Self::relident2name(inventory, rel).unwrap_or("???"),
                 record,
             ),
             UpdCmd::Delete(rel, record) => record_delete(
                 writer,
-                Self::relident2name(inventory, rel).unwrap_or(&"???"),
+                Self::relident2name(inventory, rel).unwrap_or("???"),
                 record,
             ),
             UpdCmd::DeleteKey(rel, record) => {
-                let rname = Self::relident2name(inventory, rel).unwrap_or(&"???");
+                let rname = Self::relident2name(inventory, rel).unwrap_or("???");
                 write!(writer, "delete_key {} {}", rname, record,)
             }
             UpdCmd::Modify(rel, key, mutator) => {
-                let rname = Self::relident2name(inventory, rel).unwrap_or(&"???");
+                let rname = Self::relident2name(inventory, rel).unwrap_or("???");
                 write!(writer, "modify {} {} <- {}", rname, key, mutator,)
             }
         }
@@ -185,31 +185,27 @@ where
         upd: &Update<DDValue>,
     ) -> IOResult<()> {
         match upd {
-            Update::Insert { relid, v } => record_insert(
-                writer,
-                inventory.get_table_name(*relid).unwrap_or(&"???"),
-                v,
-            ),
+            Update::Insert { relid, v } => {
+                record_insert(writer, inventory.get_table_name(*relid).unwrap_or("???"), v)
+            }
             Update::InsertOrUpdate { relid, v } => record_insert_or_update(
                 writer,
-                inventory.get_table_name(*relid).unwrap_or(&"???"),
+                inventory.get_table_name(*relid).unwrap_or("???"),
                 v,
             ),
-            Update::DeleteValue { relid, v } => record_delete(
-                writer,
-                inventory.get_table_name(*relid).unwrap_or(&"???"),
-                v,
-            ),
+            Update::DeleteValue { relid, v } => {
+                record_delete(writer, inventory.get_table_name(*relid).unwrap_or("???"), v)
+            }
             Update::DeleteKey { relid, k } => write!(
                 writer,
                 "delete_key {} {}",
-                inventory.get_table_name(*relid).unwrap_or(&"???"),
+                inventory.get_table_name(*relid).unwrap_or("???"),
                 k,
             ),
             Update::Modify { relid, k, m } => write!(
                 writer,
                 "modify {} {} <- {}",
-                inventory.get_table_name(*relid).unwrap_or(&"???"),
+                inventory.get_table_name(*relid).unwrap_or("???"),
                 k,
                 m,
             ),
@@ -247,7 +243,7 @@ where
     }
 
     fn apply_updates_dynamic(&self, upds: &mut dyn Iterator<Item = UpdCmd>) -> Result<(), String> {
-        self.do_record_updates(upds, |i, w, u| Self::record_upd_cmd(i, w, &u))
+        self.do_record_updates(upds, |i, w, u| Self::record_upd_cmd(i, w, u))
     }
 
     fn clear_relation(&self, rid: RelId) -> Result<(), String> {
@@ -255,7 +251,7 @@ where
         writeln!(
             &mut writer,
             "clear {};",
-            self.inventory.get_table_name(rid).unwrap_or(&"???")
+            self.inventory.get_table_name(rid).unwrap_or("???")
         )
         .map_err(|e| e.to_string())
     }
@@ -265,7 +261,7 @@ where
         writeln!(
             &mut writer,
             "query_index {}({});",
-            self.inventory.get_index_name(iid).unwrap_or(&"???"),
+            self.inventory.get_index_name(iid).unwrap_or("???"),
             key
         )
         .and(Ok(vec![]))
@@ -277,7 +273,7 @@ where
         writeln!(
             &mut writer,
             "dump_index {};",
-            self.inventory.get_index_name(iid).unwrap_or(&"???")
+            self.inventory.get_index_name(iid).unwrap_or("???")
         )
         .and(Ok(vec![]))
         .map_err(|e| e.to_string())
@@ -301,7 +297,7 @@ where
     }
 
     fn apply_updates(&self, upds: &mut dyn Iterator<Item = Update<DDValue>>) -> Result<(), String> {
-        self.do_record_updates(upds, |i, w, u| Self::record_val_upd(i, w, &u))
+        self.do_record_updates(upds, |i, w, u| Self::record_val_upd(i, w, u))
     }
 
     fn query_index(&self, iid: IdxId, key: DDValue) -> Result<BTreeSet<DDValue>, String> {
@@ -309,7 +305,7 @@ where
         writeln!(
             &mut writer,
             "query_index {}({});",
-            self.inventory.get_index_name(iid).unwrap_or(&"???"),
+            self.inventory.get_index_name(iid).unwrap_or("???"),
             key
         )
         .map(|_| BTreeSet::new())
@@ -321,7 +317,7 @@ where
         writeln!(
             &mut writer,
             "dump_index {};",
-            self.inventory.get_index_name(iid).unwrap_or(&"???")
+            self.inventory.get_index_name(iid).unwrap_or("???")
         )
         .map(|_| BTreeSet::new())
         .map_err(|e| e.to_string())
@@ -342,7 +338,7 @@ where
         writeln!(
             &mut writer,
             "dump {};",
-            self.inventory.get_table_name(rid).unwrap_or(&"???")
+            self.inventory.get_table_name(rid).unwrap_or("???")
         )
         .map_err(|e| e.to_string())
     }

--- a/rust/template/differential_datalog/src/replay.rs
+++ b/rust/template/differential_datalog/src/replay.rs
@@ -421,11 +421,6 @@ mod tests {
         }
 
         #[cfg(feature = "c_api")]
-        fn get_table_original_cname(&self, _tname: &str) -> Result<&'static CStr, String> {
-            unimplemented!()
-        }
-
-        #[cfg(feature = "c_api")]
         fn get_table_cname(&self, _tid: RelId) -> Result<&'static CStr, String> {
             unimplemented!()
         }

--- a/rust/template/differential_datalog_test/lib.rs
+++ b/rust/template/differential_datalog_test/lib.rs
@@ -1129,7 +1129,7 @@ fn test_map(nthreads: usize) {
     }
 
     fn ffun(v: &DDValue) -> bool {
-        let U64(ref uv) = U64::from_ddvalue_ref(&v);
+        let U64(ref uv) = U64::from_ddvalue_ref(v);
         *uv > 10
     }
 
@@ -1610,7 +1610,7 @@ fn test_recursion(nthreads: usize) {
     };
 
     fn ffun(v: &DDValue) -> bool {
-        let Tuple2(ref fst, ref snd) = Tuple2::<String>::from_ddvalue_ref(&v);
+        let Tuple2(ref fst, ref snd) = Tuple2::<String>::from_ddvalue_ref(v);
         *fst != *snd
     }
 

--- a/rust/template/src/build.rs
+++ b/rust/template/src/build.rs
@@ -26,10 +26,7 @@ fn libtool() {
     }
     println!("cargo:rerun-if-changed=src/lib.rs");
     println!("cargo:rerun-if-changed=src/main.rs");
-    println!("cargo:rerun-if-changed=src/api/mod.rs");
-    println!("cargo:rerun-if-changed=src/api/c_api.rs");
     println!("cargo:rerun-if-changed=src/ovsdb_api.rs");
-    println!("cargo:rerun-if-changed=src/update_handler.rs");
 
     let lib = "libdatalog_example_ddlog";
 

--- a/rust/template/types/lib.rs
+++ b/rust/template/types/lib.rs
@@ -41,7 +41,6 @@ use ::timely::dataflow::scopes;
 use ::timely::worker;
 
 use ::ddlog_derive::{FromRecord, IntoRecord, Mutator};
-use ::differential_datalog::ddval::DDValue;
 use ::differential_datalog::ddval::DDValConvert;
 use ::differential_datalog::program;
 use ::differential_datalog::program::TupleTS;

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -200,6 +200,7 @@ rustLibFiles =
         , ("differential_datalog/src/ddlog.rs"                    , $(embedFile "rust/template/differential_datalog/src/ddlog.rs"))
         , ("differential_datalog/src/ddval/mod.rs"                , $(embedFile "rust/template/differential_datalog/src/ddval/mod.rs"))
         , ("differential_datalog/src/ddval/ddvalue.rs"            , $(embedFile "rust/template/differential_datalog/src/ddval/ddvalue.rs"))
+        , ("differential_datalog/src/ddval/any.rs"                , $(embedFile "rust/template/differential_datalog/src/ddval/any.rs"))
         , ("differential_datalog/src/ddval/ddval_convert.rs"      , $(embedFile "rust/template/differential_datalog/src/ddval/ddval_convert.rs"))
         , ("differential_datalog/src/lib.rs"                      , $(embedFile "rust/template/differential_datalog/src/lib.rs"))
         , ("differential_datalog/src/profile.rs"                  , $(embedFile "rust/template/differential_datalog/src/profile.rs"))
@@ -925,7 +926,7 @@ compileMainLib :: (?cfg::Config, ?specname::String, ?modules::M.Map ModuleName D
 compileMainLib d d3log_rel_map nodes cstate =
     mainHeader                             $+$
     reexports                              $+$
-    mkUpdateDeserializer d                 $+$
+    mkAnyDeserialize d                     $+$
     mkDDValueFromRecord d                  $+$ -- Function to convert cmd_parser::Record to Value
     mkIndexesIntoArrId d cstate            $+$
     mkRelEnum d                            $+$ -- 'enum Relations'
@@ -1002,11 +1003,11 @@ ppModuleReexports d ModuleReexports{..} =
 
 
 -- Generate Deserialize implementation for UpdateSerializer wrapper.
-mkUpdateDeserializer :: (?crate_graph::CrateGraph, ?specname::String) => DatalogProgram -> Doc
-mkUpdateDeserializer d =
-    "decl_update_deserializer!(UpdateSerializer," <> commaSep rels <> ");"
+mkAnyDeserialize :: (?crate_graph::CrateGraph, ?specname::String) => DatalogProgram -> Doc
+mkAnyDeserialize d =
+    "decl_any_deserialize!(" <> commaSep rels <> ");"
     where
-    rels = map (\rel -> "(" <> pp (relIdentifier d rel) <> "," <+> mkType d Nothing rel <> ")" )
+    rels = map (\rel -> "(" <> pp (relIdentifier d rel) <> "u64 ," <+> mkType d Nothing rel <> ")" )
            $ filter (\rel -> elem (relRole rel) [RelInput, RelOutput])
            $ M.elems $ progRelations d
 

--- a/test/datalog_tests/ddvalue_test.dat
+++ b/test/datalog_tests/ddvalue_test.dat
@@ -1,0 +1,10 @@
+# Add one record per transaction to guarantee deterministic output order
+# (the ordering of `Any` may vary across Rust compiler releases).
+
+start;
+insert ddvalue_test::DDValTest1("foo", 1, ["bar", "buzz"]),
+commit dump_changes;
+
+start;
+insert ddvalue_test::DDValTest2([(1, "foo"), (2, "bar")], (true, [5,4,3,2,1])),
+commit dump_changes;

--- a/test/datalog_tests/ddvalue_test.dl
+++ b/test/datalog_tests/ddvalue_test.dl
@@ -1,0 +1,15 @@
+/* Test `Any` API. */
+
+input relation DDValTest1(x: string, y: usize, z: Vec<istring>)
+input relation DDValTest2(a: Map<usize, string>, b: (bool, Set<u128>))
+
+output relation DDValTestOutput(relname: string, ddval: Any)
+
+DDValTestOutput("DDValTest1", x.to_any()) :- DDValTest1[x].
+DDValTestOutput("DDValTest2", x.to_any()) :- DDValTest2[x].
+
+output relation DDValTest1Output[DDValTest1]
+output relation DDValTest2Output[DDValTest2]
+
+DDValTest1Output[from_any(x).unwrap_or_default()] :- DDValTestOutput("DDValTest1", x).
+DDValTest2Output[from_any(x).unwrap_or_default()] :- DDValTestOutput("DDValTest2", x).

--- a/test/datalog_tests/ddvalue_test.dump.expected
+++ b/test/datalog_tests/ddvalue_test.dump.expected
@@ -1,0 +1,8 @@
+ddvalue_test::DDValTest1Output:
+ddvalue_test::DDValTest1{.x = "foo", .y = 1, .z = ["bar", "buzz"]}: +1
+ddvalue_test::DDValTestOutput:
+ddvalue_test::DDValTestOutput{.relname = "DDValTest1", .ddval = ddvalue_test::DDValTest1{.x = "foo", .y = 1, .z = ["bar", "buzz"]}}: +1
+ddvalue_test::DDValTest2Output:
+ddvalue_test::DDValTest2{.a = [(1, "foo"), (2, "bar")], .b = (true, [1, 2, 3, 4, 5])}: +1
+ddvalue_test::DDValTestOutput:
+ddvalue_test::DDValTestOutput{.relname = "DDValTest2", .ddval = ddvalue_test::DDValTest2{.a = [(1, "foo"), (2, "bar")], .b = (true, [1, 2, 3, 4, 5])}}: +1

--- a/test/datalog_tests/lib_test_no_flatbuf.dl
+++ b/test/datalog_tests/lib_test_no_flatbuf.dl
@@ -1,0 +1,1 @@
+import time_test

--- a/test/datalog_tests/lib_test_no_flatbuf.dl
+++ b/test/datalog_tests/lib_test_no_flatbuf.dl
@@ -1,1 +1,2 @@
 import time_test
+import ddvalue_test

--- a/test/datalog_tests/rust_api_test/Cargo.toml
+++ b/test/datalog_tests/rust_api_test/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2018"
 
 [dependencies]
 
+serde_json = "1.0.64"
+serde = "1.0"
+
 # The generated Rust project contains several crates that must be imported
 # by the client program.
 differential_datalog = { path = "../tutorial_ddlog/differential_datalog" }

--- a/test/datalog_tests/test-libs.sh
+++ b/test/datalog_tests/test-libs.sh
@@ -29,5 +29,16 @@ test_lib hashset_test
 test_lib group_test
 test_lib base64_test
 
-# No flatbuf support for Time, Date, etc yet
-FLATBUF=0 ./run-test.sh time_test.dl release
+# Tests for libraries that do not support flatbuf serialization.
+FLATBUF=0 ./run-test.sh lib_test_no_flatbuf.dl release
+
+# $1 - test name
+test_nofb_lib() {
+    echo Running $1 test
+    RUST_BACKTRACE=full /usr/bin/time ./lib_test_no_flatbuf_ddlog/target/release/lib_test_no_flatbuf_cli --no-init-snapshot < $1.dat > $1.dump
+    diff $1.dump.expected $1.dump
+}
+
+
+test_nofb_lib time_test
+test_nofb_lib ddvalue_test

--- a/test/datalog_tests/time_test.dat
+++ b/test/datalog_tests/time_test.dat
@@ -1,10 +1,10 @@
 start;
-insert TITest[TITest{.t = "10:11:12.000000000"}],
-insert DITest[DITest{.d = "2010-10-15"}],
-insert DTITest[DTITest{.d = time::DateTime{.date = "2010-10-15", .time = "10:11:12.000000000" }}],
+insert time_test::TITest(.t = "10:11:12.000000000"),
+insert time_test::DITest(.d = "2010-10-15"),
+insert time_test::DTITest(.d = time::DateTime{.date = "2010-10-15", .time = "10:11:12.000000000" }),
 commit;
-dump TTest;
-dump Extract;
-dump DTest;
-dump DTTest;
+dump time_test::TTest;
+dump time_test::Extract;
+dump time_test::DTest;
+dump time_test::DTTest;
 exit

--- a/test/datalog_tests/time_test.dump.expected
+++ b/test/datalog_tests/time_test.dump.expected
@@ -1,138 +1,62 @@
-DTTest:
-DTTest{.s = "\"\".string2datetime().unwrap_or_default()", .t = ddlog_std::Ok{.res = time::DateTime{.date = "0000-01-01", .time = "00:00:00.000000000"}}}: +1
-DTTest{.s = "2020-04-14T10:11:12", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.103104105"}}}: +1
-DTTest{.s = "Error in format string '%incorrectformat'", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.103104105"}}}: +1
-DTTest{.s = "Extract date 2020-04-14T10:11:12", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.103104105"}}}: +1
-DTTest{.s = "Extract shifted 2020-04-14T10:11:12", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.103104105"}}}: +1
-DTTest{.s = "datetime_from_unix_timestamp(10000000)", .t = ddlog_std::Ok{.res = time::DateTime{.date = "1970-04-26", .time = "17:46:40.000000000"}}}: +1
-DTTest{.s = "datetime_parse(\"2020-10-10T10:20:30\", \"%Y-%m-%dT%H:%M:%S\")", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-10-10", .time = "10:20:30.000000000"}}}: +1
-DTTest{.s = "datetime_parse(\"2020/10/10T10:20:30\", \"%Y-%m-%dT%H:%M:%S\")", .t = ddlog_std::Err{.err = "input contains invalid characters"}}: +1
-DTTest{.s = "datetime_parse(\"Wed Mar 05 07:45:30 MST 2025\", \"%a %b %d %H:%M:%S %Z %Y\")", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2025-03-05", .time = "07:45:30.000000000"}}}: +1
-DTTest{.s = "datetime_parse(datetime_format(2020-04-14T10:11:12, %Y-%m-%dT%H::%M).result_or_error(), %Y-%m-%dT%H::%M)", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:00.000000000"}}}: +1
-DTTest{.s = "get_datetime(tz_datetime_parse_from_rfc2822(\"Tue, 1 Jul 2003 10:52:37 GMT\"))", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2003-07-01", .time = "10:52:37.000000000"}}}: +1
-DTTest{.s = "string2datetime(\"2020-10-10T10:20:30\")", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-10-10", .time = "10:20:30.000000000"}}}: +1
-DTTest{.s = "string2datetime(to_string(2020-04-14T10:11:12))", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.000000000"}}}: +1
-DTZTest:
-DTZTest{.s = "\"\".tz_datetime_parse_from_rfc2822().unwrap_or_default()", .t = ddlog_std::Ok{.res = "0000-01-01T00:00:00+00:00"}}: +1
-DTZTest{.s = "2020-04-14T10:11:12.103104105+00:00", .t = ddlog_std::Ok{.res = "2020-04-14T10:11:12.103104105+00:00"}}: +1
-DTZTest{.s = "Error in format string '%incorrectformat'", .t = ddlog_std::Ok{.res = "2020-04-14T10:11:12.103104105+00:00"}}: +1
-DTZTest{.s = "RFC 2822: Tue, 14 Apr 2020 10:11:12 +0000", .t = ddlog_std::Ok{.res = "2020-04-14T10:11:12.103104105+00:00"}}: +1
-DTZTest{.s = "RFC 3339: 2020-04-14T10:11:12.103104105+00:00", .t = ddlog_std::Ok{.res = "2020-04-14T10:11:12.103104105+00:00"}}: +1
-DTZTest{.s = "string2datetime(\"2020-10-10T10:20:30\").utc()", .t = ddlog_std::Ok{.res = "2020-10-10T10:20:30+00:00"}}: +1
-DTZTest{.s = "tz_datetime_parse(\"2020-10-10T10:20:30 +02:00\", \"%Y-%m-%dT%H:%M:%S %z\")", .t = ddlog_std::Ok{.res = "2020-10-10T10:20:30+02:00"}}: +1
-DTZTest{.s = "tz_datetime_parse(\"2020/10/10T10:20:30 -02:00\", \"%Y/%m/%dT%H:%M:%S %z\")", .t = ddlog_std::Ok{.res = "2020-10-10T10:20:30-03:00"}}: +1
-DTZTest{.s = "tz_datetime_parse(\"Wed Mar 05 07:45:30 MST 2025\", \"%a %b %d %H:%M:%S %Z %Y\")", .t = ddlog_std::Err{.err = "input is not enough for unique date and time"}}: +1
-DTZTest{.s = "tz_datetime_parse_from_rfc2822(\"Tue, 1 Jul 2003 10:52:37 +0200\")", .t = ddlog_std::Ok{.res = "2003-07-01T10:52:37+02:00"}}: +1
-DTZTest{.s = "tz_datetime_parse_from_rfc2822(\"Tue, 1 Jul 2003 10:52:37 GMT\")", .t = ddlog_std::Ok{.res = "2003-07-01T10:52:37+00:00"}}: +1
-DTZTest{.s = "tz_datetime_parse_from_rfc3339(\"2020-10-10T10:20:30-03:00\")", .t = ddlog_std::Ok{.res = "2020-10-10T10:20:30-03:00"}}: +1
-DTest:
-DTest{.s = "2020-04-14", .t = ddlog_std::Ok{.res = "2020-04-14"}}: +1
-DTest{.s = "Error in format string '%incorrectformat'", .t = ddlog_std::Ok{.res = "2020-04-14"}}: +1
-DTest{.s = "Ok{from_julian_day(2000000)}", .t = ddlog_std::Ok{.res = "0763-09-18"}}: +1
-DTest{.s = "Ok{next_day(2020-04-14)}", .t = ddlog_std::Ok{.res = "2020-04-15"}}: +1
-DTest{.s = "Ok{previous_day(2020-04-14)}", .t = ddlog_std::Ok{.res = "2020-04-13"}}: +1
-DTest{.s = "date_parse(\"2020/04/14\", \"%Y/%m/%d\")", .t = ddlog_std::Ok{.res = "2020-04-14"}}: +1
-DTest{.s = "date_parse(date_format(2020-04-14, %Y-%m-%dT).result_or_error(), %Y-%m-%dT)", .t = ddlog_std::Ok{.res = "2020-04-14"}}: +1
-DTest{.s = "string2date(to_string(someDate()))", .t = ddlog_std::Ok{.res = "2020-04-14"}}: +1
-DTest{.s = "try_from_iso_ywd(32'sd2020, 8'd4, Monday)", .t = ddlog_std::Ok{.res = "2020-01-20"}}: +1
-DTest{.s = "try_from_yd(0, 0, 0).unwrap_or_default()", .t = ddlog_std::Ok{.res = "0000-01-01"}}: +1
-DTest{.s = "try_from_ymd(32'sd2020, 8'd0, 8'd14)", .t = ddlog_std::Err{.err = "Invalid date"}}: +1
-DTest{.s = "try_from_ymd(32'sd2020, 8'd04, 8'd14)", .t = ddlog_std::Ok{.res = "2020-04-14"}}: +1
-DTest{.s = "try_from_ymd(32'sd2020, 8'd13, 8'd14)", .t = ddlog_std::Err{.err = "Invalid date"}}: +1
-DTest{.s = "try_from_yo(32'sd2020, 16'd100)", .t = ddlog_std::Ok{.res = "2020-04-09"}}: +1
-DTest{.s = "try_from_yo(32'sd2020, 16'd367)", .t = ddlog_std::Err{.err = "Invalid date"}}: +1
-Extract:
-Extract{.s = "day(2020-04-14)", .v = 14}: +1
-Extract{.s = "hour(10:11:12.103104105)", .v = 10}: +1
-Extract{.s = "microsecond(10:11:12.103104105)", .v = 103104}: +1
-Extract{.s = "millisecond(10:11:12.103104105)", .v = 103}: +1
-Extract{.s = "minute(10:11:12.103104105)", .v = 11}: +1
-Extract{.s = "month(2020-04-14)", .v = 4}: +1
-Extract{.s = "nanosecond(10:11:12.103104105)", .v = 103104105}: +1
-Extract{.s = "ordinal(2020-04-14)", .v = 105}: +1
-Extract{.s = "second(10:11:12.103104105)", .v = 12}: +1
-Extract{.s = "week(2020-04-14)", .v = 16}: +1
-Extract{.s = "year(2020-04-14)", .v = 2020}: +1
-TTest:
-TTest{.s = "10:11:12.103104105", .t = ddlog_std::Ok{.res = "10:11:12.103104105"}}: +1
-TTest{.s = "Error in format string '%incorrectformat'", .t = ddlog_std::Ok{.res = "10:11:12.103104105"}}: +1
-TTest{.s = "Ok(midnight())", .t = ddlog_std::Ok{.res = "00:00:00.000000000"}}: +1
-TTest{.s = "SomeTime: 10:11:12.103104105", .t = ddlog_std::Ok{.res = "10:11:12.103104105"}}: +1
-TTest{.s = "string2time(to_string(result_unwrap_or_default(try_from_hms(8'd10, 8'd10, 8'd10))))", .t = ddlog_std::Ok{.res = "10:10:10.000000000"}}: +1
-TTest{.s = "string2time(to_string(result_unwrap_or_default(try_from_hms_micro(8'd10, 8'd10, 8'd10, 32'd10))))", .t = ddlog_std::Ok{.res = "10:10:10.000010000"}}: +1
-TTest{.s = "string2time(to_string(result_unwrap_or_default(try_from_hms_milli(8'd10, 8'd10, 8'd10, 16'd10))))", .t = ddlog_std::Ok{.res = "10:10:10.010000000"}}: +1
-TTest{.s = "string2time(to_string(result_unwrap_or_default(try_from_hms_nano(8'd10, 8'd10, 8'd10, 32'd10))))", .t = ddlog_std::Ok{.res = "10:10:10.000000010"}}: +1
-TTest{.s = "time_parse(\"10:10\", \"%T\")", .t = ddlog_std::Err{.err = "premature end of input"}}: +1
-TTest{.s = "time_parse(\"10:10:10\", \"%T\")", .t = ddlog_std::Ok{.res = "10:10:10.000000000"}}: +1
-TTest{.s = "time_parse(\"10:10:10.102030405\", \"%T.%f\")", .t = ddlog_std::Ok{.res = "10:10:10.102030405"}}: +1
-TTest{.s = "time_parse(time_format(10:11:12.103104105, %H::%M::%S).unwrap_or_default(), %H::%M::%S)", .t = ddlog_std::Ok{.res = "10:11:12.000000000"}}: +1
-TTest{.s = "try_from_hms(100, 0, 0).unwrap_or_default()", .t = ddlog_std::Ok{.res = "00:00:00.000000000"}}: +1
-TTest{.s = "try_from_hms(8'd0, 8'd60, 8'd0)", .t = ddlog_std::Err{.err = "illegal time value"}}: +1
-TTest{.s = "try_from_hms(8'd10, 8'd10, 8'd10)", .t = ddlog_std::Ok{.res = "10:10:10.000000000"}}: +1
-TTest{.s = "try_from_hms(8'd23, 8'd0, 8'd0)", .t = ddlog_std::Ok{.res = "23:00:00.000000000"}}: +1
-TTest{.s = "try_from_hms(8'd24, 8'd0, 8'd0)", .t = ddlog_std::Err{.err = "illegal time value"}}: +1
-TTest{.s = "try_from_hms_micro(8'd10, 8'd10, 8'd10, 32'd10)", .t = ddlog_std::Ok{.res = "10:10:10.000010000"}}: +1
-TTest{.s = "try_from_hms_milli(8'd10, 8'd10, 8'd10, 16'd10)", .t = ddlog_std::Ok{.res = "10:10:10.010000000"}}: +1
-TTest{.s = "try_from_hms_nano(8'd10, 8'd10, 8'd10, 32'd10)", .t = ddlog_std::Ok{.res = "10:10:10.000000010"}}: +1
-TTest{.s = "10:11:12.000000000", .t = ddlog_std::Ok{.res = "10:11:12.000000000"}}
-TTest{.s = "10:11:12.103104105", .t = ddlog_std::Ok{.res = "10:11:12.103104105"}}
-TTest{.s = "Error in format string '%incorrectformat'", .t = ddlog_std::Ok{.res = "10:11:12.103104105"}}
-TTest{.s = "Ok(midnight())", .t = ddlog_std::Ok{.res = "00:00:00.000000000"}}
-TTest{.s = "SomeTime: 10:11:12.103104105", .t = ddlog_std::Ok{.res = "10:11:12.103104105"}}
-TTest{.s = "string2time(to_string(result_unwrap_or_default(try_from_hms(8'd10, 8'd10, 8'd10))))", .t = ddlog_std::Ok{.res = "10:10:10.000000000"}}
-TTest{.s = "string2time(to_string(result_unwrap_or_default(try_from_hms_micro(8'd10, 8'd10, 8'd10, 32'd10))))", .t = ddlog_std::Ok{.res = "10:10:10.000010000"}}
-TTest{.s = "string2time(to_string(result_unwrap_or_default(try_from_hms_milli(8'd10, 8'd10, 8'd10, 16'd10))))", .t = ddlog_std::Ok{.res = "10:10:10.010000000"}}
-TTest{.s = "string2time(to_string(result_unwrap_or_default(try_from_hms_nano(8'd10, 8'd10, 8'd10, 32'd10))))", .t = ddlog_std::Ok{.res = "10:10:10.000000010"}}
-TTest{.s = "time_parse(\"10:10\", \"%T\")", .t = ddlog_std::Err{.err = "premature end of input"}}
-TTest{.s = "time_parse(\"10:10:10\", \"%T\")", .t = ddlog_std::Ok{.res = "10:10:10.000000000"}}
-TTest{.s = "time_parse(\"10:10:10.102030405\", \"%T.%f\")", .t = ddlog_std::Ok{.res = "10:10:10.102030405"}}
-TTest{.s = "time_parse(time_format(10:11:12.103104105, %H::%M::%S).unwrap_or_default(), %H::%M::%S)", .t = ddlog_std::Ok{.res = "10:11:12.000000000"}}
-TTest{.s = "try_from_hms(100, 0, 0).unwrap_or_default()", .t = ddlog_std::Ok{.res = "00:00:00.000000000"}}
-TTest{.s = "try_from_hms(8'd0, 8'd60, 8'd0)", .t = ddlog_std::Err{.err = "illegal time value"}}
-TTest{.s = "try_from_hms(8'd10, 8'd10, 8'd10)", .t = ddlog_std::Ok{.res = "10:10:10.000000000"}}
-TTest{.s = "try_from_hms(8'd23, 8'd0, 8'd0)", .t = ddlog_std::Ok{.res = "23:00:00.000000000"}}
-TTest{.s = "try_from_hms(8'd24, 8'd0, 8'd0)", .t = ddlog_std::Err{.err = "illegal time value"}}
-TTest{.s = "try_from_hms_micro(8'd10, 8'd10, 8'd10, 32'd10)", .t = ddlog_std::Ok{.res = "10:10:10.000010000"}}
-TTest{.s = "try_from_hms_milli(8'd10, 8'd10, 8'd10, 16'd10)", .t = ddlog_std::Ok{.res = "10:10:10.010000000"}}
-TTest{.s = "try_from_hms_nano(8'd10, 8'd10, 8'd10, 32'd10)", .t = ddlog_std::Ok{.res = "10:10:10.000000010"}}
-Extract{.s = "day(2020-04-14)", .v = 14}
-Extract{.s = "hour(10:11:12.103104105)", .v = 10}
-Extract{.s = "microsecond(10:11:12.103104105)", .v = 103104}
-Extract{.s = "millisecond(10:11:12.103104105)", .v = 103}
-Extract{.s = "minute(10:11:12.103104105)", .v = 11}
-Extract{.s = "month(2020-04-14)", .v = 4}
-Extract{.s = "nanosecond(10:11:12.103104105)", .v = 103104105}
-Extract{.s = "ordinal(2020-04-14)", .v = 105}
-Extract{.s = "second(10:11:12.103104105)", .v = 12}
-Extract{.s = "week(2020-04-14)", .v = 16}
-Extract{.s = "year(2020-04-14)", .v = 2020}
-DTest{.s = "2010-10-15", .t = ddlog_std::Ok{.res = "2010-10-15"}}
-DTest{.s = "2020-04-14", .t = ddlog_std::Ok{.res = "2020-04-14"}}
-DTest{.s = "Error in format string '%incorrectformat'", .t = ddlog_std::Ok{.res = "2020-04-14"}}
-DTest{.s = "Ok{from_julian_day(2000000)}", .t = ddlog_std::Ok{.res = "0763-09-18"}}
-DTest{.s = "Ok{next_day(2020-04-14)}", .t = ddlog_std::Ok{.res = "2020-04-15"}}
-DTest{.s = "Ok{previous_day(2020-04-14)}", .t = ddlog_std::Ok{.res = "2020-04-13"}}
-DTest{.s = "date_parse(\"2020/04/14\", \"%Y/%m/%d\")", .t = ddlog_std::Ok{.res = "2020-04-14"}}
-DTest{.s = "date_parse(date_format(2020-04-14, %Y-%m-%dT).result_or_error(), %Y-%m-%dT)", .t = ddlog_std::Ok{.res = "2020-04-14"}}
-DTest{.s = "string2date(to_string(someDate()))", .t = ddlog_std::Ok{.res = "2020-04-14"}}
-DTest{.s = "try_from_iso_ywd(32'sd2020, 8'd4, Monday)", .t = ddlog_std::Ok{.res = "2020-01-20"}}
-DTest{.s = "try_from_yd(0, 0, 0).unwrap_or_default()", .t = ddlog_std::Ok{.res = "0000-01-01"}}
-DTest{.s = "try_from_ymd(32'sd2020, 8'd0, 8'd14)", .t = ddlog_std::Err{.err = "Invalid date"}}
-DTest{.s = "try_from_ymd(32'sd2020, 8'd04, 8'd14)", .t = ddlog_std::Ok{.res = "2020-04-14"}}
-DTest{.s = "try_from_ymd(32'sd2020, 8'd13, 8'd14)", .t = ddlog_std::Err{.err = "Invalid date"}}
-DTest{.s = "try_from_yo(32'sd2020, 16'd100)", .t = ddlog_std::Ok{.res = "2020-04-09"}}
-DTest{.s = "try_from_yo(32'sd2020, 16'd367)", .t = ddlog_std::Err{.err = "Invalid date"}}
-DTTest{.s = "\"\".string2datetime().unwrap_or_default()", .t = ddlog_std::Ok{.res = time::DateTime{.date = "0000-01-01", .time = "00:00:00.000000000"}}}
-DTTest{.s = "2010-10-15T10:11:12", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2010-10-15", .time = "10:11:12.000000000"}}}
-DTTest{.s = "2020-04-14T10:11:12", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.103104105"}}}
-DTTest{.s = "Error in format string '%incorrectformat'", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.103104105"}}}
-DTTest{.s = "Extract date 2020-04-14T10:11:12", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.103104105"}}}
-DTTest{.s = "Extract shifted 2020-04-14T10:11:12", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.103104105"}}}
-DTTest{.s = "datetime_from_unix_timestamp(10000000)", .t = ddlog_std::Ok{.res = time::DateTime{.date = "1970-04-26", .time = "17:46:40.000000000"}}}
-DTTest{.s = "datetime_parse(\"2020-10-10T10:20:30\", \"%Y-%m-%dT%H:%M:%S\")", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-10-10", .time = "10:20:30.000000000"}}}
-DTTest{.s = "datetime_parse(\"2020/10/10T10:20:30\", \"%Y-%m-%dT%H:%M:%S\")", .t = ddlog_std::Err{.err = "input contains invalid characters"}}
-DTTest{.s = "datetime_parse(\"Wed Mar 05 07:45:30 MST 2025\", \"%a %b %d %H:%M:%S %Z %Y\")", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2025-03-05", .time = "07:45:30.000000000"}}}
-DTTest{.s = "datetime_parse(datetime_format(2020-04-14T10:11:12, %Y-%m-%dT%H::%M).result_or_error(), %Y-%m-%dT%H::%M)", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:00.000000000"}}}
-DTTest{.s = "get_datetime(tz_datetime_parse_from_rfc2822(\"Tue, 1 Jul 2003 10:52:37 GMT\"))", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2003-07-01", .time = "10:52:37.000000000"}}}
-DTTest{.s = "string2datetime(\"2020-10-10T10:20:30\")", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-10-10", .time = "10:20:30.000000000"}}}
-DTTest{.s = "string2datetime(to_string(2020-04-14T10:11:12))", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.000000000"}}}
+time_test::TTest{.s = "10:11:12.000000000", .t = ddlog_std::Ok{.res = "10:11:12.000000000"}}
+time_test::TTest{.s = "10:11:12.103104105", .t = ddlog_std::Ok{.res = "10:11:12.103104105"}}
+time_test::TTest{.s = "Error in format string '%incorrectformat'", .t = ddlog_std::Ok{.res = "10:11:12.103104105"}}
+time_test::TTest{.s = "Ok(midnight())", .t = ddlog_std::Ok{.res = "00:00:00.000000000"}}
+time_test::TTest{.s = "SomeTime: 10:11:12.103104105", .t = ddlog_std::Ok{.res = "10:11:12.103104105"}}
+time_test::TTest{.s = "string2time(to_string(result_unwrap_or_default(try_from_hms(8'd10, 8'd10, 8'd10))))", .t = ddlog_std::Ok{.res = "10:10:10.000000000"}}
+time_test::TTest{.s = "string2time(to_string(result_unwrap_or_default(try_from_hms_micro(8'd10, 8'd10, 8'd10, 32'd10))))", .t = ddlog_std::Ok{.res = "10:10:10.000010000"}}
+time_test::TTest{.s = "string2time(to_string(result_unwrap_or_default(try_from_hms_milli(8'd10, 8'd10, 8'd10, 16'd10))))", .t = ddlog_std::Ok{.res = "10:10:10.010000000"}}
+time_test::TTest{.s = "string2time(to_string(result_unwrap_or_default(try_from_hms_nano(8'd10, 8'd10, 8'd10, 32'd10))))", .t = ddlog_std::Ok{.res = "10:10:10.000000010"}}
+time_test::TTest{.s = "time_parse(\"10:10\", \"%T\")", .t = ddlog_std::Err{.err = "premature end of input"}}
+time_test::TTest{.s = "time_parse(\"10:10:10\", \"%T\")", .t = ddlog_std::Ok{.res = "10:10:10.000000000"}}
+time_test::TTest{.s = "time_parse(\"10:10:10.102030405\", \"%T.%f\")", .t = ddlog_std::Ok{.res = "10:10:10.102030405"}}
+time_test::TTest{.s = "time_parse(time_format(10:11:12.103104105, %H::%M::%S).unwrap_or_default(), %H::%M::%S)", .t = ddlog_std::Ok{.res = "10:11:12.000000000"}}
+time_test::TTest{.s = "try_from_hms(100, 0, 0).unwrap_or_default()", .t = ddlog_std::Ok{.res = "00:00:00.000000000"}}
+time_test::TTest{.s = "try_from_hms(8'd0, 8'd60, 8'd0)", .t = ddlog_std::Err{.err = "illegal time value"}}
+time_test::TTest{.s = "try_from_hms(8'd10, 8'd10, 8'd10)", .t = ddlog_std::Ok{.res = "10:10:10.000000000"}}
+time_test::TTest{.s = "try_from_hms(8'd23, 8'd0, 8'd0)", .t = ddlog_std::Ok{.res = "23:00:00.000000000"}}
+time_test::TTest{.s = "try_from_hms(8'd24, 8'd0, 8'd0)", .t = ddlog_std::Err{.err = "illegal time value"}}
+time_test::TTest{.s = "try_from_hms_micro(8'd10, 8'd10, 8'd10, 32'd10)", .t = ddlog_std::Ok{.res = "10:10:10.000010000"}}
+time_test::TTest{.s = "try_from_hms_milli(8'd10, 8'd10, 8'd10, 16'd10)", .t = ddlog_std::Ok{.res = "10:10:10.010000000"}}
+time_test::TTest{.s = "try_from_hms_nano(8'd10, 8'd10, 8'd10, 32'd10)", .t = ddlog_std::Ok{.res = "10:10:10.000000010"}}
+time_test::Extract{.s = "day(2020-04-14)", .v = 14}
+time_test::Extract{.s = "hour(10:11:12.103104105)", .v = 10}
+time_test::Extract{.s = "microsecond(10:11:12.103104105)", .v = 103104}
+time_test::Extract{.s = "millisecond(10:11:12.103104105)", .v = 103}
+time_test::Extract{.s = "minute(10:11:12.103104105)", .v = 11}
+time_test::Extract{.s = "month(2020-04-14)", .v = 4}
+time_test::Extract{.s = "nanosecond(10:11:12.103104105)", .v = 103104105}
+time_test::Extract{.s = "ordinal(2020-04-14)", .v = 105}
+time_test::Extract{.s = "second(10:11:12.103104105)", .v = 12}
+time_test::Extract{.s = "week(2020-04-14)", .v = 16}
+time_test::Extract{.s = "year(2020-04-14)", .v = 2020}
+time_test::DTest{.s = "2010-10-15", .t = ddlog_std::Ok{.res = "2010-10-15"}}
+time_test::DTest{.s = "2020-04-14", .t = ddlog_std::Ok{.res = "2020-04-14"}}
+time_test::DTest{.s = "Error in format string '%incorrectformat'", .t = ddlog_std::Ok{.res = "2020-04-14"}}
+time_test::DTest{.s = "Ok{from_julian_day(2000000)}", .t = ddlog_std::Ok{.res = "0763-09-18"}}
+time_test::DTest{.s = "Ok{next_day(2020-04-14)}", .t = ddlog_std::Ok{.res = "2020-04-15"}}
+time_test::DTest{.s = "Ok{previous_day(2020-04-14)}", .t = ddlog_std::Ok{.res = "2020-04-13"}}
+time_test::DTest{.s = "date_parse(\"2020/04/14\", \"%Y/%m/%d\")", .t = ddlog_std::Ok{.res = "2020-04-14"}}
+time_test::DTest{.s = "date_parse(date_format(2020-04-14, %Y-%m-%dT).result_or_error(), %Y-%m-%dT)", .t = ddlog_std::Ok{.res = "2020-04-14"}}
+time_test::DTest{.s = "string2date(to_string(someDate()))", .t = ddlog_std::Ok{.res = "2020-04-14"}}
+time_test::DTest{.s = "try_from_iso_ywd(32'sd2020, 8'd4, Monday)", .t = ddlog_std::Ok{.res = "2020-01-20"}}
+time_test::DTest{.s = "try_from_yd(0, 0, 0).unwrap_or_default()", .t = ddlog_std::Ok{.res = "0000-01-01"}}
+time_test::DTest{.s = "try_from_ymd(32'sd2020, 8'd0, 8'd14)", .t = ddlog_std::Err{.err = "Invalid date"}}
+time_test::DTest{.s = "try_from_ymd(32'sd2020, 8'd04, 8'd14)", .t = ddlog_std::Ok{.res = "2020-04-14"}}
+time_test::DTest{.s = "try_from_ymd(32'sd2020, 8'd13, 8'd14)", .t = ddlog_std::Err{.err = "Invalid date"}}
+time_test::DTest{.s = "try_from_yo(32'sd2020, 16'd100)", .t = ddlog_std::Ok{.res = "2020-04-09"}}
+time_test::DTest{.s = "try_from_yo(32'sd2020, 16'd367)", .t = ddlog_std::Err{.err = "Invalid date"}}
+time_test::DTTest{.s = "\"\".string2datetime().unwrap_or_default()", .t = ddlog_std::Ok{.res = time::DateTime{.date = "0000-01-01", .time = "00:00:00.000000000"}}}
+time_test::DTTest{.s = "2010-10-15T10:11:12", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2010-10-15", .time = "10:11:12.000000000"}}}
+time_test::DTTest{.s = "2020-04-14T10:11:12", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.103104105"}}}
+time_test::DTTest{.s = "Error in format string '%incorrectformat'", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.103104105"}}}
+time_test::DTTest{.s = "Extract date 2020-04-14T10:11:12", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.103104105"}}}
+time_test::DTTest{.s = "Extract shifted 2020-04-14T10:11:12", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.103104105"}}}
+time_test::DTTest{.s = "datetime_from_unix_timestamp(10000000)", .t = ddlog_std::Ok{.res = time::DateTime{.date = "1970-04-26", .time = "17:46:40.000000000"}}}
+time_test::DTTest{.s = "datetime_parse(\"2020-10-10T10:20:30\", \"%Y-%m-%dT%H:%M:%S\")", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-10-10", .time = "10:20:30.000000000"}}}
+time_test::DTTest{.s = "datetime_parse(\"2020/10/10T10:20:30\", \"%Y-%m-%dT%H:%M:%S\")", .t = ddlog_std::Err{.err = "input contains invalid characters"}}
+time_test::DTTest{.s = "datetime_parse(\"Wed Mar 05 07:45:30 MST 2025\", \"%a %b %d %H:%M:%S %Z %Y\")", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2025-03-05", .time = "07:45:30.000000000"}}}
+time_test::DTTest{.s = "datetime_parse(datetime_format(2020-04-14T10:11:12, %Y-%m-%dT%H::%M).result_or_error(), %Y-%m-%dT%H::%M)", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:00.000000000"}}}
+time_test::DTTest{.s = "get_datetime(tz_datetime_parse_from_rfc2822(\"Tue, 1 Jul 2003 10:52:37 GMT\"))", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2003-07-01", .time = "10:52:37.000000000"}}}
+time_test::DTTest{.s = "string2datetime(\"2020-10-10T10:20:30\")", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-10-10", .time = "10:20:30.000000000"}}}
+time_test::DTTest{.s = "string2datetime(to_string(2020-04-14T10:11:12))", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.000000000"}}}


### PR DESCRIPTION
We are starting to build an infrastructure to help implement more of the
D3log runtime in DDlog.  However, the features added here can be useful
in other contexts.

This commit exposes the `DDValue` type, a type-erased wrapper around
any DDlog value, to DDlog programs.  This enables DDlog programs to
manipulate collections of heterogeneous values in a type-agnostic manner.
For instance, in D3log we want to put all records of all output
relations in a single relation, and route them without knowing their
exact types.

We cannot expose `DDValue` directly, since for performance reasons some
of its operations, namely comparisons methods from `Eq` and `Ord` traits,
are unsafe: comparing DDValue's backed by different types leads to undefined
behavior.  We therefore introduce `DDAny`, a safe wrapper around `DDValue`
and expose it in the DDlog standard library (`ddlog_std`), along with
methods to convert DDlog types to and from `DDAny`.

Serialization/Deserialization
-----------------------------

The `Serialize` implementation of `Any` simply invokes the `Serialize`
implementation of its underlying type.

However, since we cannot deserialize a value without knowing its type,
`Any` does not implement `trait Deserialize`.  More precisely, it does
have a `Deserialize` implementation, as mandated by DDlog for all types;
however this implementation always fails.

We do provide a way to deserialize into `Any` provided the caller knows
the relation id the type being deserialized belongs to.  To this end, we
introduce a new trait `AnyDeserialize` that maps an input relation id to
a deserialization function for records in that relation.  We also
provide a `DeserializeSeed` implementation that wraps around this
function and can be used to implement `Deserialize` for complex types
containing `Any` as a field.  The `rust_api_test`

Caveats
-------

`Any` relies on Rust's TypeId mechanism to order instances
with different underlying types.  As a result, the ordering may
differ across Rust compiler releases.