### PR TITLE
Add identity views for input tables in DDlogJooqProvider

### DIFF
--- a/sql/src/test/java/ddlog/JooqProviderTestBase.java
+++ b/sql/src/test/java/ddlog/JooqProviderTestBase.java
@@ -574,6 +574,18 @@ public abstract class JooqProviderTestBase {
         assertTrue(aggResults.contains(arrayAgg3));
     }
 
+    @Test
+    public void testIdentityViews() {
+        create.execute("insert into hosts values ('n1', 10, true)");
+        create.batch("insert into hosts values ('n54', 18, false)",
+                "insert into hosts values ('n9', 2, true)").execute();
+
+        final Result<Record> readFromInput = create.fetch("select * from hosts");
+        assertTrue(readFromInput.contains(test1));
+        assertTrue(readFromInput.contains(test2));
+        assertTrue(readFromInput.contains(test3));
+    }
+
     public static <R extends SqlStatement> DDlogAPI compileAndLoad(final List<R> ddl, ToPrestoTranslator<R> translator) throws IOException, DDlogException {
         final Translator t = new Translator(null);
         ddl.forEach(x -> t.translateSqlStatement(translator.toPresto(x)));

--- a/sql/src/test/java/ddlog/JooqProviderTestCalcite.java
+++ b/sql/src/test/java/ddlog/JooqProviderTestCalcite.java
@@ -31,6 +31,10 @@ public class JooqProviderTestCalcite extends JooqProviderTestBase {
         String checkArrayType = "create view check_array_type as select distinct col3, " +
                 "ARRAY_AGG(capacity) over (partition by col3) as agg " +
                 "from base_array_table";
+
+        String identityViewName = DDlogJooqProvider.toIdentityViewName("hosts");
+        String hostidentityView = String.format("create view %s as select distinct * from hosts", identityViewName);
+
         List<String> ddl = new ArrayList<>();
         ddl.add(s1);
         ddl.add(v2);
@@ -39,6 +43,7 @@ public class JooqProviderTestCalcite extends JooqProviderTestBase {
         ddl.add(checkNotNullColumns);
         ddl.add(arrayTable);
         ddl.add(checkArrayType);
+        ddl.add(hostidentityView);
 
         ddlogAPI = compileAndLoad(
                 ddl.stream().map(CalciteSqlStatement::new).collect(Collectors.toList()),


### PR DESCRIPTION
The DDlogJooqProvider should handle `select * <input_table>`, where `input_table` is technically an input relation in DDlog. Because DDlog cannot query on input relations, the DDlogJooqProvider will try to redirect `selects` to the identity view for that input_table.

It is the responsibility of the caller to create the proper identity views.

Signed-off-by: Amy Tai <amy.tai.2009@gmail.com>