### PR TITLE
Feature-gate dynamic deserialization.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+- Feature-gate `AnyDeserialize` impl.  The DDlog compiler generates an
+  implementation of the `AnyDeserialize` trait, which allows clients to
+  deserialize instances of `ddlog_std::Any` provided they know relation id of
+  the value being deserialized.  This feature is not used by most applications,
+  but can cause significant code bloat and slow down compilation.   We
+  feature-gate this impl, so that only users who require this functionality
+  have to pay the price.
+
 ## [1.0.0] - Nov 9, 2021
 
 ### Self-profiler revamp.

--- a/rust/template/Cargo.toml
+++ b/rust/template/Cargo.toml
@@ -14,6 +14,7 @@ command-line = ["cmd_parser", "rustop"]
 nested_ts_32 = ["differential_datalog/nested_ts_32"]
 c_api = ["differential_datalog/c_api"]
 checked_weights = ["differential_datalog/checked_weights"]
+deserialize_any = []
 
 [dependencies]
 abomonation = "0.7"

--- a/rust/template/differential_datalog/src/api/mod.rs
+++ b/rust/template/differential_datalog/src/api/mod.rs
@@ -43,7 +43,7 @@ pub struct HDDlog {
     pub print_err: Option<extern "C" fn(msg: *const c_char)>,
     pub inventory: BoxedInventory,
     pub d3log_localizer: BoxedLocalizer,
-    pub any_deserialize: BoxedDeserialize,
+    pub any_deserialize: Option<BoxedDeserialize>,
     pub flatbuf_converter: BoxedFlatbufConverter,
     /// When set, all commands sent to the program are recorded in
     /// the specified `.dat` file so that they can be replayed later.
@@ -60,7 +60,7 @@ impl HDDlog {
         print_err: Option<extern "C" fn(msg: *const c_char)>,
         init_ddlog: fn(Arc<dyn RelationCallback>) -> Program,
         inventory: BoxedInventory,
-        any_deserialize: BoxedDeserialize,
+        any_deserialize: Option<BoxedDeserialize>,
         d3log_localizer: BoxedLocalizer,
         flatbuf_converter: BoxedFlatbufConverter,
     ) -> Result<(Self, DeltaMap<DDValue>), String> {

--- a/test/datalog_tests/rust_api_test/Cargo.toml
+++ b/test/datalog_tests/rust_api_test/Cargo.toml
@@ -11,6 +11,6 @@ serde = "1.0"
 # The generated Rust project contains several crates that must be imported
 # by the client program.
 differential_datalog = { path = "../tutorial_ddlog/differential_datalog" }
-tutorial = { path = "../tutorial_ddlog" }
+tutorial = { path = "../tutorial_ddlog", features = ["deserialize_any"] }
 ddlog_rt = { path = "../tutorial_ddlog/types/ddlog_rt" }
 types = { path = "../tutorial_ddlog/types" }

--- a/test/datalog_tests/rust_api_test/src/main.rs
+++ b/test/datalog_tests/rust_api_test/src/main.rs
@@ -200,7 +200,7 @@ fn ddval_deserialize_test(ddlog: &HDDlog) {
     let json_string = serde_json::to_string(&val).unwrap();
 
     // Deserialize using AnyDeserializeSeed.
-    let seed = AnyDeserializeSeed::from_relid(&*ddlog.any_deserialize, Relations::Word1 as RelId).unwrap();
+    let seed = AnyDeserializeSeed::from_relid(&**ddlog.any_deserialize.as_ref().unwrap(), Relations::Word1 as RelId).unwrap();
     let val_deserialized = seed.deserialize(&mut serde_json::Deserializer::from_str(json_string.as_str())).unwrap();
 
     assert_eq!(val, val_deserialized);


### PR DESCRIPTION
We generate a `AnyDeserialize` implementation that allows
deserializing into instances of `Any` given relation id.
This impl is not used by most applications, but causes massive
code bloat.  The reason is that is uses erased_serde, which
forces all `Deserialize` impls to get specialized for
`erased_serde::Deserializer`.  We feature-gate this impl, so only
clients who want to use it can enable it.

Signed-off-by: Leonid Ryzhyk <lryzhyk@vmware.com>