### PR TITLE
Cleaner and faster `group_by`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Experimental features to support implementing parts of D3log runtime in DDlog.
   See #1065 for details.
 
+### Language and standard library changes
+
+- The semantics of the `group_by` operator changed in a subtle way.  A group
+  now contain exactly one occurrence of each value. See #1070 for details.
+
+- Removed `ddlog_std::count(Group)` and `ddlog_std::group_count(Group)` methods
+  to avoid changing their behavior in a non-backwards-compatible way.  Added
+  `count_distinct(Group)` instead, which returns the count of distinct values in
+  the group.
+
+- Removed `ddlog_std::group_sum(Group)`.  Added
+  `function sum_of(g: Group<'K, 'V>, f: function('V): 'N): 'N` instead.
+
 ## [0.47.0] - Aug 19, 2021
 
 ### OVSDB-to-DDlog compiler update

--- a/lib/ddlog_std.dl
+++ b/lib/ddlog_std.dl
@@ -505,9 +505,9 @@ extern function group_key(g: Group<'K, 'V>): 'K
  * Standard aggregates
  */
 
-/* Returns the number of elements in the group, which is guaranteed
+/* Returns the number of distinct elements in the group, which is guaranteed
  * to be >0. */
-extern function group_count(g: Group<'K, 'V>): usize
+extern function group_count_distinct(g: Group<'K, 'V>): usize
 
 /* Returns the first element of the group.
  * It always exists, as aggregation cannot return an empty group. */
