### PR TITLE
Upgrade to FlatBuffers v2.0.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Closures that depend on generic types generate invalid Rust (#1072).
 
+### FlatBuffers
+
+- Upgrade to FlatBuffers v2.0.0.  The previous version of FlatBuffers used in
+  DDlog is not compatible with recent OS X releases.
+  
+
 ## [0.48.2] - Sep 13, 2021
 
 ### Bug fixes

--- a/lib/ddlog_std.flatbuf.rs
+++ b/lib/ddlog_std.flatbuf.rs
@@ -70,6 +70,7 @@ impl<'a, T, F> FromFlatBuffer<fbrt::Vector<'a, F>> for ddlog_std::Vec<T>
 where
     T: Ord + FromFlatBuffer<F::Inner>,
     F: fbrt::Follow<'a> + 'a,
+    <F as fbrt::Follow<'a>>::Inner: Debug,
 {
     fn from_flatbuf(fb: fbrt::Vector<'a, F>) -> ::std::result::Result<Self, String> {
         let mut vec = ddlog_std::Vec::with_capacity(fb.len());
@@ -110,6 +111,7 @@ impl<'a, T, F> FromFlatBuffer<fbrt::Vector<'a, F>> for ddlog_std::Set<T>
 where
     T: Ord + FromFlatBuffer<F::Inner>,
     F: fbrt::Follow<'a> + 'a,
+    <F as fbrt::Follow<'a>>::Inner: Debug,
 {
     fn from_flatbuf(fb: fbrt::Vector<'a, F>) -> ::std::result::Result<Self, String> {
         let mut set = ddlog_std::Set::new();
@@ -152,6 +154,7 @@ where
 impl<'a, K, V, F> FromFlatBuffer<fbrt::Vector<'a, F>> for ddlog_std::Map<K, V>
 where
     F: fbrt::Follow<'a> + 'a,
+    <F as fbrt::Follow<'a>>::Inner: Debug,
     K: Ord,
     ddlog_std::tuple2<K, V>: FromFlatBuffer<F::Inner>,
 {

--- a/lib/hashset.flatbuf.rs
+++ b/lib/hashset.flatbuf.rs
@@ -25,6 +25,7 @@ impl<'a, T, F> FromFlatBuffer<fbrt::Vector<'a, F>> for crate::typedefs::hashset:
 where
     T: ::core::hash::Hash + ::core::cmp::Eq + ::core::clone::Clone + FromFlatBuffer<F::Inner>,
     F: fbrt::Follow<'a> + 'a,
+    <F as fbrt::Follow<'a>>::Inner: Debug,
 {
     fn from_flatbuf(
         fb: fbrt::Vector<'a, F>,

--- a/lib/tinyset.flatbuf.rs
+++ b/lib/tinyset.flatbuf.rs
@@ -27,6 +27,7 @@ impl<'a, T, F> FromFlatBuffer<fbrt::Vector<'a, F>> for Set64<T>
 where
     T: Ord + FromFlatBuffer<F::Inner> + u64set::Fits64,
     F: fbrt::Follow<'a> + 'a,
+    <F as fbrt::Follow<'a>>::Inner: Debug,
 {
     fn from_flatbuf(fb: fbrt::Vector<'a, F>) -> Result<Self, String> {
         let mut set = Set64::new();

--- a/rust/template/Cargo.toml
+++ b/rust/template/Cargo.toml
@@ -38,8 +38,8 @@ phf = { version = "0.10.0", features = ["macros"] }
 
 # FlatBuffers dependency enabled by the `flatbuf` feature.
 # flatbuffers crate version must be in sync with the flatc compiler and Java
-# libraries: flatbuffers "0.6" <-> FlatBuffers "1.11.0".
-flatbuffers = { version = "0.6", optional = true }
+# libraries: flatbuffers "2.0.0" <-> FlatBuffers "2.0.0".
+flatbuffers = { version = "2.0.0", optional = true }
 
 [dependencies.differential_datalog]
 path = "./differential_datalog"

--- a/test/datalog_tests/ovn_ftl.dl
+++ b/test/datalog_tests/ovn_ftl.dl
@@ -5,7 +5,7 @@
 // -Flow: the output table
 // -Logical_Switch
 
-typedef stage = LS_IN_ACL
+typedef stage_t = LS_IN_ACL
               | LS_OUT_ACL
               | LR_IN_ADMISSION
               | LR_IN_IP_INPUT
@@ -36,7 +36,7 @@ typedef stage = LS_IN_ACL
               | LS_OUT_PORT_SEC_IP
               | LS_OUT_PORT_SEC_L2
 
-output relation Flow(lr: bigint, stage: stage, prio: bigint, matchStr: string, actionStr: string)
+output relation Flow(lr: bigint, stage: stage_t, prio: bigint, matchStr: string, actionStr: string)
 input relation Logical_Router(lr: bigint)
 input relation Logical_Router_Port(name: string, lr: bigint, mac: string, enabled: bool)
 

--- a/test/datalog_tests/tutorial.dat
+++ b/test/datalog_tests/tutorial.dat
@@ -181,9 +181,9 @@ echo Evens:;
 dump Evens;
 
 start;
-insert Vector(["a", "--", "b"], "--"),
-insert Vector(["--", "a", "b"], "--"),
-insert Vector(["a", "b", "--"], "--"),
+insert Vect(["a", "--", "b"], "--"),
+insert Vect(["--", "a", "b"], "--"),
+insert Vect(["a", "b", "--"], "--"),
 commit;
 
 echo Prefix:;

--- a/test/datalog_tests/tutorial.dl
+++ b/test/datalog_tests/tutorial.dl
@@ -292,10 +292,10 @@ function prefixBefore(vec: Vec<'A>, v: 'A): Vec<'A> {
     res
 }
 
-input relation Vector(vec: Vec<string>, sep: string)
+input relation Vect(vec: Vec<string>, sep: string)
 output relation Prefix(vec: Vec<string>)
 
-Prefix(prefixBefore(vec, sep)) :- Vector(vec, sep).
+Prefix(prefixBefore(vec, sep)) :- Vect(vec, sep).
 
 /*
  * Example: Multiple heads
@@ -689,8 +689,8 @@ input relation Load_Balancer (
     name:         string
 )
 
-typedef stage = LS_IN_PRE_LB
-              | LS_OUT_PRE_LB
+typedef stage_t = LS_IN_PRE_LB
+                | LS_OUT_PRE_LB
 
 input relation Logical_Switch (
     ls:  bigint
@@ -698,7 +698,7 @@ input relation Logical_Switch (
 
 // Relation that represents OVS flows.
 output relation Flow(lr: bigint,
-                     stage: stage,
+                     stage: stage_t,
                      prio: bigint,
                      matchStr: string,
                      actionStr: string)
@@ -735,7 +735,7 @@ Flow(.lr=ls,
 
 // Introduce another Flow relation, so that we can compare the results of the two encodings.
 output relation Flow1(lr: bigint,
-                      stage: stage,
+                      stage: stage_t,
                       prio: bigint,
                       matchStr: string,
                       actionStr: string)

--- a/tools/install-flatbuf.sh
+++ b/tools/install-flatbuf.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-FLATBUF_VERSION="1.11.0"
+FLATBUF_VERSION="2.0.0"
 set -ex
 
 retry() {
@@ -9,13 +9,11 @@ retry() {
 }
 
 fetch_flatbuf_unix() {
-    rm -rf flatbuffers
-    mkdir flatbuffers
-    curl -L https://github.com/google/flatbuffers/archive/v${FLATBUF_VERSION}.tar.gz | tar -zx -C flatbuffers --strip-components 1
+    git clone https://github.com/google/flatbuffers.git --branch v${FLATBUF_VERSION}
 }
 
 fetch_flatbuf_windows() {
-    curl -L https://github.com/google/flatbuffers/releases/download/v${FLATBUF_VERSION}/flatc_windows_exe.zip > fb.zip && unzip fb.zip
+    curl -L https://github.com/google/flatbuffers/releases/download/v${FLATBUF_VERSION}/Windows.flatc.binary.zip > fb.zip && unzip fb.zip
 }
 
 echo "Installing Flatbuf"
@@ -36,7 +34,7 @@ if [ "x`flatbuffers/flatc --version`" != "xflatc version ${FLATBUF_VERSION}" ]; 
         cd ..
     else
         retry fetch_flatbuf_unix
-        # On Windows, fetch pre-build executable instead of compiling from source.
+        # On Windows, fetch pre-built executable instead of compiling from source.
         retry fetch_flatbuf_windows
     fi
 fi


### PR DESCRIPTION
Upgrade to FlatBuffers v2.0.0.  The previous version of FlatBuffers used in DDlog is not compatible with recent OS X releases.

Fixes #1019 