### PR TITLE
[self-profiler]: "Change profiling" feature. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-- Bug fixes and improvements in tutorial and SQL to DDlog compiler.
+### SQL-to-DDlog compiler
+
+- Bug fixes and improvements in SQL-to-DDlog compiler.
 - Enable SQL-to-DDlog compiler to translate `array_length` function calls, which appear in SQL dialects such as H2 and Postgres.
+
+### New features
+
+- Added change profiling support to the DDlog self-profiler.  Unlike arrangement size
+  profiling, which tracks the number of records in each arrangment, the change profile
+  shows the amount of churn.  For example adding one record and deleting one record will
+  show up as two changes in the change profile, but will cancel out in the size profile.
+  The self-profiler now support the `profile change on/off` commands (also available
+  through the API), which enables change profiling for selected transactions.
+  When change profiling is disabled, the recording stops, but the previously accumulated
+  profile is preserved.  By selectively enabling change profiling for a subset of transactions,
+  the user can focus their analysis on specific parts of the program.
+
+- Limited support for dynamic typing.  We introduce a new type `Any` to the standard
+  library, which can represent any DDlog value, along with two library functions
+  `to_any()` and `from_any()` that convert values to and from this type.  This
+  feature can be used to, e.g., store a mix of values of different types in a
+  set or map.
+
+- Experimental features to support implementing parts of D3log runtime in DDlog.
+  See #1065 for details.
 
 ## [0.47.0] - Aug 19, 2021
 

--- a/doc/profiling.md
+++ b/doc/profiling.md
@@ -63,6 +63,10 @@ addition to memory profiling.  CPU profiling is not enabled by default, as
 it can slow down the program somewhat, especially for large programs
 that handle many small updates.
 
+1. `profile change on/off;` - enables/disables recording of the number of
+insertions and deletions per arrangement, used to construct arrangement
+change profile (see below).
+
 1. `profile;` - returns information about program's CPU and memory usage.  CPU
 usage is expressed as the total amount of time DDlog spent evaluating each operator,
 assuming CPU profiling was enabled.  For example the following CPU profile
@@ -94,6 +98,31 @@ with the `LabeledNode(.node=child, .scc=childscc)` literal.
   451,529 and 372,446 records respectively (the numbered variables, e.g., `_0`)
   indicate one or more fields used to index the relation by.
 
+  In addition, if change profiling was enabled for some parts of the execution,
+  the self-profiler also outputs the "Counts of changes" profile:
+  ```
+  Counts of changes (insertions+deletions) to arrangements
+  ...
+  451529      Arrange: LabeledNode{.node=_, .scc=_0} 136
+  372446      Arrange: LabeledNode{.node=_0, .scc=_} 132
+  ```
+  Unlike the arrangement size profile, which tracks the number of records in
+  each arrangment, this profile shows the amount of churn.  For example adding one
+  record and deleting one record will show up as two changes in the change
+  profile, but will cancel out in the size profile.  Identifying relations that
+  see the most churn helps to understand the performance of the program, as such
+  relations are responsible for most recomputation performed by DDlog.  In a
+  typical profiling session, the user identifies expensive operators in the CPU
+  profile and looks up the relations that are inputs to this operator in the
+  change profile to identify the ones with high churn.
+
+  When change profiling is disabled, the recording stops, but the previously
+  accumulated profile is preserved.  By selectively enabling change profiling for
+  a subset of transactions, the user can focus their analysis on specific parts of
+  the program, for example they may not be interested in the number of changes
+  during initial population of input relations, but may want to make sure that
+  subsequent small incremental input updates do not cause excessive churn in
+  derived relations.
 
 ## DDShow-based profiling
 

--- a/java/ddlogapi.c
+++ b/java/ddlogapi.c
@@ -706,6 +706,13 @@ JNIEXPORT void JNICALL Java_ddlogapi_DDlogAPI_ddlog_1enable_1cpu_1profiling(
     }
 }
 
