### PR TITLE
Fix parsing ambiguity in index declaration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
+## [Unreleased]
 
-- ddlog_clone C and Java API to clone a ddlog_record.
+### API changes
+
+- `ddlog_clone()`: C and Java API to clone a `ddlog_record`.
+
+### Bug fixes
+
+- Fixed parser bug caused by grammar ambiguity whereby `index` could be interpreted
+  as part of an index declaration or as a regular identifier.
 
 ## [0.49.0] - Oct 4, 2021
 

--- a/src/Language/DifferentialDatalog/Parse.hs
+++ b/src/Language/DifferentialDatalog/Parse.hs
@@ -47,7 +47,6 @@ import Data.Char
 import Data.Word
 import Numeric
 import GHC.Float
---import Debug.Trace
 
 import Language.DifferentialDatalog.Syntax
 import Language.DifferentialDatalog.Statement
@@ -903,7 +902,14 @@ field = isfield *> dot *> varIdent
     where isfield = try $ lookAhead $ do
                         _ <- dot
                         _ <- notFollowedBy relIdent
-                        varIdent
+                        field_name <- varIdent
+                        -- We don't declare "index" as a reserved word, as we'd
+                        -- like to make it a legal identifier.  This creates
+                        -- parsing ambiguity when a rule is immediately followed
+                        -- by and index declaration:
+                        -- `R :- ... var v = x. index IndexName() on ...`.
+                        -- Handle this special case below.
+                        when (field_name == "index") $ notFollowedBy indexIdent
 tupField = isfield *> dot *> lexeme decimal
     where isfield = try $ lookAhead $ do
                         _ <- dot

--- a/test/datalog_tests/simple3.dat
+++ b/test/datalog_tests/simple3.dat
@@ -13,3 +13,6 @@ commit dump_changes;
 start;
 modify Rhosts ddlog_std::Some{"n1"} <- Thosts{.up = ddlog_std::None},
 commit dump_changes;
+
+dump_index Rhosts_by_id;
+query_index Rhosts_by_id("n1");

--- a/test/datalog_tests/simple3.dl
+++ b/test/datalog_tests/simple3.dl
@@ -217,6 +217,13 @@ input relation Rhosts[Thosts] primary key (row) (row.id)
 output relation Rhostsv[Thosts]
 Rhostsv[v0] :- Rhosts[v],var v0 = v.
 
+// Make sure 'index' is not parsed as field name ('var v0 = v.index') in this context.
+index Rhosts_by_id(id: string) on Rhosts[Thosts{.id = Some{id}}]
+
+input relation RelWithIndexField(index: usize)
+output relation ORelWithIndexField(index: usize)
+
+ORelWithIndexField(i) :- RelWithIndexField[r], var i = r.index.
 
 /**********************************************************/
 

--- a/test/datalog_tests/simple3.dump.expected
+++ b/test/datalog_tests/simple3.dump.expected
@@ -15,3 +15,5 @@ Thosts{.id = ddlog_std::Some{.x = "n1"}, .capacity = ddlog_std::Some{.x = 10}, .
 Rhostsv:
 Thosts{.id = ddlog_std::Some{.x = "n1"}, .capacity = ddlog_std::Some{.x = 10}, .up = ddlog_std::None{}}: +1
 Thosts{.id = ddlog_std::Some{.x = "n1"}, .capacity = ddlog_std::Some{.x = 10}, .up = ddlog_std::Some{.x = true}}: -1
+Thosts{.id = ddlog_std::Some{.x = "n1"}, .capacity = ddlog_std::Some{.x = 10}, .up = ddlog_std::None{}}
+Thosts{.id = ddlog_std::Some{.x = "n1"}, .capacity = ddlog_std::Some{.x = 10}, .up = ddlog_std::None{}}


### PR DESCRIPTION
The following failed to parse:

```
R2[u] :- R1[v], var u = v.

index R1(id: string) on ...
```

The parser interpreted the dot followed by `index` as a field access
(`v.index`).  This is because we deliberately did not declare `index`
as a keyword as we want to allow using it as a valid identifier.

The solution is to perform some extra lookahead in the field access
expression whenever field name is equal to "index".

@amytai 