### PR TITLE
Fix ddlog-sql test class naming

### DIFF
--- a/sql/src/test/java/ddlog/JooqProviderCalciteTest.java
+++ b/sql/src/test/java/ddlog/JooqProviderCalciteTest.java
@@ -16,7 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class JooqProviderTestCalcite extends JooqProviderTestBase {
+public class JooqProviderCalciteTest extends JooqProviderTestBase {
 
     @BeforeClass
     public static void setup() throws IOException, DDlogException {
@@ -33,7 +33,7 @@ public class JooqProviderTestCalcite extends JooqProviderTestBase {
                 "from base_array_table";
 
         String identityViewName = DDlogJooqProvider.toIdentityViewName("hosts");
-        String hostidentityView = String.format("create view %s as select distinct * from hosts", identityViewName);
+        String hostIdentityView = String.format("create view %s as select distinct * from hosts", identityViewName);
 
         List<String> ddl = new ArrayList<>();
         ddl.add(s1);
@@ -43,7 +43,7 @@ public class JooqProviderTestCalcite extends JooqProviderTestBase {
         ddl.add(checkNotNullColumns);
         ddl.add(arrayTable);
         ddl.add(checkArrayType);
-        ddl.add(hostidentityView);
+        ddl.add(hostIdentityView);
 
         ddlogAPI = compileAndLoad(
                 ddl.stream().map(CalciteSqlStatement::new).collect(Collectors.toList()),

--- a/sql/src/test/java/ddlog/JooqProviderPrestoTest.java
+++ b/sql/src/test/java/ddlog/JooqProviderPrestoTest.java
@@ -38,7 +38,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class JooqProviderTestPresto extends JooqProviderTestBase {
+public class JooqProviderPrestoTest extends JooqProviderTestBase {
 
     @BeforeClass
     public static void setup() throws IOException, DDlogException {
@@ -53,6 +53,9 @@ public class JooqProviderTestPresto extends JooqProviderTestBase {
                 "ARRAY_AGG(capacity) over (partition by col3) as agg " +
                 "from base_array_table";
 
+        String identityViewName = DDlogJooqProvider.toIdentityViewName("hosts");
+        String hostIdentityView = String.format("create view %s as select distinct * from hosts", identityViewName);
+
         List<String> ddl = new ArrayList<>();
         ddl.add(s1);
         ddl.add(v2);
@@ -61,6 +64,7 @@ public class JooqProviderTestPresto extends JooqProviderTestBase {
         ddl.add(checkNotNullColumns);
         ddl.add(arrayTable);
         ddl.add(checkArrayType);
+        ddl.add(hostIdentityView);
 
         ddlogAPI = compileAndLoad(
                 ddl.stream().map(PrestoSqlStatement::new).collect(Collectors.toList()),

--- a/sql/src/test/java/ddlog/JooqProviderTestBase.java
+++ b/sql/src/test/java/ddlog/JooqProviderTestBase.java
@@ -541,6 +541,7 @@ public abstract class JooqProviderTestBase {
 
     @Test
     public void testArrayAggTypes() {
+        skipIfTestBase();
         assert(create != null);
         create.execute("insert into base_array_table values ('n1', 10, 10)");
         create.batch("insert into base_array_table values ('n54', 18, 18)",
@@ -576,6 +577,7 @@ public abstract class JooqProviderTestBase {
 
     @Test
     public void testIdentityViews() {
+        skipIfTestBase();
         create.execute("insert into hosts values ('n1', 10, true)");
         create.batch("insert into hosts values ('n54', 18, false)",
                 "insert into hosts values ('n9', 2, true)").execute();

--- a/sql/src/test/java/ddlog/SetTest.java
+++ b/sql/src/test/java/ddlog/SetTest.java
@@ -27,7 +27,7 @@ package ddlog;
 import com.vmware.ddlog.translator.TranslationException;
 import org.junit.Test;
 
-public class SetTests extends BaseQueriesTest {
+public class SetTest extends BaseQueriesTest {
     @Test
     public void unionTest() {
         String query = "create view v0 as SELECT DISTINCT column1 FROM t1 UNION SELECT DISTINCT column1 FROM t2";


### PR DESCRIPTION
Maven needs test classes to end in *Test, so previously JooqProviderTest<Calcite|Presto> and SetTests weren't actually running when `mvn test` is called. Renamed these test classes and added patch to JooqProviderPrestoTest to make a recent test pass.

This patch also means the number of tests run in IntelliJ is equal to the number of tests run by mvn from the command line.

Signed-off-by: Amy Tai <amy.tai.2009@gmail.com>