+JNIEXPORT void JNICALL Java_ddlogapi_DDlogAPI_ddlog_1enable_1change_1profiling(
+    JNIEnv *env, jobject obj, jlong progHandle, jboolean enable) {
+    if (ddlog_enable_change_profiling((ddlog_prog)progHandle, enable) < 0) {
+        throwDDlogException(env, NULL);
+    }
+}
+
 void log_callback(uintptr_t callbackInfo, int level, const char *msg) {
     struct CallbackInfo* cbi = (struct CallbackInfo*)callbackInfo;
     JNIEnv* env;

--- a/java/ddlogapi/DDlogAPI.java
+++ b/java/ddlogapi/DDlogAPI.java
@@ -55,6 +55,7 @@ public class DDlogAPI {
     static native int ddlog_clear_relation(long hprog, int relid);
     static native String ddlog_profile(long hprog);
     static native void ddlog_enable_cpu_profiling(long hprog, boolean enable) throws DDlogException;
+    static native void ddlog_enable_change_profiling(long hprog, boolean enable) throws DDlogException;
     static native long ddlog_log_replace_callback(int module, long old_cbinfo, ObjIntConsumer<String> cb, int max_level);
     static native long ddlog_log_replace_default_callback(long old_cbinfo, ObjIntConsumer<String> cb, int max_level);
 
@@ -645,6 +646,16 @@ public class DDlogAPI {
     public void enableCpuProfiling(boolean enable) throws DDlogException {
         this.checkHandle();
         DDlogAPI.ddlog_enable_cpu_profiling(this.hprog, enable);
+    }
+
+    /**
+     * Controls recording of the number of insertions and deletions per arrangement.
+     *
+     * See <code>ddlog.h: ddlog_enable_change_profiling()</code>
+     */
+    public void enableChangeProfiling(boolean enable) throws DDlogException {
+        this.checkHandle();
+        DDlogAPI.ddlog_enable_change_profiling(this.hprog, enable);
     }
 
     /**

--- a/rust/template/ddlog.h
+++ b/rust/template/ddlog.h
@@ -801,6 +801,21 @@ extern void ddlog_free_json(char *json);
 extern int ddlog_enable_cpu_profiling(ddlog_prog prog, bool enable);
 
 /*
+ * Controls recording of the number of insertions and deletions per
+ * arrangement.  Unlike the arrangement size profile, which tracks the
+ * number of records in each arrangment, this feature tracks the amount
+ * of churn.  For example adding one record and deleting one record will
+ * show up as two changes in the change profile (but will cancel out in
+ * the size profile).
+ *
+ * When change profiling is disabled, the recording stops, but the
+ * previously accumulated profile is preserved.  By selectively enabling
+ * change profiling for a subset of transactions, the user can focus
+ * the analysis on specific parts of the program.
+ */
+extern int ddlog_enable_change_profiling(ddlog_prog prog, bool enable);
+
+/*
  * Returns DDlog program runtime profile as a C string.
  *
  * The returned string must be deallocated using `ddlog_string_free()`.

--- a/rust/template/differential_datalog/src/api/c_api.rs
+++ b/rust/template/differential_datalog/src/api/c_api.rs
@@ -818,6 +818,24 @@ pub unsafe extern "C" fn ddlog_enable_cpu_profiling(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn ddlog_enable_change_profiling(
+    prog: *const HDDlog,
+    enable: bool,
+) -> raw::c_int {
+    if prog.is_null() {
+        return -1;
+    }
+    let prog = &*prog;
+
+    prog.enable_change_profiling(enable)
+        .map(|_| 0)
+        .unwrap_or_else(|e| {
+            prog.eprintln(&format!("ddlog_enable_change_profiling(): error: {}", e));
+            -1
+        })
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn ddlog_enable_timely_profiling(
     prog: *const HDDlog,
     enable: bool,

--- a/rust/template/differential_datalog/src/api/mod.rs
+++ b/rust/template/differential_datalog/src/api/mod.rs
@@ -268,6 +268,12 @@ impl DDlogProfiling for HDDlog {
         Ok(())
     }
 
+    fn enable_change_profiling(&self, enable: bool) -> Result<(), String> {
+        self.record_command(|r| r.enable_change_profiling(enable));
+        self.prog.lock().unwrap().enable_change_profiling(enable);
+        Ok(())
+    }
+
     fn enable_timely_profiling(&self, enable: bool) -> Result<(), String> {
         self.record_command(|r| r.enable_timely_profiling(enable));
         self.prog.lock().unwrap().enable_timely_profiling(enable);

--- a/rust/template/differential_datalog/src/ddlog.rs
+++ b/rust/template/differential_datalog/src/ddlog.rs
@@ -345,6 +345,19 @@ pub trait DDlogProfiling {
     /// therefore disabled by default.
     fn enable_cpu_profiling(&self, enable: bool) -> Result<(), String>;
 
+    /// Controls recording of the number of insertions and deletions per
+    /// arrangement.  Unlike the arrangement size profile, which tracks the
+    /// number of records in each arrangment, this feature tracks the amount
+    /// of churn.  For example adding one record and deleting one record will
+    /// show up as two changes in the change profile (but will cancel out in
+    /// the size profile).
+    ///
+    /// When change profiling is disabled, the recording stops, but the
+    /// previously accumulated profile is preserved.  By selectively enabling
+    /// change profiling for a subset of transactions, the user can focus
+    /// the analysis on specific parts of the program.
+    fn enable_change_profiling(&self, enable: bool) -> Result<(), String>;
+
     fn enable_timely_profiling(&self, enable: bool) -> Result<(), String>;
 
     /// returns DDlog program runtime profile

--- a/rust/template/differential_datalog/src/program/config.rs
+++ b/rust/template/differential_datalog/src/program/config.rs
@@ -182,6 +182,7 @@ pub(super) struct SelfProfilingRig {
     pub(super) profiling_data: Option<ProfilingData>,
     pub(super) profile_cpu: Option<Arc<AtomicBool>>,
     pub(super) profile_timely: Option<Arc<AtomicBool>>,
+    pub(super) profile_change: Option<Arc<AtomicBool>>,
 }
 
 impl SelfProfilingRig {
@@ -195,7 +196,8 @@ impl SelfProfilingRig {
             // Profiling data structure
             let profile = Arc::new(Mutex::new(Profile::new()));
 
-            let (profile_cpu, profile_timely) = (
+            let (profile_cpu, profile_timely, profile_change) = (
+                Arc::new(AtomicBool::new(false)),
                 Arc::new(AtomicBool::new(false)),
                 Arc::new(AtomicBool::new(false)),
             );
@@ -205,8 +207,12 @@ impl SelfProfilingRig {
             let profile_thread =
                 thread::spawn(move || Program::prof_thread_func(profile_recv, cloned_profile));
 
-            let profiling_data =
-                ProfilingData::new(profile_cpu.clone(), profile_timely.clone(), profile_send);
+            let profiling_data = ProfilingData::new(
+                profile_cpu.clone(),
+                profile_timely.clone(),
+                profile_change.clone(),
+                profile_send,
+            );
 
             Self {
                 profile: Some(profile),
@@ -214,6 +220,7 @@ impl SelfProfilingRig {
                 profiling_data: Some(profiling_data),
                 profile_cpu: Some(profile_cpu),
                 profile_timely: Some(profile_timely),
+                profile_change: Some(profile_change),
             }
         } else {
             Self {
@@ -222,6 +229,7 @@ impl SelfProfilingRig {
                 profiling_data: None,
                 profile_cpu: None,
                 profile_timely: None,
+                profile_change: None,
             }
         }
     }

--- a/rust/template/differential_datalog/src/replay.rs
+++ b/rust/template/differential_datalog/src/replay.rs
@@ -363,6 +363,16 @@ where
         .map_err(|e| e.to_string())
     }
 
+    fn enable_change_profiling(&self, enable: bool) -> Result<(), String> {
+        let mut writer = self.writer.lock().unwrap();
+        writeln!(
+            &mut writer,
+            "profile change {};",
+            if enable { "on" } else { "off" }
+        )
+        .map_err(|e| e.to_string())
+    }
+
     fn enable_timely_profiling(&self, enable: bool) -> Result<(), String> {
         let mut writer = self.writer.lock().unwrap();
         writeln!(

--- a/rust/template/src/main.rs
+++ b/rust/template/src/main.rs
@@ -100,6 +100,9 @@ fn handle_cmd(
             .profile()
             .map(|profile| println!("Profile:\n{}", profile)),
         Command::Profile(Some(ProfileCmd::Cpu(enable))) => hddlog.enable_cpu_profiling(enable),
+        Command::Profile(Some(ProfileCmd::Change(enable))) => {
+            hddlog.enable_change_profiling(enable)
+        }
         Command::Profile(Some(ProfileCmd::Timely(enable))) => {
             hddlog.enable_timely_profiling(enable)
         }


### PR DESCRIPTION
Added change profiling support to the DDlog self-profiler.  Unlike
arrangement size profiling, which tracks the number of records in each
arrangment, the change profile shows the amount of churn.  For example
adding one record and deleting one record will show up as two changes in
the change profile, but will cancel out in the size profile.
Identifying relations that see the most churn helps to understand the
performance of the program, as such relations are responsible for most
recomputation performed by DDlog.  In a typical profiling session, the
user identifies expensive operators in the CPU profile and looks up the
relations that are inputs to this operator in the change profile to
identify the ones with high churn.

The self-profiler now support the `profile change on/off` commands (also
available through the API), which enables change profiling for selected
transactions.  When change profiling is disabled, the recording stops,
but the previously accumulated profile is preserved.  By selectively
enabling change profiling for a subset of transactions, the user can
focus their analysis on specific parts of the program.

@blp 