### PR TITLE
Reflect distributed outputs back to DDlog.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,11 @@ jobs:
       #with:
       #  path: test/datalog_tests/tutorial_ddlog
       #  key: ${{ runner.os }}-tutorial
-      - name: Run tutorial test
+      - if: ${{ runner.os == 'Windows' }}
+        name: Run path test
+        run: stack --no-terminal test --ta '-p path'
+      - if: ${{ runner.os != 'Windows' }}
+        name: Run tutorial test
         run: stack --no-terminal test --ta '-p tutorial'
       - name: Install ddlog executables
         run: stack --no-terminal install

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -74,6 +74,14 @@ test-path:
         - ./test.sh negative
         - ./test.sh path
 
+test-lb:
+    extends: .private_runner
+    stage: test
+    tags:
+        - ddlog-ci-1
+    script:
+        - ./test.sh lb
+
 # Run individual stack-based tests, when possible combining them with Java tests
 # that depend on the same DDlog program.
 test-tutorial:

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -72,6 +72,7 @@ data TOption = Help
              | RustFlatBuffers
              | NestedTS32
              | D3log
+             | D3logDev
 
 options :: [OptDescr TOption]
 options = [ Option ['h'] ["help"]             (NoArg Help)                      "Display help message."
@@ -99,6 +100,7 @@ options = [ Option ['h'] ["help"]             (NoArg Help)                      
           , Option []    ["rust-flatbuffers"] (NoArg RustFlatBuffers)           "Build flatbuffers bindings for Rust"
           , Option []    ["nested-ts-32"]     (NoArg NestedTS32)                "Use 32-bit instead of 16-bit nested timestamps. Supports recursive programs that may perform >65,536 iterations. Slightly increases the memory footprint of the program."
           , Option []    ["d3log"]            (NoArg D3log)                     "Compile the input program to execute in the distributed DDlog (D3log) environment."
+          , Option []    ["d3log-dev"]        (NoArg D3logDev)                  "Compile the input program to execute in the D3log environment with experimental reflective features enabled."
           ]
 
 addOption :: Config -> TOption -> IO Config
@@ -131,6 +133,7 @@ addOption config RunRustfmt       = return config { confRunRustfmt = True }
 addOption config RustFlatBuffers  = return config { confRustFlatBuffers = True }
 addOption config NestedTS32       = return config { confNestedTS32 = True }
 addOption config D3log            = return config { confD3log = True }
+addOption config D3logDev         = return config { confD3log = True, confD3logDev = True }
 
 validateConfig :: Config -> IO ()
 validateConfig Config {..} = do

--- a/lib/d3log/reflect.dl
+++ b/lib/d3log/reflect.dl
@@ -1,0 +1,31 @@
+/* Reflect the contents of all distributed relations and streams
+ * back to DDlog, so that the D3log runtime can manipulate it
+ * (buffer, route, forward, etc).
+ *
+ * Relations declared here are populated by compiler-generated rules
+ * when the compiler is run with `--d3log-dev` flag. */
+
+import ddlog_std
+import internment
+
+// Rows from distributed relations.
+//
+// `relname`     - relation name
+// `fact`        - row in the relation
+// `destination` - destination specified via @-annotation, if any
+relation DistributedRelFacts(
+    relname: istring,
+    fact: Any,
+    destination: Option<D3logLocationId>
+)
+
+// Rows from distributed streams.
+//
+// `relname`     - stream name
+// `fact`        - record in the stream
+// `destination` - destination specified via @-annotation, if any
+stream DistributedStreamFacts(
+    relname: istring,
+    fact: Any,
+    destination: Option<D3logLocationId>
+)

--- a/lib/ddlog_log.rs
+++ b/lib/ddlog_log.rs
@@ -57,7 +57,7 @@ static LOG_CONFIG: Lazy<sync::RwLock<LogConfig>> =
 #[allow(clippy::ptr_arg, clippy::trivially_copy_pass_by_ref)]
 pub fn log(module: &i32, level: &i32, msg: &String) {
     let cfg = LOG_CONFIG.read().unwrap();
-    if let Some((cb, current_level)) = cfg.mod_callbacks.get(&module) {
+    if let Some((cb, current_level)) = cfg.mod_callbacks.get(module) {
         if *level <= *current_level {
             cb(*level, msg.as_str());
         }

--- a/lib/ddlog_std.dl
+++ b/lib/ddlog_std.dl
@@ -82,6 +82,28 @@ function to_string(ts: DDNestedTS): string {
 }
 
 /*
+ * Type-erased representation of any DDlog value.  Allows storing
+ * instances of different types, unknown at compile time, in the same
+ * relation.
+ *
+ * Any value can be converted to `Any`.  Conversely A `Any` can be
+ * converted back to the strongly typed representation.
+ *
+ * Note: `Any` relies on Rust's TypeId mechanism to order instances
+ * with different underlying types.  As a result, the ordering may
+ * differ across Rust compiler releases.
+ */
+extern type Any
+
+/* Convert arbitrary DDlog type to Any. */
+extern function to_any(#[by_val] x: 'T): Any
+
+/* Convert `Any` back to an instance of type `'T`.
+ * Returns `None` if `value` stores an instance of a
+ * different type. */
+extern function from_any(#[by_val] value: Any): Option<'T>
+
+/*
  * Ref
  */
 #[size=8]

--- a/lib/ddlog_std.rs
+++ b/lib/ddlog_std.rs
@@ -22,6 +22,7 @@ SOFTWARE.
 */
 
 use abomonation::Abomonation;
+pub use differential_datalog::ddval::{Any, DDValue};
 /// Rust implementation of DDlog standard library functions and types.
 use differential_datalog::record::{arg_extract, Record};
 use differential_datalog::triomphe::Arc;
@@ -53,6 +54,16 @@ const XX_SEED2: u64 = 0x20b09801dce5ff84;
 
 pub fn default<T: Default>() -> T {
     T::default()
+}
+
+// Any
+
+pub fn to_any<T: DDValConvert>(x: T) -> Any {
+    Any::new(x.into_ddvalue())
+}
+
+pub fn from_any<T: 'static + DDValConvert>(value: Any) -> Option<T> {
+    <Option<T>>::from(T::try_from_ddvalue(DDValue::from(value)))
 }
 
 // Result

--- a/rust/template/Cargo.toml
+++ b/rust/template/Cargo.toml
@@ -33,6 +33,7 @@ erased-serde = "0.3"
 crossbeam-channel = "0.5.0"
 enum-primitive-derive = "0.2.1"
 triomphe = "0.1.3"
+phf = { version = "0.10.0", features = ["macros"] }
 
 # FlatBuffers dependency enabled by the `flatbuf` feature.
 # flatbuffers crate version must be in sync with the flatc compiler and Java

--- a/rust/template/cmd_parser/lib.rs
+++ b/rust/template/cmd_parser/lib.rs
@@ -58,11 +58,11 @@ where
                     }
                     Err(ReadlineError::Eof) => {
                         println!("CTRL-D");
-                        save_history(&rl);
+                        save_history(rl);
                         return Ok(());
                     }
                     Err(err) => {
-                        save_history(&rl);
+                        save_history(rl);
                         return Err(format!("Readline failure: {}", err));
                     }
                 }

--- a/rust/template/differential_datalog/src/api/c_api.rs
+++ b/rust/template/differential_datalog/src/api/c_api.rs
@@ -77,7 +77,7 @@ impl ddlog_log_destination {
         Ok(match self.mode {
             ddlog_log_mode::ddlog_log_disabled => None,
             ddlog_log_mode::ddlog_log_to_socket => Some(LoggingDestination::Socket {
-                sockaddr: SocketAddr::from_str(&address.as_ref().ok_or_else(|| {
+                sockaddr: SocketAddr::from_str(address.as_ref().ok_or_else(|| {
                     "ddlog_log_to_socket requires socket address in address_str".to_string()
                 })?)
                 .map_err(|e| {

--- a/rust/template/differential_datalog/src/ddlog.rs
+++ b/rust/template/differential_datalog/src/ddlog.rs
@@ -13,7 +13,7 @@ use std::ops::Deref;
 use std::sync::Arc as StdArc;
 use triomphe::Arc;
 
-use crate::ddval::DDValue;
+use crate::ddval::{Any, DDValue};
 use crate::program::RelId;
 use crate::program::Update;
 use crate::program::{ArrId, IdxId};
@@ -411,4 +411,13 @@ pub trait DDlog: DDlogDynamic {
 
     /// Dump all values in an index.
     fn dump_index(&self, index: IdxId) -> Result<BTreeSet<DDValue>, String>;
+}
+
+pub type AnyDeserializeFunc =
+    fn(&mut dyn erased_serde::Deserializer) -> Result<Any, erased_serde::Error>;
+
+/// Given an input relation id, returns a function that deserializes the record
+/// type of this relation.
+pub trait AnyDeserialize {
+    fn get_deserialize(&self, relid: RelId) -> Option<AnyDeserializeFunc>;
 }

--- a/rust/template/differential_datalog/src/ddval/any.rs
+++ b/rust/template/differential_datalog/src/ddval/any.rs
@@ -1,0 +1,165 @@
+//! `Any` is a wrapper around `DDValue` that makes it safe to use
+//! outside of the DDlog runtime by providing safe implementations
+//! of `Ord` ans `Eq` traits, which work even if their arguments
+//! wrap different types.
+
+use crate::{
+    ddval::DDValue,
+    program::RelId,
+    record::{FromRecord, IntoRecord, Mutator, Record},
+    AnyDeserialize, AnyDeserializeFunc,
+};
+
+use std::{
+    cmp::Ordering,
+    fmt,
+    fmt::{Debug, Formatter},
+    hash::{Hash, Hasher},
+    ops::{Deref, DerefMut},
+    option::Option,
+    result::Result,
+};
+
+use serde::{
+    de::{DeserializeSeed, Error},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
+
+#[derive(Default, Clone)]
+pub struct Any(DDValue);
+
+impl Hash for Any {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.deref().hash(state)
+    }
+}
+
+impl Any {
+    pub fn new(val: DDValue) -> Self {
+        Any(val)
+    }
+}
+
+impl From<DDValue> for Any {
+    fn from(val: DDValue) -> Self {
+        Any::new(val)
+    }
+}
+
+impl From<Any> for DDValue {
+    fn from(any: Any) -> Self {
+        any.0
+    }
+}
+
+impl Deref for Any {
+    type Target = DDValue;
+
+    fn deref(&self) -> &DDValue {
+        &self.0
+    }
+}
+
+impl DerefMut for Any {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl Debug for Any {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        Debug::fmt(self.deref(), f)
+    }
+}
+
+impl IntoRecord for Any {
+    fn into_record(self) -> Record {
+        self.0.into_record()
+    }
+}
+
+impl FromRecord for Any {
+    fn from_record(val: &Record) -> Result<Self, String> {
+        DDValue::from_record(val).map(Self::new)
+    }
+}
+
+impl Mutator<Any> for Record {
+    fn mutate(&self, v: &mut Any) -> Result<(), String> {
+        self.mutate(v.deref_mut())
+    }
+}
+
+impl Eq for Any {}
+
+impl PartialEq for Any {
+    fn eq(&self, other: &Self) -> bool {
+        self.safe_eq(other)
+    }
+}
+
+impl PartialOrd for Any {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.safe_cmp(&*other))
+    }
+}
+
+impl Ord for Any {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.safe_cmp(&*other)
+    }
+}
+
+impl Serialize for Any {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.deref().serialize(serializer)
+    }
+}
+
+// This implementation always fails, as we cannot deserialize `Any`
+// without knowing the actual type.
+impl<'de> Deserialize<'de> for Any {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        DDValue::deserialize(deserializer).map(Self::new)
+    }
+}
+
+/// A `DeserializeSeed` implementation for `Any` that wraps an instance
+/// of `AnyDeserializeFunc`.
+/// This can be used to construct `Deserialize` implementations for more
+/// complex types that contain fields of type `Any`.
+pub struct AnyDeserializeSeed(AnyDeserializeFunc);
+
+impl AnyDeserializeSeed {
+    pub fn new(func: AnyDeserializeFunc) -> Self {
+        AnyDeserializeSeed(func)
+    }
+
+    pub fn from_relid<D>(ddlog: &D, relid: RelId) -> Option<Self>
+    where
+        D: AnyDeserialize + ?Sized,
+    {
+        ddlog.get_deserialize(relid).map(AnyDeserializeSeed::new)
+    }
+}
+
+impl<'de> DeserializeSeed<'de> for AnyDeserializeSeed {
+    type Value = Any;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Any, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        (self.0)(&mut <dyn erased_serde::Deserializer>::erase(deserializer))
+            .map_err(D::Error::custom)
+    }
+}

--- a/rust/template/differential_datalog/src/ddval/ddval_convert.rs
+++ b/rust/template/differential_datalog/src/ddval/ddval_convert.rs
@@ -308,3 +308,9 @@ where
         }
     };
 }
+
+impl Default for DDValue {
+    fn default() -> Self {
+        ().into_ddvalue()
+    }
+}

--- a/rust/template/differential_datalog/src/ddval/mod.rs
+++ b/rust/template/differential_datalog/src/ddval/mod.rs
@@ -53,8 +53,10 @@
 
 #[macro_use]
 mod ddval_convert;
+mod any;
 mod ddvalue;
 
+pub use any::{Any, AnyDeserializeSeed};
 pub use ddval_convert::DDValConvert;
 pub use ddvalue::DDValue;
 

--- a/rust/template/differential_datalog/src/lib.rs
+++ b/rust/template/differential_datalog/src/lib.rs
@@ -28,8 +28,8 @@ mod test_record;
 
 pub use callback::Callback;
 pub use ddlog::{
-    D3log, D3logLocalizer, D3logLocationId, DDlog, DDlogDump, DDlogDynamic, DDlogInventory,
-    DDlogProfiling,
+    AnyDeserialize, AnyDeserializeFunc, D3log, D3logLocalizer, D3logLocationId, DDlog, DDlogDump,
+    DDlogDynamic, DDlogInventory, DDlogProfiling,
 };
 pub use replay::CommandRecorder;
 pub use triomphe;

--- a/rust/template/differential_datalog/src/profile.rs
+++ b/rust/template/differential_datalog/src/profile.rs
@@ -179,7 +179,7 @@ impl Profile {
                             let context = context.as_ref().expect(
                                 "Operates events should always have valid context attached",
                             );
-                            self.handle_operates(&o, context);
+                            self.handle_operates(o, context);
                         }
                         event => {
                             if *profile_timely {
@@ -189,7 +189,7 @@ impl Profile {
                                     stats.handle_event(
                                         *duration,
                                         *id,
-                                        &event,
+                                        event,
                                         &self.op_address,
                                         &self.short_names,
                                     );

--- a/rust/template/differential_datalog/src/program/mod.rs
+++ b/rust/template/differential_datalog/src/program/mod.rs
@@ -436,14 +436,14 @@ pub enum XFormArrangement {
 impl XFormArrangement {
     pub fn description(&self) -> &str {
         match self {
-            XFormArrangement::FlatMap { description, .. } => &description,
-            XFormArrangement::FilterMap { description, .. } => &description,
-            XFormArrangement::Aggregate { description, .. } => &description,
-            XFormArrangement::Join { description, .. } => &description,
-            XFormArrangement::Semijoin { description, .. } => &description,
-            XFormArrangement::Antijoin { description, .. } => &description,
-            XFormArrangement::StreamJoin { description, .. } => &description,
-            XFormArrangement::StreamSemijoin { description, .. } => &description,
+            XFormArrangement::FlatMap { description, .. } => description,
+            XFormArrangement::FilterMap { description, .. } => description,
+            XFormArrangement::Aggregate { description, .. } => description,
+            XFormArrangement::Join { description, .. } => description,
+            XFormArrangement::Semijoin { description, .. } => description,
+            XFormArrangement::Antijoin { description, .. } => description,
+            XFormArrangement::StreamJoin { description, .. } => description,
+            XFormArrangement::StreamSemijoin { description, .. } => description,
         }
     }
 
@@ -618,16 +618,16 @@ pub enum XFormCollection {
 impl XFormCollection {
     pub fn description(&self) -> &str {
         match self {
-            XFormCollection::Arrange { description, .. } => &description,
-            XFormCollection::Differentiate { description, .. } => &description,
-            XFormCollection::Map { description, .. } => &description,
-            XFormCollection::FlatMap { description, .. } => &description,
-            XFormCollection::Filter { description, .. } => &description,
-            XFormCollection::FilterMap { description, .. } => &description,
-            XFormCollection::Inspect { description, .. } => &description,
-            XFormCollection::StreamJoin { description, .. } => &description,
-            XFormCollection::StreamSemijoin { description, .. } => &description,
-            XFormCollection::StreamXForm { description, .. } => &description,
+            XFormCollection::Arrange { description, .. } => description,
+            XFormCollection::Differentiate { description, .. } => description,
+            XFormCollection::Map { description, .. } => description,
+            XFormCollection::FlatMap { description, .. } => description,
+            XFormCollection::Filter { description, .. } => description,
+            XFormCollection::FilterMap { description, .. } => description,
+            XFormCollection::Inspect { description, .. } => description,
+            XFormCollection::StreamJoin { description, .. } => description,
+            XFormCollection::StreamSemijoin { description, .. } => description,
+            XFormCollection::StreamXForm { description, .. } => description,
         }
     }
 
@@ -1138,7 +1138,7 @@ impl Program {
     fn get_delayed_relation(&self, relid: RelId) -> Option<&DelayedRelation> {
         for drel in &self.delayed_rels {
             if drel.id == relid {
-                return Some(&drel);
+                return Some(drel);
             }
         }
         None
@@ -1283,7 +1283,7 @@ impl Program {
                 afun,
                 ref next,
             } => {
-                let arr = with_prof_context(&description, || col.flat_map(afun).arrange_by_key());
+                let arr = with_prof_context(description, || col.flat_map(afun).arrange_by_key());
                 Self::xform_arrangement(&arr, &*next, arrangements, lookup_collection)
             }
             XFormCollection::Differentiate {
@@ -1295,7 +1295,7 @@ impl Program {
                     <dyn Any>::downcast_ref::<<S::Timestamp as Timestamp>::Summary>(&(1 as TS))
                         .expect("Differentiate operator used in recursive context");
 
-                let diff = with_prof_context(&description, || {
+                let diff = with_prof_context(description, || {
                     col.concat(
                         &col.delay(move |t| one.results_in(t).expect("Integer overflow in Differentiate: maximal number of transactions exceeded")).negate())
                 });
@@ -1307,7 +1307,7 @@ impl Program {
                 mfun,
                 ref next,
             } => {
-                let mapped = with_prof_context(&description, || col.map(mfun));
+                let mapped = with_prof_context(description, || col.map(mfun));
                 Self::xform_collection(mapped, &*next, arrangements, lookup_collection)
             }
             XFormCollection::FlatMap {
@@ -1315,7 +1315,7 @@ impl Program {
                 fmfun,
                 ref next,
             } => {
-                let flattened = with_prof_context(&description, || {
+                let flattened = with_prof_context(description, || {
                     col.flat_map(move |x| fmfun(x).into_iter().flatten())
                 });
                 Self::xform_collection(flattened, &*next, arrangements, lookup_collection)
@@ -1325,7 +1325,7 @@ impl Program {
                 ffun,
                 ref next,
             } => {
-                let filtered = with_prof_context(&description, || col.filter(ffun));
+                let filtered = with_prof_context(description, || col.filter(ffun));
                 Self::xform_collection(filtered, &*next, arrangements, lookup_collection)
             }
             XFormCollection::FilterMap {
@@ -1333,7 +1333,7 @@ impl Program {
                 fmfun,
                 ref next,
             } => {
-                let flattened = with_prof_context(&description, || col.flat_map(fmfun));
+                let flattened = with_prof_context(description, || col.flat_map(fmfun));
                 Self::xform_collection(flattened, &*next, arrangements, lookup_collection)
             }
             XFormCollection::Inspect {
@@ -1341,7 +1341,7 @@ impl Program {
                 ifun,
                 ref next,
             } => {
-                let inspect = with_prof_context(&description, || {
+                let inspect = with_prof_context(description, || {
                     col.inspect(move |(v, ts, w)| ifun(v, ts.to_tuple_ts(), *w))
                 });
                 Self::xform_collection(inspect, &*next, arrangements, lookup_collection)
@@ -1353,7 +1353,7 @@ impl Program {
                 jfun,
                 ref next,
             } => {
-                let join = with_prof_context(&description, || {
+                let join = with_prof_context(description, || {
                     // arrange input collection
                     let collection_with_keys = col.flat_map(afun);
                     let arr = match arrangements.lookup_arr(arrangement) {
@@ -1386,7 +1386,7 @@ impl Program {
                 jfun,
                 ref next,
             } => {
-                let join = with_prof_context(&description, || {
+                let join = with_prof_context(description, || {
                     // arrange input collection
                     let collection_with_keys = col.flat_map(afun);
                     let arr = match arrangements.lookup_arr(arrangement) {
@@ -1499,7 +1499,7 @@ impl Program {
                 afun,
                 ref next,
             } => {
-                let arr = with_prof_context(&description, || col.flat_map(afun).arrange_by_key());
+                let arr = with_prof_context(description, || col.flat_map(afun).arrange_by_key());
                 Self::xform_arrangement(&arr, &*next, arrangements, lookup_collection)
             }
             XFormCollection::Differentiate {
@@ -1511,7 +1511,7 @@ impl Program {
                     <dyn Any>::downcast_ref::<<S::Timestamp as Timestamp>::Summary>(&(1 as TS))
                         .expect("Differentiate operator used in recursive context");
 
-                let diff = with_prof_context(&description, || {
+                let diff = with_prof_context(description, || {
                     col.concat(
                         &col.delay(move |t| one.results_in(t).expect("Integer overflow in Differentiate: maximal number of transactions exceeded")).negate())
                 });
@@ -1523,7 +1523,7 @@ impl Program {
                 mfun,
                 ref next,
             } => {
-                let mapped = with_prof_context(&description, || col.map(mfun));
+                let mapped = with_prof_context(description, || col.map(mfun));
                 Self::streamless_xform_collection(mapped, &*next, arrangements, lookup_collection)
             }
             XFormCollection::FlatMap {
@@ -1531,7 +1531,7 @@ impl Program {
                 fmfun,
                 ref next,
             } => {
-                let flattened = with_prof_context(&description, || {
+                let flattened = with_prof_context(description, || {
                     col.flat_map(move |x| fmfun(x).into_iter().flatten())
                 });
                 Self::streamless_xform_collection(
@@ -1546,7 +1546,7 @@ impl Program {
                 ffun,
                 ref next,
             } => {
-                let filtered = with_prof_context(&description, || col.filter(ffun));
+                let filtered = with_prof_context(description, || col.filter(ffun));
                 Self::streamless_xform_collection(filtered, &*next, arrangements, lookup_collection)
             }
             XFormCollection::FilterMap {
@@ -1554,7 +1554,7 @@ impl Program {
                 fmfun,
                 ref next,
             } => {
-                let flattened = with_prof_context(&description, || col.flat_map(fmfun));
+                let flattened = with_prof_context(description, || col.flat_map(fmfun));
                 Self::streamless_xform_collection(
                     flattened,
                     &*next,
@@ -1567,7 +1567,7 @@ impl Program {
                 ifun,
                 ref next,
             } => {
-                let inspect = with_prof_context(&description, || {
+                let inspect = with_prof_context(description, || {
                     col.inspect(move |(v, ts, w)| ifun(v, ts.to_tuple_ts(), *w))
                 });
                 Self::streamless_xform_collection(inspect, &*next, arrangements, lookup_collection)
@@ -1579,7 +1579,7 @@ impl Program {
                 jfun,
                 ref next,
             } => {
-                let join = with_prof_context(&description, || {
+                let join = with_prof_context(description, || {
                     // arrange input collection
                     let collection_with_keys = col.flat_map(afun);
                     let arr = match arrangements.lookup_arr(arrangement) {
@@ -1612,7 +1612,7 @@ impl Program {
                 jfun,
                 ref next,
             } => {
-                let join = with_prof_context(&description, || {
+                let join = with_prof_context(description, || {
                     // arrange input collection
                     let collection_with_keys = col.flat_map(afun);
                     let arr = match arrangements.lookup_arr(arrangement) {
@@ -1669,7 +1669,7 @@ impl Program {
                 ref description,
                 fmfun,
                 ref next,
-            } => with_prof_context(&description, || {
+            } => with_prof_context(description, || {
                 Self::streamless_xform_collection(
                     arr.flat_map_ref(move |_, v| match fmfun(v.clone()) {
                         Some(iter) => iter,
@@ -1684,7 +1684,7 @@ impl Program {
                 ref description,
                 fmfun,
                 ref next,
-            } => with_prof_context(&description, || {
+            } => with_prof_context(description, || {
                 Self::streamless_xform_collection(
                     arr.flat_map_ref(move |_, v| fmfun(v.clone())),
                     &*next,
@@ -1698,7 +1698,7 @@ impl Program {
                 aggfun,
                 ref next,
             } => {
-                let col = with_prof_context(&description, || {
+                let col = with_prof_context(description, || {
                     ffun.map_or_else(
                         || {
                             arr.reduce(move |key, src, dst| {
@@ -1729,7 +1729,7 @@ impl Program {
                 ref next,
             } => match arrangements.lookup_arr(arrangement) {
                 ArrangementFlavor::Local(DataflowArrangement::Map(arranged)) => {
-                    let col = with_prof_context(&description, || {
+                    let col = with_prof_context(description, || {
                         ffun.map_or_else(
                             || arr.join_core(&arranged, jfun),
                             |f| arr.filter(move |_, v| f(v)).join_core(&arranged, jfun),
@@ -1738,7 +1738,7 @@ impl Program {
                     Self::streamless_xform_collection(col, &*next, arrangements, lookup_collection)
                 }
                 ArrangementFlavor::Foreign(DataflowArrangement::Map(arranged)) => {
-                    let col = with_prof_context(&description, || {
+                    let col = with_prof_context(description, || {
                         ffun.map_or_else(
                             || arr.join_core(&arranged, jfun),
                             |f| arr.filter(move |_, v| f(v)).join_core(&arranged, jfun),
@@ -1757,7 +1757,7 @@ impl Program {
                 ref next,
             } => match arrangements.lookup_arr(arrangement) {
                 ArrangementFlavor::Local(DataflowArrangement::Set(arranged)) => {
-                    let col = with_prof_context(&description, || {
+                    let col = with_prof_context(description, || {
                         ffun.map_or_else(
                             || arr.join_core(&arranged, jfun),
                             |f| arr.filter(move |_, v| f(v)).join_core(&arranged, jfun),
@@ -1766,7 +1766,7 @@ impl Program {
                     Self::streamless_xform_collection(col, &*next, arrangements, lookup_collection)
                 }
                 ArrangementFlavor::Foreign(DataflowArrangement::Set(arranged)) => {
-                    let col = with_prof_context(&description, || {
+                    let col = with_prof_context(description, || {
                         ffun.map_or_else(
                             || arr.join_core(&arranged, jfun),
                             |f| arr.filter(move |_, v| f(v)).join_core(&arranged, jfun),
@@ -1783,9 +1783,9 @@ impl Program {
                 ref next,
             } => match arrangements.lookup_arr(arrangement) {
                 ArrangementFlavor::Local(DataflowArrangement::Set(arranged)) => {
-                    let col = with_prof_context(&description, || {
+                    let col = with_prof_context(description, || {
                         ffun.map_or_else(
-                            || antijoin_arranged(&arr, &arranged).map(|(_, v)| v),
+                            || antijoin_arranged(arr, &arranged).map(|(_, v)| v),
                             |f| {
                                 antijoin_arranged(&arr.filter(move |_, v| f(v)), &arranged)
                                     .map(|(_, v)| v)
@@ -1795,9 +1795,9 @@ impl Program {
                     Self::streamless_xform_collection(col, &*next, arrangements, lookup_collection)
                 }
                 ArrangementFlavor::Foreign(DataflowArrangement::Set(arranged)) => {
-                    let col = with_prof_context(&description, || {
+                    let col = with_prof_context(description, || {
                         ffun.map_or_else(
-                            || antijoin_arranged(&arr, &arranged).map(|(_, v)| v),
+                            || antijoin_arranged(arr, &arranged).map(|(_, v)| v),
                             |f| {
                                 antijoin_arranged(&arr.filter(move |_, v| f(v)), &arranged)
                                     .map(|(_, v)| v)
@@ -1816,7 +1816,7 @@ impl Program {
                 jfun,
                 ref next,
             } => {
-                let col = with_prof_context(&description, || {
+                let col = with_prof_context(description, || {
                     // Map `rel` into `(key, value)` pairs, filtering out
                     // records where `kfun` returns `None`.
                     // FIXME: The key will need to be cloned below.  To avoid
@@ -1868,7 +1868,7 @@ impl Program {
                 jfun,
                 ref next,
             } => {
-                let col = with_prof_context(&description, || {
+                let col = with_prof_context(description, || {
                     // Extract join key from `rel`, filtering out
                     // FIXME: The key will need to be cloned below.  To avoid
                     // this overhead, we need a version of `lookup_map` that
@@ -2401,7 +2401,7 @@ impl RunningProgram {
                 new
             }
             Update::DeleteValue { v, .. } => {
-                let present = s.remove(&v);
+                let present = s.remove(v);
                 if present {
                     Self::delta_dec(ds, v);
                 }
@@ -2532,7 +2532,7 @@ impl RunningProgram {
                     m.mutate(new)?;
                     Self::delta_dec(ds, &old);
                     updates.push(Update::DeleteValue { relid, v: old });
-                    Self::delta_inc(ds, &new);
+                    Self::delta_inc(ds, new);
                     updates.push(Update::Insert {
                         relid,
                         v: new.clone(),

--- a/rust/template/differential_datalog/src/program/worker.rs
+++ b/rust/template/differential_datalog/src/program/worker.rs
@@ -776,7 +776,7 @@ fn render_relation<S>(
         with_prof_context(arrangement.name(), || {
             arrangements.insert(
                 (relation.id, arr_id),
-                arrangement.build_arrangement_root(&render_context, &collection),
+                arrangement.build_arrangement_root(render_context, &collection),
             )
         });
     }

--- a/rust/template/differential_datalog/src/render/arrange_by.rs
+++ b/rust/template/differential_datalog/src/render/arrange_by.rs
@@ -105,7 +105,7 @@ impl<'a> ArrangeBy<'a> {
             }
 
             ArrangementKind::Map { value_function } => {
-                self.render_map(&collection, value_function, &arrangement_name)
+                self.render_map(collection, value_function, &arrangement_name)
             }
         }
     }
@@ -185,7 +185,7 @@ impl<'a> ArrangeBy<'a> {
             }
 
             ArrangementKind::Map { value_function } => {
-                self.render_map(&collection, value_function, &arrangement_name)
+                self.render_map(collection, value_function, &arrangement_name)
             }
         }
     }
@@ -242,7 +242,7 @@ impl<'a> ArrangeBy<'a> {
                 });
 
                 let arranged =
-                    keyed.arrange_named::<OrdKeySpine<_, _, _, Offset>>(&arrangement_name);
+                    keyed.arrange_named::<OrdKeySpine<_, _, _, Offset>>(arrangement_name);
 
                 Err(Arrangement::Set(arranged))
             }

--- a/rust/template/differential_datalog/src/replay.rs
+++ b/rust/template/differential_datalog/src/replay.rs
@@ -154,25 +154,25 @@ where
         match upd {
             UpdCmd::Insert(rel, record) => record_insert(
                 writer,
-                Self::relident2name(inventory, rel).unwrap_or(&"???"),
+                Self::relident2name(inventory, rel).unwrap_or("???"),
                 record,
             ),
             UpdCmd::InsertOrUpdate(rel, record) => record_insert_or_update(
                 writer,
-                Self::relident2name(inventory, rel).unwrap_or(&"???"),
+                Self::relident2name(inventory, rel).unwrap_or("???"),
                 record,
             ),
             UpdCmd::Delete(rel, record) => record_delete(
                 writer,
-                Self::relident2name(inventory, rel).unwrap_or(&"???"),
+                Self::relident2name(inventory, rel).unwrap_or("???"),
                 record,
             ),
             UpdCmd::DeleteKey(rel, record) => {
-                let rname = Self::relident2name(inventory, rel).unwrap_or(&"???");
+                let rname = Self::relident2name(inventory, rel).unwrap_or("???");
                 write!(writer, "delete_key {} {}", rname, record,)
             }
             UpdCmd::Modify(rel, key, mutator) => {
-                let rname = Self::relident2name(inventory, rel).unwrap_or(&"???");
+                let rname = Self::relident2name(inventory, rel).unwrap_or("???");
                 write!(writer, "modify {} {} <- {}", rname, key, mutator,)
             }
         }
@@ -185,31 +185,27 @@ where
         upd: &Update<DDValue>,
     ) -> IOResult<()> {
         match upd {
-            Update::Insert { relid, v } => record_insert(
-                writer,
-                inventory.get_table_name(*relid).unwrap_or(&"???"),
-                v,
-            ),
+            Update::Insert { relid, v } => {
+                record_insert(writer, inventory.get_table_name(*relid).unwrap_or("???"), v)
+            }
             Update::InsertOrUpdate { relid, v } => record_insert_or_update(
                 writer,
-                inventory.get_table_name(*relid).unwrap_or(&"???"),
+                inventory.get_table_name(*relid).unwrap_or("???"),
                 v,
             ),
-            Update::DeleteValue { relid, v } => record_delete(
-                writer,
-                inventory.get_table_name(*relid).unwrap_or(&"???"),
-                v,
-            ),
+            Update::DeleteValue { relid, v } => {
+                record_delete(writer, inventory.get_table_name(*relid).unwrap_or("???"), v)
+            }
             Update::DeleteKey { relid, k } => write!(
                 writer,
                 "delete_key {} {}",
-                inventory.get_table_name(*relid).unwrap_or(&"???"),
+                inventory.get_table_name(*relid).unwrap_or("???"),
                 k,
             ),
             Update::Modify { relid, k, m } => write!(
                 writer,
                 "modify {} {} <- {}",
-                inventory.get_table_name(*relid).unwrap_or(&"???"),
+                inventory.get_table_name(*relid).unwrap_or("???"),
                 k,
                 m,
             ),
@@ -247,7 +243,7 @@ where
     }
 
     fn apply_updates_dynamic(&self, upds: &mut dyn Iterator<Item = UpdCmd>) -> Result<(), String> {
-        self.do_record_updates(upds, |i, w, u| Self::record_upd_cmd(i, w, &u))
+        self.do_record_updates(upds, |i, w, u| Self::record_upd_cmd(i, w, u))
     }
 
     fn clear_relation(&self, rid: RelId) -> Result<(), String> {
@@ -255,7 +251,7 @@ where
         writeln!(
             &mut writer,
             "clear {};",
-            self.inventory.get_table_name(rid).unwrap_or(&"???")
+            self.inventory.get_table_name(rid).unwrap_or("???")
         )
         .map_err(|e| e.to_string())
     }
@@ -265,7 +261,7 @@ where
         writeln!(
             &mut writer,
             "query_index {}({});",
-            self.inventory.get_index_name(iid).unwrap_or(&"???"),
+            self.inventory.get_index_name(iid).unwrap_or("???"),
             key
         )
         .and(Ok(vec![]))
@@ -277,7 +273,7 @@ where
         writeln!(
             &mut writer,
             "dump_index {};",
-            self.inventory.get_index_name(iid).unwrap_or(&"???")
+            self.inventory.get_index_name(iid).unwrap_or("???")
         )
         .and(Ok(vec![]))
         .map_err(|e| e.to_string())
@@ -301,7 +297,7 @@ where
     }
 
     fn apply_updates(&self, upds: &mut dyn Iterator<Item = Update<DDValue>>) -> Result<(), String> {
-        self.do_record_updates(upds, |i, w, u| Self::record_val_upd(i, w, &u))
+        self.do_record_updates(upds, |i, w, u| Self::record_val_upd(i, w, u))
     }
 
     fn query_index(&self, iid: IdxId, key: DDValue) -> Result<BTreeSet<DDValue>, String> {
@@ -309,7 +305,7 @@ where
         writeln!(
             &mut writer,
             "query_index {}({});",
-            self.inventory.get_index_name(iid).unwrap_or(&"???"),
+            self.inventory.get_index_name(iid).unwrap_or("???"),
             key
         )
         .map(|_| BTreeSet::new())
@@ -321,7 +317,7 @@ where
         writeln!(
             &mut writer,
             "dump_index {};",
-            self.inventory.get_index_name(iid).unwrap_or(&"???")
+            self.inventory.get_index_name(iid).unwrap_or("???")
         )
         .map(|_| BTreeSet::new())
         .map_err(|e| e.to_string())
@@ -342,7 +338,7 @@ where
         writeln!(
             &mut writer,
             "dump {};",
-            self.inventory.get_table_name(rid).unwrap_or(&"???")
+            self.inventory.get_table_name(rid).unwrap_or("???")
         )
         .map_err(|e| e.to_string())
     }

--- a/rust/template/differential_datalog/src/replay.rs
+++ b/rust/template/differential_datalog/src/replay.rs
@@ -421,11 +421,6 @@ mod tests {
         }
 
         #[cfg(feature = "c_api")]
-        fn get_table_original_cname(&self, _tname: &str) -> Result<&'static CStr, String> {
-            unimplemented!()
-        }
-
-        #[cfg(feature = "c_api")]
         fn get_table_cname(&self, _tid: RelId) -> Result<&'static CStr, String> {
             unimplemented!()
         }

--- a/rust/template/differential_datalog_test/lib.rs
+++ b/rust/template/differential_datalog_test/lib.rs
@@ -1129,7 +1129,7 @@ fn test_map(nthreads: usize) {
     }
 
     fn ffun(v: &DDValue) -> bool {
-        let U64(ref uv) = U64::from_ddvalue_ref(&v);
+        let U64(ref uv) = U64::from_ddvalue_ref(v);
         *uv > 10
     }
 
@@ -1610,7 +1610,7 @@ fn test_recursion(nthreads: usize) {
     };
 
     fn ffun(v: &DDValue) -> bool {
-        let Tuple2(ref fst, ref snd) = Tuple2::<String>::from_ddvalue_ref(&v);
+        let Tuple2(ref fst, ref snd) = Tuple2::<String>::from_ddvalue_ref(v);
         *fst != *snd
     }
 

--- a/rust/template/src/build.rs
+++ b/rust/template/src/build.rs
@@ -26,10 +26,7 @@ fn libtool() {
     }
     println!("cargo:rerun-if-changed=src/lib.rs");
     println!("cargo:rerun-if-changed=src/main.rs");
-    println!("cargo:rerun-if-changed=src/api/mod.rs");
-    println!("cargo:rerun-if-changed=src/api/c_api.rs");
     println!("cargo:rerun-if-changed=src/ovsdb_api.rs");
-    println!("cargo:rerun-if-changed=src/update_handler.rs");
 
     let lib = "libdatalog_example_ddlog";
 

--- a/rust/template/types/lib.rs
+++ b/rust/template/types/lib.rs
@@ -41,7 +41,6 @@ use ::timely::dataflow::scopes;
 use ::timely::worker;
 
 use ::ddlog_derive::{FromRecord, IntoRecord, Mutator};
-use ::differential_datalog::ddval::DDValue;
 use ::differential_datalog::ddval::DDValConvert;
 use ::differential_datalog::program;
 use ::differential_datalog::program::TupleTS;

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -948,8 +948,8 @@ data ModuleReexports = ModuleReexports {
 }
 
 mkD3logImpl :: (?cfg::Config, ?crate_graph::CrateGraph, ?specname::String) => DatalogProgram -> M.Map String String -> Doc
-mkD3logImpl d d3log_rel_map =
-    "impl_trait_d3log!(" <> commaSep rels <> ");"
+mkD3logImpl d d3log_rel_map | confD3logDev ?cfg = "impl_trait_d3log!();"
+                            | otherwise = "impl_trait_d3log!(" <> commaSep rels <> ");"
     where
     rels = map (\(rout_name, rin_name) ->
                  let rout = getRelation d rout_name

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -200,6 +200,7 @@ rustLibFiles =
         , ("differential_datalog/src/ddlog.rs"                    , $(embedFile "rust/template/differential_datalog/src/ddlog.rs"))
         , ("differential_datalog/src/ddval/mod.rs"                , $(embedFile "rust/template/differential_datalog/src/ddval/mod.rs"))
         , ("differential_datalog/src/ddval/ddvalue.rs"            , $(embedFile "rust/template/differential_datalog/src/ddval/ddvalue.rs"))
+        , ("differential_datalog/src/ddval/any.rs"                , $(embedFile "rust/template/differential_datalog/src/ddval/any.rs"))
         , ("differential_datalog/src/ddval/ddval_convert.rs"      , $(embedFile "rust/template/differential_datalog/src/ddval/ddval_convert.rs"))
         , ("differential_datalog/src/lib.rs"                      , $(embedFile "rust/template/differential_datalog/src/lib.rs"))
         , ("differential_datalog/src/profile.rs"                  , $(embedFile "rust/template/differential_datalog/src/profile.rs"))
@@ -925,7 +926,7 @@ compileMainLib :: (?cfg::Config, ?specname::String, ?modules::M.Map ModuleName D
 compileMainLib d d3log_rel_map nodes cstate =
     mainHeader                             $+$
     reexports                              $+$
-    mkUpdateDeserializer d                 $+$
+    mkAnyDeserialize d                     $+$
     mkDDValueFromRecord d                  $+$ -- Function to convert cmd_parser::Record to Value
     mkIndexesIntoArrId d cstate            $+$
     mkRelEnum d                            $+$ -- 'enum Relations'
@@ -1002,11 +1003,11 @@ ppModuleReexports d ModuleReexports{..} =
 
 
 -- Generate Deserialize implementation for UpdateSerializer wrapper.
-mkUpdateDeserializer :: (?crate_graph::CrateGraph, ?specname::String) => DatalogProgram -> Doc
-mkUpdateDeserializer d =
-    "decl_update_deserializer!(UpdateSerializer," <> commaSep rels <> ");"
+mkAnyDeserialize :: (?crate_graph::CrateGraph, ?specname::String) => DatalogProgram -> Doc
+mkAnyDeserialize d =
+    "decl_any_deserialize!(" <> commaSep rels <> ");"
     where
-    rels = map (\rel -> "(" <> pp (relIdentifier d rel) <> "," <+> mkType d Nothing rel <> ")" )
+    rels = map (\rel -> "(" <> pp (relIdentifier d rel) <> "u64 ," <+> mkType d Nothing rel <> ")" )
            $ filter (\rel -> elem (relRole rel) [RelInput, RelOutput])
            $ M.elems $ progRelations d
 

--- a/src/Language/DifferentialDatalog/Config.hs
+++ b/src/Language/DifferentialDatalog/Config.hs
@@ -57,6 +57,7 @@ data Config = Config { confDatalogFile     :: FilePath
                      , confRustFlatBuffers :: Bool
                      , confNestedTS32      :: Bool
                      , confD3log           :: Bool
+                     , confD3logDev        :: Bool
                      }
 
 defaultConfig :: Config
@@ -81,4 +82,5 @@ defaultConfig = Config { confDatalogFile     = ""
                        , confRustFlatBuffers = False
                        , confNestedTS32      = False
                        , confD3log           = False
+                       , confD3logDev        = False
                        }

--- a/src/Language/DifferentialDatalog/D3log.hs
+++ b/src/Language/DifferentialDatalog/D3log.hs
@@ -37,11 +37,31 @@ import Data.Maybe
 import qualified Data.Map as M
 import qualified Data.Set as S
 
+import Language.DifferentialDatalog.Pos
 import Language.DifferentialDatalog.Config
 import Language.DifferentialDatalog.Module
 import Language.DifferentialDatalog.Name
 import Language.DifferentialDatalog.Syntax
 import Language.DifferentialDatalog.Type
+import Language.DifferentialDatalog.NS
+
+tStringInternFunc :: Type
+tStringInternFunc = tFunction [ArgType nopos False tString] (tIntern tString)
+
+eStringInternFunc :: Expr
+eStringInternFunc = eTyped (eFunc "internment::intern") tStringInternFunc
+
+tToAnyFunc :: Type -> Type
+tToAnyFunc t = tFunction [ArgType nopos False t] $ tOpaque (mOD_STD ++ "::Any") []
+
+eToAnyFunc :: Type -> Expr
+eToAnyFunc t = eTyped (eFunc $ mOD_STD ++ "::to_any") $ tToAnyFunc t
+
+sTREAM_FACTS :: String
+sTREAM_FACTS = "d3log::reflect::DistributedStreamFacts"
+
+rEL_FACTS :: String
+rEL_FACTS = "d3log::reflect::DistributedRelFacts"
 
 -- Converts a D3log program with location annotations into a regular DDlog
 -- program.  In the new program distributed relations (i.e., relations whose
@@ -49,50 +69,85 @@ import Language.DifferentialDatalog.Type
 -- with location information, so that the D3log runtime can determine the
 -- destination of each record.
 --
--- For each relation 'R[T]' that appears in the head of at least one rule
--- with location annotation, we introduce a fresh output relation
--- '__out_R[(Option<D3logLocationId>, T)]' and replaces all occurrences
--- 'R' in the head of a rule with '__out_R'.
+-- The exact behavior depends on whether the program is compiled with '--d3log'
+-- or '--d3log-dev' flag.  In the former case, for each relation 'R[T]' that
+-- appears in the head of at least one rule with location annotation, we
+-- introduce a fresh output relation '__out_R[(Option<D3logLocationId>, T)]'
+-- and replace all occurrences of 'R' in the head of a rule with '__out_R'.
+--
+-- In the latter case, we replace all occurrences of 'R' in the head of a rule
+-- with either 'd3log::reflect::DistributedStreamFacts' if 'R' is a stream or
+-- 'd3log::reflect::DistributedRelFacts' if it is a relation or multiset.
 --
 -- Returns modified program along with a map from newly introduced output
 -- relation names to corresponding input relations: '__out_R -> R'
 processD3logAnnotations :: (?cfg::Config) => DatalogProgram -> (DatalogProgram, M.Map String String)
 processD3logAnnotations d | confD3log ?cfg == False = (d, M.empty)
-                          | otherwise = 
+                          | otherwise =
     (d { progRelations = rels', progRules = rules' }, M.fromList $ map (\n -> (outRelName n, n)) $ S.toList loc_rels)
     where
     -- Find annotated relations.
     loc_rels = progLocalizedRelations d
-    
+
     -- For each localized relation 'R[T]', convert 'R'
     -- into an input relation and generate a new output relation
     -- 'output relation __out_R[(Option<D3logLocationId>, T)]'.
     rels' = foldl' (\rels rname ->
                      let rel = progRelations d M.! rname
-                         rel_in = rel{relRole = RelInput}
+                         -- Remote inputs must be multisets as they can
+                         -- receive updates from more than one upstream
+                         -- components.
+                         rel_in_sem = if relSemantics rel == RelSet
+                                      then RelMultiset
+                                      else relSemantics rel
+                         rel_in = rel{
+                            relRole = RelInput,
+                            relSemantics = rel_in_sem
+                         }
                          rel_out = rel{
                              relName = outRelName $ relName rel,
-                             relRole = RelOutput,
+                             -- When implementing D3log in DDlog, we feed these
+                             -- relations to 'DistributedRelFacts' and
+                             -- 'DistributedStreamFacts'.
+                             relRole = if confD3logDev ?cfg then RelInternal else RelOutput,
                              relType = tTuple [locationSpecifierType, relType rel]
                          }
-                     in M.insert (name rel_in) rel_in $
-                        M.insert (name rel_out) rel_out $
-                        M.delete rname rels)
+                         rels_ = M.insert (name rel_in) rel_in $
+                                 M.delete rname rels
+                     in if confD3logDev ?cfg
+                        then rels_
+                        else M.insert (name rel_out) rel_out rels_)
                    (progRelations d) loc_rels
 
     -- Rewrite rules:
+    -- If 'confD3logDev' is False:
     --  'R[x] :- Body.' --> '__out_R[(None, x)] :- Body.'
     --  and
     --  'R[x] @n :- Body.' --> '__out_R[(Some{n}, x)] :- Body.'
+    --
+    -- If 'confD3logDev' is True:
+    --  'R[x] :- Body.' --> 'DistributedRelFacts("R", x, None) :- Body.'
+    --  and
+    --  'R[x] @n :- Body.' --> 'DistributedRelFacts("R", x, Some{n}) :- Body.'
     rules' = map (\rule ->
                    let rlhead = head $ ruleLHS rule
                        rname = atomRelation $ lhsAtom rlhead
+                       rel = getRelation d rname
                        loc_expr = case lhsLocation rlhead of
                                        Nothing -> eNone $ tUser lOCATION_TYPE []
                                        Just l  -> eSome l $ tUser lOCATION_TYPE []
-                       val' = eTuple [loc_expr, atomVal $ lhsAtom rlhead]
+                       head_rel = if confD3logDev ?cfg
+                                  then reflectRelName rel
+                                  else outRelName rname
+                       val' = if confD3logDev ?cfg
+                              then eStruct head_rel [
+                                        (identifierWithPos "relname", eApply eStringInternFunc [eString rname]),
+                                        (identifierWithPos "fact", eApply (eToAnyFunc $ relType rel) [atomVal $ lhsAtom rlhead]),
+                                        (identifierWithPos "destination", loc_expr) ]
+                                           (tUser head_rel [])
+                              else eTuple [loc_expr, atomVal $ lhsAtom rlhead, loc_expr]
                        atom' = (lhsAtom rlhead) {
-                           atomRelation = outRelName rname,
+                           atomRelation = head_rel,
                            atomVal = val'
                        }
                        rlhead' = rlhead {
@@ -113,6 +168,11 @@ outRelName rel = scoped rel_scope $ "__out_" ++ rel_name
     where
     rel_scope = nameScope rel
     rel_name = nameLocalStr rel
+
+reflectRelName :: Relation -> String
+reflectRelName rel = if relSemantics rel == RelStream
+                     then sTREAM_FACTS
+                     else rEL_FACTS
 
 -- A localized relation must appear with location annotation
 -- in the head of at least one rule.

--- a/src/Language/DifferentialDatalog/Module.hs-boot
+++ b/src/Language/DifferentialDatalog/Module.hs-boot
@@ -1,3 +1,5 @@
+{-# LANGUAGE ImplicitParams #-}
+
 module Language.DifferentialDatalog.Module where
 
 import qualified Data.Map as M
@@ -6,6 +8,7 @@ import Control.Monad.Trans.Except
 
 import Language.DifferentialDatalog.Syntax
 import Language.DifferentialDatalog.Name
+import Language.DifferentialDatalog.Config
 
 data DatalogModule
 emptyModule :: ModuleName -> DatalogModule
@@ -19,5 +22,5 @@ nameScope :: (WithName a) => a -> ModuleName
 nameLocal :: (WithName a) => a -> Doc
 nameLocalStr :: (WithName a) => a -> String
 scoped :: ModuleName -> String -> String
-parseDatalogProgram :: [FilePath] -> Bool -> String -> FilePath -> ExceptT String IO ([DatalogModule], DatalogProgram, M.Map ModuleName (Doc, Doc, Doc))
+parseDatalogProgram :: (?cfg::Config) => [FilePath] -> Bool -> String -> FilePath -> ExceptT String IO ([DatalogModule], DatalogProgram, M.Map ModuleName (Doc, Doc, Doc))
 stdLibs :: [ModuleName]

--- a/src/Language/DifferentialDatalog/Syntax.hs
+++ b/src/Language/DifferentialDatalog/Syntax.hs
@@ -49,6 +49,7 @@ module Language.DifferentialDatalog.Syntax (
         tUser,
         tVar,
         tOpaque,
+        tIntern,
         tFunction,
         structFields,
         structLookupField,
@@ -56,6 +57,7 @@ module Language.DifferentialDatalog.Syntax (
         structFieldGuarded,
         Field(..),
         IdentifierWithPos(..),
+        identifierWithPos,
         TypeDef(..),
         tdefIsExtern,
         Constructor(..),
@@ -257,6 +259,8 @@ instance WithName IdentifierWithPos where
     name = idName
     setName i n = i{idName = n}
 
+identifierWithPos n = IdentifierWithPos nopos n
+
 data Type = TBool     {typePos :: Pos}
           | TInt      {typePos :: Pos}
           | TString   {typePos :: Pos}
@@ -285,6 +289,7 @@ tUser           = TUser     nopos
 tVar            = TVar      nopos
 tOpaque         = TOpaque   nopos
 tFunction as t  = TFunction nopos as t
+tIntern t       = tOpaque "internment::Intern" [t]
 
 structGetField :: Type -> String -> Field
 structGetField t f = fromJust $ structLookupField t f

--- a/test.sh
+++ b/test.sh
@@ -103,7 +103,7 @@ souffle=("static_analysis:Souffle static analysis test."
          "souffle_tests6:Souffle tests part6"
          "souffle_tests7:Souffle tests part7")
 
-d3log=()
+d3log=("lb:Mock load balancer")
 
 misc=("span_string"
       "span_uuid"
@@ -326,7 +326,9 @@ souffle_tests7() {
 }
 
 # 'd3log' test group.
-
+lb() {
+    ${THIS_DIR}/test/datalog_tests/lb_test/test.sh
+}
 
 # 'stack' test group.
 

--- a/test/datalog_tests/ddvalue_test.dat
+++ b/test/datalog_tests/ddvalue_test.dat
@@ -1,0 +1,10 @@
+# Add one record per transaction to guarantee deterministic output order
+# (the ordering of `Any` may vary across Rust compiler releases).
+
+start;
+insert ddvalue_test::DDValTest1("foo", 1, ["bar", "buzz"]),
+commit dump_changes;
+
+start;
+insert ddvalue_test::DDValTest2([(1, "foo"), (2, "bar")], (true, [5,4,3,2,1])),
+commit dump_changes;

--- a/test/datalog_tests/ddvalue_test.dl
+++ b/test/datalog_tests/ddvalue_test.dl
@@ -1,0 +1,15 @@
+/* Test `Any` API. */
+
+input relation DDValTest1(x: string, y: usize, z: Vec<istring>)
+input relation DDValTest2(a: Map<usize, string>, b: (bool, Set<u128>))
+
+output relation DDValTestOutput(relname: string, ddval: Any)
+
+DDValTestOutput("DDValTest1", x.to_any()) :- DDValTest1[x].
+DDValTestOutput("DDValTest2", x.to_any()) :- DDValTest2[x].
+
+output relation DDValTest1Output[DDValTest1]
+output relation DDValTest2Output[DDValTest2]
+
+DDValTest1Output[from_any(x).unwrap_or_default()] :- DDValTestOutput("DDValTest1", x).
+DDValTest2Output[from_any(x).unwrap_or_default()] :- DDValTestOutput("DDValTest2", x).

--- a/test/datalog_tests/ddvalue_test.dump.expected
+++ b/test/datalog_tests/ddvalue_test.dump.expected
@@ -1,0 +1,8 @@
+ddvalue_test::DDValTest1Output:
+ddvalue_test::DDValTest1{.x = "foo", .y = 1, .z = ["bar", "buzz"]}: +1
+ddvalue_test::DDValTestOutput:
+ddvalue_test::DDValTestOutput{.relname = "DDValTest1", .ddval = ddvalue_test::DDValTest1{.x = "foo", .y = 1, .z = ["bar", "buzz"]}}: +1
+ddvalue_test::DDValTest2Output:
+ddvalue_test::DDValTest2{.a = [(1, "foo"), (2, "bar")], .b = (true, [1, 2, 3, 4, 5])}: +1
+ddvalue_test::DDValTestOutput:
+ddvalue_test::DDValTestOutput{.relname = "DDValTest2", .ddval = ddvalue_test::DDValTest2{.a = [(1, "foo"), (2, "bar")], .b = (true, [1, 2, 3, 4, 5])}}: +1

--- a/test/datalog_tests/lb.dl
+++ b/test/datalog_tests/lb.dl
@@ -1,0 +1,17 @@
+typedef Payload = usize
+
+input relation Data(dat: Payload)
+input relation Workers(id: D3logLocationId)
+
+relation AllWorkers(workers: Vec<D3logLocationId>)
+
+AllWorkers(workers) :-
+    Workers(worker_id),
+    var workers = worker_id.group_by(()).to_vec().
+
+relation BalancedData(dat: Payload)
+
+BalancedData(dat) @worker :-
+    Data(dat),
+    AllWorkers(workers),
+    var worker = workers.nth(dat.hash64() % workers.len()).unwrap_or_default().

--- a/test/datalog_tests/lb.dump.expected
+++ b/test/datalog_tests/lb.dump.expected
@@ -1,0 +1,10 @@
+
+State after transaction 1
+Changes to relation __out_BalancedData
+BalancedData{.dat = 2} @ Some(100) +1
+BalancedData{.dat = 1} @ Some(200) +1
+
+State after transaction 2
+Changes to relation __out_BalancedData
+BalancedData{.dat = 1} @ Some(100) +1
+BalancedData{.dat = 1} @ Some(200) -1

--- a/test/datalog_tests/lb.dump.expected
+++ b/test/datalog_tests/lb.dump.expected
@@ -1,10 +1,10 @@
 
 State after transaction 1
 Changes to relation __out_BalancedData
-BalancedData{.dat = 2} @ Some(100) +1
-BalancedData{.dat = 1} @ Some(200) +1
+(ddlog_std::Some{.x = 100}, BalancedData{.dat = 1}, ddlog_std::Some{.x = 100}) +1
+(ddlog_std::Some{.x = 200}, BalancedData{.dat = 2}, ddlog_std::Some{.x = 200}) +1
 
 State after transaction 2
 Changes to relation __out_BalancedData
-BalancedData{.dat = 1} @ Some(100) +1
-BalancedData{.dat = 1} @ Some(200) -1
+(ddlog_std::Some{.x = 100}, BalancedData{.dat = 1}, ddlog_std::Some{.x = 100}) -1
+(ddlog_std::Some{.x = 200}, BalancedData{.dat = 1}, ddlog_std::Some{.x = 200}) +1

--- a/test/datalog_tests/lb_reflective.dat
+++ b/test/datalog_tests/lb_reflective.dat
@@ -1,0 +1,14 @@
+start;
+
+insert lb::Data(100),
+insert lb::Data(200),
+insert lb::Data(300),
+insert lb::Workers(1),
+
+commit dump_changes;
+
+start;
+
+insert lb::Workers(2),
+
+commit dump_changes;

--- a/test/datalog_tests/lb_reflective.dl
+++ b/test/datalog_tests/lb_reflective.dl
@@ -1,0 +1,15 @@
+import lb
+import d3log::reflect
+
+output relation OutputRelFacts(
+    relname: istring,
+    fact: Any,
+    destination: Option<D3logLocationId>)
+
+output stream OutputStreamFacts(
+    relname: istring,
+    fact: Any,
+    destination: Option<D3logLocationId>)
+
+OutputRelFacts(relname, fact, destination) :- DistributedRelFacts(relname, fact, destination).
+OutputStreamFacts(relname, fact, destination) :- DistributedStreamFacts(relname, fact, destination).

--- a/test/datalog_tests/lb_reflective.dump.expected
+++ b/test/datalog_tests/lb_reflective.dump.expected
@@ -1,0 +1,9 @@
+OutputRelFacts:
+OutputRelFacts{.relname = "lb::BalancedData", .fact = lb::BalancedData{.dat = 100}, .destination = ddlog_std::Some{.x = 1}}: +1
+OutputRelFacts{.relname = "lb::BalancedData", .fact = lb::BalancedData{.dat = 200}, .destination = ddlog_std::Some{.x = 1}}: +1
+OutputRelFacts{.relname = "lb::BalancedData", .fact = lb::BalancedData{.dat = 300}, .destination = ddlog_std::Some{.x = 1}}: +1
+OutputRelFacts:
+OutputRelFacts{.relname = "lb::BalancedData", .fact = lb::BalancedData{.dat = 100}, .destination = ddlog_std::Some{.x = 1}}: -1
+OutputRelFacts{.relname = "lb::BalancedData", .fact = lb::BalancedData{.dat = 100}, .destination = ddlog_std::Some{.x = 2}}: +1
+OutputRelFacts{.relname = "lb::BalancedData", .fact = lb::BalancedData{.dat = 200}, .destination = ddlog_std::Some{.x = 1}}: -1
+OutputRelFacts{.relname = "lb::BalancedData", .fact = lb::BalancedData{.dat = 200}, .destination = ddlog_std::Some{.x = 2}}: +1

--- a/test/datalog_tests/lb_test/Cargo.toml
+++ b/test/datalog_tests/lb_test/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "lb_test"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+
+# The generated Rust project contains several crates that must be imported
+# by the client program.
+differential_datalog = {path = "../lb_ddlog/differential_datalog"}
+lb = {path = "../lb_ddlog"}
+ddlog_rt = {path = "../lb_ddlog/types/ddlog_rt"}
+types = {path = "../lb_ddlog/types"}

--- a/test/datalog_tests/lb_test/src/main.rs
+++ b/test/datalog_tests/lb_test/src/main.rs
@@ -1,0 +1,91 @@
+use lb_ddlog::api::HDDlog;
+
+use lb_ddlog::Relations;
+
+use lb_ddlog::relid2name;
+
+use lb_ddlog::typedefs::*;
+
+use differential_datalog::{D3log, DDlog, DDlogDynamic};
+use differential_datalog::DeltaMap;
+use differential_datalog::ddval::DDValue;
+use differential_datalog::ddval::DDValConvert;
+use differential_datalog::program::RelId;
+use differential_datalog::program::Update;
+
+fn main() -> Result<(), String> {
+
+    let (hddlog, _) = HDDlog::run(1, false)?;
+
+    hddlog.transaction_start()?;
+
+    let updates = vec![
+        Update::Insert {
+            relid: Relations::Data as RelId,
+            v: Data {
+                dat: 1,
+            }
+            .into_ddvalue(),
+        },
+        Update::Insert {
+            relid: Relations::Data as RelId,
+            v: Data {
+                dat: 2,
+            }
+            .into_ddvalue(),
+        },
+        Update::Insert {
+            relid: Relations::Workers as RelId,
+            v: Workers {
+                id: 100,
+            }
+            .into_ddvalue(),
+        },
+        Update::Insert {
+            relid: Relations::Workers as RelId,
+            v: Workers {
+                id: 200,
+            }
+            .into_ddvalue(),
+        },
+    ];
+    hddlog.apply_updates(&mut updates.into_iter())?;
+
+    let delta = hddlog.transaction_commit_dump_changes()?;
+
+    println!("\nState after transaction 1");
+    dump_delta(&hddlog, delta);
+
+    hddlog.transaction_start()?;
+
+    let updates = vec![
+        Update::Insert {
+            relid: Relations::Workers as RelId,
+            v: Workers {
+                id: 300,
+            }
+            .into_ddvalue(),
+        },
+    ];
+    hddlog.apply_updates(&mut updates.into_iter())?;
+
+    let delta = hddlog.transaction_commit_dump_changes()?;
+
+    println!("\nState after transaction 2");
+    dump_delta(&hddlog, delta);
+
+    hddlog.stop().unwrap();
+    Ok(())
+}
+
+fn dump_delta(hddlog: &HDDlog, delta: DeltaMap<DDValue>) {
+    for (rel, changes) in delta.into_iter() {
+        println!("Changes to relation {}", relid2name(rel).unwrap());
+        for (val, weight) in changes.into_iter() {
+            match hddlog.d3log_localize_val(rel, val) {
+                Ok((loc_id, _in_rel, inner_val)) => println!("{} @ {:?} {:+}", inner_val, loc_id, weight),
+                Err(val) => println!("{} {:+}", val, weight)
+            }
+        }
+    }
+}

--- a/test/datalog_tests/lb_test/src/main.rs
+++ b/test/datalog_tests/lb_test/src/main.rs
@@ -1,11 +1,9 @@
-use lb_ddlog::api::HDDlog;
 
 use lb_ddlog::Relations;
-
 use lb_ddlog::relid2name;
-
 use lb_ddlog::typedefs::*;
 
+use differential_datalog::api::HDDlog;
 use differential_datalog::{D3log, DDlog, DDlogDynamic};
 use differential_datalog::DeltaMap;
 use differential_datalog::ddval::DDValue;
@@ -15,7 +13,7 @@ use differential_datalog::program::Update;
 
 fn main() -> Result<(), String> {
 
-    let (hddlog, _) = HDDlog::run(1, false)?;
+    let (hddlog, _) = lb_ddlog::run(1, false)?;
 
     hddlog.transaction_start()?;
 

--- a/test/datalog_tests/lb_test/test.sh
+++ b/test/datalog_tests/lb_test/test.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -ex
+
+# When running in CI, the DDlog compiler should be prinstalled by the build stage.
+if [ -z "${IS_CI_RUN}" ]; then
+    stack install
+fi
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+DATALOG_TEST_DIR="${THIS_DIR}/../"
+
+#(cd "${DATALOG_TEST_DIR}" && DDLOGFLAGS="--d3log" ./run-test.sh lb release)
+
+(cd "${THIS_DIR}" && cargo run > "${DATALOG_TEST_DIR}/lb.dump")
+
+diff -q "${DATALOG_TEST_DIR}/lb.dump" "${DATALOG_TEST_DIR}/lb.dump.expected"

--- a/test/datalog_tests/lb_test/test.sh
+++ b/test/datalog_tests/lb_test/test.sh
@@ -10,7 +10,9 @@ fi
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 DATALOG_TEST_DIR="${THIS_DIR}/../"
 
-#(cd "${DATALOG_TEST_DIR}" && DDLOGFLAGS="--d3log" ./run-test.sh lb release)
+(cd "${DATALOG_TEST_DIR}" && FLATBUF=0 DDLOGFLAGS="--d3log-dev" ./run-test.sh lb_reflective release)
+
+(cd "${DATALOG_TEST_DIR}" && ddlog -L../../lib -i lb.dl --d3log)
 
 (cd "${THIS_DIR}" && cargo run > "${DATALOG_TEST_DIR}/lb.dump")
 

--- a/test/datalog_tests/lib_test_no_flatbuf.dl
+++ b/test/datalog_tests/lib_test_no_flatbuf.dl
@@ -1,0 +1,1 @@
+import time_test

--- a/test/datalog_tests/lib_test_no_flatbuf.dl
+++ b/test/datalog_tests/lib_test_no_flatbuf.dl
@@ -1,1 +1,2 @@
 import time_test
+import ddvalue_test

--- a/test/datalog_tests/run-test.sh
+++ b/test/datalog_tests/run-test.sh
@@ -107,7 +107,7 @@ fi
 
 if [ -f ${base}.dat ]; then
     # Run script with input data
-    (set -x; /usr/bin/time ${base}_ddlog/target/${build}/${base}_cli <${base}.dat >${base}.dump)
+    (set -x; /usr/bin/time ${base}_ddlog/target/${build}/${base}_cli < ${base}.dat > ${base}.dump)
     # Compare outputs
     if [ -f ${base}.dump.expected.gz ]; then
         zdiff -q ${base}.dump ${base}.dump.expected.gz

--- a/test/datalog_tests/rust_api_test/Cargo.toml
+++ b/test/datalog_tests/rust_api_test/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2018"
 
 [dependencies]
 
+serde_json = "1.0.64"
+serde = "1.0"
+
 # The generated Rust project contains several crates that must be imported
 # by the client program.
 differential_datalog = { path = "../tutorial_ddlog/differential_datalog" }

--- a/test/datalog_tests/test-libs.sh
+++ b/test/datalog_tests/test-libs.sh
@@ -29,5 +29,16 @@ test_lib hashset_test
 test_lib group_test
 test_lib base64_test
 
-# No flatbuf support for Time, Date, etc yet
-FLATBUF=0 ./run-test.sh time_test.dl release
+# Tests for libraries that do not support flatbuf serialization.
+FLATBUF=0 ./run-test.sh lib_test_no_flatbuf.dl release
+
+# $1 - test name
+test_nofb_lib() {
+    echo Running $1 test
+    RUST_BACKTRACE=full /usr/bin/time ./lib_test_no_flatbuf_ddlog/target/release/lib_test_no_flatbuf_cli --no-init-snapshot < $1.dat > $1.dump
+    diff $1.dump.expected $1.dump
+}
+
+
+test_nofb_lib time_test
+test_nofb_lib ddvalue_test

--- a/test/datalog_tests/time_test.dat
+++ b/test/datalog_tests/time_test.dat
@@ -1,10 +1,10 @@
 start;
-insert TITest[TITest{.t = "10:11:12.000000000"}],
-insert DITest[DITest{.d = "2010-10-15"}],
-insert DTITest[DTITest{.d = time::DateTime{.date = "2010-10-15", .time = "10:11:12.000000000" }}],
+insert time_test::TITest(.t = "10:11:12.000000000"),
+insert time_test::DITest(.d = "2010-10-15"),
+insert time_test::DTITest(.d = time::DateTime{.date = "2010-10-15", .time = "10:11:12.000000000" }),
 commit;
-dump TTest;
-dump Extract;
-dump DTest;
-dump DTTest;
+dump time_test::TTest;
+dump time_test::Extract;
+dump time_test::DTest;
+dump time_test::DTTest;
 exit

--- a/test/datalog_tests/time_test.dump.expected
+++ b/test/datalog_tests/time_test.dump.expected
@@ -1,138 +1,62 @@
-DTTest:
-DTTest{.s = "\"\".string2datetime().unwrap_or_default()", .t = ddlog_std::Ok{.res = time::DateTime{.date = "0000-01-01", .time = "00:00:00.000000000"}}}: +1
-DTTest{.s = "2020-04-14T10:11:12", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.103104105"}}}: +1
-DTTest{.s = "Error in format string '%incorrectformat'", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.103104105"}}}: +1
-DTTest{.s = "Extract date 2020-04-14T10:11:12", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.103104105"}}}: +1
-DTTest{.s = "Extract shifted 2020-04-14T10:11:12", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.103104105"}}}: +1
-DTTest{.s = "datetime_from_unix_timestamp(10000000)", .t = ddlog_std::Ok{.res = time::DateTime{.date = "1970-04-26", .time = "17:46:40.000000000"}}}: +1
-DTTest{.s = "datetime_parse(\"2020-10-10T10:20:30\", \"%Y-%m-%dT%H:%M:%S\")", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-10-10", .time = "10:20:30.000000000"}}}: +1
-DTTest{.s = "datetime_parse(\"2020/10/10T10:20:30\", \"%Y-%m-%dT%H:%M:%S\")", .t = ddlog_std::Err{.err = "input contains invalid characters"}}: +1
-DTTest{.s = "datetime_parse(\"Wed Mar 05 07:45:30 MST 2025\", \"%a %b %d %H:%M:%S %Z %Y\")", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2025-03-05", .time = "07:45:30.000000000"}}}: +1
-DTTest{.s = "datetime_parse(datetime_format(2020-04-14T10:11:12, %Y-%m-%dT%H::%M).result_or_error(), %Y-%m-%dT%H::%M)", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:00.000000000"}}}: +1
-DTTest{.s = "get_datetime(tz_datetime_parse_from_rfc2822(\"Tue, 1 Jul 2003 10:52:37 GMT\"))", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2003-07-01", .time = "10:52:37.000000000"}}}: +1
-DTTest{.s = "string2datetime(\"2020-10-10T10:20:30\")", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-10-10", .time = "10:20:30.000000000"}}}: +1
-DTTest{.s = "string2datetime(to_string(2020-04-14T10:11:12))", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.000000000"}}}: +1
-DTZTest:
-DTZTest{.s = "\"\".tz_datetime_parse_from_rfc2822().unwrap_or_default()", .t = ddlog_std::Ok{.res = "0000-01-01T00:00:00+00:00"}}: +1
-DTZTest{.s = "2020-04-14T10:11:12.103104105+00:00", .t = ddlog_std::Ok{.res = "2020-04-14T10:11:12.103104105+00:00"}}: +1
-DTZTest{.s = "Error in format string '%incorrectformat'", .t = ddlog_std::Ok{.res = "2020-04-14T10:11:12.103104105+00:00"}}: +1
-DTZTest{.s = "RFC 2822: Tue, 14 Apr 2020 10:11:12 +0000", .t = ddlog_std::Ok{.res = "2020-04-14T10:11:12.103104105+00:00"}}: +1
-DTZTest{.s = "RFC 3339: 2020-04-14T10:11:12.103104105+00:00", .t = ddlog_std::Ok{.res = "2020-04-14T10:11:12.103104105+00:00"}}: +1
-DTZTest{.s = "string2datetime(\"2020-10-10T10:20:30\").utc()", .t = ddlog_std::Ok{.res = "2020-10-10T10:20:30+00:00"}}: +1
-DTZTest{.s = "tz_datetime_parse(\"2020-10-10T10:20:30 +02:00\", \"%Y-%m-%dT%H:%M:%S %z\")", .t = ddlog_std::Ok{.res = "2020-10-10T10:20:30+02:00"}}: +1
-DTZTest{.s = "tz_datetime_parse(\"2020/10/10T10:20:30 -02:00\", \"%Y/%m/%dT%H:%M:%S %z\")", .t = ddlog_std::Ok{.res = "2020-10-10T10:20:30-03:00"}}: +1
-DTZTest{.s = "tz_datetime_parse(\"Wed Mar 05 07:45:30 MST 2025\", \"%a %b %d %H:%M:%S %Z %Y\")", .t = ddlog_std::Err{.err = "input is not enough for unique date and time"}}: +1
-DTZTest{.s = "tz_datetime_parse_from_rfc2822(\"Tue, 1 Jul 2003 10:52:37 +0200\")", .t = ddlog_std::Ok{.res = "2003-07-01T10:52:37+02:00"}}: +1
-DTZTest{.s = "tz_datetime_parse_from_rfc2822(\"Tue, 1 Jul 2003 10:52:37 GMT\")", .t = ddlog_std::Ok{.res = "2003-07-01T10:52:37+00:00"}}: +1
-DTZTest{.s = "tz_datetime_parse_from_rfc3339(\"2020-10-10T10:20:30-03:00\")", .t = ddlog_std::Ok{.res = "2020-10-10T10:20:30-03:00"}}: +1
-DTest:
-DTest{.s = "2020-04-14", .t = ddlog_std::Ok{.res = "2020-04-14"}}: +1
-DTest{.s = "Error in format string '%incorrectformat'", .t = ddlog_std::Ok{.res = "2020-04-14"}}: +1
-DTest{.s = "Ok{from_julian_day(2000000)}", .t = ddlog_std::Ok{.res = "0763-09-18"}}: +1
-DTest{.s = "Ok{next_day(2020-04-14)}", .t = ddlog_std::Ok{.res = "2020-04-15"}}: +1
-DTest{.s = "Ok{previous_day(2020-04-14)}", .t = ddlog_std::Ok{.res = "2020-04-13"}}: +1
-DTest{.s = "date_parse(\"2020/04/14\", \"%Y/%m/%d\")", .t = ddlog_std::Ok{.res = "2020-04-14"}}: +1
-DTest{.s = "date_parse(date_format(2020-04-14, %Y-%m-%dT).result_or_error(), %Y-%m-%dT)", .t = ddlog_std::Ok{.res = "2020-04-14"}}: +1
-DTest{.s = "string2date(to_string(someDate()))", .t = ddlog_std::Ok{.res = "2020-04-14"}}: +1
-DTest{.s = "try_from_iso_ywd(32'sd2020, 8'd4, Monday)", .t = ddlog_std::Ok{.res = "2020-01-20"}}: +1
-DTest{.s = "try_from_yd(0, 0, 0).unwrap_or_default()", .t = ddlog_std::Ok{.res = "0000-01-01"}}: +1
-DTest{.s = "try_from_ymd(32'sd2020, 8'd0, 8'd14)", .t = ddlog_std::Err{.err = "Invalid date"}}: +1
-DTest{.s = "try_from_ymd(32'sd2020, 8'd04, 8'd14)", .t = ddlog_std::Ok{.res = "2020-04-14"}}: +1
-DTest{.s = "try_from_ymd(32'sd2020, 8'd13, 8'd14)", .t = ddlog_std::Err{.err = "Invalid date"}}: +1
-DTest{.s = "try_from_yo(32'sd2020, 16'd100)", .t = ddlog_std::Ok{.res = "2020-04-09"}}: +1
-DTest{.s = "try_from_yo(32'sd2020, 16'd367)", .t = ddlog_std::Err{.err = "Invalid date"}}: +1
-Extract:
-Extract{.s = "day(2020-04-14)", .v = 14}: +1
-Extract{.s = "hour(10:11:12.103104105)", .v = 10}: +1
-Extract{.s = "microsecond(10:11:12.103104105)", .v = 103104}: +1
-Extract{.s = "millisecond(10:11:12.103104105)", .v = 103}: +1
-Extract{.s = "minute(10:11:12.103104105)", .v = 11}: +1
-Extract{.s = "month(2020-04-14)", .v = 4}: +1
-Extract{.s = "nanosecond(10:11:12.103104105)", .v = 103104105}: +1
-Extract{.s = "ordinal(2020-04-14)", .v = 105}: +1
-Extract{.s = "second(10:11:12.103104105)", .v = 12}: +1
-Extract{.s = "week(2020-04-14)", .v = 16}: +1
-Extract{.s = "year(2020-04-14)", .v = 2020}: +1
-TTest:
-TTest{.s = "10:11:12.103104105", .t = ddlog_std::Ok{.res = "10:11:12.103104105"}}: +1
-TTest{.s = "Error in format string '%incorrectformat'", .t = ddlog_std::Ok{.res = "10:11:12.103104105"}}: +1
-TTest{.s = "Ok(midnight())", .t = ddlog_std::Ok{.res = "00:00:00.000000000"}}: +1
-TTest{.s = "SomeTime: 10:11:12.103104105", .t = ddlog_std::Ok{.res = "10:11:12.103104105"}}: +1
-TTest{.s = "string2time(to_string(result_unwrap_or_default(try_from_hms(8'd10, 8'd10, 8'd10))))", .t = ddlog_std::Ok{.res = "10:10:10.000000000"}}: +1
-TTest{.s = "string2time(to_string(result_unwrap_or_default(try_from_hms_micro(8'd10, 8'd10, 8'd10, 32'd10))))", .t = ddlog_std::Ok{.res = "10:10:10.000010000"}}: +1
-TTest{.s = "string2time(to_string(result_unwrap_or_default(try_from_hms_milli(8'd10, 8'd10, 8'd10, 16'd10))))", .t = ddlog_std::Ok{.res = "10:10:10.010000000"}}: +1
-TTest{.s = "string2time(to_string(result_unwrap_or_default(try_from_hms_nano(8'd10, 8'd10, 8'd10, 32'd10))))", .t = ddlog_std::Ok{.res = "10:10:10.000000010"}}: +1
-TTest{.s = "time_parse(\"10:10\", \"%T\")", .t = ddlog_std::Err{.err = "premature end of input"}}: +1
-TTest{.s = "time_parse(\"10:10:10\", \"%T\")", .t = ddlog_std::Ok{.res = "10:10:10.000000000"}}: +1
-TTest{.s = "time_parse(\"10:10:10.102030405\", \"%T.%f\")", .t = ddlog_std::Ok{.res = "10:10:10.102030405"}}: +1
-TTest{.s = "time_parse(time_format(10:11:12.103104105, %H::%M::%S).unwrap_or_default(), %H::%M::%S)", .t = ddlog_std::Ok{.res = "10:11:12.000000000"}}: +1
-TTest{.s = "try_from_hms(100, 0, 0).unwrap_or_default()", .t = ddlog_std::Ok{.res = "00:00:00.000000000"}}: +1
-TTest{.s = "try_from_hms(8'd0, 8'd60, 8'd0)", .t = ddlog_std::Err{.err = "illegal time value"}}: +1
-TTest{.s = "try_from_hms(8'd10, 8'd10, 8'd10)", .t = ddlog_std::Ok{.res = "10:10:10.000000000"}}: +1
-TTest{.s = "try_from_hms(8'd23, 8'd0, 8'd0)", .t = ddlog_std::Ok{.res = "23:00:00.000000000"}}: +1
-TTest{.s = "try_from_hms(8'd24, 8'd0, 8'd0)", .t = ddlog_std::Err{.err = "illegal time value"}}: +1
-TTest{.s = "try_from_hms_micro(8'd10, 8'd10, 8'd10, 32'd10)", .t = ddlog_std::Ok{.res = "10:10:10.000010000"}}: +1
-TTest{.s = "try_from_hms_milli(8'd10, 8'd10, 8'd10, 16'd10)", .t = ddlog_std::Ok{.res = "10:10:10.010000000"}}: +1
-TTest{.s = "try_from_hms_nano(8'd10, 8'd10, 8'd10, 32'd10)", .t = ddlog_std::Ok{.res = "10:10:10.000000010"}}: +1
-TTest{.s = "10:11:12.000000000", .t = ddlog_std::Ok{.res = "10:11:12.000000000"}}
-TTest{.s = "10:11:12.103104105", .t = ddlog_std::Ok{.res = "10:11:12.103104105"}}
-TTest{.s = "Error in format string '%incorrectformat'", .t = ddlog_std::Ok{.res = "10:11:12.103104105"}}
-TTest{.s = "Ok(midnight())", .t = ddlog_std::Ok{.res = "00:00:00.000000000"}}
-TTest{.s = "SomeTime: 10:11:12.103104105", .t = ddlog_std::Ok{.res = "10:11:12.103104105"}}
-TTest{.s = "string2time(to_string(result_unwrap_or_default(try_from_hms(8'd10, 8'd10, 8'd10))))", .t = ddlog_std::Ok{.res = "10:10:10.000000000"}}
-TTest{.s = "string2time(to_string(result_unwrap_or_default(try_from_hms_micro(8'd10, 8'd10, 8'd10, 32'd10))))", .t = ddlog_std::Ok{.res = "10:10:10.000010000"}}
-TTest{.s = "string2time(to_string(result_unwrap_or_default(try_from_hms_milli(8'd10, 8'd10, 8'd10, 16'd10))))", .t = ddlog_std::Ok{.res = "10:10:10.010000000"}}
-TTest{.s = "string2time(to_string(result_unwrap_or_default(try_from_hms_nano(8'd10, 8'd10, 8'd10, 32'd10))))", .t = ddlog_std::Ok{.res = "10:10:10.000000010"}}
-TTest{.s = "time_parse(\"10:10\", \"%T\")", .t = ddlog_std::Err{.err = "premature end of input"}}
-TTest{.s = "time_parse(\"10:10:10\", \"%T\")", .t = ddlog_std::Ok{.res = "10:10:10.000000000"}}
-TTest{.s = "time_parse(\"10:10:10.102030405\", \"%T.%f\")", .t = ddlog_std::Ok{.res = "10:10:10.102030405"}}
-TTest{.s = "time_parse(time_format(10:11:12.103104105, %H::%M::%S).unwrap_or_default(), %H::%M::%S)", .t = ddlog_std::Ok{.res = "10:11:12.000000000"}}
-TTest{.s = "try_from_hms(100, 0, 0).unwrap_or_default()", .t = ddlog_std::Ok{.res = "00:00:00.000000000"}}
-TTest{.s = "try_from_hms(8'd0, 8'd60, 8'd0)", .t = ddlog_std::Err{.err = "illegal time value"}}
-TTest{.s = "try_from_hms(8'd10, 8'd10, 8'd10)", .t = ddlog_std::Ok{.res = "10:10:10.000000000"}}
-TTest{.s = "try_from_hms(8'd23, 8'd0, 8'd0)", .t = ddlog_std::Ok{.res = "23:00:00.000000000"}}
-TTest{.s = "try_from_hms(8'd24, 8'd0, 8'd0)", .t = ddlog_std::Err{.err = "illegal time value"}}
-TTest{.s = "try_from_hms_micro(8'd10, 8'd10, 8'd10, 32'd10)", .t = ddlog_std::Ok{.res = "10:10:10.000010000"}}
-TTest{.s = "try_from_hms_milli(8'd10, 8'd10, 8'd10, 16'd10)", .t = ddlog_std::Ok{.res = "10:10:10.010000000"}}
-TTest{.s = "try_from_hms_nano(8'd10, 8'd10, 8'd10, 32'd10)", .t = ddlog_std::Ok{.res = "10:10:10.000000010"}}
-Extract{.s = "day(2020-04-14)", .v = 14}
-Extract{.s = "hour(10:11:12.103104105)", .v = 10}
-Extract{.s = "microsecond(10:11:12.103104105)", .v = 103104}
-Extract{.s = "millisecond(10:11:12.103104105)", .v = 103}
-Extract{.s = "minute(10:11:12.103104105)", .v = 11}
-Extract{.s = "month(2020-04-14)", .v = 4}
-Extract{.s = "nanosecond(10:11:12.103104105)", .v = 103104105}
-Extract{.s = "ordinal(2020-04-14)", .v = 105}
-Extract{.s = "second(10:11:12.103104105)", .v = 12}
-Extract{.s = "week(2020-04-14)", .v = 16}
-Extract{.s = "year(2020-04-14)", .v = 2020}
-DTest{.s = "2010-10-15", .t = ddlog_std::Ok{.res = "2010-10-15"}}
-DTest{.s = "2020-04-14", .t = ddlog_std::Ok{.res = "2020-04-14"}}
-DTest{.s = "Error in format string '%incorrectformat'", .t = ddlog_std::Ok{.res = "2020-04-14"}}
-DTest{.s = "Ok{from_julian_day(2000000)}", .t = ddlog_std::Ok{.res = "0763-09-18"}}
-DTest{.s = "Ok{next_day(2020-04-14)}", .t = ddlog_std::Ok{.res = "2020-04-15"}}
-DTest{.s = "Ok{previous_day(2020-04-14)}", .t = ddlog_std::Ok{.res = "2020-04-13"}}
-DTest{.s = "date_parse(\"2020/04/14\", \"%Y/%m/%d\")", .t = ddlog_std::Ok{.res = "2020-04-14"}}
-DTest{.s = "date_parse(date_format(2020-04-14, %Y-%m-%dT).result_or_error(), %Y-%m-%dT)", .t = ddlog_std::Ok{.res = "2020-04-14"}}
-DTest{.s = "string2date(to_string(someDate()))", .t = ddlog_std::Ok{.res = "2020-04-14"}}
-DTest{.s = "try_from_iso_ywd(32'sd2020, 8'd4, Monday)", .t = ddlog_std::Ok{.res = "2020-01-20"}}
-DTest{.s = "try_from_yd(0, 0, 0).unwrap_or_default()", .t = ddlog_std::Ok{.res = "0000-01-01"}}
-DTest{.s = "try_from_ymd(32'sd2020, 8'd0, 8'd14)", .t = ddlog_std::Err{.err = "Invalid date"}}
-DTest{.s = "try_from_ymd(32'sd2020, 8'd04, 8'd14)", .t = ddlog_std::Ok{.res = "2020-04-14"}}
-DTest{.s = "try_from_ymd(32'sd2020, 8'd13, 8'd14)", .t = ddlog_std::Err{.err = "Invalid date"}}
-DTest{.s = "try_from_yo(32'sd2020, 16'd100)", .t = ddlog_std::Ok{.res = "2020-04-09"}}
-DTest{.s = "try_from_yo(32'sd2020, 16'd367)", .t = ddlog_std::Err{.err = "Invalid date"}}
-DTTest{.s = "\"\".string2datetime().unwrap_or_default()", .t = ddlog_std::Ok{.res = time::DateTime{.date = "0000-01-01", .time = "00:00:00.000000000"}}}
-DTTest{.s = "2010-10-15T10:11:12", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2010-10-15", .time = "10:11:12.000000000"}}}
-DTTest{.s = "2020-04-14T10:11:12", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.103104105"}}}
-DTTest{.s = "Error in format string '%incorrectformat'", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.103104105"}}}
-DTTest{.s = "Extract date 2020-04-14T10:11:12", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.103104105"}}}
-DTTest{.s = "Extract shifted 2020-04-14T10:11:12", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.103104105"}}}
-DTTest{.s = "datetime_from_unix_timestamp(10000000)", .t = ddlog_std::Ok{.res = time::DateTime{.date = "1970-04-26", .time = "17:46:40.000000000"}}}
-DTTest{.s = "datetime_parse(\"2020-10-10T10:20:30\", \"%Y-%m-%dT%H:%M:%S\")", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-10-10", .time = "10:20:30.000000000"}}}
-DTTest{.s = "datetime_parse(\"2020/10/10T10:20:30\", \"%Y-%m-%dT%H:%M:%S\")", .t = ddlog_std::Err{.err = "input contains invalid characters"}}
-DTTest{.s = "datetime_parse(\"Wed Mar 05 07:45:30 MST 2025\", \"%a %b %d %H:%M:%S %Z %Y\")", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2025-03-05", .time = "07:45:30.000000000"}}}
-DTTest{.s = "datetime_parse(datetime_format(2020-04-14T10:11:12, %Y-%m-%dT%H::%M).result_or_error(), %Y-%m-%dT%H::%M)", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:00.000000000"}}}
-DTTest{.s = "get_datetime(tz_datetime_parse_from_rfc2822(\"Tue, 1 Jul 2003 10:52:37 GMT\"))", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2003-07-01", .time = "10:52:37.000000000"}}}
-DTTest{.s = "string2datetime(\"2020-10-10T10:20:30\")", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-10-10", .time = "10:20:30.000000000"}}}
-DTTest{.s = "string2datetime(to_string(2020-04-14T10:11:12))", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.000000000"}}}
+time_test::TTest{.s = "10:11:12.000000000", .t = ddlog_std::Ok{.res = "10:11:12.000000000"}}
+time_test::TTest{.s = "10:11:12.103104105", .t = ddlog_std::Ok{.res = "10:11:12.103104105"}}
+time_test::TTest{.s = "Error in format string '%incorrectformat'", .t = ddlog_std::Ok{.res = "10:11:12.103104105"}}
+time_test::TTest{.s = "Ok(midnight())", .t = ddlog_std::Ok{.res = "00:00:00.000000000"}}
+time_test::TTest{.s = "SomeTime: 10:11:12.103104105", .t = ddlog_std::Ok{.res = "10:11:12.103104105"}}
+time_test::TTest{.s = "string2time(to_string(result_unwrap_or_default(try_from_hms(8'd10, 8'd10, 8'd10))))", .t = ddlog_std::Ok{.res = "10:10:10.000000000"}}
+time_test::TTest{.s = "string2time(to_string(result_unwrap_or_default(try_from_hms_micro(8'd10, 8'd10, 8'd10, 32'd10))))", .t = ddlog_std::Ok{.res = "10:10:10.000010000"}}
+time_test::TTest{.s = "string2time(to_string(result_unwrap_or_default(try_from_hms_milli(8'd10, 8'd10, 8'd10, 16'd10))))", .t = ddlog_std::Ok{.res = "10:10:10.010000000"}}
+time_test::TTest{.s = "string2time(to_string(result_unwrap_or_default(try_from_hms_nano(8'd10, 8'd10, 8'd10, 32'd10))))", .t = ddlog_std::Ok{.res = "10:10:10.000000010"}}
+time_test::TTest{.s = "time_parse(\"10:10\", \"%T\")", .t = ddlog_std::Err{.err = "premature end of input"}}
+time_test::TTest{.s = "time_parse(\"10:10:10\", \"%T\")", .t = ddlog_std::Ok{.res = "10:10:10.000000000"}}
+time_test::TTest{.s = "time_parse(\"10:10:10.102030405\", \"%T.%f\")", .t = ddlog_std::Ok{.res = "10:10:10.102030405"}}
+time_test::TTest{.s = "time_parse(time_format(10:11:12.103104105, %H::%M::%S).unwrap_or_default(), %H::%M::%S)", .t = ddlog_std::Ok{.res = "10:11:12.000000000"}}
+time_test::TTest{.s = "try_from_hms(100, 0, 0).unwrap_or_default()", .t = ddlog_std::Ok{.res = "00:00:00.000000000"}}
+time_test::TTest{.s = "try_from_hms(8'd0, 8'd60, 8'd0)", .t = ddlog_std::Err{.err = "illegal time value"}}
+time_test::TTest{.s = "try_from_hms(8'd10, 8'd10, 8'd10)", .t = ddlog_std::Ok{.res = "10:10:10.000000000"}}
+time_test::TTest{.s = "try_from_hms(8'd23, 8'd0, 8'd0)", .t = ddlog_std::Ok{.res = "23:00:00.000000000"}}
+time_test::TTest{.s = "try_from_hms(8'd24, 8'd0, 8'd0)", .t = ddlog_std::Err{.err = "illegal time value"}}
+time_test::TTest{.s = "try_from_hms_micro(8'd10, 8'd10, 8'd10, 32'd10)", .t = ddlog_std::Ok{.res = "10:10:10.000010000"}}
+time_test::TTest{.s = "try_from_hms_milli(8'd10, 8'd10, 8'd10, 16'd10)", .t = ddlog_std::Ok{.res = "10:10:10.010000000"}}
+time_test::TTest{.s = "try_from_hms_nano(8'd10, 8'd10, 8'd10, 32'd10)", .t = ddlog_std::Ok{.res = "10:10:10.000000010"}}
+time_test::Extract{.s = "day(2020-04-14)", .v = 14}
+time_test::Extract{.s = "hour(10:11:12.103104105)", .v = 10}
+time_test::Extract{.s = "microsecond(10:11:12.103104105)", .v = 103104}
+time_test::Extract{.s = "millisecond(10:11:12.103104105)", .v = 103}
+time_test::Extract{.s = "minute(10:11:12.103104105)", .v = 11}
+time_test::Extract{.s = "month(2020-04-14)", .v = 4}
+time_test::Extract{.s = "nanosecond(10:11:12.103104105)", .v = 103104105}
+time_test::Extract{.s = "ordinal(2020-04-14)", .v = 105}
+time_test::Extract{.s = "second(10:11:12.103104105)", .v = 12}
+time_test::Extract{.s = "week(2020-04-14)", .v = 16}
+time_test::Extract{.s = "year(2020-04-14)", .v = 2020}
+time_test::DTest{.s = "2010-10-15", .t = ddlog_std::Ok{.res = "2010-10-15"}}
+time_test::DTest{.s = "2020-04-14", .t = ddlog_std::Ok{.res = "2020-04-14"}}
+time_test::DTest{.s = "Error in format string '%incorrectformat'", .t = ddlog_std::Ok{.res = "2020-04-14"}}
+time_test::DTest{.s = "Ok{from_julian_day(2000000)}", .t = ddlog_std::Ok{.res = "0763-09-18"}}
+time_test::DTest{.s = "Ok{next_day(2020-04-14)}", .t = ddlog_std::Ok{.res = "2020-04-15"}}
+time_test::DTest{.s = "Ok{previous_day(2020-04-14)}", .t = ddlog_std::Ok{.res = "2020-04-13"}}
+time_test::DTest{.s = "date_parse(\"2020/04/14\", \"%Y/%m/%d\")", .t = ddlog_std::Ok{.res = "2020-04-14"}}
+time_test::DTest{.s = "date_parse(date_format(2020-04-14, %Y-%m-%dT).result_or_error(), %Y-%m-%dT)", .t = ddlog_std::Ok{.res = "2020-04-14"}}
+time_test::DTest{.s = "string2date(to_string(someDate()))", .t = ddlog_std::Ok{.res = "2020-04-14"}}
+time_test::DTest{.s = "try_from_iso_ywd(32'sd2020, 8'd4, Monday)", .t = ddlog_std::Ok{.res = "2020-01-20"}}
+time_test::DTest{.s = "try_from_yd(0, 0, 0).unwrap_or_default()", .t = ddlog_std::Ok{.res = "0000-01-01"}}
+time_test::DTest{.s = "try_from_ymd(32'sd2020, 8'd0, 8'd14)", .t = ddlog_std::Err{.err = "Invalid date"}}
+time_test::DTest{.s = "try_from_ymd(32'sd2020, 8'd04, 8'd14)", .t = ddlog_std::Ok{.res = "2020-04-14"}}
+time_test::DTest{.s = "try_from_ymd(32'sd2020, 8'd13, 8'd14)", .t = ddlog_std::Err{.err = "Invalid date"}}
+time_test::DTest{.s = "try_from_yo(32'sd2020, 16'd100)", .t = ddlog_std::Ok{.res = "2020-04-09"}}
+time_test::DTest{.s = "try_from_yo(32'sd2020, 16'd367)", .t = ddlog_std::Err{.err = "Invalid date"}}
+time_test::DTTest{.s = "\"\".string2datetime().unwrap_or_default()", .t = ddlog_std::Ok{.res = time::DateTime{.date = "0000-01-01", .time = "00:00:00.000000000"}}}
+time_test::DTTest{.s = "2010-10-15T10:11:12", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2010-10-15", .time = "10:11:12.000000000"}}}
+time_test::DTTest{.s = "2020-04-14T10:11:12", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.103104105"}}}
+time_test::DTTest{.s = "Error in format string '%incorrectformat'", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.103104105"}}}
+time_test::DTTest{.s = "Extract date 2020-04-14T10:11:12", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.103104105"}}}
+time_test::DTTest{.s = "Extract shifted 2020-04-14T10:11:12", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.103104105"}}}
+time_test::DTTest{.s = "datetime_from_unix_timestamp(10000000)", .t = ddlog_std::Ok{.res = time::DateTime{.date = "1970-04-26", .time = "17:46:40.000000000"}}}
+time_test::DTTest{.s = "datetime_parse(\"2020-10-10T10:20:30\", \"%Y-%m-%dT%H:%M:%S\")", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-10-10", .time = "10:20:30.000000000"}}}
+time_test::DTTest{.s = "datetime_parse(\"2020/10/10T10:20:30\", \"%Y-%m-%dT%H:%M:%S\")", .t = ddlog_std::Err{.err = "input contains invalid characters"}}
+time_test::DTTest{.s = "datetime_parse(\"Wed Mar 05 07:45:30 MST 2025\", \"%a %b %d %H:%M:%S %Z %Y\")", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2025-03-05", .time = "07:45:30.000000000"}}}
+time_test::DTTest{.s = "datetime_parse(datetime_format(2020-04-14T10:11:12, %Y-%m-%dT%H::%M).result_or_error(), %Y-%m-%dT%H::%M)", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:00.000000000"}}}
+time_test::DTTest{.s = "get_datetime(tz_datetime_parse_from_rfc2822(\"Tue, 1 Jul 2003 10:52:37 GMT\"))", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2003-07-01", .time = "10:52:37.000000000"}}}
+time_test::DTTest{.s = "string2datetime(\"2020-10-10T10:20:30\")", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-10-10", .time = "10:20:30.000000000"}}}
+time_test::DTTest{.s = "string2datetime(to_string(2020-04-14T10:11:12))", .t = ddlog_std::Ok{.res = time::DateTime{.date = "2020-04-14", .time = "10:11:12.000000000"}}}


### PR DESCRIPTION
@convolvatron , @mbudiu-vmw: only the last commit in this PR is new compared to #1060 (github wouldn't let me submit a PR to a PR), so please only review that commit.

--------------------

This is another step towards an infrastructure to implement more
of the D3log logic in DDlog.  In the current architecture, distributed
relations, i.e., relations whose records are exchanged across nodes, are
cut into pairs of input/output relations, where the output relation
contains records to be shipped to a remote location.  These are consumed
by the Rust D3log runtime, which is responsible for buffering and
routing the records to their destinations.

The stateful part of the D3log runtime must deal with changing cluster
membership, and may actually benefit from D3log's declarative,
incremental semantics.  In order to port this logic to DDlog and keep it
generic, we must first convert all distributed output facts to `Any` and
collect them in one DDlog relation, so that it can be processed by
application-independent D3log runtime.  Since we currently don't have
general meta-programming facilities in DDLog, we implement this as a
one-off compiler extension.

Specifically, this commit introduces the following changes:
- A new DDlog compiler CLI switch: `--d3log-dev`, which enables the
  following features.  Note that the old `--d3log` flag is still
  supported, as we don't want to break existing D3log code.  Once
  all of it has been ported, we will remove the old `--d3log` behavior
  and rename `--d3log-dev` to `--d3log`.

- `lib/d3log/reflect.dl` library declares the following two tables that
  will collect all distributed facts:

  ```
  // Rows from distributed relations.
  //
  // `relname`     - relation name
  // `fact`        - row in the relation
  // `destination` - destination specified via @-annotation, if any
  relation DistributedRelFacts(
      relname: istring,
      fact: Any,
      destination: Option<D3logLocationId>
  )

  // Rows from distributed streams.
  //
  // `relname`     - stream name
  // `fact`        - record in the stream
  // `destination` - destination specified via @-annotation, if any
  stream DistributedStreamFacts(
      relname: istring,
      fact: Any,
      destination: Option<D3logLocationId>
  )
  ```

  Note that we need two separate tables for stream and non-stream tables
  (relations and multisets).

- The compiler rewrites rules that write into distributed relations to
  populate the above tables instead.

- As before (with the `--d3log` switch) distributed tables are
  converted into input tables with the same signature, so that D3log
  can feed remote facts to them.  One important caveat is that
  distributed `relations`'s are converted to `input multiset`'s,
  as required by the D3log semantics.