### PR TITLE
ddlog-sql: translate array_length function to DDlog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 - Bug fixes and improvements in tutorial and SQL to DDlog compiler.
+- Enable SQL-to-DDlog compiler to translate `array_length` function calls, which appear in SQL dialects such as H2 and Postgres.
 
 ## [0.47.0] - Aug 19, 2021
 

--- a/sql/lib/sql.dl
+++ b/sql/lib/sql.dl
@@ -14,6 +14,10 @@ function sql_array_contains(a: Vec<'A>, e: 'A): bool {
     vec_contains(a, e)
 }
 
+function sql_array_length(a: Vec<'A>): signed<64> {
+    vec_len(a) as signed<64>
+}
+
 function sql_extract_week(d: Date): signed<64> {
     week(d) as signed<8> as signed<64>
 }

--- a/sql/src/main/java/com/vmware/ddlog/translator/ExpressionTranslationVisitor.java
+++ b/sql/src/main/java/com/vmware/ddlog/translator/ExpressionTranslationVisitor.java
@@ -469,6 +469,7 @@ public class ExpressionTranslationVisitor extends AstVisitor<DDlogExpression, Tr
                 return args.get(0).getType();
             case "count":
             case "count_distinct":
+            case "array_length":
                 if (args.size() == 0)
                     return DDlogTSigned.signed64;
                 return DDlogTSigned.signed64.setMayBeNull(args.get(0).getType().mayBeNull);

--- a/sql/src/test/java/ddlog/AggregatesTest.java
+++ b/sql/src/test/java/ddlog/AggregatesTest.java
@@ -507,4 +507,31 @@ public class AggregatesTest extends BaseQueriesTest {
                 "Rv1[v2] :- Rt1[v],var groupResult = (v).group_by(()),var aggResult = agg(groupResult),var v1 = aggResult,var v2 = v1.";
         this.testTranslation(query, program);
     }
+
+    @Test
+    public void arrayLengthTest() {
+        String query = "create view v1 as select array_length(array_agg(column2)) from t1";
+        String program = this.header(false) +
+                "typedef TRtmp = TRtmp{col0:signed<64>}\n" +
+                "function agg(g: Group<(), Tt1>):TRtmp {\n" +
+                "var array_agg = vec_empty(): Vec<string>;\n" +
+                "(for ((i, _) in g) {\n" +
+                "var v = i;\n" +
+                "(var incr = v.column2);\n" +
+                "(vec_push(array_agg, incr))}\n" +
+                ");\n" +
+                "(TRtmp{.col0 = sql_array_length(array_agg)})\n" +
+                "}\n" +
+                "\n" +
+                "input relation Rt1[Tt1]\n" +
+                "input relation Rt2[Tt2]\n" +
+                "input relation Rt3[Tt3]\n" +
+                "input relation Rt4[Tt4]\n" +
+                "relation Rtmp[TRtmp]\n" +
+                "output relation Rv1[TRtmp]\n" +
+                "Rv1[v2] :- Rt1[v],var groupResult = (v).group_by(()),var aggResult = agg(groupResult),var v1 = aggResult,var v2 = v1.";
+        
+        this.testTranslation(query, program);
+
+    }
 }


### PR DESCRIPTION
array_length is a non-standard SQL function that is alternately called array_length (in Postgres and H2 dialects) and cardinality (in Presto and Calcite dialects). Either instantiation of the function determines the length of the passed array.

For now, we need array_length for a use-case. If there are use-cases for `cardinality` in the future, we can add a similar function.

Signed-off-by: Amy Tai <amy.tai.2009@gmail.com>