### PR TITLE
Expose DDlogJooqProvider DSLContext

### DIFF
--- a/sql/src/main/java/com/vmware/ddlog/DDlogJooqProvider.java
+++ b/sql/src/main/java/com/vmware/ddlog/DDlogJooqProvider.java
@@ -117,6 +117,10 @@ public final class DDlogJooqProvider implements MockDataProvider {
         }
     }
 
+    public DSLContext getDslContext() {
+        return dslContext;
+    }
+
     /*
      * All executed SQL queries against a JOOQ connection are received here
      */
@@ -266,6 +270,7 @@ public final class DDlogJooqProvider implements MockDataProvider {
                 return exception(insert.toString());
             }
             final SqlNode[] values = ((SqlBasicCall) insert.getSource()).getOperands();
+
             final String tableName = ((SqlIdentifier) insert.getTargetTable()).getSimple();
             final List<Field<?>> fields = tablesToFields.get(tableName.toUpperCase());
             if (fields == null) {

--- a/sql/src/main/java/com/vmware/ddlog/util/sql/CalciteUtils.java
+++ b/sql/src/main/java/com/vmware/ddlog/util/sql/CalciteUtils.java
@@ -26,6 +26,7 @@ package com.vmware.ddlog.util.sql;
 import org.apache.calcite.avatica.util.Casing;
 import org.apache.calcite.sql.parser.SqlAbstractParserImpl;
 import org.apache.calcite.sql.parser.ddl.SqlDdlParserImpl;
+import org.apache.calcite.sql.validate.SqlConformanceEnum;
 
 import java.io.StringReader;
 
@@ -48,6 +49,7 @@ public class CalciteUtils {
         ret.setUnquotedCasing(Casing.TO_LOWER);
         ret.setQuotedCasing(Casing.TO_LOWER);
         ret.setIdentifierMaxLength(100);
+        ret.setConformance(SqlConformanceEnum.PRESTO);
 
         return ret;
     }


### PR DESCRIPTION
Expose this previously private variable so that external classes can access the metadata of the tables stored in the DDlogJooqProvider.

Signed-off-by: Amy Tai <amy.tai.2009@gmail.com>