### PR TITLE
Fix performance regression in v0.48.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+- Fixed compilation speed regression in v0.48.0.
+
 ## [0.48.0] - Sep 6, 2021
 
 ### SQL-to-DDlog compiler

--- a/src/Language/DifferentialDatalog/Compile.hs
+++ b/src/Language/DifferentialDatalog/Compile.hs
@@ -2811,9 +2811,10 @@ rhsVarsAfter d rl i =
     case ruleRHS rl !! i of
          -- Inspect operators cannot change the collection it inspects. No variables are dropped.
          RHSInspect _ -> rhsVarsAfter d rl (i-1)
-         _            -> filter (\f -> (elem f $ (ruleLHSVars d rl)) ||
-                                       (any (elem f) $ map (ruleRHSTermVars d rl) [i+1..length (ruleRHS rl) - 1]))
+         _            -> filter (\f -> (elem f $ (ruleLHSVars d rl)) || (any (elem f) vars_after))
                                 $ ruleRHSVars d rl (i+1)
+    where
+    vars_after = map (ruleRHSTermVars d rl) [i+1..length (ruleRHS rl) - 1]
 
 mkProg :: (?crate_graph :: CrateGraph, ?specname :: String) => DatalogProgram -> CompilerState -> [ProgNode] -> Doc
 mkProg d cstate nodes =

--- a/src/Language/DifferentialDatalog/Rule.hs
+++ b/src/Language/DifferentialDatalog/Rule.hs
@@ -102,14 +102,14 @@ ruleRHSVars' :: DatalogProgram -> Rule -> Int -> [Var]
 ruleRHSVars' _ _  i | i < 0 = []
 ruleRHSVars' d rl i =
     case ruleRHS rl !! i of
-         RHSLiteral True  a            -> nub $ exprVarDecls d (CtxRuleRAtom rl i) (atomVal a) ++ vs
+         RHSLiteral True  a            -> exprVarDecls d (CtxRuleRAtom rl i) (atomVal a) ++ vs
          RHSLiteral False _            -> vs
          -- assignment introduces new variables
-         RHSCondition (E e@(ESet _ l _)) -> nub $ exprVarDecls d (CtxSetL e (CtxRuleRCond rl i)) l ++ vs
+         RHSCondition (E e@(ESet _ l _)) -> exprVarDecls d (CtxSetL e (CtxRuleRCond rl i)) l ++ vs
          -- condition does not introduce new variables
          RHSCondition _                -> vs
          -- FlatMap introduces variables
-         RHSFlatMap pat _              -> nub $ exprVarDecls d (CtxRuleRFlatMapVars rl i) pat ++ vs
+         RHSFlatMap pat _              -> exprVarDecls d (CtxRuleRFlatMapVars rl i) pat ++ vs
          -- Inspect does not introduce new variables
          RHSInspect _                  -> vs
          -- group_by hides all variables except group-by vars


### PR DESCRIPTION
The change in how `group_by` interacts with variable visibility in
release 0.48.0 slowed down the compiler >2x on large programs.  It
appears that this was due to a a butterfly effect in `rhsVarsAfter`,
which caused it to recompute a sub-expression multiple times.  To solve
this, we move the expression to a `where` clause.  As an additional
optimization, we remove and expensive unnecessary `nub` in
`ruleRHSVars`.