@@ -523,14 +523,6 @@ extern function group_to_vec(g: Group<'K, 'V>): Vec<'V>
 extern function group_to_map(g: Group<'K1, ('K2,'V)>): Map<'K2,'V>
 extern function group_to_setmap(g: Group<'K1, ('K2,'V)>): Map<'K2,Set<'V>>
 
-/* Returns the sum of all values in the group, ignoring weights.
- *
- * `V` must satisfy the `Add<Output = V>` Rust type bound.
- * The DDlog compiler does not currently enforce this constraint,
- * however the Rust compiler will return an error if it is violated.
- */
-extern function group_sum(g: Group<'K, 'V>): 'V
-
 extern function group_set_unions(g: Group<'K, Set<'A>>): Set<'A>
 
 /* Optimized version of group_set_unions that, when the group consits of
@@ -545,13 +537,8 @@ function key(g: Group<'K, 'V>): 'K {
     group_key(g)
 }
 
-function count(g: Group<'K, 'V>): usize {
-    group_count(g)
-}
-
-/* The number of elements in the group.  The result is always greater than 0. */
-function size(g: Group<'K, 'V>): usize {
-    group_count(g)
+function count_distinct(g: Group<'K, 'V>): usize {
+    group_count_distinct(g)
 }
 
 /* The first element of the group.  This operation is well defined,
@@ -591,8 +578,8 @@ function to_setmap(g: Group<'K1, ('K2,'V)>): Map<'K2,Set<'V>> {
 }
 
 function group_unzip(g: Group<'K, ('X,'Y)>): (Vec<'X>, Vec<'Y>) = {
-    var xs: Vec<'X> = vec_with_capacity(g.size());
-    var ys: Vec<'Y> = vec_with_capacity(g.size());
+    var xs: Vec<'X> = vec_with_capacity(g.count_distinct());
+    var ys: Vec<'Y> = vec_with_capacity(g.count_distinct());
     for ((v, _) in g) {
         (var x, var y) = v;
         vec_push(xs, x);

--- a/lib/debug.rs
+++ b/lib/debug.rs
@@ -90,8 +90,8 @@ pub fn debug_event_join<
 pub fn debug_split_group<K: Clone, I: 'static + Clone, V: Clone + 'static>(
     g: &ddlog_std::Group<K, ddlog_std::tuple2<I, V>>,
 ) -> ddlog_std::tuple2<ddlog_std::Vec<I>, ddlog_std::Group<K, V>> {
-    let mut inputs = ddlog_std::Vec::with_capacity(ddlog_std::group_count(g) as usize);
-    let mut vals = ::std::vec::Vec::with_capacity(ddlog_std::group_count(g) as usize);
+    let mut inputs = ddlog_std::Vec::with_capacity(ddlog_std::group_count_distinct(g) as usize);
+    let mut vals = ::std::vec::Vec::with_capacity(ddlog_std::group_count_distinct(g) as usize);
     for ddlog_std::tuple2(ddlog_std::tuple2(i, v), w) in g.iter() {
         inputs.push(i);
         vals.push(ddlog_std::tuple2(v, w));

--- a/lib/group.dl
+++ b/lib/group.dl
@@ -33,7 +33,7 @@ SOFTWARE.
 
 /* Applies closure `f` to each element of the group. */
 function map(g: Group<'K, 'V1>, f: function('V1): 'V2): Vec<'V2> {
-    var res = vec_with_capacity(g.count());
+    var res = vec_with_capacity(g.count_distinct());
     for ((x, _) in g) {
         res.push(f(x))
     };
@@ -162,3 +162,9 @@ function fold(g: Group<'K,'V>, f: function('B, 'V): 'B, initializer: 'B): 'B {
     };
     res
 }
+
+/* Apply `f` to each distinct value in the group and sum up the results.
+ *
+ * `'N` must be a numeric type.
+ */
+extern function sum_of(g: Group<'K, 'V>, f: function('V): 'N): 'N

--- a/lib/group.rs
+++ b/lib/group.rs
@@ -1,0 +1,17 @@
+use std::{default::Default, ops::Add};
+
+use ddlog_rt::Closure;
+use ddlog_std::Group;
+
+pub fn sum_of<K, V: Clone, N: Add<Output = N> + Default>(
+    g: &Group<K, V>,
+    f: &Box<dyn Closure<*const V, N>>,
+) -> N {
+    let mut sum = N::default();
+
+    for v in g.val_iter() {
+        sum = sum + f.call(v);
+    }
+
+    sum
+}

--- a/lib/souffle_lib.dl
+++ b/lib/souffle_lib.dl
@@ -91,7 +91,7 @@ function lnot(l: Tunsigned): Tunsigned {
     if (l != 0) 0 else 1
 }
 function group_count32(g: Group<'K, 'V>): Tnumber {
-    castTo32(group_count(g))
+    castTo32(group_count_distinct(g))
 }
 function ftoi(l: double): signed<32> {
     match (int_from_d(l)) {
@@ -162,13 +162,13 @@ function exp(l: signed<32>): signed<32> {
 }
 function group_mean(g: Group<'K, signed<32>>): signed<32> {
     var sum = group_sum(g);
-    var count = group_count(g);
+    var count = group_count_distinct(g);
     // count can never be 0
     sum / (count as signed<64> as signed<32>)
 }
 function group_mean_d(g: Group<'K, double>): double {
     var sum = group_sum(g);
-    var count = group_count(g);
+    var count = group_count_distinct(g);
     // count can never be 0
     sum / (count as double)
 }

--- a/lib/souffle_lib.dl
+++ b/lib/souffle_lib.dl
@@ -90,9 +90,6 @@ function lor(l: Tunsigned, r: Tunsigned): Tunsigned {
 function lnot(l: Tunsigned): Tunsigned {
     if (l != 0) 0 else 1
 }
-function group_count32(g: Group<'K, 'V>): Tnumber {
-    castTo32(group_count_distinct(g))
-}
 function ftoi(l: double): signed<32> {
     match (int_from_d(l)) {
         None -> 0,
@@ -160,15 +157,69 @@ function log(l: signed<32>): signed<32> {
 function exp(l: signed<32>): signed<32> {
     ftoi(exp_d(l as double))
 }
-function group_mean(g: Group<'K, signed<32>>): signed<32> {
-    var sum = group_sum(g);
+function souffle_group_count32(g: Group<'K, 'V>): Tnumber {
+    castTo32(group_count_distinct(g))
+}
+
+/*
+ In all the group functions below, the group has structure Group<'K, ('V, X)>
+ where is the X we want to aggregate.  'K is the group key.
+ 'V is the type of all tuples that are in context, and it really is ignored
+
+ Moreover, the group iterators have the structure:
+    for (((_, n), _) in g)
+ This is because for a Group<'K, 'A> the iterator iterates over
+ values of type ('A, weight), and the weight is only interesting
+ for streams, and thus it is ignored here.  In the triple
+ ((_, n), _) n is really the value we want to aggregate.
+ The first dash is the tuple, which we ignore, and the last dash is
+ the weight.
+*/
+
+function souffle_group_max(g: Group<'K, ('V, 'N)>): 'N {
+    var result = g.first().1;
+    for (((_, n), _) in g) {
+        result = max(n, result);
+    };
+    result
+}
+function souffle_group_min(g: Group<'K, ('V, 'N)>): 'N {
+    var result = g.first().1;
+    for (((_, n), _) in g) {
+        result = min(n, result);
+    };
+    result
+}
+function souffle_group_mean(g: Group<'K, ('V, signed<32>)>): signed<32> {
+    var sum = souffle_group_sum(g);
     var count = group_count_distinct(g);
     // count can never be 0
     sum / (count as signed<64> as signed<32>)
 }
-function group_mean_d(g: Group<'K, double>): double {
-    var sum = group_sum(g);
+function souffle_group_mean_d(g: Group<'K, ('V, double)>): double {
+    var sum = souffle_group_sum_d(g);
     var count = group_count_distinct(g);
     // count can never be 0
     sum / (count as double)
+}
+function souffle_group_sum(g: Group<'K, ('V, Tnumber)>): Tnumber {
+    var sum = 0;
+    for (((_, n), _) in g) {
+        sum = sum + n;
+    };
+    sum
+}
+function souffle_group_sum_u(g: Group<'K, ('V, Tunsigned)>): Tunsigned {
+    var sum = 0;
+    for (((_, n), _) in g) {
+        sum = sum + n;
+    };
+    sum
+}
+function souffle_group_sum_d(g: Group<'K, ('V, double)>): double {
+    var sum = 0.0;
+    for (((_, n), _) in g) {
+        sum = sum + n;
+    };
+    sum
 }

--- a/lib/tinyset.rs
+++ b/lib/tinyset.rs
@@ -299,7 +299,7 @@ pub fn difference<X: u64set::Fits64 + Clone>(s1: &Set64<X>, s2: &Set64<X>) -> Se
 pub fn group_to_set<K, V: u64set::Fits64>(g: &ddlog_std::Group<K, V>) -> Set64<V> {
     let mut res = Set64::new();
     for ref v in g.val_iter() {
-        insert(&mut res, v);
+        insert(&mut res, v.clone());
     }
     res
 }
@@ -321,7 +321,7 @@ pub fn group_set_unions<K, V: u64set::Fits64 + Clone>(
 pub fn group_setref_unions<K, V: u64set::Fits64 + Ord + Clone>(
     g: &ddlog_std::Group<K, ddlog_std::Ref<Set64<V>>>,
 ) -> ddlog_std::Ref<Set64<V>> {
-    if ddlog_std::group_count(g) == 1 {
+    if ddlog_std::group_count_distinct(g) == 1 {
         ddlog_std::group_first(g)
     } else {
         let mut res = ddlog_std::ref_new(Set64 {

--- a/src/Language/DifferentialDatalog/DatalogProgram.hs
+++ b/src/Language/DifferentialDatalog/DatalogProgram.hs
@@ -170,16 +170,16 @@ progTypeMap :: DatalogProgram -> (Type -> Type) -> DatalogProgram
 progTypeMap d fun = runIdentity $ progTypeMapM d (return . fun)
 
 -- | Apply function to all rule RHS terms in the program
-progRHSMapM :: (Monad m) => DatalogProgram -> (RuleRHS -> m RuleRHS) -> m DatalogProgram
+progRHSMapM :: (Monad m) => DatalogProgram -> (Rule -> Int -> RuleRHS -> m [RuleRHS]) -> m DatalogProgram
 progRHSMapM d fun = do
     rs <- mapM (\r -> do
-                 rhs <- mapM fun $ ruleRHS r
+                 rhs <- concat <$> (mapIdxM (\rhs rhs_idx -> fun r rhs_idx rhs) $ ruleRHS r)
                  return r { ruleRHS = rhs })
                $ progRules d
     return d { progRules = rs }
 
-progRHSMap :: DatalogProgram -> (RuleRHS -> RuleRHS) -> DatalogProgram
-progRHSMap d fun = runIdentity $ progRHSMapM d (return . fun)
+progRHSMap :: DatalogProgram -> (Rule -> Int -> RuleRHS -> [RuleRHS]) -> DatalogProgram
+progRHSMap d fun = runIdentity $ progRHSMapM d (\rl rhs_idx rhs -> return $ fun rl rhs_idx rhs)
 
 -- | Apply function to all atoms in the program
 progAtomMapM :: (Monad m) => DatalogProgram -> (Atom -> m Atom) -> m DatalogProgram

--- a/test/antrea/networkpolicy_controller.dl
+++ b/test/antrea/networkpolicy_controller.dl
@@ -441,7 +441,7 @@ PodMatchesPositiveRequirements(sel_uid, pod) :-
     var expected_matches = vec_len(positive_requirements),
     var req = FlatMap(positive_requirements),
     PodSatisfiesRequirement(pod@&k8s::Pod{.namespace = namespace}, req),
-    var num_matches = Aggregate((sel_uid, pod, expected_matches), group_count(())),
+    var num_matches = Aggregate((sel_uid, pod, expected_matches), group_count_distinct(())),
     num_matches == expected_matches.
 
 // `PodViolatesNegativeRequirements`: For each selector in `PodSelector`,

--- a/test/datalog_tests/dcm1.dl
+++ b/test/datalog_tests/dcm1.dl
@@ -1,4 +1,5 @@
 import intern
+import group
 
 input relation NODE(name: IString, unschedulable: bool,
 	out_of_disk: bool, memory_pressure: bool,
@@ -133,16 +134,16 @@ function cast_bit64_to_bigint(x: bit<64>): bigint = { x as bigint }
 function cast_bit64_to_signedbit64(x: bit<64>): signed<64> = { x as signed<64> }
 
 CPUUSEDPERNODE(node_name, cpu) :-
-	POD(.node_name = node_name, .cpu_request = cpu_request),
-	var cpu = cpu_request.group_by((node_name)).group_sum().
+	pod in POD(.node_name = node_name),
+	var cpu = pod.group_by((node_name)).sum_of(|pod| pod.cpu_request).
 
 MEMORYUSEDPERNODE(node_name, memory) :-
-	POD(.node_name = node_name, .memory_request = memory_request),
-	var memory = memory_request.group_by((node_name)).group_sum().
+	pod in POD(.node_name = node_name),
+	var memory = pod.group_by((node_name)).sum_of(|pod| pod.memory_request).
 
 PODSUSEDPERNODE(node_name, pods):-
-	POD(.node_name = node_name, .pods_request = pods_request),
-	var pods = pods_request.group_by((node_name)).group_sum().
+	pod in POD(.node_name = node_name),
+	var pods = pod.group_by((node_name)).sum_of(|pod| pod.pods_request).
 
 SPARECAPACITY(node_name, cpu_remaining, memory_remaining, pods_remaining) :-
 	POD(.node_name = node_name),
@@ -307,7 +308,7 @@ function pod_matches_expression(
 
 INTERPODAFFINITYMATCHESGROUPBY(pod_name, num_matches):-
     INTERPODAFFINITYMATCHESINNER(pod_name, matches, node_name),
-    var num_matches = Aggregate((pod_name), group_count(())).
+    var num_matches = Aggregate((pod_name), group_count_distinct((matches, node_name))).
 
 INTERPODAFFINITYMATCHES(pod_name, matches, node_name, num_matches):-
     INTERPODAFFINITYMATCHESGROUPBY(pod_name, num_matches),
@@ -315,7 +316,7 @@ INTERPODAFFINITYMATCHES(pod_name, matches, node_name, num_matches):-
 
 NODETAINTSGROUP(node_name, num_taints):-
     NODETAINTS(node_name, taint_key, taint_value, taint_effect),
-    var num_taints =  Aggregate((node_name), group_count(())).
+    var num_taints =  Aggregate((node_name), group_count_distinct((taint_key, taint_value, taint_effect))).
 
 PODSTHATTOLERATENODETAINTS(pod_name, node_name):-
         PODSTOASSIGN(.pod_name = pod_name),
@@ -323,7 +324,7 @@ PODSTHATTOLERATENODETAINTS(pod_name, node_name):-
         NODETAINTSGROUP(node_name, num_taints),
         PODTOLERATIONS(.pod_name = pod_name, .tolerations_key = taint_key, .tolerations_value = tolerations_value, .tolerations_effect = tolerations_effect, .tolerations_operator = tolerations_operator),
         ((istring_str(tolerations_effect) == "null" or tolerations_effect == taint_effect) and (istring_str(tolerations_operator) == "Exists" or tolerations_value == taint_value)),
-        var groupsize = Aggregate((pod_name, node_name, num_taints), group_count(())),
+        var groupsize = Aggregate((pod_name, node_name, num_taints), group_count_distinct((taint_key, taint_value, taint_effect, tolerations_value, tolerations_effect, tolerations_operator))),
         (groupsize == num_taints).
 
 NODESTHATHAVETOLERATIONS(node_name):-

--- a/test/datalog_tests/group_test.dat
+++ b/test/datalog_tests/group_test.dat
@@ -21,3 +21,4 @@ dump group_test::All1;
 dump group_test::Any1;
 dump group_test::Count1;
 dump group_test::Fold1;
+dump group_test::SumUp1;

--- a/test/datalog_tests/group_test.dl
+++ b/test/datalog_tests/group_test.dl
@@ -102,7 +102,7 @@ output relation Count1(x: usize, count: usize)
 
 Count1(x, count) :-
     Data(x,y,z,q),
-    var count = ().group_by(x).count().
+    var count = ().group_by(x).count_distinct().
 
 // fold
 output relation Fold1(x: usize, sum: bigint)
@@ -110,3 +110,10 @@ output relation Fold1(x: usize, sum: bigint)
 Fold1(x, count) :-
     Data(x,y,z,q),
     var count = z.group_by(x).fold(|s0, z| z.fold(|s1, v| s1 + v, s0), 0).
+
+// sum_of
+output relation SumUp1(x: usize, sum: bigint)
+
+SumUp1(x, count) :-
+    d in Data(x,y,z,q),
+    var count = d.group_by(x).sum_of(|d| d.z.nth(0).unwrap_or_default()).

--- a/test/datalog_tests/group_test.dump.expected
+++ b/test/datalog_tests/group_test.dump.expected
@@ -25,3 +25,5 @@ group_test::Count1{.x = 1, .count = 4}
 group_test::Count1{.x = 2, .count = 2}
 group_test::Fold1{.x = 1, .sum = 20}
 group_test::Fold1{.x = 2, .sum = 14}
+group_test::SumUp1{.x = 1, .sum = 4}
+group_test::SumUp1{.x = 2, .sum = 3}

--- a/test/datalog_tests/simple.dl
+++ b/test/datalog_tests/simple.dl
@@ -1,6 +1,7 @@
 import allocate
 import fp
 import print
+import group
 
 /* Test types */
 
@@ -765,16 +766,16 @@ function find_x_in_group(ys: Group<'A, 'A>): bool {
 }
 
 output relation Aggregate1(x: string, cnt: bit<64>)
-Aggregate1(x, cnt) :- AggregateMe1(x,y), var cnt = y.group_by(x).count().
+Aggregate1(x, cnt) :- AggregateMe1(x,y), var cnt = y.group_by(x).count_distinct().
 
 output relation AggregateCnt(cnt: bit<64>)
-AggregateCnt(cnt) :- AggregateMe1(x,y), var cnt = ().group_by(()).count().
+AggregateCnt(cnt) :- AggregateMe1(x,y), var cnt = ().group_by(()).count_distinct().
 
 output relation AggregateCnt2(cnt: bit<64>)
-AggregateCnt2(cnt) :- AggregateMe1(x,y), var cnt = 1.group_by(()).group_sum().
+AggregateCnt2(cnt) :- AggregateMe1(x,y), var cnt = (x, y).group_by(()).sum_of(|xy| 1).
 
 output relation AggregateCnt3(cnt: bit<64>)
-AggregateCnt3(cnt) :- AggregateMe1(x,y), y != "1", var cnt = 1.group_by(()).group_sum().
+AggregateCnt3(cnt) :- AggregateMe1(x,y), y != "1", var cnt = (x,y).group_by(()).count_distinct().
 
 output relation Aggregate2(x: string, set: Set<string>)
 Aggregate2(x, set) :- AggregateMe1(x,y), var set = y.group_by(x).to_set().
@@ -791,7 +792,7 @@ Disaggregate(x,y) :- AggregateMe1(x,y), var set = y.group_by(x).to_set(), var y 
 input relation AggregateMeInts(x: string, y: bit<32>)
 
 output relation Sum(x: string, sum: bit<32>)
-Sum(x, sum) :- AggregateMeInts(x, y), var sum = y.group_by(x).group_sum().
+Sum(x, sum) :- AggregateMeInts(x, y), var sum = y.group_by(x).sum_of(|y| y).
 
 input relation AggregateMe3(x: string, y: string, z: string)
 
@@ -799,7 +800,7 @@ output relation AggregateByX(x: string, cnt: bit<64>)
 
 // Old syntax for group_by.
 AggregateByX(x, cnt) :- AggregateMe3(x,y,z), AggregateMe1(x,y),
-                        var cnt = Aggregate((x), group_count(())).
+                        var cnt = Aggregate((x), group_count_distinct((y,z))).
 
 output relation Concat(s: string)
 // Old syntax for group_by.

--- a/test/datalog_tests/simple2.dl
+++ b/test/datalog_tests/simple2.dl
@@ -1,5 +1,6 @@
 import fp
 import inspect_log as log
+import group
 
 /* Test `arrangeInput` logic in Compile.hs */
 
@@ -115,7 +116,7 @@ input relation InputTuples(x: bit<32>, y: bit<32>)
 
 InspectSimpleSum(x, total) :-
     InputTuples(x, y),
-    var total = y.group_by(x).group_sum(),
+    var total = y.group_by(x).sum_of(|y| y),
     Inspect {
         var z = 1 + 2;
         var w = ddlog_weight;
@@ -389,7 +390,7 @@ MapOfVecs([ (100, 100) -> [0.1, -100, 0, 1000000],
 output relation VecOfMaps(m: Vec<Map<(u32, bigint), double>>)
 VecOfMaps([ [(100, 100) -> 0.1],
             [(100, 100) -> 0.1, (1000, -100) -> -0.1],
-            [(100, 100) -> 0.1, (1000, -100) -> -0.1, (1000, -10000000000000000000000000000000000000) -> -0]
+            [(100, 100) -> 0.1, (1000, -100) -> -0.1, (1000, -10000000000000000000000000000000000000) -> 0]
           ]).
 
 /* Variable shadowing (now legal). */

--- a/test/datalog_tests/streams.dl
+++ b/test/datalog_tests/streams.dl
@@ -2,6 +2,7 @@
 
 import json
 import hashset
+import group
 
 typedef Object = Object {
     field: u128
@@ -137,7 +138,7 @@ StreamFold(k, s) :- StreamOfSums-1(k, s).
 
 StreamOfSums(k, s) :-
     StreamFold(k, v),
-    var s = v.group_by(k).group_sum().
+    var s = v.group_by(k).sum_of(|v| v).
 
 // Stream fold with enable/disable control
 
@@ -152,7 +153,7 @@ ControlledStreamFold(k, s) :- ControlledStreamOfSums-1(k, s),
 
 ControlledStreamOfSums(k, s) :-
     ControlledStreamFold(k, v),
-    var s = v.group_by(k).group_sum(),
+    var s = v.group_by(k).sum_of(|v| v),
     EnableK(k).
 
 /* Compute sum, average, and unique values aggregates over the same stream. */

--- a/test/test-ovn.sh
+++ b/test/test-ovn.sh
@@ -38,7 +38,7 @@ clone_repo https://github.com/ddlog-dev/ovn-test-data.git ovn-test-data v5
 # TODO: use -j6 once build script is fixed
 # TODO: use primary OVN repo
 (cd ovn &&
- git checkout ddlog_ci16 &&
+ git checkout ddlog_ci16-1 &&
  ./boot.sh &&
  ./configure --with-ddlog=../../lib --with-ovs-source=../ovs --enable-shared &&
  (make northd/ddlog.stamp && make check -j1 NORTHD_CLI=1 ||


### PR DESCRIPTION
Due to historical reasons and my stupidity, we ended up with an
implementation of `group_by` with odd semantics that was also expensive
to maintain.

The `group_by` transformation `<expr>.group_by(<vars>)` consists of
two operators: projection (by applying `<expr>` to all records) and
grouping records that share the same values of `<vars>`.  In the
previous implementation, grouping was performed before projection, so
given the following rule:

```
R(x, y, z),
var group = x.group_by(z).
```

and relation `R` containing records:

```
R(.x = 1, .y = 1, .z = 1), // weight =1
R(.x = 1, .y = 2, .z = 1), // weight =1
```

we produced a group with key `z=1` and two elements
`{(.x=1, .y=1), (.x=1, .y=2)}`, both with weight=1.  In this case,
`group.count()` would return 2.  The projection was applied while
enumerating the group, so that

```
for((x,w) in group) {...}
```

would encounter value `.x=1` with weight `1` twice.

In other words, this was kind of a multiset semantics where the same
value could appear multiple times, and the actual weight of the value in
the multiset had to be computed by summing up the weights of all
occurrences.  If one wanted to get the number of distinct elements in
the multiset or enumerate all distinct elements they had to first
convert the group into a set using `to_set()`.  All of this is really
easy to get wrong, and I've both encountered and written broken code
that didn't handle groups correctly.

Performance-wise, the biggest hit came from packing all visible
variables into the group at the cost of cloning them all, storing them
in an arrangement, and sorting values in a group (which DD does
internally).  Under some circumstances (large values or values with
expensive comparison operations) this could introduce huge overhead.
I've seen 100x in at least one benchmark.

The fix is to swap the order of operations:

1. Projection: takes a tuple of all variables visible in the current
   scope and applies `expr` to it to obtain a single value.  Returns
   a new collection where each record contains the group key (consisting
   of group-by variables) and the projected value. The weight of the
   record is the sum of all weights of records that are mapped to the
   same projected record.  In the above example, `y` is projected away
   and the projected relation only contains one record.
   ```
   R-projected(.z = 1, .x = 1), // weight = 2
   ```

2. Grouping: groups records that share the same key (internally,
   the projected relation is first arranged by key and the reduced).
   In our example this will yield a single group with one element
   with weight 2:
   ```
   R-grouped(Group{.key = 1, values = {(1, weight = 2)}})
   ```

One side effect of this is that the behavior of `Group::count()`
is different.  Instead of returning the number of values in a group
before project (2 in the example) it now returns the number of
unique values.  For example `().group_by(..).count()` always returns
1 in the new implementation, but could be greater than one before.
To avoid changing the behavior of existing code, I removed this function
altogether and added `count_unique()` instead, which is also a more
descriptive name for what the function actually does.

Signed-off-by: Leonid Ryzhyk <lryzhyk@vmware.com>