### PR TITLE
Fix the implementation of `Intern::default()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Bug fixes
+
+- Fixed a bug in the implementation of `Intern<>` that could lead to incorrect
+  behavior of comparison operators and `hashXXX()` functions.
+
 ## [0.48.1] - Sep 7, 2021
 
 - Fixed compilation speed regression in v0.48.0.

--- a/lib/internment.rs
+++ b/lib/internment.rs
@@ -35,7 +35,7 @@ use std::{
 /// In addition to memory deduplication, this type is optimized for fast comparison.
 /// To this end, we store a 64-bit hash along with the interned value and use this hash for
 /// comparison, only falling back to by-value comparison in case of a hash collision.
-#[derive(Default, Eq, PartialEq, Clone)]
+#[derive(Eq, PartialEq, Clone)]
 pub struct Intern<A>
 where
     A: Eq + Send + Sync + Hash + 'static,
@@ -49,6 +49,12 @@ impl<T: Hash + Eq + Send + Sync + 'static> Hash for Intern<T> {
         H: Hasher,
     {
         self.interned.as_ref().0.hash(state)
+    }
+}
+
+impl<T: Default + Eq + Send + Sync + Hash + 'static> Default for Intern<T> {
+    fn default() -> Self {
+        Self::new(T::default())
     }
 }
 


### PR DESCRIPTION
Auto-deriving `Default` for `Intern` meant that instead of initializing
the hash stored inside `ArcIntern` to the actual hash of the default value
of the interned type, we initialized it to 0, violating the invariant
that equal values must have equal hashes.  This could cause `Ord` and
`Hash` traits to behave incorrectly for interned values.

Signed-off-by: Leonid Ryzhyk <lryzhyk@vmware.com>