### PR TITLE
Translate vector-type fields properly in DDlogJooqProvider

### DIFF
--- a/java/ddlogapi/DDlogRecord.java
+++ b/java/ddlogapi/DDlogRecord.java
@@ -387,6 +387,30 @@ public class DDlogRecord {
         return DDlogAPI.ddlog_get_double(this.handle);
     }
 
+    public boolean isVector() {
+        return DDlogAPI.ddlog_is_vector(this.checkHandle());
+    }
+    
+    public boolean isBool() {
+        return DDlogAPI.ddlog_is_bool(this.checkHandle());
+    }
+
+    public boolean isInt() {
+        return DDlogAPI.ddlog_is_int(this.checkHandle());
+    }
+
+    public boolean isFloat() {
+        return DDlogAPI.ddlog_is_float(this.checkHandle());
+    }
+
+    public boolean isDouble() {
+        return DDlogAPI.ddlog_is_double(this.checkHandle());
+    }
+
+    public boolean isString() {
+        return DDlogAPI.ddlog_is_string(this.checkHandle());
+    }
+
     public boolean isStruct() {
         return DDlogAPI.ddlog_is_struct(this.checkHandle());
     }

--- a/sql/src/test/java/ddlog/JooqProviderTestBase.java
+++ b/sql/src/test/java/ddlog/JooqProviderTestBase.java
@@ -542,23 +542,30 @@ public abstract class JooqProviderTestBase {
     @Test
     public void testArrayAggTypes() {
         assert(create != null);
-        create.execute("insert into \nhosts values ('n1', 10, true)");
-        create.batch("insert into hosts values ('n54', 18, false)",
-                "insert into hosts values ('n9', 2, true)").execute();
+        create.execute("insert into base_array_table values ('n1', 10, 10)");
+        create.batch("insert into base_array_table values ('n54', 18, 18)",
+                "insert into base_array_table values ('n9', 1, 3)",
+                "insert into base_array_table values ('n10', 2, 3)",
+                "insert into base_array_table values ('n11', 3, 3)"
+                ).execute();
 
-        final Field<String> field1 = field("id", String.class);
+        create.insertInto(table("base_array_table"))
+                .values("n3", null, 18)
+                .execute();
+
+        final Field<Integer> field1 = field("col3", Integer.class);
         final Field<Object> field2 = field("agg", Object.class);
 
         final Record arrayAgg1 = create.newRecord(field1, field2);
         final Record arrayAgg2 = create.newRecord(field1, field2);
         final Record arrayAgg3 = create.newRecord(field1, field2);
 
-        arrayAgg1.setValue(field1, "n1");
+        arrayAgg1.setValue(field1, 10);
         arrayAgg1.setValue(field2, new Integer[] {10});
-        arrayAgg2.setValue(field1, "n54");
-        arrayAgg2.setValue(field2, new Integer[] {18});
-        arrayAgg3.setValue(field1, "n9");
-        arrayAgg3.setValue(field2, new Integer[] {2});
+        arrayAgg2.setValue(field1, 18);
+        arrayAgg2.setValue(field2, new Integer[] {null, 18});
+        arrayAgg3.setValue(field1, 3);
+        arrayAgg3.setValue(field2, new Integer[] {1,2,3});
 
         // Make sure selects read out the same content inserted above
         final Result<Record> aggResults = create.fetch("select * from check_array_type");

--- a/sql/src/test/java/ddlog/JooqProviderTestBase.java
+++ b/sql/src/test/java/ddlog/JooqProviderTestBase.java
@@ -539,6 +539,34 @@ public abstract class JooqProviderTestBase {
         }
     }
 
+    @Test
+    public void testArrayAggTypes() {
+        assert(create != null);
+        create.execute("insert into \nhosts values ('n1', 10, true)");
+        create.batch("insert into hosts values ('n54', 18, false)",
+                "insert into hosts values ('n9', 2, true)").execute();
+
+        final Field<String> field1 = field("id", String.class);
+        final Field<Object> field2 = field("agg", Object.class);
+
+        final Record arrayAgg1 = create.newRecord(field1, field2);
+        final Record arrayAgg2 = create.newRecord(field1, field2);
+        final Record arrayAgg3 = create.newRecord(field1, field2);
+
+        arrayAgg1.setValue(field1, "n1");
+        arrayAgg1.setValue(field2, new Integer[] {10});
+        arrayAgg2.setValue(field1, "n54");
+        arrayAgg2.setValue(field2, new Integer[] {18});
+        arrayAgg3.setValue(field1, "n9");
+        arrayAgg3.setValue(field2, new Integer[] {2});
+
+        // Make sure selects read out the same content inserted above
+        final Result<Record> aggResults = create.fetch("select * from check_array_type");
+        assertTrue(aggResults.contains(arrayAgg1));
+        assertTrue(aggResults.contains(arrayAgg2));
+        assertTrue(aggResults.contains(arrayAgg3));
+    }
+
     public static <R extends SqlStatement> DDlogAPI compileAndLoad(final List<R> ddl, ToPrestoTranslator<R> translator) throws IOException, DDlogException {
         final Translator t = new Translator(null);
         ddl.forEach(x -> t.translateSqlStatement(translator.toPresto(x)));

--- a/sql/src/test/java/ddlog/JooqProviderTestCalcite.java
+++ b/sql/src/test/java/ddlog/JooqProviderTestCalcite.java
@@ -26,13 +26,15 @@ public class JooqProviderTestCalcite extends JooqProviderTestBase {
         String v1 = "create view good_hosts as select distinct * from hosts where capacity < 10";
         String checkArrayParse = "create table junk (testCol integer array)";
         String checkNotNullColumns = "create table not_null (test_col1 integer not null, test_col2 varchar(36) not null)";
-
+        String checkArrayType = "create view check_array_type as select distinct id, ARRAY_AGG(capacity) over (partition by id) as agg " +
+                "from hosts";
         List<String> ddl = new ArrayList<>();
         ddl.add(s1);
         ddl.add(v2);
         ddl.add(v1);
         ddl.add(checkArrayParse);
         ddl.add(checkNotNullColumns);
+        ddl.add(checkArrayType);
 
         ddlogAPI = compileAndLoad(
                 ddl.stream().map(CalciteSqlStatement::new).collect(Collectors.toList()),

--- a/sql/src/test/java/ddlog/JooqProviderTestCalcite.java
+++ b/sql/src/test/java/ddlog/JooqProviderTestCalcite.java
@@ -26,14 +26,18 @@ public class JooqProviderTestCalcite extends JooqProviderTestBase {
         String v1 = "create view good_hosts as select distinct * from hosts where capacity < 10";
         String checkArrayParse = "create table junk (testCol integer array)";
         String checkNotNullColumns = "create table not_null (test_col1 integer not null, test_col2 varchar(36) not null)";
-        String checkArrayType = "create view check_array_type as select distinct id, ARRAY_AGG(capacity) over (partition by id) as agg " +
-                "from hosts";
+
+        String arrayTable = "create table base_array_table (id varchar(36), capacity integer, col3 integer)";
+        String checkArrayType = "create view check_array_type as select distinct col3, " +
+                "ARRAY_AGG(capacity) over (partition by col3) as agg " +
+                "from base_array_table";
         List<String> ddl = new ArrayList<>();
         ddl.add(s1);
         ddl.add(v2);
         ddl.add(v1);
         ddl.add(checkArrayParse);
         ddl.add(checkNotNullColumns);
+        ddl.add(arrayTable);
         ddl.add(checkArrayType);
 
         ddlogAPI = compileAndLoad(

--- a/sql/src/test/java/ddlog/JooqProviderTestPresto.java
+++ b/sql/src/test/java/ddlog/JooqProviderTestPresto.java
@@ -47,6 +47,8 @@ public class JooqProviderTestPresto extends JooqProviderTestBase {
         String v1 = "create view good_hosts as select distinct * from hosts where capacity < 10";
         String checkArrayParse = "create table junk (testCol integer array)";
         String checkNotNullColumns = "create table not_null (test_col1 integer not null, test_col2 varchar(36) not null)";
+        String checkArrayType = "create view check_array_type as select distinct id, ARRAY_AGG(capacity) over (partition by id) as agg " +
+                "from hosts";
 
         List<String> ddl = new ArrayList<>();
         ddl.add(s1);
@@ -54,6 +56,7 @@ public class JooqProviderTestPresto extends JooqProviderTestBase {
         ddl.add(v1);
         ddl.add(checkArrayParse);
         ddl.add(checkNotNullColumns);
+        ddl.add(checkArrayType);
 
         ddlogAPI = compileAndLoad(
                 ddl.stream().map(PrestoSqlStatement::new).collect(Collectors.toList()),

--- a/sql/src/test/java/ddlog/JooqProviderTestPresto.java
+++ b/sql/src/test/java/ddlog/JooqProviderTestPresto.java
@@ -47,8 +47,11 @@ public class JooqProviderTestPresto extends JooqProviderTestBase {
         String v1 = "create view good_hosts as select distinct * from hosts where capacity < 10";
         String checkArrayParse = "create table junk (testCol integer array)";
         String checkNotNullColumns = "create table not_null (test_col1 integer not null, test_col2 varchar(36) not null)";
-        String checkArrayType = "create view check_array_type as select distinct id, ARRAY_AGG(capacity) over (partition by id) as agg " +
-                "from hosts";
+
+        String arrayTable = "create table base_array_table (id varchar(36), capacity integer, col3 integer)";
+        String checkArrayType = "create view check_array_type as select distinct col3, " +
+                "ARRAY_AGG(capacity) over (partition by col3) as agg " +
+                "from base_array_table";
 
         List<String> ddl = new ArrayList<>();
         ddl.add(s1);
@@ -56,6 +59,7 @@ public class JooqProviderTestPresto extends JooqProviderTestBase {
         ddl.add(v1);
         ddl.add(checkArrayParse);
         ddl.add(checkNotNullColumns);
+        ddl.add(arrayTable);
         ddl.add(checkArrayType);
 
         ddlogAPI = compileAndLoad(


### PR DESCRIPTION
Signed-off-by: Amy Tai <amy.tai.2009@gmail.com>

Previously, vector-type columns (i.e. ARRAY_AGG) would not get properly handled by the DDlogJooqProvider during writeback (DDlogJooqProvider::onChange), because the Jooq H2 backend stores the type of array columns as Object.class. Instead, in the writeback function, we infer the type of the column from the DDlog record, which should have all typing informaiton.