### PR TITLE
Efficient SQL join implementation

### DIFF
--- a/sql/src/main/java/com/vmware/ddlog/DDlogHandle.java
+++ b/sql/src/main/java/com/vmware/ddlog/DDlogHandle.java
@@ -113,11 +113,7 @@ public class DDlogHandle {
      * This corresponds to the naming convention followed by the SQL -> DDlog compiler
      */
     public String relationNameToTableName(final String relationName) {
-        for (Map.Entry<String, DDlogRelationDeclaration> me : this.program.tableToRelation.entrySet()) {
-            if (me.getValue().getName().name.equals(relationName))
-                return me.getKey();
-        }
-        throw new RuntimeException("Table not found for relation " + relationName);
+        return this.program.relationNameToTableName(relationName);
     }
 
     public void queryIndex(String index, DDlogRecord key, Consumer<DDlogRecord> consumer) throws DDlogException {

--- a/sql/src/main/java/com/vmware/ddlog/DDlogHandle.java
+++ b/sql/src/main/java/com/vmware/ddlog/DDlogHandle.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2021 VMware, Inc.
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.vmware.ddlog;
+
+import com.vmware.ddlog.ir.DDlogProgram;
+import com.vmware.ddlog.ir.DDlogRelationDeclaration;
+import com.vmware.ddlog.ir.DDlogTUser;
+import com.vmware.ddlog.ir.DDlogType;
+import com.vmware.ddlog.translator.RelationName;
+import com.vmware.ddlog.translator.Translator;
+import com.vmware.ddlog.util.sql.SqlStatement;
+import com.vmware.ddlog.util.sql.ToPrestoTranslator;
+import ddlogapi.*;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Consumer;
+
+public class DDlogHandle {
+    DDlogProgram program;
+    DDlogAPI api;
+
+    // Unfortunately, `create index` statements have to be passed separately, because neither Calcite nor Presto
+    // supports them, so we must pass them as SQL strings.
+    public <R extends SqlStatement> DDlogHandle(final List<R> ddl, final ToPrestoTranslator<R> translator,
+                                         final List<String> createIndexStatements)
+            throws IOException, DDlogException {
+        final Translator t = new Translator();
+        ddl.forEach(x -> t.translateSqlStatement(translator.toPresto(x)));
+        createIndexStatements.forEach(t::translateCreateIndexStatement);
+
+        this.program = t.getDDlogProgram();
+        // System.out.println(this.program.toString());
+        final String fileName = "/tmp/program.dl";
+        File tmp = new File(fileName);
+        BufferedWriter bw = new BufferedWriter(new FileWriter(tmp));
+        bw.write(this.program.toString());
+        bw.close();
+        DDlogAPI.CompilationResult result = new DDlogAPI.CompilationResult(true);
+        DDlogAPI.compileDDlogProgram(fileName, result, "../lib", "./lib");
+        if (!result.isSuccess())
+            throw new RuntimeException("Failed to compile ddlog program");
+        this.api = DDlogAPI.loadDDlog();
+    }
+
+    public void stop() throws DDlogException {
+        this.api.stop();
+    }
+
+    public void transactionStart() throws DDlogException {
+        this.api.transactionStart();
+    }
+
+    public void transactionCommitDumpChanges(Consumer<DDlogCommand<DDlogRecord>> onChange) throws DDlogException {
+        this.api.transactionCommitDumpChanges(onChange);
+    }
+
+    public void transactionRollback() throws DDlogException {
+        this.api.transactionRollback();
+    }
+
+    public String getTableName(int relationId) throws DDlogException {
+        return this.api.getTableName(relationId);
+    }
+
+    public int getTableId(String relationName) throws DDlogException {
+        return this.api.getTableId(relationName);
+    }
+
+    public void applyUpdates(DDlogRecCommand[] commands) throws DDlogException {
+        this.api.applyUpdates(commands);
+    }
+
+    public String ddlogTableTypeName(final String tableName) {
+        DDlogRelationDeclaration rel = this.program.getRelationFromTable(tableName);
+        return Objects.requireNonNull(rel).getType().to(DDlogTUser.class).name;
+    }
+
+    public String ddlogRelationName(final String tableName) {
+        DDlogRelationDeclaration rel = this.program.getRelationFromTable(tableName);
+        return Objects.requireNonNull(rel).getName().name;
+    }
+
+    /*
+     * This corresponds to the naming convention followed by the SQL -> DDlog compiler
+     */
+    public String relationNameToTableName(final String relationName) {
+        for (Map.Entry<String, DDlogRelationDeclaration> me : this.program.tableToRelation.entrySet()) {
+            if (me.getValue().getName().name.equals(relationName))
+                return me.getKey();
+        }
+        throw new RuntimeException("Table not found for relation " + relationName);
+    }
+
+    public void queryIndex(String index, DDlogRecord key, Consumer<DDlogRecord> consumer) throws DDlogException {
+        this.api.queryIndex(index, key, consumer);
+    }
+}

--- a/sql/src/main/java/com/vmware/ddlog/DDlogJooqHelper.java
+++ b/sql/src/main/java/com/vmware/ddlog/DDlogJooqHelper.java
@@ -127,7 +127,7 @@ public class DDlogJooqHelper {
                 matchExpressionFromWhere(where, indexToFieldsMap.get(matchingIndex.getIndexName()), context);
 
         dDlogAPI.queryIndex(
-                DDlogIndexDeclaration.indexName(matchingIndex.getIndexName()),
+                DDlogIndexDeclaration.indexName(matchingIndex.getIndexName()).name,
                 indexKey,
                 x -> clonedResults.add(x.clone())
         );

--- a/sql/src/main/java/com/vmware/ddlog/DDlogJooqHelper.java
+++ b/sql/src/main/java/com/vmware/ddlog/DDlogJooqHelper.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableList;
 import com.vmware.ddlog.ir.DDlogIndexDeclaration;
 import com.vmware.ddlog.util.sql.CreateIndexParser;
 import com.vmware.ddlog.util.sql.ParsedCreateIndex;
-import ddlogapi.DDlogAPI;
 import ddlogapi.DDlogException;
 import ddlogapi.DDlogRecord;
 import org.apache.calcite.sql.*;
@@ -28,13 +27,13 @@ public class DDlogJooqHelper {
     private final Map<String, List<Field<?>>> tablesToFields;
     private final Map<String, List<ParsedCreateIndex>> tablesToIndexesMap = new HashMap<>();
     private final Map<String, List<Field<?>>> indexToFieldsMap = new HashMap<>();
-    private final DDlogAPI dDlogAPI;
+    private final DDlogHandle handle;
     private boolean sealed = false;
 
     public DDlogJooqHelper(Map<String, List<Field<?>>> tablesToFields,
-                           DDlogAPI ddlogAPI) {
+                           DDlogHandle ddlogAPI) {
         this.tablesToFields = tablesToFields;
-        this.dDlogAPI = ddlogAPI;
+        this.handle = ddlogAPI;
     }
 
     public void addIndex(String sqlString) {
@@ -126,7 +125,7 @@ public class DDlogJooqHelper {
         final DDlogRecord indexKey =
                 matchExpressionFromWhere(where, indexToFieldsMap.get(matchingIndex.getIndexName()), context);
 
-        dDlogAPI.queryIndex(
+        handle.queryIndex(
                 DDlogIndexDeclaration.indexName(matchingIndex.getIndexName()).name,
                 indexKey,
                 x -> clonedResults.add(x.clone())

--- a/sql/src/main/java/com/vmware/ddlog/DDlogJooqProvider.java
+++ b/sql/src/main/java/com/vmware/ddlog/DDlogJooqProvider.java
@@ -24,11 +24,10 @@
 
 package com.vmware.ddlog;
 
-import com.vmware.ddlog.ir.DDlogRelationDeclaration;
 import com.vmware.ddlog.ir.DDlogType;
+import com.vmware.ddlog.translator.RelationName;
 import com.vmware.ddlog.util.sql.CreateIndexParser;
 import com.vmware.ddlog.util.sql.H2SqlStatement;
-import com.vmware.ddlog.util.sql.ParsedCreateIndex;
 import ddlogapi.*;
 import org.apache.calcite.sql.*;
 import org.apache.calcite.sql.parser.SqlParser;
@@ -605,7 +604,7 @@ public final class DDlogJooqProvider implements MockDataProvider {
      * This corresponds to the naming convention followed by the SQL -> DDlog compiler
      */
     private static String ddlogRelationName(final String tableName) {
-        return DDlogRelationDeclaration.relationName(tableName.toLowerCase());
+        return RelationName.makeRelationName(tableName);
     }
 
     /*

--- a/sql/src/main/java/com/vmware/ddlog/ir/BodyTermAggregate.java
+++ b/sql/src/main/java/com/vmware/ddlog/ir/BodyTermAggregate.java
@@ -28,22 +28,24 @@ import com.facebook.presto.sql.tree.Node;
 
 import javax.annotation.Nullable;
 
-public class DDlogRHSLiteral extends DDlogRuleRHS {
-    public final boolean polarity;
-    public final DDlogAtom atom;
+public class BodyTermAggregate extends RuleBodyTerm {
+    final String var;
+    final String[] groupBy;
+    final String aggFunc;
+    final DDlogExpression aggExpr;
 
-    public DDlogRHSLiteral(@Nullable Node node, boolean polarity, DDlogAtom atom) {
+    public BodyTermAggregate(@Nullable Node node, String var, String aggFunc, DDlogExpression aggExpr, String... groupBy) {
         super(node);
-        this.polarity = polarity;
-        this.atom = atom;
+        this.var = var;
+        this.groupBy = groupBy;
+        this.aggFunc = aggFunc;
+        this.aggExpr = aggExpr;
     }
 
     @Override
     public String toString() {
-        String result = "";
-        if (!this.polarity)
-            result = "not ";
-        result += this.atom.toString();
-        return result;
+        return "var " + this.var + " = Aggregate((" +
+                String.join(", ", this.groupBy) + "), " + this.aggFunc +
+                "(" + this.aggExpr.toString() + "))";
     }
 }

--- a/sql/src/main/java/com/vmware/ddlog/ir/BodyTermFlatMap.java
+++ b/sql/src/main/java/com/vmware/ddlog/ir/BodyTermFlatMap.java
@@ -28,22 +28,18 @@ import com.facebook.presto.sql.tree.Node;
 
 import javax.annotation.Nullable;
 
-public class DDlogEField extends DDlogExpression {
-    private final DDlogExpression struct;
-    public final String field;
+public class BodyTermFlatMap extends RuleBodyTerm {
+    final String var;
+    final DDlogExpression mapExpr;
 
-    public DDlogEField(@Nullable Node node, DDlogExpression struct, String field, DDlogType type) {
-        super(node, type);
-        this.struct = struct;
-        this.field = field;
-    }
-
-    public DDlogExpression getStruct() {
-        return this.struct;
+    public BodyTermFlatMap(@Nullable Node node, String var, DDlogExpression mapExpr) {
+        super(node);
+        this.var = var;
+        this.mapExpr = mapExpr;
     }
 
     @Override
     public String toString() {
-        return this.struct.toString() + "." + this.field;
+        return "var " + this.var + " = FlatMap(" + this.mapExpr + ")";
     }
 }

--- a/sql/src/main/java/com/vmware/ddlog/ir/BodyTermGroupby.java
+++ b/sql/src/main/java/com/vmware/ddlog/ir/BodyTermGroupby.java
@@ -28,22 +28,21 @@ import com.facebook.presto.sql.tree.Node;
 
 import javax.annotation.Nullable;
 
-public class DDlogEField extends DDlogExpression {
-    private final DDlogExpression struct;
-    public final String field;
+public class BodyTermGroupby extends RuleBodyTerm {
+    final String var;
+    final DDlogExpression rhsProject;
+    final String[] rhsGroupByVars;
 
-    public DDlogEField(@Nullable Node node, DDlogExpression struct, String field, DDlogType type) {
-        super(node, type);
-        this.struct = struct;
-        this.field = field;
-    }
-
-    public DDlogExpression getStruct() {
-        return this.struct;
+    public BodyTermGroupby(@Nullable Node node, String var, DDlogExpression rhsProject, String... rhsGroupByVars) {
+        super(node);
+        this.var = var;
+        this.rhsProject = rhsProject;
+        this.rhsGroupByVars = rhsGroupByVars;
     }
 
     @Override
     public String toString() {
-        return this.struct.toString() + "." + this.field;
+        return "var " + this.var + " = " + this.rhsProject.toString() +
+                ".group_by((" + String.join(", ", this.rhsGroupByVars) + "))";
     }
 }

--- a/sql/src/main/java/com/vmware/ddlog/ir/BodyTermLiteral.java
+++ b/sql/src/main/java/com/vmware/ddlog/ir/BodyTermLiteral.java
@@ -28,22 +28,22 @@ import com.facebook.presto.sql.tree.Node;
 
 import javax.annotation.Nullable;
 
-public class DDlogEField extends DDlogExpression {
-    private final DDlogExpression struct;
-    public final String field;
+public class BodyTermLiteral extends RuleBodyTerm {
+    public final boolean polarity;
+    public final DDlogAtom atom;
 
-    public DDlogEField(@Nullable Node node, DDlogExpression struct, String field, DDlogType type) {
-        super(node, type);
-        this.struct = struct;
-        this.field = field;
-    }
-
-    public DDlogExpression getStruct() {
-        return this.struct;
+    public BodyTermLiteral(@Nullable Node node, boolean polarity, DDlogAtom atom) {
+        super(node);
+        this.polarity = polarity;
+        this.atom = atom;
     }
 
     @Override
     public String toString() {
-        return this.struct.toString() + "." + this.field;
+        String result = "";
+        if (!this.polarity)
+            result = "not ";
+        result += this.atom.toString();
+        return result;
     }
 }

--- a/sql/src/main/java/com/vmware/ddlog/ir/DDlogAtom.java
+++ b/sql/src/main/java/com/vmware/ddlog/ir/DDlogAtom.java
@@ -24,30 +24,27 @@
 
 package com.vmware.ddlog.ir;
 
-import com.vmware.ddlog.util.Linq;
+import com.vmware.ddlog.translator.RelationName;
 import com.facebook.presto.sql.tree.Node;
 
 import javax.annotation.Nullable;
 
 public class DDlogAtom extends DDlogNode {
-    public final String relation;
+    public final RelationName relation;
     public final DDlogExpression val;
 
-    public DDlogAtom(@Nullable Node node, String relation, DDlogExpression val) {
+    public DDlogAtom(@Nullable Node node, RelationName relation, DDlogExpression val) {
         super(node);
         this.relation = relation;
         this.val = val;
     }
 
+    public DDlogType getType() {
+        return this.val.getType();
+    }
+
     @Override
     public String toString() {
-        if (this.val instanceof DDlogEStruct) {
-            DDlogEStruct struct = (DDlogEStruct)this.val;
-            return this.relation + "(" + String.join(",",
-                Linq.map(struct.fields, f ->
-                        (f.getName().isEmpty() ? "" : "." + f.getName()) + " = "
-                                + f.getValue().toString(), String.class)) + ")";
-        }
         return this.relation + "[" + this.val.toString() + "]";
     }
 }

--- a/sql/src/main/java/com/vmware/ddlog/ir/DDlogEnvironment.java
+++ b/sql/src/main/java/com/vmware/ddlog/ir/DDlogEnvironment.java
@@ -24,26 +24,24 @@
 
 package com.vmware.ddlog.ir;
 
-import com.facebook.presto.sql.tree.Node;
+import com.vmware.ddlog.translator.environment.IEnvironment;
 
-import javax.annotation.Nullable;
+/**
+ * This is not a real DDlog expression; it stands for a SQL expression that
+ * evaluates to an environment.
+ */
+public class DDlogEnvironment extends DDlogExpression {
+    private final IEnvironment environment;
 
-public class DDlogEField extends DDlogExpression {
-    private final DDlogExpression struct;
-    public final String field;
-
-    public DDlogEField(@Nullable Node node, DDlogExpression struct, String field, DDlogType type) {
-        super(node, type);
-        this.struct = struct;
-        this.field = field;
+    public DDlogEnvironment(IEnvironment environment) {
+        super(null);
+        this.environment = environment;
     }
 
-    public DDlogExpression getStruct() {
-        return this.struct;
-    }
+    public IEnvironment getEnvironment() { return this.environment; }
 
     @Override
     public String toString() {
-        return this.struct.toString() + "." + this.field;
+        return this.environment.toString();
     }
 }

--- a/sql/src/main/java/com/vmware/ddlog/ir/DDlogIndexDeclaration.java
+++ b/sql/src/main/java/com/vmware/ddlog/ir/DDlogIndexDeclaration.java
@@ -25,6 +25,7 @@
 package com.vmware.ddlog.ir;
 
 import com.facebook.presto.sql.tree.Node;
+import com.vmware.ddlog.translator.RelationName;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -34,13 +35,12 @@ import java.util.stream.Collectors;
  * The intermediate representation for a DDlog index during SQL -> DDlog translation.
  */
 public class DDlogIndexDeclaration extends DDlogNode {
-
-    private final String name;
+    private final RelationName name;
     private final List<DDlogField> fields;
     private final DDlogRelationDeclaration baseRelation;
     private final String baseRelationTypeString;
 
-    public DDlogIndexDeclaration(@Nullable Node node, String name,
+    public DDlogIndexDeclaration(@Nullable Node node, RelationName name,
                                  List<DDlogField> fields, DDlogRelationDeclaration baseRelation,
                                  String baseRelationTypeString) {
         super(node);
@@ -51,19 +51,18 @@ public class DDlogIndexDeclaration extends DDlogNode {
         this.baseRelationTypeString = baseRelationTypeString;
     }
 
-    public String getName() {
+    public RelationName getName() {
         return this.name;
     }
 
-    public static String indexName(String name) {
-        return "I" + name;
+    public static RelationName indexName(String name) {
+        return new RelationName("I" + name, name,null);
     }
 
     @Override
     public String toString() {
         return "index " + this.name
-                + "(" + String.join(",",
-                    this.fields.stream().map(DDlogField::toString).collect(Collectors.toList()))  + ") on " +
+                + "(" + this.fields.stream().map(DDlogField::toString).collect(Collectors.joining(",")) + ") on " +
                 this.baseRelation.getName() +
                 "[" + this.baseRelation.getType() +
                 "{" + this.baseRelationTypeString + "}" +

--- a/sql/src/main/java/com/vmware/ddlog/ir/DDlogProgram.java
+++ b/sql/src/main/java/com/vmware/ddlog/ir/DDlogProgram.java
@@ -32,6 +32,7 @@ import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class DDlogProgram extends DDlogNode {
     // We are missing some of the fields that can never be generated from SQL
@@ -41,7 +42,7 @@ public class DDlogProgram extends DDlogNode {
     public final List<DDlogIndexDeclaration> indexes;
     public final List<DDlogRule> rules;
     public final List<DDlogImport> imports;
-    public final HashMap<String, DDlogRelationDeclaration> tableToRelation;
+    private final HashMap<String, DDlogRelationDeclaration> tableToRelation;
 
     DDlogProgram(List<DDlogTypeDef> typedefs, List<DDlogFunction> functions, List<DDlogRelationDeclaration> relations,
                  List<DDlogIndexDeclaration> indexes,
@@ -89,5 +90,17 @@ public class DDlogProgram extends DDlogNode {
     @Nullable
     public DDlogRelationDeclaration getRelationFromTable(String tableName) {
         return this.tableToRelation.get(tableName.toLowerCase());
+    }
+
+    public void addTableRelation(String tableName, DDlogRelationDeclaration relation) {
+        this.tableToRelation.put(tableName, relation);
+    }
+
+    public String relationNameToTableName(final String relationName) {
+        for (Map.Entry<String, DDlogRelationDeclaration> me : this.tableToRelation.entrySet()) {
+            if (me.getValue().getName().name.equals(relationName))
+                return me.getKey();
+        }
+        throw new RuntimeException("Table not found for relation " + relationName);
     }
 }

--- a/sql/src/main/java/com/vmware/ddlog/ir/DDlogProgram.java
+++ b/sql/src/main/java/com/vmware/ddlog/ir/DDlogProgram.java
@@ -26,9 +26,11 @@ package com.vmware.ddlog.ir;
 
 import com.vmware.ddlog.util.Linq;
 
+import javax.annotation.Nullable;
 import java.io.FileNotFoundException;
 import java.io.PrintWriter;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 public class DDlogProgram extends DDlogNode {
@@ -39,6 +41,7 @@ public class DDlogProgram extends DDlogNode {
     public final List<DDlogIndexDeclaration> indexes;
     public final List<DDlogRule> rules;
     public final List<DDlogImport> imports;
+    public final HashMap<String, DDlogRelationDeclaration> tableToRelation;
 
     DDlogProgram(List<DDlogTypeDef> typedefs, List<DDlogFunction> functions, List<DDlogRelationDeclaration> relations,
                  List<DDlogIndexDeclaration> indexes,
@@ -50,6 +53,7 @@ public class DDlogProgram extends DDlogNode {
         this.indexes = indexes;
         this.rules = rules;
         this.imports = imports;
+        this.tableToRelation = new HashMap<>();
     }
 
     public DDlogProgram() {
@@ -80,5 +84,10 @@ public class DDlogProgram extends DDlogNode {
         try (PrintWriter out = new PrintWriter(filename)) {
             out.println(this.toString());
         }
+    }
+
+    @Nullable
+    public DDlogRelationDeclaration getRelationFromTable(String tableName) {
+        return this.tableToRelation.get(tableName.toLowerCase());
     }
 }

--- a/sql/src/main/java/com/vmware/ddlog/ir/DDlogRelationDeclaration.java
+++ b/sql/src/main/java/com/vmware/ddlog/ir/DDlogRelationDeclaration.java
@@ -25,12 +25,14 @@
 package com.vmware.ddlog.ir;
 
 import com.facebook.presto.sql.tree.Node;
+import com.vmware.ddlog.translator.RelationName;
 import com.vmware.ddlog.util.Linq;
 
 import javax.annotation.Nullable;
 import java.util.List;
 
 public class DDlogRelationDeclaration extends DDlogNode {
+
     public enum Role {
         Input,
         Output,
@@ -51,14 +53,13 @@ public class DDlogRelationDeclaration extends DDlogNode {
     }
 
     private final Role role;
-    private final String name;
+    private final RelationName name;
     private final DDlogType type;
     private final String primaryKeyVariable = "row";
     @Nullable
     private DDlogExpression keyExpression = null;
 
-    public DDlogRelationDeclaration(@Nullable Node node, Role role, String name,
-                                    DDlogType type) {
+    public DDlogRelationDeclaration(@Nullable Node node, Role role, RelationName name, DDlogType type) {
         super(node);
         this.role = role;
         this.name = this.checkNull(name);
@@ -76,7 +77,7 @@ public class DDlogRelationDeclaration extends DDlogNode {
         return result;
     }
 
-    public String getName() {
+    public RelationName getName() {
         return this.name;
     }
 

--- a/sql/src/main/java/com/vmware/ddlog/ir/DDlogRule.java
+++ b/sql/src/main/java/com/vmware/ddlog/ir/DDlogRule.java
@@ -36,18 +36,18 @@ import java.util.List;
  * but when translating SQL we never need more than 1.
  */
 public class DDlogRule extends DDlogNode {
-    public final DDlogAtom lhs;
-    public final List<DDlogRuleRHS> rhs;
+    public final DDlogAtom head;
+    public final List<RuleBodyTerm> body;
 
-    public DDlogRule(@Nullable Node node, DDlogAtom lhs, List<DDlogRuleRHS> rhs) {
+    public DDlogRule(@Nullable Node node, DDlogAtom head, List<RuleBodyTerm> body) {
         super(node);
-        this.lhs = this.checkNull(lhs);
-        this.rhs = this.checkNull(rhs);
+        this.head = this.checkNull(head);
+        this.body = this.checkNull(body);
     }
 
-    public DDlogRule(@Nullable Node node, DDlogAtom lhs, DDlogRuleRHS rhs) {
-        this(node, lhs, new ArrayList<DDlogRuleRHS>());
-        this.rhs.add(this.checkNull(rhs));
+    public DDlogRule(@Nullable Node node, DDlogAtom head, RuleBodyTerm body) {
+        this(node, head, new ArrayList<RuleBodyTerm>());
+        this.body.add(this.checkNull(body));
     }
 
     @Override
@@ -58,10 +58,10 @@ public class DDlogRule extends DDlogNode {
         if (!result.isEmpty())
             result += "\n";
          */
-        result += this.lhs.toString();
-        if (!this.rhs.isEmpty()) {
+        result += this.head.toString();
+        if (!this.body.isEmpty()) {
             result += " :- " + String.join(",",
-                Linq.map(this.rhs, DDlogRuleRHS::toString));
+                Linq.map(this.body, RuleBodyTerm::toString));
         }
         result += ".";
         return result;

--- a/sql/src/main/java/com/vmware/ddlog/ir/RuleBody.java
+++ b/sql/src/main/java/com/vmware/ddlog/ir/RuleBody.java
@@ -35,44 +35,37 @@ import java.util.List;
  * A partially-constructed relation; contains part of the RHS of a relation,
  * and the type produced by the RHS.
  */
-public class RelationRHS extends DDlogNode {
+public class RuleBody extends DDlogNode {
     private final String rowVariable;
     private final DDlogType type;
-    private final List<DDlogRuleRHS> definitions;
+    private final List<RuleBodyTerm> definitions;
 
-    public RelationRHS(@Nullable Node node, String rowVariable, DDlogType type) {
+    public RuleBody(@Nullable Node node, String rowVariable, DDlogType type) {
         super(node);
         this.rowVariable = rowVariable;
         this.type = this.checkNull(type);
-        this.definitions = new ArrayList<DDlogRuleRHS>();
+        this.definitions = new ArrayList<RuleBodyTerm>();
     }
 
-    public RelationRHS addDefinition(DDlogExpression expression) {
-        this.definitions.add(new DDlogRHSCondition(expression.getNode(), expression));
+    public RuleBody addDefinition(DDlogExpression expression) {
+        this.definitions.add(new RuleBodyCondition(expression.getNode(), expression));
         return this;
     }
 
-    public void addAssignment(String from) {
-        DDlogExpression expr = new DDlogESet(this.node,
-                new DDlogEVarDecl(this.node, this.rowVariable, this.type),
-                new DDlogEVar(this.node, from, this.type));
-        this.addDefinition(expr);
-    }
-
     @SuppressWarnings("UnusedReturnValue")
-    public RelationRHS addDefinition(DDlogRuleRHS rhs) {
+    public RuleBody addDefinition(RuleBodyTerm rhs) {
         this.definitions.add(rhs);
         return this;
     }
 
     public DDlogType getType() { return this.type; }
 
-    public List<DDlogRuleRHS> getDefinitions() {
+    public List<RuleBodyTerm> getDefinitions() {
         return this.definitions; }
 
     @Override
     public String toString() {
-        return String.join(",", Linq.map(this.definitions, DDlogRuleRHS::toString));
+        return String.join(",", Linq.map(this.definitions, RuleBodyTerm::toString));
     }
 
     public DDlogExpression getRowVariable(boolean declare) {

--- a/sql/src/main/java/com/vmware/ddlog/ir/RuleBodyCondition.java
+++ b/sql/src/main/java/com/vmware/ddlog/ir/RuleBodyCondition.java
@@ -22,24 +22,22 @@
  *
  */
 
-package com.vmware.ddlog.translator;
+package com.vmware.ddlog.ir;
 
-import com.facebook.presto.sql.tree.AstVisitor;
-import com.facebook.presto.sql.tree.DereferenceExpression;
-import com.facebook.presto.sql.tree.Identifier;
+import com.facebook.presto.sql.tree.Node;
 
-/**
- * A simple visitor which extracts a column name from an expression.
- * This returns null for most expressions.
- */
-public class ExpressionColumnName extends AstVisitor<String, Void> {
-    @Override
-    protected String visitIdentifier(Identifier id, Void context) {
-        return id.getValue().toLowerCase();
+import javax.annotation.Nullable;
+
+public class RuleBodyCondition extends RuleBodyTerm {
+    private final DDlogExpression expr;
+
+    public RuleBodyCondition(@Nullable Node node, DDlogExpression expr) {
+        super(node);
+        this.expr = this.checkNull(expr);
     }
 
     @Override
-    protected String visitDereferenceExpression(DereferenceExpression expression, Void context) {
-        return expression.getField().getValue().toLowerCase();
+    public String toString() {
+        return this.expr.toString();
     }
 }

--- a/sql/src/main/java/com/vmware/ddlog/ir/RuleBodyTerm.java
+++ b/sql/src/main/java/com/vmware/ddlog/ir/RuleBodyTerm.java
@@ -28,21 +28,11 @@ import com.facebook.presto.sql.tree.Node;
 
 import javax.annotation.Nullable;
 
-public class DDlogRHSGroupby extends DDlogRuleRHS {
-    final String var;
-    final DDlogExpression rhsProject;
-    final String[] rhsGroupByVars;
-
-    public DDlogRHSGroupby(@Nullable Node node, String var, DDlogExpression rhsProject, String... rhsGroupByVars) {
+/**
+ * A term in the body of a rule.
+ */
+public abstract class RuleBodyTerm extends DDlogNode {
+    protected RuleBodyTerm(@Nullable Node node) {
         super(node);
-        this.var = var;
-        this.rhsProject = rhsProject;
-        this.rhsGroupByVars = rhsGroupByVars;
-    }
-
-    @Override
-    public String toString() {
-        return "var " + this.var + " = " + this.rhsProject.toString() +
-                ".group_by((" + String.join(", ", this.rhsGroupByVars) + "))";
     }
 }

--- a/sql/src/main/java/com/vmware/ddlog/ir/RuleBodyVarDef.java
+++ b/sql/src/main/java/com/vmware/ddlog/ir/RuleBodyVarDef.java
@@ -27,23 +27,25 @@ package com.vmware.ddlog.ir;
 import com.facebook.presto.sql.tree.Node;
 
 import javax.annotation.Nullable;
+import java.util.Objects;
 
-public class DDlogEField extends DDlogExpression {
-    private final DDlogExpression struct;
-    public final String field;
+public class RuleBodyVarDef extends RuleBodyCondition {
+    private final String var;
+    private final DDlogType exprType;
 
-    public DDlogEField(@Nullable Node node, DDlogExpression struct, String field, DDlogType type) {
-        super(node, type);
-        this.struct = struct;
-        this.field = field;
+    public RuleBodyVarDef(@Nullable Node node, String var, DDlogExpression expr) {
+        super(node, new DDlogESet(node,
+                new DDlogEVarDecl(node, var, expr.getType()),
+                expr));
+        this.var = var;
+        this.exprType = Objects.requireNonNull(expr.type);
     }
 
-    public DDlogExpression getStruct() {
-        return this.struct;
+    public DDlogType getExprType() {
+        return this.exprType;
     }
 
-    @Override
-    public String toString() {
-        return this.struct.toString() + "." + this.field;
+    public String getVar() {
+        return this.var;
     }
 }

--- a/sql/src/main/java/com/vmware/ddlog/translator/AggregateVisitor.java
+++ b/sql/src/main/java/com/vmware/ddlog/translator/AggregateVisitor.java
@@ -26,6 +26,7 @@ package com.vmware.ddlog.translator;
 
 import com.facebook.presto.sql.tree.*;
 import com.vmware.ddlog.util.Ternary;
+import com.vmware.ddlog.util.Utilities;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -94,7 +95,7 @@ public class AggregateVisitor
             this.decomposition.addNode(fc);
             return Ternary.Yes;
         }
-        String name = TranslationVisitor.convertQualifiedName(fc.getName());
+        String name = Utilities.convertQualifiedName(fc.getName());
         Ternary result = Ternary.Maybe;
         boolean isAggregate = SqlSemantics.semantics.isAggregateFunction(name);
         if (isAggregate) {

--- a/sql/src/main/java/com/vmware/ddlog/translator/ColumnNameVisitor.java
+++ b/sql/src/main/java/com/vmware/ddlog/translator/ColumnNameVisitor.java
@@ -22,28 +22,24 @@
  *
  */
 
-package com.vmware.ddlog.ir;
+package com.vmware.ddlog.translator;
 
-import com.facebook.presto.sql.tree.Node;
+import com.facebook.presto.sql.tree.AstVisitor;
+import com.facebook.presto.sql.tree.DereferenceExpression;
+import com.facebook.presto.sql.tree.Identifier;
 
-import javax.annotation.Nullable;
-
-public class DDlogEField extends DDlogExpression {
-    private final DDlogExpression struct;
-    public final String field;
-
-    public DDlogEField(@Nullable Node node, DDlogExpression struct, String field, DDlogType type) {
-        super(node, type);
-        this.struct = struct;
-        this.field = field;
-    }
-
-    public DDlogExpression getStruct() {
-        return this.struct;
+/**
+ * A simple visitor which extracts a column name from an expression.
+ * This returns null for most expressions.
+ */
+public class ColumnNameVisitor extends AstVisitor<String, Void> {
+    @Override
+    protected String visitIdentifier(Identifier id, Void context) {
+        return id.getValue().toLowerCase();
     }
 
     @Override
-    public String toString() {
-        return this.struct.toString() + "." + this.field;
+    protected String visitDereferenceExpression(DereferenceExpression expression, Void context) {
+        return expression.getField().getValue().toLowerCase();
     }
 }

--- a/sql/src/main/java/com/vmware/ddlog/translator/CompilerState.java
+++ b/sql/src/main/java/com/vmware/ddlog/translator/CompilerState.java
@@ -28,13 +28,14 @@ import com.vmware.ddlog.ir.*;
 
 import javax.annotation.Nullable;
 import java.util.HashMap;
+import java.util.Objects;
 
 /**
  * Part of the TranslationContext that is shared between multiple
  * translation contexts.  This contains the program and allocated
  * symbols, for example.
  */
-public class TranslationState {
+public class CompilerState {
     private final DDlogProgram program;
     private final HashMap<String, DDlogRelationDeclaration> relations;
     public final ExpressionTranslationVisitor etv;
@@ -48,7 +49,7 @@ public class TranslationState {
     @Nullable
     private SymbolTable localSymbols;
 
-    public TranslationState() {
+    public CompilerState() {
         this.program = new DDlogProgram();
         this.program.imports.add(new DDlogImport("fp", ""));
         this.program.imports.add(new DDlogImport("time", ""));
@@ -71,7 +72,7 @@ public class TranslationState {
 
     void add(DDlogRelationDeclaration relation) {
         this.program.relations.add(relation);
-        this.relations.put(relation.getName(), relation);
+        this.relations.put(relation.getName().name, relation);
     }
 
     void add(DDlogIndexDeclaration index) {
@@ -83,8 +84,7 @@ public class TranslationState {
     }
 
     String freshLocalName(String prefix) {
-        assert this.localSymbols != null;
-        return this.localSymbols.freshName(prefix);
+        return Objects.requireNonNull(this.localSymbols).freshName(prefix);
     }
 
     void beginTranslation() {
@@ -100,8 +100,8 @@ public class TranslationState {
     }
 
     @Nullable
-    DDlogRelationDeclaration getRelation(String name) {
-        return this.relations.get(name);
+    DDlogRelationDeclaration getRelation(RelationName name) {
+        return this.relations.get(name.name);
     }
 
     DDlogProgram getProgram() {

--- a/sql/src/main/java/com/vmware/ddlog/translator/JoinColumns.java
+++ b/sql/src/main/java/com/vmware/ddlog/translator/JoinColumns.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2021 VMware, Inc.
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.vmware.ddlog.translator;
+
+import com.facebook.presto.sql.tree.*;
+import com.vmware.ddlog.ir.DDlogExpression;
+import com.vmware.ddlog.ir.DDlogType;
+import com.vmware.ddlog.translator.environment.EnvHandle;
+import com.vmware.ddlog.translator.environment.IEnvironment;
+import com.vmware.ddlog.util.Utilities;
+
+import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Objects;
+
+/**
+ * This visitor inspects the predicate of a join to detect whether it is an equijoin.
+ * If it is, it maintains a list of pairs of columns checked for equivalence.
+ */
+public class JoinColumns extends AstVisitor<Void, Void> {
+    // Maps a column in the right table to the equal column in the left table.
+    @Nullable
+    protected HashMap<String, String> rightToLeftColumn;
+    protected final HashSet<String> leftColumns;
+    // Type of each column
+    protected HashMap<String, DDlogType> leftColumnType;
+    // For each column in the left table keep here the variable name used in the code to match it
+    protected HashMap<String, String> leftColumnVariable;
+    protected EnvHandle leftEnvironment;
+    protected EnvHandle rightEnvironment;
+    @Nullable
+    protected Expression condition;
+
+    public JoinColumns(TranslationContext leftContext, TranslationContext rightContext) {
+        this.rightToLeftColumn = new HashMap<>();
+        this.leftColumns = new HashSet<>();
+        this.leftColumnVariable = new HashMap<>();
+        this.leftEnvironment = leftContext.environment;
+        this.rightEnvironment = rightContext.environment;
+        this.leftColumnType = new HashMap<>();
+        this.condition = null;
+    }
+
+    public boolean isEquiJoin() {
+        return this.rightToLeftColumn != null;
+    }
+
+    public void analyze(Expression condition) {
+        this.condition = condition;
+        this.process(condition);
+    }
+
+    public Expression getCondition() {
+        return Objects.requireNonNull(this.condition);
+    }
+
+    // Called when the join expression is not equivalent to an equijoin.
+    protected Void setNotEquijoin() {
+        this.rightToLeftColumn = null;
+        return null;
+    }
+
+    @Override
+    protected Void visitExpression(Expression node, Void context) {
+        return this.setNotEquijoin();
+    }
+
+    public void addColumnPair(String left, String right) {
+        Objects.requireNonNull(this.rightToLeftColumn).put(right, left);
+        this.leftColumns.add(left);
+    }
+
+    @Override
+    protected Void visitLogicalBinaryExpression(LogicalBinaryExpression node, Void context) {
+        if (node.getOperator() != LogicalBinaryExpression.Operator.AND)
+            return this.setNotEquijoin();
+        this.process(node.getLeft(), context);
+        if (this.isEquiJoin())
+            this.process(node.getRight(), context);
+        return null;
+    }
+
+    @Nullable
+    public String findLeftVariable(String rightColumn) {
+        if (!this.isEquiJoin())
+            throw new RuntimeException("Not an equijoin");
+        Objects.requireNonNull(this.rightToLeftColumn);
+        String leftColumn = this.rightToLeftColumn.get(rightColumn);
+        if (leftColumn == null)
+            return null;
+        return Objects.requireNonNull(this.leftColumnVariable.get(leftColumn));
+    }
+
+    @Nullable
+    public String findLeftColumn(String rightColumn) {
+        return Objects.requireNonNull(this.rightToLeftColumn).get(rightColumn);
+    }
+
+    public void setColumnVariable(String name, String varName, DDlogType type) {
+        this.leftColumnVariable.put(name, varName);
+        this.leftColumnType.put(name, type);
+    }
+
+    boolean isLeftColumn(String column) {
+        return this.leftColumns.contains(column);
+    }
+
+    public DDlogType findLeftType(String rightColumn) {
+        String leftColumn = Objects.requireNonNull(this.rightToLeftColumn).get(rightColumn);
+        return Objects.requireNonNull(this.leftColumnType.get(leftColumn));
+    }
+
+    static class ColumnReference {
+        @Nullable
+        final String originalTableName;
+        final String column;
+        final Expression expression;
+
+        ColumnReference(Expression expression) {
+            this.expression = expression;
+            if (expression instanceof DereferenceExpression) {
+                DereferenceExpression dleft = (DereferenceExpression)expression;
+                Identifier tbl = (Identifier)dleft.getBase();
+                if (tbl == null)
+                    throw new TranslationException("Unexpected column reference " + expression, expression);
+                this.originalTableName = tbl.getValue();
+                this.column = dleft.getField().getValue();
+            } else if (expression instanceof Identifier) {
+                this.originalTableName = null;
+                this.column = ((Identifier)expression).getValue();
+            } else {
+                throw new TranslationException("Unexpected column reference " + expression, expression);
+            }
+        }
+
+        @Override
+        public String toString() {
+            return this.expression.toString();
+        }
+    }
+
+    /**
+     * Find out of a column reference is to the left table.
+     * @param column  Column reference.
+     * @return        True if this refers to the left table, false if it refers to the right table.
+     * Throw if it is ambiguous or refers to neither.
+     */
+    boolean isLeftTable(ColumnReference column) {
+        if (column.originalTableName != null) {
+            String tableName = column.originalTableName;
+            IEnvironment scope = this.leftEnvironment.lookupRelation(tableName);
+            if (scope != null) {
+                DDlogExpression col = scope.lookupIdentifier(column.column);
+                if (col == null)
+                    throw new TranslationException("Column " + Utilities.singleQuote(column.column)
+                            + " not present in " + Utilities.singleQuote(tableName),
+                            column.expression);
+                return true;
+            }
+            scope = this.rightEnvironment.lookupRelation(tableName);
+            if (scope != null) {
+                DDlogExpression col = scope.lookupIdentifier(column.column);
+                if (col == null)
+                    throw new TranslationException("Column " + Utilities.singleQuote(column.column) +
+                            " not present in " + Utilities.singleQuote(tableName), column.expression);
+                return false;
+            }
+            throw new TranslationException("Column " + Utilities.singleQuote(column.toString()) +
+                    " not in one of the joined relation", column.expression);
+        } else {
+            // no table specified, try to guess
+            boolean mayBeLeft = false;
+            boolean mayBeRight = false;
+            if (this.leftEnvironment.lookupIdentifier(column.column) != null)
+                mayBeLeft = true;
+            if (this.rightEnvironment.lookupIdentifier(column.column) != null)
+                mayBeRight = true;
+            if (mayBeLeft && mayBeRight)
+                throw new TranslationException("Column name " + Utilities.singleQuote(column.toString()) +
+                        " is ambiguous; could be in either joined table ", column.expression);
+            if (mayBeLeft)
+                return true;
+            if (mayBeRight)
+                return false;
+            throw new TranslationException("Column name " + Utilities.singleQuote(column.toString()) +
+                    " could not be found in either joined relation", column.expression);
+        }
+    }
+
+    @Override
+    protected Void visitComparisonExpression(ComparisonExpression node, Void context) {
+        if (node.getOperator() != ComparisonExpression.Operator.EQUAL) {
+            this.rightToLeftColumn = null;
+            return null;
+        }
+        ColumnReference leftColumn = new ColumnReference(node.getLeft());
+        ColumnReference rightColumn = new ColumnReference(node.getRight());
+        boolean left = this.isLeftTable(leftColumn);
+        boolean right = this.isLeftTable(rightColumn);
+        if (left == right)
+            throw new TranslationException(" Columns joined " + Utilities.singleQuote(leftColumn.toString()) +
+                    " and " + Utilities.singleQuote(rightColumn.toString()) + " must be from different tables", node);
+        if (right) {
+            // need to swap
+            this.addColumnPair(rightColumn.column, leftColumn.column);
+        } else {
+            this.addColumnPair(leftColumn.column, rightColumn.column);
+        }
+        return null;
+    }
+}

--- a/sql/src/main/java/com/vmware/ddlog/translator/RelationName.java
+++ b/sql/src/main/java/com/vmware/ddlog/translator/RelationName.java
@@ -56,7 +56,7 @@ public class RelationName {
     }
 
     public static String makeRelationName(String tableName) {
-        return "R" + tableName.toLowerCase();
+        return "R" + tableName;
     }
 
     public String toString() {

--- a/sql/src/main/java/com/vmware/ddlog/translator/RelationName.java
+++ b/sql/src/main/java/com/vmware/ddlog/translator/RelationName.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2021 VMware, Inc.
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.vmware.ddlog.translator;
+
+import com.facebook.presto.sql.tree.*;
+
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+/**
+ * Represents a DDlog relation name.
+ * Relation names have some different rules from SQL table names, so they cannot be identical.
+ */
+public class RelationName {
+    @Nullable
+    private final String originalName;
+    public final String name;
+    @Nullable
+    public final Node node;
+
+    public RelationName(String name, @Nullable String originalName, @Nullable Node node) {
+        this.name = name;
+        this.node = node;
+        this.originalName = originalName;
+        if (!isValid(name))
+            throw new RuntimeException("Invalid relation name " + name);
+    }
+
+    public static boolean isValid(String name) {
+        if (name.length() == 0)
+            return false;
+        char first = name.charAt(0);
+        return Character.isLetter(first) && !Character.isLowerCase(first);
+    }
+
+    public static String makeRelationName(String tableName) {
+        return "R" + tableName.toLowerCase();
+    }
+
+    public String toString() {
+        return this.name;
+    }
+
+    public String originalName() {
+        return Objects.requireNonNull(this.originalName);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RelationName that = (RelationName) o;
+        return name.equals(that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return this.name.hashCode();
+    }
+}

--- a/sql/src/main/java/com/vmware/ddlog/translator/RelationNameVisitor.java
+++ b/sql/src/main/java/com/vmware/ddlog/translator/RelationNameVisitor.java
@@ -22,29 +22,30 @@
  *
  */
 
-package com.vmware.ddlog.ir;
+package com.vmware.ddlog.translator;
 
-import com.facebook.presto.sql.tree.Node;
-import com.vmware.ddlog.translator.Scope;
+import com.facebook.presto.sql.tree.*;
+import com.vmware.ddlog.util.Utilities;
 
 import javax.annotation.Nullable;
 
 /**
- * This is not a real DDlog expression; it stands for a SQL expression that
- * evaluates to a scope.
+ * A simple visitor which extracts a relation name from a Relation (if possible).
  */
-public class DDlogScope extends DDlogExpression {
-    private final Scope scope;
-
-    public DDlogScope(Scope scope) {
-        super(scope.node);
-        this.scope = scope;
+public class RelationNameVisitor extends AstVisitor<String, Void> {
+    @Override
+    protected String visitTable(Table node, Void context) {
+        return Utilities.convertQualifiedName(node.getName());
     }
 
-    public Scope getScope() { return this.scope; }
-
     @Override
-    public String toString() {
-        return "Scope: " + this.scope.getName();
+    protected String visitAliasedRelation(AliasedRelation node, Void context) {
+        return node.getAlias().getValue();
+    }
+
+    @Nullable
+    @Override
+    protected String visitRelation(Relation node, Void context) {
+        return null;
     }
 }

--- a/sql/src/main/java/com/vmware/ddlog/translator/SymbolTable.java
+++ b/sql/src/main/java/com/vmware/ddlog/translator/SymbolTable.java
@@ -31,11 +31,6 @@ import java.util.HashSet;
  */
 public class SymbolTable {
     private final HashSet<String> names = new HashSet<String>();
-    private int counter;
-
-    public SymbolTable() {
-        this.counter = 0;
-    }
 
     public void addName(String name) {
         if (this.names.contains(name))
@@ -45,14 +40,20 @@ public class SymbolTable {
 
     public String freshName(String prefix) {
         String name = prefix;
+        int counter = 0;
         while (true) {
             if (this.names.contains(name)) {
-                name = prefix + this.counter;
-                this.counter++;
+                name = prefix + counter;
+                counter++;
             } else {
                 this.addName(name);
                 return name;
             }
         }
+    }
+
+    @Override
+    public String toString() {
+        return String.join(", ", names);
     }
 }

--- a/sql/src/main/java/com/vmware/ddlog/translator/TranslationContext.java
+++ b/sql/src/main/java/com/vmware/ddlog/translator/TranslationContext.java
@@ -238,8 +238,10 @@ class TranslationContext {
         return this.compilerState.etv.process(expr, this);
     }
 
-    void add(DDlogRelationDeclaration relation) {
+    void add(DDlogRelationDeclaration relation, @Nullable String originalTableName) {
         this.compilerState.add(relation);
+        if (originalTableName != null)
+            this.compilerState.getProgram().tableToRelation.put(originalTableName, relation);
     }
 
     void add(DDlogIndexDeclaration index) {

--- a/sql/src/main/java/com/vmware/ddlog/translator/TranslationContext.java
+++ b/sql/src/main/java/com/vmware/ddlog/translator/TranslationContext.java
@@ -241,7 +241,7 @@ class TranslationContext {
     void add(DDlogRelationDeclaration relation, @Nullable String originalTableName) {
         this.compilerState.add(relation);
         if (originalTableName != null)
-            this.compilerState.getProgram().tableToRelation.put(originalTableName, relation);
+            this.compilerState.getProgram().addTableRelation(originalTableName, relation);
     }
 
     void add(DDlogIndexDeclaration index) {

--- a/sql/src/main/java/com/vmware/ddlog/translator/TranslationVisitor.java
+++ b/sql/src/main/java/com/vmware/ddlog/translator/TranslationVisitor.java
@@ -129,7 +129,7 @@ class TranslationVisitor extends AstVisitor<DDlogIRNode, TranslationContext> {
         String outVarName = context.freshLocalName("v");
         DDlogRelationDeclaration relDecl = new DDlogRelationDeclaration(node, role, relName, body.getType());
         if (role == DDlogRelationDeclaration.Role.Output) {
-            context.getProgram().tableToRelation.put(Objects.requireNonNull(tableName), relDecl);
+            context.getProgram().addTableRelation(Objects.requireNonNull(tableName), relDecl);
         }
         DDlogAtom lhs = new DDlogAtom(node, relName, new DDlogEVar(node, outVarName, relDecl.getType()));
         List<RuleBodyTerm> definitions = body.getDefinitions();

--- a/sql/src/main/java/com/vmware/ddlog/translator/Translator.java
+++ b/sql/src/main/java/com/vmware/ddlog/translator/Translator.java
@@ -93,8 +93,9 @@ public class Translator {
         ParsedCreateIndex parsedIndex = CreateIndexParser.parse(sql);
 
         // Find the typedef of the base relation, so we can populate the typedef of the index
+        RelationName rn = new RelationName(RelationName.makeRelationName(parsedIndex.getTableName()), null, null);
         final DDlogRelationDeclaration baseRelation =
-                this.translationContext.getRelation(DDlogRelationDeclaration.relationName(parsedIndex.getTableName()));
+                this.translationContext.getRelation(rn);
         if (baseRelation == null) {
             throw new RuntimeException("Cannot find base table that index refers to");
         }
@@ -111,8 +112,8 @@ public class Translator {
             throw new RuntimeException("Cannot find base table that index refers to");
         }
         // We need the fields of the base relation both for the typedef of the index and to populate the index rule
-        List<DDlogField> baseRelationFields = Objects.requireNonNull(baseTableTypeDef.getType()).
-                to(DDlogTStruct.class).getFields();
+        List<DDlogField> baseRelationFields = Objects.requireNonNull(baseTableTypeDef.getType())
+                .to(DDlogTStruct.class).getFields();
         // Holds the field typing information of the index
         List<DDlogField> indexFields = new ArrayList<>();
         // Used to populate the index rule, based on DDlog index creation syntax
@@ -131,8 +132,8 @@ public class Translator {
             }
         }
 
-        String dIndexName = DDlogIndexDeclaration.indexName(parsedIndex.getIndexName());
-        this.translationContext.reserveGlobalName(dIndexName);
+        RelationName dIndexName = DDlogIndexDeclaration.indexName(parsedIndex.getIndexName());
+        this.translationContext.reserveGlobalName(dIndexName.name);
 
         // Create the index and add to the current DDlog program
         DDlogIndexDeclaration ddlogIndex = new DDlogIndexDeclaration(null, dIndexName, indexFields, baseRelation,

--- a/sql/src/main/java/com/vmware/ddlog/translator/WindowVisitor.java
+++ b/sql/src/main/java/com/vmware/ddlog/translator/WindowVisitor.java
@@ -27,7 +27,9 @@ package com.vmware.ddlog.translator;
 import com.facebook.presto.sql.tree.*;
 import com.vmware.ddlog.util.Linq;
 import com.vmware.ddlog.util.Ternary;
+import com.vmware.ddlog.util.Utilities;
 
+import javax.rmi.CORBA.Util;
 import java.util.*;
 
 /**
@@ -141,7 +143,7 @@ public class WindowVisitor
             String gb = context.freshLocalName("gb");
             wag.groupOn.add(new SingleColumn(e, new Identifier(gb)));
         }
-        String name = TranslationVisitor.convertQualifiedName(fc.getName());
+        String name = Utilities.convertQualifiedName(fc.getName());
         Ternary result = Ternary.Maybe;
         boolean isAggregate = SqlSemantics.semantics.isAggregateFunction(name);
         if (isAggregate) {

--- a/sql/src/main/java/com/vmware/ddlog/translator/environment/DeleteEnvironment.java
+++ b/sql/src/main/java/com/vmware/ddlog/translator/environment/DeleteEnvironment.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2021 VMware, Inc.
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.vmware.ddlog.translator.environment;
+
+import com.vmware.ddlog.ir.DDlogExpression;
+import com.vmware.ddlog.util.IndentStringBuilder;
+
+import javax.annotation.Nullable;
+import java.util.HashSet;
+
+/**
+ * This environment makes some identifiers from its child invisible.
+ */
+public class DeleteEnvironment extends IEnvironment {
+    final IEnvironment base;
+    final HashSet<String> toDelete;
+
+    public DeleteEnvironment(IEnvironment base, HashSet<String> toDelete) {
+        this.base = base;
+        this.toDelete = toDelete;
+    }
+
+    @Override
+    public IEnvironment cloneEnv() {
+        return new DeleteEnvironment(this.base.cloneEnv(), this.toDelete);
+    }
+
+    @Nullable
+    @Override
+    public DDlogExpression lookupIdentifier(String identifier) {
+        if (this.toDelete.contains(identifier))
+            return null;
+        return this.base.lookupIdentifier(identifier);
+    }
+
+    @Nullable
+    @Override
+    public IEnvironment lookupRelation(String identifier) {
+        if (this.toDelete.contains(identifier))
+            return null;
+        return this.base.lookupRelation(identifier);
+    }
+
+    @Override
+    public IndentStringBuilder toString(IndentStringBuilder builder) {
+        return builder.append("Delete ")
+                .append(this.toDelete.toString())
+                .increase()
+                .append(this.base)
+                .decrease();
+    }
+}

--- a/sql/src/main/java/com/vmware/ddlog/translator/environment/EmptyEnvironment.java
+++ b/sql/src/main/java/com/vmware/ddlog/translator/environment/EmptyEnvironment.java
@@ -22,28 +22,34 @@
  *
  */
 
-package com.vmware.ddlog.ir;
+package com.vmware.ddlog.translator.environment;
 
-import com.facebook.presto.sql.tree.Node;
+import com.vmware.ddlog.ir.DDlogExpression;
+import com.vmware.ddlog.util.IndentStringBuilder;
 
 import javax.annotation.Nullable;
 
-public class DDlogEField extends DDlogExpression {
-    private final DDlogExpression struct;
-    public final String field;
-
-    public DDlogEField(@Nullable Node node, DDlogExpression struct, String field, DDlogType type) {
-        super(node, type);
-        this.struct = struct;
-        this.field = field;
+public class EmptyEnvironment extends IEnvironment {
+    @Override
+    public IEnvironment cloneEnv() {
+        return this;
     }
 
-    public DDlogExpression getStruct() {
-        return this.struct;
+    @Nullable
+    @Override
+    public DDlogExpression lookupIdentifier(String identifier) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public IEnvironment lookupRelation(String identifier) {
+        return null;
     }
 
     @Override
-    public String toString() {
-        return this.struct.toString() + "." + this.field;
+    public IndentStringBuilder toString(IndentStringBuilder builder) {
+        return builder.append("Empty");
     }
+
 }

--- a/sql/src/main/java/com/vmware/ddlog/translator/environment/EnvHandle.java
+++ b/sql/src/main/java/com/vmware/ddlog/translator/environment/EnvHandle.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2021 VMware, Inc.
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.vmware.ddlog.translator.environment;
+
+import com.vmware.ddlog.ir.DDlogExpression;
+
+import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.HashSet;
+
+/**
+ * Provides the basic environment operations.
+ */
+public class EnvHandle {
+    IEnvironment environment;
+    @Nullable
+    IEnvironment last = null;
+
+    public EnvHandle() {
+        this.environment = new EmptyEnvironment();
+    }
+
+    /**
+     * Cleaup the scope stack.
+     */
+    public void exitAllScopes() {
+        this.environment = new EmptyEnvironment();
+    }
+
+    /**
+     * Pop the last scope from the stack.
+     */
+    public void exitLastScope() {
+        if (this.environment instanceof StackedEnvironment) {
+            this.environment = ((StackedEnvironment)this.environment).bottom;
+            return;
+        }
+        throw new RuntimeException("Not a stack");
+    }
+
+    public void save() {
+        if (this.last != null)
+            throw new RuntimeException("Environment already saved");
+        this.last = this.environment;
+        this.environment = new EmptyEnvironment();
+    }
+
+    public void restore() {
+        if (this.last == null)
+            throw new RuntimeException("No environment saved");
+        this.environment = this.last;
+        this.last = null;
+    }
+
+    @Nullable
+    public DDlogExpression lookupIdentifier(String identifier) {
+        return this.environment.lookupIdentifier(identifier);
+    }
+
+    @Nullable
+    public IEnvironment lookupRelation(String identifier) {
+        return this.environment.lookupRelation(identifier);
+    }
+
+    public void stack(IEnvironment environment) {
+        this.environment = new StackedEnvironment(environment, this.environment);
+    }
+
+    public void stack(EnvHandle container) {
+        this.stack(container.environment);
+    }
+
+    public void renameDown(String from, String to) {
+        HashMap<String, String> map = new HashMap<>();
+        map.put(from, to);
+        this.environment = new RenameDownEnvironment(this.environment, map);
+    }
+
+    public void renameDown(HashMap<String, String> map) {
+        this.environment = new RenameDownEnvironment(this.environment, map);
+    }
+
+    public void delete(String delete) {
+        HashSet<String> del = new HashSet<>();
+        del.add(delete);
+        this.environment = new DeleteEnvironment(this.environment, del);
+    }
+
+    public void renameUp(String originalName, String newName, HashMap<String, String> columnRename) {
+        this.environment = new RenameUpEnvironment(this.environment, originalName, newName, columnRename);
+    }
+
+    @Override
+    public String toString() {
+        return this.environment.toString();
+    }
+
+    public void set(IEnvironment environment) {
+        this.environment = environment;
+    }
+}

--- a/sql/src/main/java/com/vmware/ddlog/translator/environment/IEnvironment.java
+++ b/sql/src/main/java/com/vmware/ddlog/translator/environment/IEnvironment.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2021 VMware, Inc.
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.vmware.ddlog.translator.environment;
+
+import com.vmware.ddlog.ir.DDlogExpression;
+import com.vmware.ddlog.util.IndentStringBuilder;
+import com.vmware.ddlog.util.Printable;
+
+import javax.annotation.Nullable;
+
+/**
+ * An environment converts identifiers into expressions.
+ */
+public abstract class IEnvironment implements Printable {
+    /**
+     * Make a copy of the data in this environment.
+     */
+    public abstract IEnvironment cloneEnv();
+
+    /**
+     * Lookup an identifier in this environment.
+     * @param identifier  Identifier to lookup.
+     * @return  null if the identifier is not found.
+     * Identifiers are usually column names.
+     */
+    @Nullable
+    public abstract DDlogExpression lookupIdentifier(String identifier);
+
+    /**
+     * Lookup a relation name in this environment.
+     * @param identifier  Identifier to lookup.
+     * @return  null if the identifier is not found.
+     */
+    @Nullable
+    public abstract IEnvironment lookupRelation(String identifier);
+
+    /**
+     * Build an identifier where things are looked up first in this and then in other.
+     * @param other  Environment to look up things that are not found in this one.
+     */
+    public IEnvironment stack(IEnvironment other) {
+        return new StackedEnvironment(this, other);
+    }
+
+    @Override
+    public String toString() {
+        IndentStringBuilder builder = new IndentStringBuilder();
+        return this.toString(builder).toString();
+    }
+
+    public abstract IndentStringBuilder toString(IndentStringBuilder builder);
+}

--- a/sql/src/main/java/com/vmware/ddlog/translator/environment/RenameDownEnvironment.java
+++ b/sql/src/main/java/com/vmware/ddlog/translator/environment/RenameDownEnvironment.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2021 VMware, Inc.
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.vmware.ddlog.translator.environment;
+
+import com.vmware.ddlog.ir.DDlogExpression;
+import com.vmware.ddlog.util.IndentStringBuilder;
+
+import javax.annotation.Nullable;
+import java.util.HashMap;
+
+/**
+ * This class renames identifiers before looking them up in children environments.
+ */
+public class RenameDownEnvironment extends IEnvironment {
+    final IEnvironment base;
+    /**
+     * Map describing how identifiers are renamed before looking them up.
+     */
+    final HashMap<String, String> rename;
+
+    public RenameDownEnvironment(IEnvironment base, HashMap<String, String> rename) {
+        this.base = base;
+        this.rename = rename;
+    }
+
+    @Override
+    public IEnvironment cloneEnv() {
+        return new RenameDownEnvironment(this.base.cloneEnv(), this.rename);
+    }
+
+    @Nullable
+    @Override
+    public DDlogExpression lookupIdentifier(String identifier) {
+        String lookup = identifier;
+        if (this.rename.containsKey(identifier))
+            lookup = this.rename.get(identifier);
+        return this.base.lookupIdentifier(lookup);
+    }
+
+    @Nullable
+    @Override
+    public IEnvironment lookupRelation(String identifier) {
+        String lookup = identifier;
+        if (this.rename.containsKey(identifier))
+            lookup = this.rename.get(identifier);
+        IEnvironment res = this.base.lookupRelation(lookup);
+        if (res == null)
+            return res;
+        return new RenameDownEnvironment(res, this.rename);
+    }
+
+    @Override
+    public IndentStringBuilder toString(IndentStringBuilder builder) {
+        return builder.append("RenameDown")
+                .append(this.rename.toString())
+                .increase()
+                .append(this.base)
+                .decrease();
+    }
+}

--- a/sql/src/main/java/com/vmware/ddlog/translator/environment/RenameUpEnvironment.java
+++ b/sql/src/main/java/com/vmware/ddlog/translator/environment/RenameUpEnvironment.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2021 VMware, Inc.
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.vmware.ddlog.translator.environment;
+
+import com.vmware.ddlog.ir.DDlogEField;
+import com.vmware.ddlog.ir.DDlogEVar;
+import com.vmware.ddlog.ir.DDlogExpression;
+import com.vmware.ddlog.ir.DDlogEnvironment;
+import com.vmware.ddlog.util.IndentStringBuilder;
+
+import javax.annotation.Nullable;
+import java.util.HashMap;
+
+/**
+ * This environment will look up things then, if found, rename them.
+ */
+public class RenameUpEnvironment extends IEnvironment {
+    private final IEnvironment base;
+    /**
+     * Original table name that will be renamed.
+     */
+    final String originalName;
+    /**
+     * New name to give to table.
+     */
+    final String newName;
+    /**
+     * Map that shows how table columns have to be renamed.
+     * Maps the name that appears in the SQL program to the name that should be used in the implementation.
+     */
+    final HashMap<String, String> renameColumn;
+
+    public RenameUpEnvironment(IEnvironment base, String sourceName, String implementationName, HashMap<String, String> renameColumn) {
+        this.base = base;
+        this.originalName = sourceName;
+        this.newName = implementationName;
+        this.renameColumn = renameColumn;
+    }
+
+    @Override
+    public IEnvironment cloneEnv() {
+        return new RenameUpEnvironment(this.base, this.originalName, this.newName, this.renameColumn);
+    }
+
+    @Nullable
+    @Override
+    public DDlogExpression lookupIdentifier(String identifier) {
+        DDlogExpression expr = this.base.lookupIdentifier(identifier);
+        if (expr == null)
+            return null;
+        DDlogEnvironment escope = expr.as(DDlogEnvironment.class);
+        if (escope != null) {
+            return escope;
+        } else {
+            // This field has a very particular shape, which we deconstruct here.
+            // This is the inverse of the TableScope.lookupColumn process.
+            DDlogEField field = expr.to(DDlogEField.class);
+            DDlogEVar var = field.getStruct().to(DDlogEVar.class);
+            if (var.var.equals(this.originalName)) {
+                // Recursively rename
+                String newFieldName = field.field;
+                if (this.renameColumn.containsKey(newFieldName))
+                    newFieldName = this.renameColumn.get(newFieldName);
+                // Build the expression with the renamed fields
+                var = new DDlogEVar(var.getNode(), this.newName, var.getType());
+                field = new DDlogEField(field.getNode(), var, newFieldName, field.getType());
+            }
+            return field;
+        }
+    }
+
+    @Nullable
+    @Override
+    public IEnvironment lookupRelation(String identifier) {
+        if (identifier.equals(this.originalName))
+            return this;
+        IEnvironment result = this.base.lookupRelation(identifier);
+        if (result == null)
+            return result;
+        return new RenameUpEnvironment(result, this.originalName, this.newName, this.renameColumn);
+    }
+
+    @Override
+    public IndentStringBuilder toString(IndentStringBuilder builder) {
+        return builder.append("RenameUp " + originalName + "->" + newName + " " + renameColumn)
+                .increase()
+                .append(this.base)
+                .decrease();
+    }
+}

--- a/sql/src/main/java/com/vmware/ddlog/translator/environment/StackedEnvironment.java
+++ b/sql/src/main/java/com/vmware/ddlog/translator/environment/StackedEnvironment.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2021 VMware, Inc.
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.vmware.ddlog.translator.environment;
+
+import com.vmware.ddlog.ir.DDlogExpression;
+import com.vmware.ddlog.util.IndentStringBuilder;
+
+import javax.annotation.Nullable;
+
+public class StackedEnvironment extends IEnvironment {
+    final IEnvironment top;
+    final IEnvironment bottom;
+
+    public StackedEnvironment(IEnvironment top, IEnvironment bottom) {
+        this.top = top;
+        this.bottom = bottom;
+    }
+
+    @Override
+    public IEnvironment cloneEnv() {
+        return new StackedEnvironment(this.top.cloneEnv(), this.bottom.cloneEnv());
+    }
+
+    @Nullable
+    @Override
+    public DDlogExpression lookupIdentifier(String identifier) {
+        DDlogExpression expr = this.top.lookupIdentifier(identifier);
+        if (expr != null)
+            return expr;
+        return this.bottom.lookupIdentifier(identifier);
+    }
+
+    @Nullable
+    @Override
+    public IEnvironment lookupRelation(String identifier) {
+        IEnvironment env = this.top.lookupRelation(identifier);
+        if (env != null)
+            return env;
+        return this.bottom.lookupRelation(identifier);
+    }
+
+    @Override
+    public IndentStringBuilder toString(IndentStringBuilder builder) {
+        return builder.append("StackedEnvironment")
+                .increase()
+                .append(top)
+                .newline()
+                .append(bottom)
+                .decrease();
+    }
+}

--- a/sql/src/main/java/com/vmware/ddlog/translator/environment/package-info.java
+++ b/sql/src/main/java/com/vmware/ddlog/translator/environment/package-info.java
@@ -22,22 +22,16 @@
  *
  */
 
-package com.vmware.ddlog.ir;
+/**
+ * Package that doesn't allow null values as method parameters.
+ */
 
-import com.facebook.presto.sql.tree.Node;
+@ParametersAreNonnullByDefault
+@FieldsAreNonnullByDefault
+@MethodsAreNonnullByDefault
+package com.vmware.ddlog.translator.environment;
 
-import javax.annotation.Nullable;
+import com.vmware.ddlog.FieldsAreNonnullByDefault;
+import com.vmware.ddlog.MethodsAreNonnullByDefault;
 
-public class DDlogRHSCondition extends DDlogRuleRHS {
-    private final DDlogExpression expr;
-
-    public DDlogRHSCondition(@Nullable Node node, DDlogExpression expr) {
-        super(node);
-        this.expr = this.checkNull(expr);
-    }
-
-    @Override
-    public String toString() {
-        return this.expr.toString();
-    }
-}
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/sql/src/main/java/com/vmware/ddlog/util/IdGen.java
+++ b/sql/src/main/java/com/vmware/ddlog/util/IdGen.java
@@ -22,28 +22,13 @@
  *
  */
 
-package com.vmware.ddlog.ir;
+package com.vmware.ddlog.util;
 
-import com.facebook.presto.sql.tree.Node;
+public class IdGen {
+    static int idGen = 0;
+    public final int id;
 
-import javax.annotation.Nullable;
-
-public class DDlogEField extends DDlogExpression {
-    private final DDlogExpression struct;
-    public final String field;
-
-    public DDlogEField(@Nullable Node node, DDlogExpression struct, String field, DDlogType type) {
-        super(node, type);
-        this.struct = struct;
-        this.field = field;
-    }
-
-    public DDlogExpression getStruct() {
-        return this.struct;
-    }
-
-    @Override
-    public String toString() {
-        return this.struct.toString() + "." + this.field;
+    public IdGen() {
+        this.id = idGen++;
     }
 }

--- a/sql/src/main/java/com/vmware/ddlog/util/IndentStringBuilder.java
+++ b/sql/src/main/java/com/vmware/ddlog/util/IndentStringBuilder.java
@@ -22,24 +22,51 @@
  *
  */
 
-package com.vmware.ddlog.ir;
+package com.vmware.ddlog.util;
 
-import com.facebook.presto.sql.tree.Node;
+public class IndentStringBuilder {
+    final StringBuilder builder;
+    int indent = 0;
+    static final int amount = 4;
 
-import javax.annotation.Nullable;
+    public IndentStringBuilder() {
+        this.builder = new StringBuilder();
+    }
 
-public class DDlogRHSFlatMap extends DDlogRuleRHS {
-    final String var;
-    final DDlogExpression mapExpr;
+    public IndentStringBuilder append(String string) {
+        for (int i = 0; i < string.length(); i++) {
+            char c = string.charAt(i);
+            this.builder.append(c);
+            if (c == '\n') {
+                for (int in = 0; in < this.indent; in++)
+                    this.builder.append(' ');
+            }
+        }
+        return this;
+    }
 
-    public DDlogRHSFlatMap(@Nullable Node node, String var, DDlogExpression mapExpr) {
-        super(node);
-        this.var = var;
-        this.mapExpr = mapExpr;
+    public IndentStringBuilder newline() {
+        return this.append("\n");
+    }
+
+    public IndentStringBuilder append(Printable object) {
+        return object.toString(this);
+    }
+
+    public IndentStringBuilder increase() {
+        this.indent += amount;
+        return this.newline();
+    }
+
+    public IndentStringBuilder decrease() {
+        this.indent -= amount;
+        if (this.indent < 0)
+            throw new RuntimeException("Negative indent");
+        return this;
     }
 
     @Override
     public String toString() {
-        return "var " + this.var + " = FlatMap(" + this.mapExpr + ")";
+        return this.builder.toString();
     }
 }

--- a/sql/src/main/java/com/vmware/ddlog/util/Printable.java
+++ b/sql/src/main/java/com/vmware/ddlog/util/Printable.java
@@ -22,14 +22,8 @@
  *
  */
 
-package com.vmware.ddlog.ir;
+package com.vmware.ddlog.util;
 
-import com.facebook.presto.sql.tree.Node;
-
-import javax.annotation.Nullable;
-
-public abstract class DDlogRuleRHS extends DDlogNode {
-    protected DDlogRuleRHS(@Nullable Node node) {
-        super(node);
-    }
+public interface Printable {
+    IndentStringBuilder toString(IndentStringBuilder builder);
 }

--- a/sql/src/main/java/com/vmware/ddlog/util/Utilities.java
+++ b/sql/src/main/java/com/vmware/ddlog/util/Utilities.java
@@ -24,6 +24,8 @@
 
 package com.vmware.ddlog.util;
 
+import com.facebook.presto.sql.tree.QualifiedName;
+
 import javax.annotation.Nullable;
 import java.util.*;
 
@@ -39,6 +41,10 @@ public class Utilities {
             result.addAll(l);
         return result;
      }
+
+    public static String convertQualifiedName(QualifiedName name) {
+        return String.join(".", name.getParts());
+    }
 
     /**
      * Given two references checks if they can be to equal objects.
@@ -58,5 +64,9 @@ public class Utilities {
      public static <K, V> void copyMap(Map<K, V> destination, Map<K, V> source) {
          for (Map.Entry<K, V> e: source.entrySet())
              destination.put(e.getKey(), e.getValue());
+     }
+
+     public static String singleQuote(String other) {
+         return "'" + other + "'";
      }
 }

--- a/sql/src/test/java/ddlog/AggregatesTest.java
+++ b/sql/src/test/java/ddlog/AggregatesTest.java
@@ -37,7 +37,7 @@ public class AggregatesTest extends BaseQueriesTest {
         String query = "create view v0 as SELECT ANY(column3) AS a FROM t1";
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{a:bool}\n" +
-                "function agg(g: Group<(), Tt1>):TRtmp {\n" +
+                "function agg(g: Group<(), TRt1>):TRtmp {\n" +
                 "var any = false: bool;\n" +
                 "(for ((i, _) in g) {\n" +
                 "var v = i;\n" +
@@ -57,7 +57,7 @@ public class AggregatesTest extends BaseQueriesTest {
         String query = "create view v0 as SELECT ANY(column3) AS a FROM t1";
         String program = this.header(true) +
                 "typedef TRtmp = TRtmp{a:Option<bool>}\n" +
-                "function agg(g: Group<(), Tt1>):TRtmp {\n" +
+                "function agg(g: Group<(), TRt1>):TRtmp {\n" +
                 "var any = Some{false}: Option<bool>;\n" +
                 "(for ((i, _) in g) {\n" +
                 "var v = i;\n" +
@@ -77,7 +77,7 @@ public class AggregatesTest extends BaseQueriesTest {
         String query = "create view v0 as SELECT NOT ANY(column3) AS a FROM t1";
         String program = this.header(true) +
                 "typedef TRtmp = TRtmp{a:Option<bool>}\n" +
-                "function agg(g: Group<(), Tt1>):TRtmp {\n" +
+                "function agg(g: Group<(), TRt1>):TRtmp {\n" +
                 "var any = Some{false}: Option<bool>;\n" +
                 "(for ((i, _) in g) {\n" +
                 "var v = i;\n" +
@@ -97,7 +97,7 @@ public class AggregatesTest extends BaseQueriesTest {
         String query = "create view v0 as SELECT EVERY(column3) AS e FROM t1";
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{e:bool}\n" +
-                "function agg(g: Group<(), Tt1>):TRtmp {\n" +
+                "function agg(g: Group<(), TRt1>):TRtmp {\n" +
                 "var every = true: bool;\n" +
                 "(for ((i, _) in g) {\n" +
                 "var v = i;\n" +
@@ -117,7 +117,7 @@ public class AggregatesTest extends BaseQueriesTest {
         String query = "create view v0 as SELECT COUNT(DISTINCT column1) AS ct FROM t1";
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{ct:signed<64>}\n" +
-                "function agg(g: Group<(), Tt1>):TRtmp {\n" +
+                "function agg(g: Group<(), TRt1>):TRtmp {\n" +
                 "var count_distinct = set_empty(): Set<signed<64>>;\n" +
                 "(for ((i, _) in g) {\n" +
                 "var v = i;\n" +
@@ -137,7 +137,7 @@ public class AggregatesTest extends BaseQueriesTest {
         String query = "create view v0 as SELECT COUNT(DISTINCT column1) AS ct FROM t1";
         String program = this.header(true) +
                 "typedef TRtmp = TRtmp{ct:signed<64>}\n" +
-                "function agg(g: Group<(), Tt1>):TRtmp {\n" +
+                "function agg(g: Group<(), TRt1>):TRtmp {\n" +
                 "var count_distinct = set_empty(): Set<signed<64>>;\n" +
                 "(for ((i, _) in g) {\n" +
                 "var v = i;\n" +
@@ -157,7 +157,7 @@ public class AggregatesTest extends BaseQueriesTest {
         String query = "create view v0 as SELECT SUM(DISTINCT column1) AS sum FROM t1";
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{sum:signed<64>}\n" +
-                "function agg(g: Group<(), Tt1>):TRtmp {\n" +
+                "function agg(g: Group<(), TRt1>):TRtmp {\n" +
                 "var sum_distinct = set_empty(): Set<signed<64>>;\n" +
                 "(for ((i, _) in g) {\n" +
                 "var v = i;\n" +
@@ -177,7 +177,7 @@ public class AggregatesTest extends BaseQueriesTest {
         String query = "create view v0 as SELECT MIN(DISTINCT column1) AS min FROM t1";
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{min:signed<64>}\n" +
-                "function agg(g: Group<(), Tt1>):TRtmp {\n" +
+                "function agg(g: Group<(), TRt1>):TRtmp {\n" +
                 "var min = (true, 64'sd0): (bool, signed<64>);\n" +
                 "(for ((i, _) in g) {\n" +
                 "var v = i;\n" +
@@ -197,7 +197,7 @@ public class AggregatesTest extends BaseQueriesTest {
         String query = "create view v0 as SELECT MIN(column1) + MAX(column1) AS total FROM t1";
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{total:signed<64>}\n" +
-                "function agg(g: Group<(), Tt1>):TRtmp {\n" +
+                "function agg(g: Group<(), TRt1>):TRtmp {\n" +
                 "var min = (true, 64'sd0): (bool, signed<64>);\n" +
                 "(var max = (true, 64'sd0): (bool, signed<64>));\n" +
                 "(for ((i, _) in g) {\n" +
@@ -211,7 +211,7 @@ public class AggregatesTest extends BaseQueriesTest {
                 this.relations(false) +
                 "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
-                "Rv0[v2] :- Rt1[v],var groupResult = (v).group_by(()),var aggResult = agg(groupResult),var v1 = aggResult,var v2 = v1.";
+                "Rv0[v1] :- Rt1[v],var groupResult = (v).group_by(()),var aggResult = agg(groupResult),var v0 = aggResult,var v1 = v0.";
         this.testTranslation(query, program);
     }
 
@@ -220,7 +220,7 @@ public class AggregatesTest extends BaseQueriesTest {
         String query = "create view v0 as SELECT MIN(column2) AS min FROM t1";
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{min:string}\n" +
-                "function agg(g: Group<(), Tt1>):TRtmp {\n" +
+                "function agg(g: Group<(), TRt1>):TRtmp {\n" +
                 "var min = (true, \"\"): (bool, string);\n" +
                 "(for ((i, _) in g) {\n" +
                 "var v = i;\n" +
@@ -240,7 +240,7 @@ public class AggregatesTest extends BaseQueriesTest {
         String query = "create view v0 as SELECT COUNT(column1) AS ct, SUM(column1) AS sum FROM t1";
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{ct:signed<64>, sum:signed<64>}\n" +
-                "function agg(g: Group<(), Tt1>):TRtmp {\n" +
+                "function agg(g: Group<(), TRt1>):TRtmp {\n" +
                 "var count = 64'sd0: signed<64>;\n" +
                 "(var sum = 64'sd0: signed<64>);\n" +
                 "(for ((i, _) in g) {\n" +
@@ -254,7 +254,7 @@ public class AggregatesTest extends BaseQueriesTest {
                 this.relations(false) +
                 "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
-                "Rv0[v2] :- Rt1[v],var groupResult = (v).group_by(()),var aggResult = agg(groupResult),var v1 = aggResult,var v2 = v1.";
+                "Rv0[v1] :- Rt1[v],var groupResult = (v).group_by(()),var aggResult = agg(groupResult),var v0 = aggResult,var v1 = v0.";
         this.testTranslation(query, program);
     }
 
@@ -263,7 +263,7 @@ public class AggregatesTest extends BaseQueriesTest {
         String query = "create view v0 as SELECT COUNT(*) AS ct FROM t1";
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{ct:signed<64>}\n" +
-                "function agg(g: Group<(), Tt1>):TRtmp {\n" +
+                "function agg(g: Group<(), TRt1>):TRtmp {\n" +
                 "var count = 64'sd0: signed<64>;\n" +
                 "(for ((i, _) in g) {\n" +
                 "var v = i;\n" +
@@ -283,14 +283,14 @@ public class AggregatesTest extends BaseQueriesTest {
         String query1 = "create view v1 as SELECT COUNT(*) as ct FROM t1";
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{ct:signed<64>}\n" +
-                "function agg(g: Group<(), Tt1>):TRtmp {\n" +
+                "function agg(g: Group<(), TRt1>):TRtmp {\n" +
                 "var count = 64'sd0: signed<64>;\n" +
                 "(for ((i, _) in g) {\n" +
                 "var v = i;\n" +
                 "(count = agg_count_R(count, 64'sd1))}\n" +
                 ");\n" +
                 "(TRtmp{.ct = count})\n}\n\n" +
-                "function agg1(g: Group<(), Tt1>):TRtmp {\n" +
+                "function agg0(g: Group<(), TRt1>):TRtmp {\n" +
                 "var count = 64'sd0: signed<64>;\n" +
                 "(for ((i, _) in g) {\n" +
                 "var v = i;\n" +
@@ -303,7 +303,7 @@ public class AggregatesTest extends BaseQueriesTest {
                 "relation Rtmp0[TRtmp]\n" +
                 "output relation Rv1[TRtmp]\n" +
                 "Rv0[v1] :- Rt1[v],var groupResult = (v).group_by(()),var aggResult = agg(groupResult),var v0 = aggResult,var v1 = v0.\n" +
-                "Rv1[v1] :- Rt1[v],var groupResult = (v).group_by(()),var aggResult = agg1(groupResult),var v0 = aggResult,var v1 = v0.";
+                "Rv1[v1] :- Rt1[v],var groupResult = (v).group_by(()),var aggResult = agg0(groupResult),var v0 = aggResult,var v1 = v0.";
         this.testTranslation(Arrays.asList(query0, query1), program, false);
     }
 
@@ -312,7 +312,7 @@ public class AggregatesTest extends BaseQueriesTest {
         String query = "create view v0 as SELECT COUNT(*) AS ct0, COUNT(*) AS ct1 FROM t1";
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{ct0:signed<64>, ct1:signed<64>}\n" +
-                "function agg(g: Group<(), Tt1>):TRtmp {\n" +
+                "function agg(g: Group<(), TRt1>):TRtmp {\n" +
                 "var count = 64'sd0: signed<64>;\n" +
                 "(for ((i, _) in g) {\n" +
                 "var v = i;\n" +
@@ -331,7 +331,7 @@ public class AggregatesTest extends BaseQueriesTest {
         String query = "create view v0 as SELECT COUNT(column1) AS ct FROM t1";
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{ct:signed<64>}\n" +
-                "function agg(g: Group<(), Tt1>):TRtmp {\n" +
+                "function agg(g: Group<(), TRt1>):TRtmp {\n" +
                 "var count = 64'sd0: signed<64>;\n" +
                 "(for ((i, _) in g) {\n" +
                 "var v = i;\n" +
@@ -351,7 +351,7 @@ public class AggregatesTest extends BaseQueriesTest {
         String query = "create view v0 as SELECT COUNT(column1) AS ct FROM t1";
         String program = this.header(true) +
                 "typedef TRtmp = TRtmp{ct:Option<signed<64>>}\n" +
-                "function agg(g: Group<(), Tt1>):TRtmp {\n" +
+                "function agg(g: Group<(), TRt1>):TRtmp {\n" +
                 "var count = None{}: Option<signed<64>>;\n" +
                 "(for ((i, _) in g) {\n" +
                 "var v = i;\n" +
@@ -371,7 +371,7 @@ public class AggregatesTest extends BaseQueriesTest {
         String query = "create view v0 as SELECT AVG(column1) AS avg FROM t1";
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{avg:signed<64>}\n" +
-                "function agg(g: Group<(), Tt1>):TRtmp {\n" +
+                "function agg(g: Group<(), TRt1>):TRtmp {\n" +
                 "var avg = (64'sd0, 64'sd0): (signed<64>, signed<64>);\n" +
                 "(for ((i, _) in g) {\n" +
                 "var v = i;\n" +
@@ -391,7 +391,7 @@ public class AggregatesTest extends BaseQueriesTest {
         String query = "create view v0 as SELECT AVG(column4) AS avg FROM t1";
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{avg:double}\n" +
-                "function agg(g: Group<(), Tt1>):TRtmp {\n" +
+                "function agg(g: Group<(), TRt1>):TRtmp {\n" +
                 "var avg = (64'f0.0, 64'f0.0): (double, double);\n" +
                 "(for ((i, _) in g) {\n" +
                 "var v = i;\n" +
@@ -411,7 +411,7 @@ public class AggregatesTest extends BaseQueriesTest {
         String query = "create view v0 as SELECT AVG(column1) AS avg FROM t1";
         String program = this.header(true) +
                 "typedef TRtmp = TRtmp{avg:Option<signed<64>>}\n" +
-                "function agg(g: Group<(), Tt1>):TRtmp {\n" +
+                "function agg(g: Group<(), TRt1>):TRtmp {\n" +
                 "var avg = None{}: Option<(signed<64>, signed<64>)>;\n" +
                 "(for ((i, _) in g) {\n" +
                 "var v = i;\n" +
@@ -431,7 +431,7 @@ public class AggregatesTest extends BaseQueriesTest {
         String query = "create view v0 as SELECT COUNT(*) AS ct FROM t1";
         String program = this.header(true) +
                 "typedef TRtmp = TRtmp{ct:signed<64>}\n" +
-                "function agg(g: Group<(), Tt1>):TRtmp {\n" +
+                "function agg(g: Group<(), TRt1>):TRtmp {\n" +
                 "var count = 64'sd0: signed<64>;\n" +
                 "(for ((i, _) in g) {\n" +
                 "var v = i;\n" +
@@ -450,7 +450,7 @@ public class AggregatesTest extends BaseQueriesTest {
         String query = "create view v0 as SELECT MAX(CASE WHEN column2 = 'foo' THEN column1 ELSE 0 END) AS m FROM t1";
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{m:signed<64>}\n" +
-                "function agg(g: Group<(), Tt1>):TRtmp {\n" +
+                "function agg(g: Group<(), TRt1>):TRtmp {\n" +
                 "var max = (true, 64'sd0): (bool, signed<64>);\n" +
                 "(for ((i, _) in g) {\n" +
                 "var v = i;\n" +
@@ -472,7 +472,7 @@ public class AggregatesTest extends BaseQueriesTest {
         String query = "create view v0 as SELECT MAX(column1) AS m FROM t1";
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{m:signed<64>}\n" +
-                "function agg(g: Group<(), Tt1>):TRtmp {\n" +
+                "function agg(g: Group<(), TRt1>):TRtmp {\n" +
                 "var max = (true, 64'sd0): (bool, signed<64>);\n" +
                 "(for ((i, _) in g) {\n" +
                 "var v = i;\n" +
@@ -492,7 +492,7 @@ public class AggregatesTest extends BaseQueriesTest {
         String query = "create view v1 as select array_agg(column2) from t1";
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{col0:Vec<string>}\n" +
-                "function agg(g: Group<(), Tt1>):TRtmp {\n" +
+                "function agg(g: Group<(), TRt1>):TRtmp {\n" +
                 "var array_agg = vec_empty(): Vec<string>;\n" +
                 "(for ((i, _) in g) {\n" +
                 "var v = i;\n" +
@@ -504,7 +504,7 @@ public class AggregatesTest extends BaseQueriesTest {
                 this.relations(false) +
                 "relation Rtmp[TRtmp]\n" +
                 "output relation Rv1[TRtmp]\n" +
-                "Rv1[v2] :- Rt1[v],var groupResult = (v).group_by(()),var aggResult = agg(groupResult),var v1 = aggResult,var v2 = v1.";
+                "Rv1[v1] :- Rt1[v],var groupResult = (v).group_by(()),var aggResult = agg(groupResult),var v0 = aggResult,var v1 = v0.";
         this.testTranslation(query, program);
     }
 
@@ -513,7 +513,7 @@ public class AggregatesTest extends BaseQueriesTest {
         String query = "create view v1 as select array_length(array_agg(column2)) from t1";
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{col0:signed<64>}\n" +
-                "function agg(g: Group<(), Tt1>):TRtmp {\n" +
+                "function agg(g: Group<(), TRt1>):TRtmp {\n" +
                 "var array_agg = vec_empty(): Vec<string>;\n" +
                 "(for ((i, _) in g) {\n" +
                 "var v = i;\n" +
@@ -522,16 +522,10 @@ public class AggregatesTest extends BaseQueriesTest {
                 ");\n" +
                 "(TRtmp{.col0 = sql_array_length(array_agg)})\n" +
                 "}\n" +
-                "\n" +
-                "input relation Rt1[Tt1]\n" +
-                "input relation Rt2[Tt2]\n" +
-                "input relation Rt3[Tt3]\n" +
-                "input relation Rt4[Tt4]\n" +
+                this.relations(false) +
                 "relation Rtmp[TRtmp]\n" +
                 "output relation Rv1[TRtmp]\n" +
-                "Rv1[v2] :- Rt1[v],var groupResult = (v).group_by(()),var aggResult = agg(groupResult),var v1 = aggResult,var v2 = v1.";
-        
+                "Rv1[v1] :- Rt1[v],var groupResult = (v).group_by(()),var aggResult = agg(groupResult),var v0 = aggResult,var v1 = v0.";
         this.testTranslation(query, program);
-
     }
 }

--- a/sql/src/test/java/ddlog/AliasTest.java
+++ b/sql/src/test/java/ddlog/AliasTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2021 VMware, Inc.
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package ddlog;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+
+// Tests for renaming
+public class AliasTest extends BaseQueriesTest {
+    @Test
+    public void testAliasWNull() {
+        String query = "create view v0 as SELECT DISTINCT t2.column1 FROM t1 AS t2";
+        String program = this.header(true) +
+                this.relations(true) +
+                "output relation Rv0[TRt2]\n" +
+                "Rv0[v1] :- Rt1[v],var v0 = TRt2{.column1 = v.column1},var v1 = v0.";
+        this.testTranslation(query, program, true);
+    }
+
+    @Test
+    public void testAlias1() {
+        String query = "create view v0 as SELECT DISTINCT t2.column1 AS x, t2.column2 as y FROM t1 AS t2";
+        String program = this.header(false) +
+                "typedef TRt20 = TRt20{x:signed<64>, y:string}\n" +
+                this.relations(false) +
+                "output relation Rv0[TRt20]\n" +
+                "Rv0[v1] :- Rt1[v],var v0 = TRt20{.x = v.column1,.y = v.column2},var v1 = v0.";
+        this.testTranslation(query, program);
+    }
+
+    @Test
+    public void testScope() {
+        String query = "create view v0 as SELECT DISTINCT t1.column1 FROM t1";
+        String program = this.header(false) +
+                this.relations(false) +
+                "output relation Rv0[TRt2]\n" +
+                "Rv0[v1] :- Rt1[v],var v0 = TRt2{.column1 = v.column1},var v1 = v0.";
+        this.testTranslation(query, program);
+    }
+
+    @Test
+    public void testScopeWNulls() {
+        String query = "create view v0 as SELECT DISTINCT t1.column1 FROM t1";
+        String program = this.header(true) +
+                this.relations(true) +
+                "output relation Rv0[TRt2]\n" +
+                "Rv0[v1] :- Rt1[v],var v0 = TRt2{.column1 = v.column1},var v1 = v0.";
+        this.testTranslation(query, program, true);
+    }
+
+    @Test
+    public void testNested3() {
+        String query = "CREATE VIEW v3 AS (SELECT DISTINCT Y.c FROM " +
+                "((SELECT DISTINCT column1 AS c FROM t2 AS X) AS Y))";
+        String program = this.header(false) +
+                "typedef TX = TX{c:signed<64>}\n" +
+                this.relations(false) +
+                "relation Y[TX]\n" +
+                "relation Rtmp0[TX]\n" +
+                "output relation Rv3[TX]\n" +
+                "Y[v1] :- Rt2[v],var v0 = TX{.c = v.column1},var v1 = v0.\n" +
+                "Rtmp0[v3] :- Y[v1],var v2 = TX{.c = v1.c},var v3 = v2.\n" +
+                "Rv3[v4] :- Rtmp0[v3],var v4 = v3.";
+        this.testTranslation(query, program);
+    }
+
+    @Test
+    public void testNested2() {
+        String query = "CREATE VIEW v3 AS (SELECT DISTINCT column1 FROM (t2 AS X) AS Y)";
+        String program = this.header(false) +
+                this.relations(false) +
+                "relation Y[TRt2]\n" +
+                "output relation Rv3[TRt2]\n" +
+                "Y[v1] :- Rt2[v],var v0 = TRt2{.column1 = v.column1},var v1 = v0.\n" +
+                "Rv3[v2] :- Y[v1],var v2 = v1.";
+        this.testTranslation(query, program);
+    }
+
+    @Test
+    public void testNestedAlias() {
+        String query = "CREATE VIEW v3 AS (SELECT DISTINCT Y.column1 FROM ((t2 AS X) AS Y))";
+        String program = this.header(false) +
+                this.relations(false) +
+                "relation Y[TRt2]\n" +
+                "output relation Rv3[TRt2]\n" +
+                "Y[v1] :- Rt2[v],var v0 = TRt2{.column1 = v.column1},var v1 = v0.\n" +
+                "Rv3[v2] :- Y[v1],var v2 = v1.";
+        this.testTranslation(query, program);
+    }
+
+    @Test
+    public void testNested1() {
+        String query = "CREATE VIEW v3 AS SELECT DISTINCT X.c FROM (SELECT DISTINCT column1 AS c FROM t2 AS X)";
+        String program = this.header(false) +
+                "typedef TX = TX{c:signed<64>}\n" +
+                this.relations(false) +
+                "relation Rtmp[TX]\n" +
+                "output relation Rv3[TX]\n" +
+                "Rtmp[v1] :- Rt2[v],var v0 = TX{.c = v.column1},var v1 = v0.\n" +
+                "Rv3[v3] :- Rtmp[v1],var v2 = TX{.c = v1.c},var v3 = v2.";
+        this.testTranslation(query, program);
+    }
+
+    @Test
+    public void testSelectStar() {
+        String query = "create view v0 as select DISTINCT *, column1 as C1 from t1";
+        String program = this.header(false) +
+                "typedef TRtmp = TRtmp{column1:signed<64>, column2:string, column3:bool, column4:double, c1:signed<64>}\n" +
+                this.relations(false) +
+                "output relation Rv0[TRtmp]\n" +
+                "Rv0[v1] :- Rt1[v],var v0 = TRtmp{" +
+                ".column1 = v.column1,.column2 = v.column2,.column3 = v.column3,.column4 = v.column4,.c1 = v.column1}," +
+                "var v1 = v0.";
+        this.testTranslation(query, program);
+    }
+
+    @Test
+    public void test2SelectStar() {
+        String query0 = "create view v0 as select DISTINCT *, column1 as C1 from t1";
+        String query1 = "create view v1 as select DISTINCT *, column1 as C1 from t1";
+        String program = this.header(false) +
+                "typedef TRtmp = TRtmp{" +
+                "column1:signed<64>, column2:string, column3:bool, column4:double, c1:signed<64>}\n" +
+                this.relations(false) +
+                "output relation Rv0[TRtmp]\n" +
+                "output relation Rv1[TRtmp]\n" +
+                "Rv0[v1] :- Rt1[v],var v0 = TRtmp{" +
+                ".column1 = v.column1,.column2 = v.column2,.column3 = v.column3,.column4 = v.column4,.c1 = v.column1}," +
+                "var v1 = v0.\n" +
+                "Rv1[v1] :- Rt1[v],var v0 = TRtmp{" +
+                ".column1 = v.column1,.column2 = v.column2,.column3 = v.column3,.column4 = v.column4,.c1 = v.column1}," +
+                "var v1 = v0.";
+        this.testTranslation(Arrays.asList(query0, query1), program, false);
+    }
+
+    @Test
+    public void testAlias() {
+        String query = "create view v0 as SELECT DISTINCT t2.column1 FROM (t1 AS t2)";
+        String program = this.header(false) +
+                this.relations(false) +
+                "output relation Rv0[TRt2]\n" +
+                "Rv0[v1] :- Rt1[v],var v0 = TRt2{.column1 = v.column1},var v1 = v0.";
+        this.testTranslation(query, program);
+    }
+}

--- a/sql/src/test/java/ddlog/BaseQueriesTest.java
+++ b/sql/src/test/java/ddlog/BaseQueriesTest.java
@@ -58,15 +58,15 @@ public class BaseQueriesTest {
             "import sql\n" +
             "import sqlop\n";
     protected final String tables =
-            "typedef Tt1 = Tt1{column1:signed<64>, column2:string, column3:bool, column4:double}\n" +
-            "typedef Tt2 = Tt2{column1:signed<64>}\n" +
-            "typedef Tt3 = Tt3{d:Date, t:Time, dt:DateTime}\n" +
-            "typedef Tt4 = Tt4{column1:Option<signed<64>>, column2:Option<string>}\n";
+            "typedef TRt1 = TRt1{column1:signed<64>, column2:string, column3:bool, column4:double}\n" +
+            "typedef TRt2 = TRt2{column1:signed<64>}\n" +
+            "typedef TRt3 = TRt3{d:Date, t:Time, dt:DateTime}\n" +
+            "typedef TRt4 = TRt4{column1:Option<signed<64>>, column2:Option<string>}\n";
     protected final String tablesWNull =
-            "typedef Tt1 = Tt1{column1:Option<signed<64>>, column2:Option<string>, column3:Option<bool>, column4:Option<double>}\n" +
-            "typedef Tt2 = Tt2{column1:Option<signed<64>>}\n" +
-            "typedef Tt3 = Tt3{d:Option<Date>, t:Option<Time>, dt:Option<DateTime>}\n" +
-            "typedef Tt4 = Tt4{column1:Option<signed<64>>, column2:Option<string>}\n";
+            "typedef TRt1 = TRt1{column1:Option<signed<64>>, column2:Option<string>, column3:Option<bool>, column4:Option<double>}\n" +
+            "typedef TRt2 = TRt2{column1:Option<signed<64>>}\n" +
+            "typedef TRt3 = TRt3{d:Option<Date>, t:Option<Time>, dt:Option<DateTime>}\n" +
+            "typedef TRt4 = TRt4{column1:Option<signed<64>>, column2:Option<string>}\n";
 
     /**
      * The expected string the generated program starts with.
@@ -84,10 +84,10 @@ public class BaseQueriesTest {
     @SuppressWarnings("unused")
     protected String relations(boolean withNull) {
         return "\n" +
-            "input relation Rt1[Tt1]\n" +
-            "input relation Rt2[Tt2]\n" +
-            "input relation Rt3[Tt3]\n" +
-            "input relation Rt4[Tt4]\n";
+            "input relation Rt1[TRt1]\n" +
+            "input relation Rt2[TRt2]\n" +
+            "input relation Rt3[TRt3]\n" +
+            "input relation Rt4[TRt4]\n";
     }
 
     protected Translator createInputTables(boolean withNulls) {
@@ -101,14 +101,14 @@ public class BaseQueriesTest {
         Assert.assertNotNull(create);
         String s = create.toString();
         Assert.assertNotNull(s);
-        Assert.assertEquals("input relation Rt1[Tt1]", s);
+        Assert.assertEquals("input relation Rt1[TRt1]", s);
 
         createStatement = "create table t2(column1 integer " + nulls + ")";
         create = t.translateSqlStatement(new PrestoSqlStatement(createStatement));
         Assert.assertNotNull(create);
         s = create.toString();
         Assert.assertNotNull(s);
-        Assert.assertEquals("input relation Rt2[Tt2]", s);
+        Assert.assertEquals("input relation Rt2[TRt2]", s);
 
         createStatement = "create table t3(d date " + nulls + ",\n" +
                 " t time " + nulls + ",\n" +
@@ -117,7 +117,7 @@ public class BaseQueriesTest {
         Assert.assertNotNull(create);
         s = create.toString();
         Assert.assertNotNull(s);
-        Assert.assertEquals("input relation Rt3[Tt3]", s);
+        Assert.assertEquals("input relation Rt3[TRt3]", s);
 
         // Table t4 always has nullable columns
         createStatement = "create table t4(column1 integer, column2 varchar(36))";
@@ -125,7 +125,7 @@ public class BaseQueriesTest {
         Assert.assertNotNull(create);
         s = create.toString();
         Assert.assertNotNull(s);
-        Assert.assertEquals("input relation Rt4[Tt4]", s);
+        Assert.assertEquals("input relation Rt4[TRt4]", s);
 
         return t;
     }

--- a/sql/src/test/java/ddlog/CastTest.java
+++ b/sql/src/test/java/ddlog/CastTest.java
@@ -37,7 +37,6 @@ public class CastTest extends BaseQueriesTest {
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{f:float}\n" +
                 this.relations(false) +
-                "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
                 "Rv0[v1] :- Rt1[v],var v0 = TRtmp{.f = v.column1 as float},var v1 = v0.";
         this.testTranslation(query, program);
@@ -49,7 +48,6 @@ public class CastTest extends BaseQueriesTest {
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{s:string}\n" +
                 this.relations(false) +
-                "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
                 "Rv0[v1] :- Rt1[v],var v0 = TRtmp{.s = [|${v.column1}|]},var v1 = v0.";
         this.testTranslation(query, program);
@@ -61,7 +59,6 @@ public class CastTest extends BaseQueriesTest {
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{i:signed<64>}\n" +
                 this.relations(false) +
-                "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
                 "Rv0[v1] :- Rt1[v],var v0 = TRtmp{.i = option_unwrap_or_default(parse_dec_i64(v.column2))},var v1 = v0.";
         this.testTranslation(query, program);
@@ -73,7 +70,6 @@ public class CastTest extends BaseQueriesTest {
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{d:double}\n" +
                 this.relations(false) +
-                "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
                 "Rv0[v1] :- Rt1[v],var v0 = TRtmp{.d = result_unwrap_or_default(parse_d(v.column2))},var v1 = v0.";
         this.testTranslation(query, program);
@@ -85,7 +81,6 @@ public class CastTest extends BaseQueriesTest {
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{d:Date}\n" +
                 this.relations(false) +
-                "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
                 "Rv0[v1] :- Rt1[v],var v0 = TRtmp{.d = result_unwrap_or_default(string2date(v.column2))},var v1 = v0.";
         this.testTranslation(query, program);
@@ -97,7 +92,6 @@ public class CastTest extends BaseQueriesTest {
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{d:Date}\n" +
                 this.relations(false) +
-                "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
                 "Rv0[v1] :- Rt1[v],var v0 = TRtmp{.d = result_unwrap_or_default(string2date([|${v.column1}|]))},var v1 = v0.";
         this.testTranslation(query, program);
@@ -109,7 +103,6 @@ public class CastTest extends BaseQueriesTest {
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{t:DateTime}\n" +
                 this.relations(false) +
-                "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
                 "Rv0[v1] :- Rt1[v],var v0 = TRtmp{.t = result_unwrap_or_default(string2datetime(v.column2))},var v1 = v0.";
         this.testTranslation(query, program);
@@ -121,7 +114,6 @@ public class CastTest extends BaseQueriesTest {
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{i:signed<64>}\n" +
                 this.relations(false) +
-                "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
                 "Rv0[v1] :- Rt1[v],var v0 = TRtmp{.i = option_unwrap_or_default(int_from_d(v.column4)) as signed<64>},var v1 = v0.";
         this.testTranslation(query, program);
@@ -133,7 +125,6 @@ public class CastTest extends BaseQueriesTest {
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{s:string}\n" +
                 this.relations(false) +
-                "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
                 "Rv0[v1] :- Rt3[v],var v0 = TRtmp{.s = [|${v.d}|]},var v1 = v0.";
         this.testTranslation(query, program);
@@ -145,7 +136,6 @@ public class CastTest extends BaseQueriesTest {
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{i:signed<64>}\n" +
                 this.relations(false) +
-                "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
                 "Rv0[v1] :- Rt1[v],var v0 = TRtmp{.i = if (v.column3) {\n64'sd1} else {\n64'sd0}},var v1 = v0.";
         this.testTranslation(query, program);
@@ -157,26 +147,17 @@ public class CastTest extends BaseQueriesTest {
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{b:bool}\n" +
                 this.relations(false) +
-                "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
                 "Rv0[v1] :- Rt1[v],var v0 = TRtmp{.b = (v.column1 != 64'sd0)},var v1 = v0.";
         this.testTranslation(query, program);
     }
 
-    @Test(expected = TranslationException.class)
-    public void testCastDateToBool() {
-        String query = "create view v0 as SELECT DISTINCT CAST(t3.d AS BOOLEAN) AS b FROM t3";
-        String program = "";
-        this.testTranslation(query, program);
-    }
-    
     @Test
     public void testCastIntToFloatWithNull() {
         String query = "create view v0 as SELECT DISTINCT CAST(t1.column1 AS FLOAT) AS f FROM t1";
         String program = this.header(true) +
                 "typedef TRtmp = TRtmp{f:Option<float>}\n" +
                 this.relations(true) +
-                "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
                 "Rv0[v1] :- Rt1[v],var v0 = TRtmp{.f = match(v.column1) {None{}: Option<signed<64>> -> None{}: Option<float>,\n" +
                 "Some{.x = var x} -> Some{.x = x as float}\n" +
@@ -190,7 +171,6 @@ public class CastTest extends BaseQueriesTest {
         String program = this.header(true) +
                 "typedef TRtmp = TRtmp{s:Option<string>}\n" +
                 this.relations(true) +
-                "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
                 "Rv0[v1] :- Rt1[v],var v0 = TRtmp{.s = match(v.column1) {None{}: Option<signed<64>> -> None{}: Option<string>,\n" +
                 "Some{.x = var x} -> Some{.x = [|${x}|]}\n" +
@@ -204,7 +184,6 @@ public class CastTest extends BaseQueriesTest {
         String program = this.header(true) +
                 "typedef TRtmp = TRtmp{i:Option<signed<64>>}\n" +
                 this.relations(true) +
-                "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
                 "Rv0[v1] :- Rt1[v],var v0 = TRtmp{.i = match(v.column2) {None{}: Option<string> -> None{}: Option<signed<64>>,\n" +
                 "Some{.x = var x} -> Some{.x = option_unwrap_or_default(parse_dec_i64(x))}\n" +
@@ -218,7 +197,6 @@ public class CastTest extends BaseQueriesTest {
         String program = this.header(true) +
                 "typedef TRtmp = TRtmp{d:Option<double>}\n" +
                 this.relations(true) +
-                "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
                 "Rv0[v1] :- Rt1[v],var v0 = TRtmp{.d = match(v.column2) {None{}: Option<string> -> None{}: Option<double>,\n" +
                 "Some{.x = var x} -> Some{.x = result_unwrap_or_default(parse_d(x))}\n" +
@@ -232,7 +210,6 @@ public class CastTest extends BaseQueriesTest {
         String program = this.header(true) +
                 "typedef TRtmp = TRtmp{d:Option<Date>}\n" +
                 this.relations(true) +
-                "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
                 "Rv0[v1] :- Rt1[v],var v0 = TRtmp{.d = match(v.column2) {None{}: Option<string> -> None{}: Option<Date>,\n" +
                 "Some{.x = var x} -> Some{.x = result_unwrap_or_default(string2date(x))}\n" +
@@ -246,7 +223,6 @@ public class CastTest extends BaseQueriesTest {
         String program = this.header(true) +
                 "typedef TRtmp = TRtmp{d:Option<Date>}\n" +
                 this.relations(true) +
-                "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
                 "Rv0[v1] :- Rt1[v],var v0 = TRtmp{.d = match(v.column1) {None{}: Option<signed<64>> -> None{}: Option<Date>,\n" +
                 "Some{.x = var x} -> Some{.x = result_unwrap_or_default(string2date([|${v.column1}|]))}\n" +
@@ -260,7 +236,6 @@ public class CastTest extends BaseQueriesTest {
         String program = this.header(true) +
                 "typedef TRtmp = TRtmp{t:Option<DateTime>}\n" +
                 this.relations(true) +
-                "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
                 "Rv0[v1] :- Rt1[v],var v0 = TRtmp{.t = match(v.column2) {None{}: Option<string> -> None{}: Option<DateTime>,\n" +
                 "Some{.x = var x} -> Some{.x = result_unwrap_or_default(string2datetime(x))}\n" +
@@ -274,7 +249,6 @@ public class CastTest extends BaseQueriesTest {
         String program = this.header(true) +
                 "typedef TRtmp = TRtmp{i:Option<signed<64>>}\n" +
                 this.relations(true) +
-                "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
                 "Rv0[v1] :- Rt1[v],var v0 = TRtmp{.i = match(v.column4) {None{}: Option<double> -> None{}: Option<signed<64>>,\n" +
                 "Some{.x = var x} -> Some{.x = option_unwrap_or_default(int_from_d(x)) as signed<64>}\n" +
@@ -288,7 +262,6 @@ public class CastTest extends BaseQueriesTest {
         String program = this.header(true) +
                 "typedef TRtmp = TRtmp{s:Option<string>}\n" +
                 this.relations(true) +
-                "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
                 "Rv0[v1] :- Rt3[v],var v0 = TRtmp{.s = match(v.d) {None{}: Option<Date> -> None{}: Option<string>,\n" +
                 "Some{.x = var x} -> Some{.x = [|${x}|]}\n" +
@@ -302,7 +275,6 @@ public class CastTest extends BaseQueriesTest {
         String program = this.header(true) +
                 "typedef TRtmp = TRtmp{i:Option<signed<64>>}\n" +
                 this.relations(true) +
-                "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
                 "Rv0[v1] :- Rt1[v],var v0 = TRtmp{.i = match(v.column3) {None{}: Option<bool> -> None{}: Option<signed<64>>,\n" +
                 "Some{.x = var x} -> Some{.x = if (x) {\n" +
@@ -318,7 +290,6 @@ public class CastTest extends BaseQueriesTest {
         String program = this.header(true) +
                 "typedef TRtmp = TRtmp{b:Option<bool>}\n" +
                 this.relations(true) +
-                "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
                 "Rv0[v1] :- Rt1[v],var v0 = TRtmp{.b = match(v.column1) {None{}: Option<signed<64>> -> None{}: Option<bool>,\n" +
                 "Some{.x = var x} -> Some{.x = (x != 64'sd0)}\n" +

--- a/sql/src/test/java/ddlog/GroupByTest.java
+++ b/sql/src/test/java/ddlog/GroupByTest.java
@@ -28,13 +28,13 @@ import org.junit.Test;
 
 import java.util.Arrays;
 
-public class GroupbyTest extends BaseQueriesTest {
+public class GroupByTest extends BaseQueriesTest {
     @Test
     public void testGroupBy() {
         String query = "create view v0 as SELECT COUNT(*) AS c FROM t1 GROUP BY column2";
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{c:signed<64>}\n" +
-                "function agg(g: Group<string, Tt1>):TRtmp {\n" +
+                "function agg(g: Group<string, TRt1>):TRtmp {\n" +
                 "(var gb) = group_key(g);\n" +
                 "(var count = 64'sd0: signed<64>);\n" +
                 "(for ((i, _) in g) {\n" +
@@ -56,7 +56,7 @@ public class GroupbyTest extends BaseQueriesTest {
         String query1 = "create view v1 as SELECT COUNT(*) AS c FROM t1 GROUP BY column2";
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{c:signed<64>}\n" +
-                "function agg(g: Group<string, Tt1>):TRtmp {\n" +
+                "function agg(g: Group<string, TRt1>):TRtmp {\n" +
                 "(var gb) = group_key(g);\n" +
                 "(var count = 64'sd0: signed<64>);\n" +
                 "(for ((i, _) in g) {\n" +
@@ -64,7 +64,7 @@ public class GroupbyTest extends BaseQueriesTest {
                 "(count = agg_count_R(count, 64'sd1))}\n" +
                 ");\n" +
                 "(TRtmp{.c = count})\n}\n\n" +
-                "function agg1(g: Group<string, Tt1>):TRtmp {\n" +
+                "function agg0(g: Group<string, TRt1>):TRtmp {\n" +
                 "(var gb) = group_key(g);\n" +
                 "(var count = 64'sd0: signed<64>);\n" +
                 "(for ((i, _) in g) {\n" +
@@ -79,7 +79,7 @@ public class GroupbyTest extends BaseQueriesTest {
                 "output relation Rv1[TRtmp]\n" +
                 "Rv0[v1] :- Rt1[v],var gb = v.column2,var groupResult = (v).group_by((gb)),var aggResult = agg(groupResult)," +
                 "var v0 = TRtmp{.c = aggResult.c},var v1 = v0.\n" +
-                "Rv1[v1] :- Rt1[v],var gb = v.column2,var groupResult = (v).group_by((gb)),var aggResult = agg1(groupResult)," +
+                "Rv1[v1] :- Rt1[v],var gb = v.column2,var groupResult = (v).group_by((gb)),var aggResult = agg0(groupResult)," +
                 "var v0 = TRtmp{.c = aggResult.c},var v1 = v0.";
         this.testTranslation(Arrays.asList(query0, query1), program, false);
     }
@@ -90,7 +90,7 @@ public class GroupbyTest extends BaseQueriesTest {
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{column2:string, c:signed<64>}\n" +
                 "typedef Tagg = Tagg{c:signed<64>}\n" +
-                "function agg(g: Group<string, Tt1>):Tagg {\n" +
+                "function agg(g: Group<string, TRt1>):Tagg {\n" +
                 "(var gb) = group_key(g);\n" +
                 "(var count = 64'sd0: signed<64>);\n" +
                 "(for ((i, _) in g) {\n" +
@@ -112,7 +112,7 @@ public class GroupbyTest extends BaseQueriesTest {
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{column2:string, column3:bool, c:signed<64>, s:signed<64>}\n" +
                 "typedef Tagg = Tagg{c:signed<64>, s:signed<64>}\n" +
-                "function agg(g: Group<(string, bool), Tt1>):Tagg {\n" +
+                "function agg(g: Group<(string, bool), TRt1>):Tagg {\n" +
                 "(var gb, var gb0) = group_key(g);\n" +
                 "(var count = 64'sd0: signed<64>);\n" +
                 "(var sum = 64'sd0: signed<64>);\n" +
@@ -126,9 +126,9 @@ public class GroupbyTest extends BaseQueriesTest {
                 this.relations(false) +
                 "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
-                "Rv0[v2] :- Rt1[v],var gb = v.column2,var gb0 = v.column3," +
-                "var groupResult = (v).group_by((gb, gb0)),var aggResult = agg(groupResult)," +
-                "var v1 = TRtmp{.column2 = gb,.column3 = gb0,.c = aggResult.c,.s = aggResult.s},var v2 = v1.";
+                "Rv0[v1] :- Rt1[v],var gb = v.column2,var gb0 = v.column3,var groupResult = (v).group_by((gb, gb0))," +
+                "var aggResult = agg(groupResult)," +
+                "var v0 = TRtmp{.column2 = gb,.column3 = gb0,.c = aggResult.c,.s = aggResult.s},var v1 = v0.";
         this.testTranslation(query, program);
     }
 
@@ -138,7 +138,7 @@ public class GroupbyTest extends BaseQueriesTest {
         String program = this.header(true) +
                 "typedef TRtmp = TRtmp{column2:Option<string>, c:signed<64>}\n" +
                 "typedef Tagg = Tagg{c:signed<64>}\n" +
-                "function agg(g: Group<Option<string>, Tt1>):Tagg {\n" +
+                "function agg(g: Group<Option<string>, TRt1>):Tagg {\n" +
                 "(var gb) = group_key(g);\n" +
                 "(var count = 64'sd0: signed<64>);\n" +
                 "(for ((i, _) in g) {\n" +
@@ -160,7 +160,7 @@ public class GroupbyTest extends BaseQueriesTest {
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{column2:string, s:signed<64>}\n" +
                 "typedef Tagg = Tagg{s:signed<64>}\n" +
-                "function agg(g: Group<string, Tt1>):Tagg {\n" +
+                "function agg(g: Group<string, TRt1>):Tagg {\n" +
                 "(var gb) = group_key(g);\n" +
                 "(var sum = 64'sd0: signed<64>);\n" +
                 "(for ((i, _) in g) {\n" +
@@ -182,7 +182,7 @@ public class GroupbyTest extends BaseQueriesTest {
         String program = this.header(true) +
                 "typedef TRtmp = TRtmp{column2:Option<string>, s:Option<signed<64>>}\n" +
                 "typedef Tagg = Tagg{s:Option<signed<64>>}\n" +
-                "function agg(g: Group<Option<string>, Tt1>):Tagg {\n" +
+                "function agg(g: Group<Option<string>, TRt1>):Tagg {\n" +
                 "(var gb) = group_key(g);\n" +
                 "(var sum = None{}: Option<signed<64>>);\n" +
                 "(for ((i, _) in g) {\n" +
@@ -207,29 +207,26 @@ public class GroupbyTest extends BaseQueriesTest {
                 "GROUP BY t1.column1\n" +
                 "HAVING (t1.column1 IN (t1.column1))";
         String program = this.header(false) +
-                "typedef Ttmp = Ttmp{column1:signed<64>, column2:string, column3:bool, column4:double, column10:signed<64>}\n" +
                 "typedef TRtmp = TRtmp{c:signed<64>}\n" +
                 "typedef Tagg = Tagg{c:signed<64>, col:bool}\n" +
-                "function agg(g: Group<signed<64>, (Tt1, Tt2)>):Tagg {\n" +
+                "function agg(g: Group<signed<64>, TRt1>):Tagg {\n" +
                 "(var gb) = group_key(g);\n" +
                 "(var count = 64'sd0: signed<64>);\n" +
                 "(for ((i, _) in g) {\n" +
-                "var v = i.0;\n" +
-                "(var v0 = i.1);\n" +
-                "(var incr = v.column2);\n" +
+                "var v1 = i;\n" +
+                "(var incr = v1.column2);\n" +
                 "(count = agg_count_R(count, incr))}\n" +
                 ");\n" +
                 "(Tagg{.c = count,.col = vec_contains(vec_push_imm(vec_empty(), gb), gb)})\n" +
                 "}\n" +
                 "\n" +
-                "input relation Rt1[Tt1]\n" +
-                "input relation Rt2[Tt2]\n" +
-                "input relation Rt3[Tt3]\n" +
-                "input relation Rt4[Tt4]\n" +
+                "input relation Rt1[TRt1]\n" +
+                "input relation Rt2[TRt2]\n" +
+                "input relation Rt3[TRt3]\n" +
+                "input relation Rt4[TRt4]\n" +
                 "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
-                "Rv0[v3] :- Rt1[v],Rt2[v0],(v.column1 == v0.column1),true,var v1 = Ttmp{.column1 = v.column1,.column2 = v.column2,.column3 = v.column3,.column4 = v.column4,.column10 = v0.column1}," +
-                "var gb = v.column1,var groupResult = (v, v0).group_by((gb)),var aggResult = agg(groupResult),var v2 = TRtmp{.c = aggResult.c},aggResult.col,var v3 = v2.";
+                "Rv0[v3] :- Rt1[TRt1{.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4}],Rt2[TRt2{.column1 = column1}],var v1 = TRt1{.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4},var gb = v1.column1,var groupResult = (v1).group_by((gb)),var aggResult = agg(groupResult),var v2 = TRtmp{.c = aggResult.c},aggResult.col,var v3 = v2.";
         this.testTranslation(query, program);
     }
 
@@ -242,29 +239,26 @@ public class GroupbyTest extends BaseQueriesTest {
                 "GROUP BY t1.column1\n" +
                 "HAVING (t1.column1 NOT IN (t1.column1))";
         String program = this.header(false) +
-                "typedef Ttmp = Ttmp{column1:signed<64>, column2:string, column3:bool, column4:double, column10:signed<64>}\n" +
                 "typedef TRtmp = TRtmp{c:signed<64>}\n" +
                 "typedef Tagg = Tagg{c:signed<64>, col:bool}\n" +
-                "function agg(g: Group<signed<64>, (Tt1, Tt2)>):Tagg {\n" +
+                "function agg(g: Group<signed<64>, TRt1>):Tagg {\n" +
                 "(var gb) = group_key(g);\n" +
                 "(var count = 64'sd0: signed<64>);\n" +
                 "(for ((i, _) in g) {\n" +
-                "var v = i.0;\n" +
-                "(var v0 = i.1);\n" +
-                "(var incr = v.column2);\n" +
+                "var v1 = i;\n" +
+                "(var incr = v1.column2);\n" +
                 "(count = agg_count_R(count, incr))}\n" +
                 ");\n" +
                 "(Tagg{.c = count,.col = (not vec_contains(vec_push_imm(vec_empty(), gb), gb))})\n" +
                 "}\n" +
                 "\n" +
-                "input relation Rt1[Tt1]\n" +
-                "input relation Rt2[Tt2]\n" +
-                "input relation Rt3[Tt3]\n" +
-                "input relation Rt4[Tt4]\n" +
+                "input relation Rt1[TRt1]\n" +
+                "input relation Rt2[TRt2]\n" +
+                "input relation Rt3[TRt3]\n" +
+                "input relation Rt4[TRt4]\n" +
                 "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
-                "Rv0[v3] :- Rt1[v],Rt2[v0],(v.column1 == v0.column1),true,var v1 = Ttmp{.column1 = v.column1,.column2 = v.column2,.column3 = v.column3,.column4 = v.column4,.column10 = v0.column1}," +
-                "var gb = v.column1,var groupResult = (v, v0).group_by((gb)),var aggResult = agg(groupResult),var v2 = TRtmp{.c = aggResult.c},aggResult.col,var v3 = v2.";
+                "Rv0[v3] :- Rt1[TRt1{.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4}],Rt2[TRt2{.column1 = column1}],var v1 = TRt1{.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4},var gb = v1.column1,var groupResult = (v1).group_by((gb)),var aggResult = agg(groupResult),var v2 = TRtmp{.c = aggResult.c},aggResult.col,var v3 = v2.";
 
         this.testTranslation(query, program);
     }
@@ -278,29 +272,26 @@ public class GroupbyTest extends BaseQueriesTest {
                 "GROUP BY t1.column1\n" +
                 "HAVING ((t1.column1 NOT IN (t1.column1)) AND (COUNT(column2) > 3))";
         String program = this.header(false) +
-                "typedef Ttmp = Ttmp{column1:signed<64>, column2:string, column3:bool, column4:double, column10:signed<64>}\n" +
                 "typedef TRtmp = TRtmp{c:signed<64>}\n" +
                 "typedef Tagg = Tagg{c:signed<64>, col:bool}\n" +
-                "function agg(g: Group<signed<64>, (Tt1, Tt2)>):Tagg {\n" +
+                "function agg(g: Group<signed<64>, TRt1>):Tagg {\n" +
                 "(var gb) = group_key(g);\n" +
                 "(var count = 64'sd0: signed<64>);\n" +
                 "(for ((i, _) in g) {\n" +
-                "var v = i.0;\n" +
-                "(var v0 = i.1);\n" +
-                "(var incr = v.column2);\n" +
+                "var v1 = i;\n" +
+                "(var incr = v1.column2);\n" +
                 "(count = agg_count_R(count, incr))}\n" +
                 ");\n" +
                 "(Tagg{.c = count,.col = ((not vec_contains(vec_push_imm(vec_empty(), gb), gb)) and (count > 64'sd3))})\n" +
                 "}\n" +
                 "\n" +
-                "input relation Rt1[Tt1]\n" +
-                "input relation Rt2[Tt2]\n" +
-                "input relation Rt3[Tt3]\n" +
-                "input relation Rt4[Tt4]\n" +
+                "input relation Rt1[TRt1]\n" +
+                "input relation Rt2[TRt2]\n" +
+                "input relation Rt3[TRt3]\n" +
+                "input relation Rt4[TRt4]\n" +
                 "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
-                "Rv0[v3] :- Rt1[v],Rt2[v0],(v.column1 == v0.column1),true,var v1 = Ttmp{.column1 = v.column1,.column2 = v.column2,.column3 = v.column3,.column4 = v.column4,.column10 = v0.column1}," +
-                "var gb = v.column1,var groupResult = (v, v0).group_by((gb)),var aggResult = agg(groupResult),var v2 = TRtmp{.c = aggResult.c},aggResult.col,var v3 = v2.";
+                "Rv0[v3] :- Rt1[TRt1{.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4}],Rt2[TRt2{.column1 = column1}],var v1 = TRt1{.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4},var gb = v1.column1,var groupResult = (v1).group_by((gb)),var aggResult = agg(groupResult),var v2 = TRtmp{.c = aggResult.c},aggResult.col,var v3 = v2.";
         this.testTranslation(query, program);
     }
 
@@ -313,29 +304,26 @@ public class GroupbyTest extends BaseQueriesTest {
                 "GROUP BY t1.column1, t1.column3\n" +
                 "HAVING ((t1.column1 > 3) NOT IN (t1.column3))";
         String program = this.header(false) +
-                "typedef Ttmp = Ttmp{column1:signed<64>, column2:string, column3:bool, column4:double, column10:signed<64>}\n" +
                 "typedef TRtmp = TRtmp{c:signed<64>}\n" +
                 "typedef Tagg = Tagg{c:signed<64>, col:bool}\n" +
-                "function agg(g: Group<(signed<64>, bool), (Tt1, Tt2)>):Tagg {\n" +
-                "(var gb, var gb2) = group_key(g);\n" +
+                "function agg(g: Group<(signed<64>, bool), TRt1>):Tagg {\n" +
+                "(var gb, var gb0) = group_key(g);\n" +
                 "(var count = 64'sd0: signed<64>);\n" +
                 "(for ((i, _) in g) {\n" +
-                "var v = i.0;\n" +
-                "(var v0 = i.1);\n" +
-                "(var incr = v.column2);\n" +
+                "var v1 = i;\n" +
+                "(var incr = v1.column2);\n" +
                 "(count = agg_count_R(count, incr))}\n" +
                 ");\n" +
-                "(Tagg{.c = count,.col = (not vec_contains(vec_push_imm(vec_empty(), gb2), (gb > 64'sd3)))})\n" +
+                "(Tagg{.c = count,.col = (not vec_contains(vec_push_imm(vec_empty(), gb0), (gb > 64'sd3)))})\n" +
                 "}\n" +
                 "\n" +
-                "input relation Rt1[Tt1]\n" +
-                "input relation Rt2[Tt2]\n" +
-                "input relation Rt3[Tt3]\n" +
-                "input relation Rt4[Tt4]\n" +
+                "input relation Rt1[TRt1]\n" +
+                "input relation Rt2[TRt2]\n" +
+                "input relation Rt3[TRt3]\n" +
+                "input relation Rt4[TRt4]\n" +
                 "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
-                "Rv0[v4] :- Rt1[v],Rt2[v0],(v.column1 == v0.column1),true,var v1 = Ttmp{.column1 = v.column1,.column2 = v.column2,.column3 = v.column3,.column4 = v.column4,.column10 = v0.column1}," +
-                "var gb = v.column1,var gb2 = v.column3,var groupResult = (v, v0).group_by((gb, gb2)),var aggResult = agg(groupResult),var v3 = TRtmp{.c = aggResult.c},aggResult.col,var v4 = v3.";
+                "Rv0[v3] :- Rt1[TRt1{.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4}],Rt2[TRt2{.column1 = column1}],var v1 = TRt1{.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4},var gb = v1.column1,var gb0 = v1.column3,var groupResult = (v1).group_by((gb, gb0)),var aggResult = agg(groupResult),var v2 = TRtmp{.c = aggResult.c},aggResult.col,var v3 = v2.";
         this.testTranslation(query, program);
     }
 
@@ -345,7 +333,7 @@ public class GroupbyTest extends BaseQueriesTest {
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{c:signed<64>}\n" +
                 "typedef Tagg = Tagg{c:signed<64>, col:bool}\n" +
-                "function agg(g: Group<signed<64>, Tt1>):Tagg {\n" +
+                "function agg(g: Group<signed<64>, TRt1>):Tagg {\n" +
                 "(var gb) = group_key(g);\n" +
                 "(var count = 64'sd0: signed<64>);\n" +
                 "(for ((i, _) in g) {\n" +
@@ -368,7 +356,7 @@ public class GroupbyTest extends BaseQueriesTest {
         String program = this.header(true) +
                 "typedef TRtmp = TRtmp{c:Option<signed<64>>}\n" +
                 "typedef Tagg = Tagg{c:Option<signed<64>>, col:Option<bool>}\n" +
-                "function agg(g: Group<Option<signed<64>>, Tt1>):Tagg {\n" +
+                "function agg(g: Group<Option<signed<64>>, TRt1>):Tagg {\n" +
                 "(var gb) = group_key(g);\n" +
                 "(var count = None{}: Option<signed<64>>);\n" +
                 "(var any = Some{false}: Option<bool>);\n" +
@@ -383,8 +371,8 @@ public class GroupbyTest extends BaseQueriesTest {
                 this.relations(true) +
                 "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
-                "Rv0[v2] :- Rt1[v],var gb = v.column1,var groupResult = (v).group_by((gb)),var aggResult = agg(groupResult)," +
-                "var v1 = TRtmp{.c = aggResult.c},unwrapBool(aggResult.col),var v2 = v1.";
+                "Rv0[v1] :- Rt1[v],var gb = v.column1,var groupResult = (v).group_by((gb))," +
+                "var aggResult = agg(groupResult),var v0 = TRtmp{.c = aggResult.c},unwrapBool(aggResult.col),var v1 = v0.";
         this.testTranslation(query, program, true);
     }
 
@@ -394,7 +382,7 @@ public class GroupbyTest extends BaseQueriesTest {
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{c:signed<64>}\n" +
                 "typedef Tagg = Tagg{c:signed<64>, col:bool}\n" +
-                "function agg(g: Group<signed<64>, Tt1>):Tagg {\n" +
+                "function agg(g: Group<signed<64>, TRt1>):Tagg {\n" +
                 "(var gb) = group_key(g);\n" +
                 "(var count = 64'sd0: signed<64>);\n" +
                 "(for ((i, _) in g) {\n" +
@@ -417,7 +405,7 @@ public class GroupbyTest extends BaseQueriesTest {
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{s:signed<64>}\n" +
                 "typedef Tagg = Tagg{s:signed<64>, col:bool}\n" +
-                "function agg(g: Group<string, Tt1>):Tagg {\n" +
+                "function agg(g: Group<string, TRt1>):Tagg {\n" +
                 "(var gb) = group_key(g);\n" +
                 "(var sum = 64'sd0: signed<64>);\n" +
                 "(var count = 64'sd0: signed<64>);\n" +
@@ -442,7 +430,7 @@ public class GroupbyTest extends BaseQueriesTest {
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{column2:string, s:signed<64>}\n" +
                 "typedef Tagg = Tagg{s:signed<64>, col:bool}\n" +
-                "function agg(g: Group<string, Tt1>):Tagg {\n" +
+                "function agg(g: Group<string, TRt1>):Tagg {\n" +
                 "(var gb) = group_key(g);\n" +
                 "(var sum = 64'sd0: signed<64>);\n" +
                 "(var count_distinct = set_empty(): Set<bool>);\n" +
@@ -457,8 +445,8 @@ public class GroupbyTest extends BaseQueriesTest {
                 this.relations(false) +
                 "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
-                "Rv0[v2] :- Rt1[v],var gb = v.column2,var groupResult = (v).group_by((gb)),var aggResult = agg(groupResult)," +
-                "var v1 = TRtmp{.column2 = gb,.s = aggResult.s},aggResult.col,var v2 = v1.";
+                "Rv0[v1] :- Rt1[v],var gb = v.column2,var groupResult = (v).group_by((gb))," +
+                "var aggResult = agg(groupResult),var v0 = TRtmp{.column2 = gb,.s = aggResult.s},aggResult.col,var v1 = v0.";
         this.testTranslation(query, program);
     }
 
@@ -468,7 +456,7 @@ public class GroupbyTest extends BaseQueriesTest {
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{s:string, c:signed<64>}\n" +
                 "typedef Tagg = Tagg{c:signed<64>}\n" +
-                "function agg(g: Group<string, Tt1>):Tagg {\n" +
+                "function agg(g: Group<string, TRt1>):Tagg {\n" +
                 "(var gb) = group_key(g);\n" +
                 "(var count = 64'sd0: signed<64>);\n" +
                 "(for ((i, _) in g) {\n" +
@@ -489,7 +477,7 @@ public class GroupbyTest extends BaseQueriesTest {
         String query = "create view v0 as SELECT substr(column2, 0, 1) AS s, COUNT(*) AS c FROM t1 GROUP BY column2";
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{s:string, c:signed<64>}\n" +
-                "function agg(g: Group<string, Tt1>):TRtmp {\n" +
+                "function agg(g: Group<string, TRt1>):TRtmp {\n" +
                 "(var gb) = group_key(g);\n" +
                 "(var count = 64'sd0: signed<64>);\n" +
                 "(for ((i, _) in g) {\n" +
@@ -514,8 +502,8 @@ public class GroupbyTest extends BaseQueriesTest {
                 this.relations(false) +
                 "relation Rtmp[TRtmp]\n" +
                 "output relation Rv[TRtmp]\n" +
-                "Rv[v2] :- Rt1[v],var gb = v.column2,var gb0 = v.column3,var groupResult = (v).group_by((gb, gb0))," +
-                "var v1 = TRtmp{.gb1 = gb,.column2 = gb,.tmp = gb0},var v2 = v1.";
+                "Rv[v1] :- Rt1[v],var gb = v.column2,var gb0 = v.column3,var groupResult = (v).group_by((gb, gb0))," +
+                "var v0 = TRtmp{.gb1 = gb,.column2 = gb,.tmp = gb0},var v1 = v0.";
         this.testTranslation(query, translation);
     }
 
@@ -528,7 +516,7 @@ public class GroupbyTest extends BaseQueriesTest {
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{col0:signed<64>}\n" +
                 "typedef Tagg = Tagg{col0:signed<64>, col1:bool}\n" +
-                "function agg(g: Group<signed<64>, Tt1>):Tagg {\n" +
+                "function agg(g: Group<signed<64>, TRt1>):Tagg {\n" +
                 "(var gb) = group_key(g);\n" +
                 "(var count = 64'sd0: signed<64>);\n" +
                 "(var array_agg = vec_empty(): Vec<signed<64>>);\n" +
@@ -536,20 +524,20 @@ public class GroupbyTest extends BaseQueriesTest {
                 "var v = i;\n" +
                 "(var incr = v.column2);\n" +
                 "(count = agg_count_R(count, incr));\n" +
-                "(var incr2 = gb);\n" +
-                "(vec_push(array_agg, incr2))}\n" +
+                "(var incr0 = gb);\n" +
+                "(vec_push(array_agg, incr0))}\n" +
                 ");\n" +
                 "(Tagg{.col0 = count,.col1 = (sql_array_length(array_agg) == count)})\n" +
                 "}\n" +
                 "\n" +
-                "input relation Rt1[Tt1]\n" +
-                "input relation Rt2[Tt2]\n" +
-                "input relation Rt3[Tt3]\n" +
-                "input relation Rt4[Tt4]\n" +
+                "input relation Rt1[TRt1]\n" +
+                "input relation Rt2[TRt2]\n" +
+                "input relation Rt3[TRt3]\n" +
+                "input relation Rt4[TRt4]\n" +
                 "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
-                "Rv0[v4] :- Rt1[v],var gb = v.column1,var groupResult = (v).group_by((gb)),var aggResult = agg(groupResult),var v3 = TRtmp{.col0 = aggResult.col0},aggResult.col1,var v4 = v3.";
-
+                "Rv0[v1] :- Rt1[v],var gb = v.column1,var groupResult = (v).group_by((gb)),var aggResult = agg(groupResult)," +
+                "var v0 = TRtmp{.col0 = aggResult.col0},aggResult.col1,var v1 = v0.";
         this.testTranslation(query, program);
     }
 
@@ -562,7 +550,7 @@ public class GroupbyTest extends BaseQueriesTest {
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{col0:signed<64>}\n" +
                 "typedef Tagg = Tagg{col0:signed<64>, col1:bool}\n" +
-                "function agg(g: Group<signed<64>, Tt1>):Tagg {\n" +
+                "function agg(g: Group<signed<64>, TRt1>):Tagg {\n" +
                 "(var gb) = group_key(g);\n" +
                 "(var count = 64'sd0: signed<64>);\n" +
                 "(var array_agg = vec_empty(): Vec<signed<64>>);\n" +
@@ -570,20 +558,20 @@ public class GroupbyTest extends BaseQueriesTest {
                 "var v = i;\n" +
                 "(var incr = v.column2);\n" +
                 "(count = agg_count_R(count, incr));\n" +
-                "(var incr2 = gb);\n" +
-                "(vec_push(array_agg, incr2))}\n" +
+                "(var incr0 = gb);\n" +
+                "(vec_push(array_agg, incr0))}\n" +
                 ");\n" +
                 "(Tagg{.col0 = count,.col1 = (sql_array_length(array_agg) < 64'sd2)})\n" +
                 "}\n" +
                 "\n" +
-                "input relation Rt1[Tt1]\n" +
-                "input relation Rt2[Tt2]\n" +
-                "input relation Rt3[Tt3]\n" +
-                "input relation Rt4[Tt4]\n" +
+                "input relation Rt1[TRt1]\n" +
+                "input relation Rt2[TRt2]\n" +
+                "input relation Rt3[TRt3]\n" +
+                "input relation Rt4[TRt4]\n" +
                 "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
-                "Rv0[v4] :- Rt1[v],var gb = v.column1,var groupResult = (v).group_by((gb)),var aggResult = agg(groupResult),var v3 = TRtmp{.col0 = aggResult.col0},aggResult.col1,var v4 = v3.";
-
+                "Rv0[v1] :- Rt1[v],var gb = v.column1,var groupResult = (v).group_by((gb)),var aggResult = agg(groupResult)," +
+                "var v0 = TRtmp{.col0 = aggResult.col0},aggResult.col1,var v1 = v0.";
         this.testTranslation(query, program);
     }
 }

--- a/sql/src/test/java/ddlog/JoinTest.java
+++ b/sql/src/test/java/ddlog/JoinTest.java
@@ -31,24 +31,19 @@ public class JoinTest extends BaseQueriesTest {
     public void testCountJoin() {
         String query = "create view v0 as SELECT COUNT(t1.column2) as ct FROM t1 JOIN t2 ON t1.column1 = t2.column1";
         String program = this.header(false) +
-                "typedef Ttmp = Ttmp{column1:signed<64>, column2:string, column3:bool, column4:double, column10:signed<64>}\n" +
                 "typedef TRtmp = TRtmp{ct:signed<64>}\n" +
-                "function agg(g: Group<(), (Tt1, Tt2)>):TRtmp {\n" +
+                "function agg(g: Group<(), TRt1>):TRtmp {\n" +
                 "var count = 64'sd0: signed<64>;\n" +
                 "(for ((i, _) in g) {\n" +
-                "var v = i.0;\n" +
-                "(var v0 = i.1);\n" +
-                "(var incr = v.column2);\n" +
+                "var v1 = i;\n" +
+                "(var incr = v1.column2);\n" +
                 "(count = agg_count_R(count, incr))}\n" +
                 ");\n" +
                 "(TRtmp{.ct = count})\n}\n" +
                 this.relations(false) +
                 "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
-                "Rv0[v3] :- Rt1[v],Rt2[v0],(v.column1 == v0.column1),true," +
-                "var v1 = Ttmp{.column1 = v.column1,.column2 = v.column2,.column3 = v.column3," +
-                ".column4 = v.column4,.column10 = v0.column1}," +
-                "var groupResult = (v, v0).group_by(()),var aggResult = agg(groupResult),var v2 = aggResult,var v3 = v2.";
+                "Rv0[v3] :- Rt1[TRt1{.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4}],Rt2[TRt2{.column1 = column1}],var v1 = TRt1{.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4},var groupResult = (v1).group_by(()),var aggResult = agg(groupResult),var v2 = aggResult,var v3 = v2.";
         this.testTranslation(query, program);
     }
 
@@ -59,10 +54,7 @@ public class JoinTest extends BaseQueriesTest {
                 "typedef Ttmp = Ttmp{column1:signed<64>, column2:string, column3:bool, column4:double, column10:signed<64>}\n" +
                 this.relations(false) +
                 "output relation Rv0[Ttmp]\n" +
-                "Rv0[v2] :- Rt1[v],Rt2[v0],true," +
-                "var v1 = Ttmp{.column1 = v.column1,.column2 = v.column2,.column3 = v.column3," +
-                ".column4 = v.column4,.column10 = v0.column1}," +
-                "var v2 = v1.";
+                "Rv0[v2] :- Rt1[TRt1{.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4}],Rt2[TRt2{.column1 = column10}],var v1 = Ttmp{.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4,.column10 = column10},var v2 = v1.";
         this.testTranslation(query, program);
     }
 
@@ -70,12 +62,9 @@ public class JoinTest extends BaseQueriesTest {
     public void testJoinStar() {
         String query = "create view v0 as SELECT DISTINCT * FROM t1 JOIN t2 ON t1.column1 = t2.column1";
         String program = this.header(false) +
-                "typedef Ttmp = Ttmp{column1:signed<64>, column2:string, column3:bool, column4:double, column10:signed<64>}\n" +
                 this.relations(false) +
-                "output relation Rv0[Ttmp]\n" +
-                "Rv0[v2] :- Rt1[v],Rt2[v0],(v.column1 == v0.column1),true," +
-                "var v1 = Ttmp{.column1 = v.column1,.column2 = v.column2,.column3 = v.column3," +
-                ".column4 = v.column4,.column10 = v0.column1},var v2 = v1.";
+                "output relation Rv0[TRt1]\n" +
+                "Rv0[v2] :- Rt1[TRt1{.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4}],Rt2[TRt2{.column1 = column1}],var v1 = TRt1{.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4},var v2 = v1.";
         this.testTranslation(query, program);
     }
 
@@ -84,13 +73,10 @@ public class JoinTest extends BaseQueriesTest {
         // mixing nulls and non-nulls
         String query = "create view v0 as SELECT DISTINCT * FROM t1 JOIN t4 ON t1.column1 = t4.column1";
         String program = this.header(false) +
-                "typedef Ttmp = Ttmp{column1:signed<64>, column2:string, column3:bool, column4:double, " +
-                "column10:Option<signed<64>>, column20:Option<string>}\n" +
+                "typedef Ttmp = Ttmp{column1:signed<64>, column2:string, column3:bool, column4:double, column10:Option<signed<64>>, column20:Option<string>}\n" +
                 this.relations(false) +
                 "output relation Rv0[Ttmp]\n" +
-                "Rv0[v2] :- Rt1[v],Rt4[v0],unwrapBool(a_eq_RN(v.column1, v0.column1)),true," +
-                "var v1 = Ttmp{.column1 = v.column1,.column2 = v.column2,.column3 = v.column3,.column4 = v.column4," +
-                ".column10 = v0.column1,.column20 = v0.column2},var v2 = v1.";
+                "Rv0[v2] :- Rt1[TRt1{.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4}],Rt4[TRt4{.column1 = Some{.x = column1},.column2 = column20}],var v1 = Ttmp{.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4,.column10 = Some{.x = column1},.column20 = column20},var v2 = v1.";
         this.testTranslation(query, program);
     }
 
@@ -98,13 +84,9 @@ public class JoinTest extends BaseQueriesTest {
     public void testJoinStarWNull() {
         String query = "create view v0 as SELECT DISTINCT * FROM t1 JOIN t2 ON t1.column1 = t2.column1";
         String program = this.header(true) +
-                "typedef Ttmp = Ttmp{column1:Option<signed<64>>, column2:Option<string>, column3:Option<bool>, " +
-                "column4:Option<double>, column10:Option<signed<64>>}\n" +
                 this.relations(true) +
-                "output relation Rv0[Ttmp]\n" +
-                "Rv0[v2] :- Rt1[v],Rt2[v0],unwrapBool(a_eq_NN(v.column1, v0.column1)),true," +
-                "var v1 = Ttmp{.column1 = v.column1,.column2 = v.column2,.column3 = v.column3,.column4 = v.column4," +
-                ".column10 = v0.column1},var v2 = v1.";
+                "output relation Rv0[TRt1]\n" +
+                "Rv0[v2] :- Rt1[TRt1{.column1 = Some{.x = column1},.column2 = column2,.column3 = column3,.column4 = column4}],Rt2[TRt2{.column1 = Some{.x = column1}}],var v1 = TRt1{.column1 = Some{.x = column1},.column2 = column2,.column3 = column3,.column4 = column4},var v2 = v1.";
         this.testTranslation(query, program, true);
     }
 
@@ -112,17 +94,12 @@ public class JoinTest extends BaseQueriesTest {
     public void testSelfJoin() {
         String query = "create view v0 as SELECT DISTINCT t1.column2, x.column3 FROM t1 JOIN (t1 AS x) ON t1.column1 = x.column1";
         String program = this.header(false) +
-                "typedef Ttmp = Ttmp{column1:signed<64>, column2:string, column3:bool, column4:double, " +
-                "column10:signed<64>, column20:string, column30:bool, column40:double}\n" +
-                "typedef TRtmp = TRtmp{column2:string, column3:bool}\n" +
+                "typedef Ttmp = Ttmp{column1:signed<64>, column2:string, column3:bool, column4:double, column20:string, column30:bool, column40:double}\n" +
+                "typedef TRx = TRx{column2:string, column3:bool}\n" +
                 this.relations(false) +
-                "relation Rtmp[TRtmp]\n" +
-                "output relation Rv0[TRtmp]\n" +
-                "Rv0[v3] :- Rt1[v],Rt1[v0],(v.column1 == v0.column1),true,var v1 = Ttmp{.column1 = v.column1," +
-                ".column2 = v.column2,.column3 = v.column3,.column4 = v.column4,.column10 = v0.column1," +
-                ".column20 = v0.column2,.column30 = v0.column3,.column40 = v0.column4}," +
-                "var v2 = TRtmp{.column2 = v.column2,.column3 = v0.column3},var v3 = v2.";
-        this.testTranslation(query, program, false);
+                "output relation Rv0[TRx]\n" +
+                "Rv0[v3] :- Rt1[TRt1{.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4}],Rt1[TRt1{.column1 = column1,.column2 = column20,.column3 = column30,.column4 = column40}],var v1 = Ttmp{.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4,.column20 = column20,.column30 = column30,.column40 = column40},var v2 = TRx{.column2 = v1.column2,.column3 = v1.column30},var v3 = v2.";
+                this.testTranslation(query, program, false);
     }
 
     @Test
@@ -130,9 +107,8 @@ public class JoinTest extends BaseQueriesTest {
         String query = "create view v0 as SELECT DISTINCT * FROM t1 NATURAL JOIN t2";
         String program = this.header(false) +
                 this.relations(false) +
-                "output relation Rv0[Tt1]\n" +
-                "Rv0[v2] :- Rt1[v],Rt2[v0],(true and (v.column1 == v0.column1))," +
-                "var v1 = Tt1{.column1 = v.column1,.column2 = v.column2,.column3 = v.column3,.column4 = v.column4},var v2 = v1.";
+                "output relation Rv0[TRt1]\n" +
+                "Rv0[v2] :- Rt1[TRt1{.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4}],Rt2[TRt2{.column1 = column1}],var v1 = TRt1{.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4},var v2 = v1.";
         this.testTranslation(query, program);
     }
 
@@ -141,26 +117,20 @@ public class JoinTest extends BaseQueriesTest {
         String query = "create view v0 as SELECT DISTINCT * FROM t1 NATURAL JOIN t2 WHERE column3";
         String program = this.header(false) +
                 this.relations(false) +
-                "output relation Rv0[Tt1]\n" +
-                "Rv0[v2] :- Rt1[v],Rt2[v0],(true and (v.column1 == v0.column1))," +
-                "var v1 = Tt1{.column1 = v.column1,.column2 = v.column2,.column3 = v.column3,.column4 = v.column4},v.column3,var v2 = v1.";
+                "output relation Rv0[TRt1]\n" +
+                "Rv0[v2] :- Rt1[TRt1{.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4}],Rt2[TRt2{.column1 = column1}],var v1 = TRt1{.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4},v1.column3,var v2 = v1.";
         this.testTranslation(query, program);
     }
 
     @Test
     public void testJoin() {
-        String query = "create view v0 as SELECT DISTINCT t0.column1, t1.column3 FROM t1 AS t0 JOIN t1 ON t0.column2 = t1.column2";
+        String query = "create view v0 as SELECT DISTINCT t0.column1, t1.column3 FROM t1 AS t0 JOIN t1 ON t1.column2 = t0.column2";
         String program = this.header(false) +
-                "typedef Ttmp = Ttmp{column1:signed<64>, column2:string, column3:bool, column4:double, " +
-                "column10:signed<64>, column20:string, column30:bool, column40:double}\n" +
-                "typedef TRtmp = TRtmp{column1:signed<64>, column3:bool}\n" +
+                "typedef Ttmp = Ttmp{column1:signed<64>, column2:string, column3:bool, column4:double, column10:signed<64>, column30:bool, column40:double}\n" +
+                "typedef TRt0 = TRt0{column1:signed<64>, column3:bool}\n" +
                 this.relations(false) +
-                "relation Rtmp[TRtmp]\n" +
-                "output relation Rv0[TRtmp]\n" +
-                "Rv0[v3] :- Rt1[v],Rt1[v0],(v.column2 == v0.column2),true," +
-                "var v1 = Ttmp{.column1 = v.column1,.column2 = v.column2,.column3 = v.column3,.column4 = v.column4," +
-                ".column10 = v0.column1,.column20 = v0.column2,.column30 = v0.column3,.column40 = v0.column4}," +
-                "var v2 = TRtmp{.column1 = v.column1,.column3 = v0.column3},var v3 = v2.";
+                "output relation Rv0[TRt0]\n" +
+                "Rv0[v3] :- Rt1[TRt1{.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4}],Rt1[TRt1{.column1 = column10,.column2 = column2,.column3 = column30,.column4 = column40}],var v1 = Ttmp{.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4,.column10 = column10,.column30 = column30,.column40 = column40},var v2 = TRt0{.column1 = v1.column1,.column3 = v1.column30},var v3 = v2.";
         this.testTranslation(query, program);
     }
 
@@ -171,8 +141,7 @@ public class JoinTest extends BaseQueriesTest {
                 "typedef Ttmp = Ttmp{column1:signed<64>, column2:string, column3:bool, column4:double, column10:signed<64>}\n" +
                 this.relations(false) +
                 "output relation Rv0[Ttmp]\n" +
-                "Rv0[v2] :- Rt1[v],Rt2[v0],true,var v1 = Ttmp{.column1 = v.column1,.column2 = v.column2,.column3 = v.column3,.column4 = v.column4,.column10 = v0.column1}," +
-                "var v2 = v1.";
+                "Rv0[v2] :- Rt1[TRt1{.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4}],Rt2[TRt2{.column1 = column10}],var v1 = Ttmp{.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4,.column10 = column10},var v2 = v1.";
         this.testTranslation(query, program);
     }
 
@@ -183,8 +152,7 @@ public class JoinTest extends BaseQueriesTest {
                 "typedef Ttmp = Ttmp{column1:Option<signed<64>>, column2:Option<string>, column3:Option<bool>, column4:Option<double>, column10:Option<signed<64>>}\n" +
                 this.relations(true) +
                 "output relation Rv0[Ttmp]\n" +
-                "Rv0[v2] :- Rt1[v],Rt2[v0],true,var v1 = Ttmp{.column1 = v.column1,.column2 = v.column2,.column3 = v.column3,.column4 = v.column4,.column10 = v0.column1}," +
-                "var v2 = v1.";
+                "Rv0[v2] :- Rt1[TRt1{.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4}],Rt2[TRt2{.column1 = column10}],var v1 = Ttmp{.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4,.column10 = column10},var v2 = v1.";
         this.testTranslation(query, program, true);
     }
 
@@ -192,19 +160,62 @@ public class JoinTest extends BaseQueriesTest {
     public void testJoinSubquery() {
         String query = "create view v0 as SELECT DISTINCT t1.column1, X.c FROM t1 CROSS JOIN (SELECT DISTINCT column1 AS c FROM t2 AS X)";
         String program = this.header(false) +
-                "typedef TRtmp = TRtmp{c:signed<64>}\n" +
+                "typedef TX = TX{c:signed<64>}\n" +
                 "typedef Ttmp = Ttmp{column1:signed<64>, column2:string, column3:bool, column4:double, c:signed<64>}\n" +
-                "typedef TRtmp1 = TRtmp1{column1:signed<64>, c:signed<64>}\n" +
+                "typedef TRtmp0 = TRtmp0{column1:signed<64>, c:signed<64>}\n" +
                 this.relations(true) +
-                "relation Rtmp[TRtmp]\n" +
-                "relation Rtmp0[TRtmp]\n" +
-                "relation Rtmp1[TRtmp1]\n" +
-                "output relation Rv0[TRtmp1]\n" +
-                "Rtmp0[v2] :- Rt2[v0],var v1 = TRtmp{.c = v0.column1},var v2 = v1.\n" +
-                "Rv0[v5] :- Rt1[v],Rtmp0[v2],true,var v3 = Ttmp{.column1 = v.column1,.column2 = v.column2," +
-                ".column3 = v.column3,.column4 = v.column4,.c = v2.c}," +
-                "var v4 = TRtmp1{.column1 = v.column1,.c = v2.c}," +
-                "var v5 = v4.";
+                "relation Rtmp[TX]\n" +
+                "output relation Rv0[TRtmp0]\n" +
+                "Rtmp[v2] :- Rt2[v0],var v1 = TX{.c = v0.column1},var v2 = v1.\n" +
+                "Rv0[v5] :- Rt1[TRt1{.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4}],Rtmp[TX{.c = c}],var v3 = Ttmp{.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4,.c = c},var v4 = TRtmp0{.column1 = v3.column1,.c = v3.c},var v5 = v4.";
+        this.testTranslation(query, program, false);
+    }
+
+    @Test
+    public void testNonEquiJoin() {
+        String query = "create view v0 as SELECT DISTINCT t1.column2, t2.column1 FROM " +
+                "t1 JOIN t2 ON t1.column1 < t2.column1";
+        String program = this.header(false) +
+                "typedef Ttmp = Ttmp{column1:signed<64>, column2:string, column3:bool, column4:double, column10:signed<64>}\n" +
+                "typedef TRtmp = TRtmp{column2:string, column1:signed<64>}\n" +
+                this.relations(true) +
+                "output relation Rv0[TRtmp]\n" +
+                "Rv0[v3] :- Rt1[v],Rt2[v0],(v.column1 < v0.column1)," +
+                "var v1 = Ttmp{.column1 = v.column1,.column2 = v.column2,.column3 = v.column3,.column4 = v.column4," +
+                ".column10 = v0.column1},var v2 = TRtmp{.column2 = v1.column2,.column1 = v1.column10},var v3 = v2.";
+        this.testTranslation(query, program, false);
+    }
+
+    @Test
+    public void testNonEquiJoin2() {
+        String query = "create view v0 as SELECT DISTINCT t1.column2, t4.column1 FROM " +
+                "t1 JOIN t4 ON t1.column1 < t4.column1";
+        String program = this.header(false) +
+                "typedef Ttmp = Ttmp{column1:signed<64>, column2:string, column3:bool, column4:double, " +
+                "column10:Option<signed<64>>, column20:Option<string>}\n" +
+                "typedef TRtmp = TRtmp{column2:string, column1:Option<signed<64>>}\n" +
+                this.relations(true) +
+                "output relation Rv0[TRtmp]\n" +
+                "Rv0[v3] :- Rt1[v],Rt4[v0],unwrapBool(a_lt_RN(v.column1, v0.column1))," +
+                "var v1 = Ttmp{.column1 = v.column1,.column2 = v.column2,.column3 = v.column3,.column4 = v.column4," +
+                ".column10 = v0.column1,.column20 = v0.column2}," +
+                "var v2 = TRtmp{.column2 = v1.column2,.column1 = v1.column10},var v3 = v2.";
+        this.testTranslation(query, program, false);
+    }
+
+    @Test
+    public void testInnerJoinSubquery() {
+        String query = "create view v0 as SELECT DISTINCT t1.column1, X.c FROM t1 " +
+                "JOIN ((SELECT DISTINCT column1 AS c FROM t2) AS X) " +
+                "ON t1.column1 = X.c WHERE column2 = 'a'";
+        String program = this.header(false) +
+                "typedef TX = TX{c:signed<64>}\n" +
+                "typedef TRtmp0 = TRtmp0{column1:signed<64>, c:signed<64>}\n" +
+                this.relations(true) +
+                "relation Rtmp[TX]\n" +
+                "output relation Rv0[TRtmp0]\n" +
+                "Rtmp[v2] :- Rt2[v0],var v1 = TX{.c = v0.column1},var v2 = v1.\n" +
+                "Rv0[v5] :- Rt1[TRt1{.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4}],Rtmp[TX{.c = column1}],var v3 = TRt1{.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4},(v3.column2 == \"a\"),var v4 = TRtmp0{.column1 = v3.column1,.c = v3.column1},var v5 = v4.";
         this.testTranslation(query, program, false);
     }
 
@@ -216,30 +227,64 @@ public class JoinTest extends BaseQueriesTest {
                 "         (SELECT DISTINCT column2 AS c FROM t1) c,\n" +
                 "         (SELECT DISTINCT column3 AS d FROM t1) d";
         String program = this.header(false) +
-                "typedef TRtmp = TRtmp{a:signed<64>}\n" +
+                "typedef TRb = TRb{a:signed<64>}\n" +
                 "typedef Ttmp = Ttmp{column1:signed<64>, column2:string, column3:bool, column4:double, a:signed<64>}\n" +
-                "typedef TRtmp1 = TRtmp1{c:string}\n" +
-                "typedef Ttmp3 = Ttmp3{column1:signed<64>, column2:string, column3:bool, column4:double, a:signed<64>, c:string}\n" +
-                "typedef TRtmp4 = TRtmp4{d:bool}\n" +
-                "typedef Ttmp6 = Ttmp6{column1:signed<64>, column2:string, column3:bool, column4:double, a:signed<64>, c:string, d:bool}\n" +
+                "typedef TRc = TRc{c:string}\n" +
+                "typedef Ttmp0 = Ttmp0{column1:signed<64>, column2:string, column3:bool, column4:double, a:signed<64>, c:string}\n" +
+                "typedef TRd = TRd{d:bool}\n" +
+                "typedef Ttmp1 = Ttmp1{column1:signed<64>, column2:string, column3:bool, column4:double, a:signed<64>, c:string, d:bool}\n" +
                 this.relations(false) +
-                "relation Rtmp[TRtmp]\n" +
-                "relation Rtmp0[TRtmp]\n" +
-                "relation Rtmp1[TRtmp1]\n" +
-                "relation Rtmp2[TRtmp1]\n" +
-                "relation Rtmp4[TRtmp4]\n" +
-                "relation Rtmp5[TRtmp4]\n" +
-                "output relation Rv0[Ttmp6]\n" +
-                "Rtmp0[v2] :- Rt1[v0],var v1 = TRtmp{.a = v0.column1},var v2 = v1.\n" +
-                "Rtmp2[v6] :- Rt1[v4],var v5 = TRtmp1{.c = v4.column2},var v6 = v5.\n" +
-                "Rtmp5[v10] :- Rt1[v8],var v9 = TRtmp4{.d = v8.column3},var v10 = v9.\n" +
-                "Rv0[v12] :- Rt1[v],Rtmp0[v2],true," +
-                "var v3 = Ttmp{.column1 = v.column1,.column2 = v.column2,.column3 = v.column3,.column4 = v.column4,.a = v2.a}," +
-                "Rtmp2[v6],true," +
-                "var v7 = Ttmp3{.column1 = v3.column1,.column2 = v3.column2,.column3 = v3.column3,.column4 = v3.column4,.a = v3.a,.c = v6.c}," +
-                "Rtmp5[v10],true," +
-                "var v11 = Ttmp6{.column1 = v7.column1,.column2 = v7.column2,.column3 = v7.column3,.column4 = v7.column4,.a = v7.a,.c = v7.c,.d = v10.d}," +
-                "var v12 = v11.";
+                "relation Rtmp[TRb]\n" +
+                "relation Rtmp0[TRc]\n" +
+                "relation Rtmp1[Ttmp]\n" +
+                "relation Rtmp2[TRd]\n" +
+                "relation Rtmp3[Ttmp0]\n" +
+                "output relation Rv0[Ttmp1]\n" +
+                "Rtmp[v2] :- Rt1[v0],var v1 = TRb{.a = v0.column1},var v2 = v1.\n" +
+                "Rtmp0[v6] :- Rt1[v4],var v5 = TRc{.c = v4.column2},var v6 = v5.\n" +
+                "Rtmp1[v7] :- Rt1[TRt1{.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4}],Rtmp[TRb{.a = a}],var v3 = Ttmp{.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4,.a = a},var v7 = v3.\n" +
+                "Rtmp2[v11] :- Rt1[v9],var v10 = TRd{.d = v9.column3},var v11 = v10.\n" +
+                "Rtmp3[v12] :- Rtmp1[Ttmp{.column1 = column10,.column2 = column20,.column3 = column30,.column4 = column40,.a = a0}],Rtmp0[TRc{.c = c}],var v8 = Ttmp0{.column1 = column10,.column2 = column20,.column3 = column30,.column4 = column40,.a = a0,.c = c},var v12 = v8.\n" +
+                "Rv0[v14] :- Rtmp3[Ttmp0{.column1 = column11,.column2 = column21,.column3 = column31,.column4 = column41,.a = a1,.c = c0}],Rtmp2[TRd{.d = d}],var v13 = Ttmp1{.column1 = column11,.column2 = column21,.column3 = column31,.column4 = column41,.a = a1,.c = c0,.d = d},var v14 = v13.";
+        this.testTranslation(query, program);
+    }
+
+    @Test
+    public void test2WayJoin() {
+        String query = "create view v0 as SELECT DISTINCT t2.column1, t4.column1 AS x FROM (t2 JOIN t4 ON t2.column1 = t4.column1)";
+        String program = this.header(false) +
+                "typedef Ttmp = Ttmp{column1:signed<64>, column10:Option<signed<64>>, column2:Option<string>}\n" +
+                "typedef TRtmp = TRtmp{column1:signed<64>, x:Option<signed<64>>}\n" +
+                this.relations(false) +
+                "output relation Rv0[TRtmp]\n" +
+                "Rv0[v3] :- Rt2[TRt2{.column1 = column1}],Rt4[TRt4{.column1 = Some{.x = column1},.column2 = column2}],var v1 = Ttmp{.column1 = column1,.column10 = Some{.x = column1},.column2 = column2},var v2 = TRtmp{.column1 = v1.column1,.x = v1.column10},var v3 = v2.";
+        this.testTranslation(query, program);
+    }
+
+    @Test
+    public void test3WayJoin() {
+        String query = "create view v0 as SELECT DISTINCT t1.column2, t2.column1, t4.column1 AS x FROM t1 JOIN " +
+                "(t2 JOIN t4 ON t2.column1 = t4.column1) ON t1.column1 = t2.column1";
+        String program = this.header(false) +
+                "typedef Ttmp = Ttmp{column1:signed<64>, column10:Option<signed<64>>, column2:Option<string>}\n" +
+                "typedef Ttmp0 = Ttmp0{column1:signed<64>, column2:string, column3:bool, column4:double, column100:Option<signed<64>>, column20:Option<string>}\n" +
+                "typedef TRtmp0 = TRtmp0{column2:string, column1:signed<64>, x:Option<signed<64>>}\n" +
+                this.relations(false) +
+                "relation Rtmp[Ttmp]\n" +
+                "output relation Rv0[TRtmp0]\n" +
+                "Rtmp[v3] :- Rt2[TRt2{.column1 = column1}],Rt4[TRt4{.column1 = Some{.x = column1},.column2 = column2}],var v2 = Ttmp{.column1 = column1,.column10 = Some{.x = column1},.column2 = column2},var v3 = v2.\n" +
+                "Rv0[v6] :- Rt1[TRt1{.column1 = column11,.column2 = column20,.column3 = column3,.column4 = column4}],Rtmp[Ttmp{.column1 = column11,.column10 = column100,.column2 = column21}],var v4 = Ttmp0{.column1 = column11,.column2 = column20,.column3 = column3,.column4 = column4,.column100 = column100,.column20 = column21},var v5 = TRtmp0{.column2 = v4.column2,.column1 = v4.column1,.x = v4.column100},var v6 = v5.";
+        this.testTranslation(query, program);
+    }
+
+    @Test
+    public void testLeftJoin() {
+        // TODO: this is not complete.
+        String query = "create view v0 as SELECT DISTINCT * FROM t1 LEFT JOIN t2 ON t1.column1 = t2.column1";
+        String program = this.header(false) +
+                this.relations(false) +
+                "output relation Rv0[TRt1]\n" +
+                "Rv0[v2] :- Rt1[TRt1{.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4}],Rt2[TRt2{.column1 = column1}],var v1 = TRt1{.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4},var v2 = v1.";
         this.testTranslation(query, program);
     }
 }

--- a/sql/src/test/java/ddlog/JooqProviderCalciteTest.java
+++ b/sql/src/test/java/ddlog/JooqProviderCalciteTest.java
@@ -21,6 +21,9 @@ public class JooqProviderCalciteTest extends JooqProviderTestBase {
 
     @BeforeClass
     public static void setup() throws IOException, DDlogException {
+        if (JooqProviderTestBase.skip)
+            throw new RuntimeException("Skipping");
+
         // SQL statements written in the Calcite dialect.
         String s1 = "create table hosts (id varchar(36), capacity integer, up boolean, primary key (id))";
         String v2 = "create view hostsv as select distinct * from hosts";

--- a/sql/src/test/java/ddlog/JooqProviderCalciteTest.java
+++ b/sql/src/test/java/ddlog/JooqProviderCalciteTest.java
@@ -4,6 +4,7 @@
  */
 package ddlog;
 
+import com.vmware.ddlog.DDlogHandle;
 import com.vmware.ddlog.DDlogJooqProvider;
 import com.vmware.ddlog.util.sql.*;
 import ddlogapi.DDlogException;
@@ -62,14 +63,14 @@ public class JooqProviderCalciteTest extends JooqProviderTestBase {
         indexStatements.add(createIndexHosts);
         indexStatements.add(testIndexParsing);
 
-        ddlogAPI = compileAndLoad(
+        ddhandle = new DDlogHandle(
                 ddl.stream().map(CalciteSqlStatement::new).collect(Collectors.toList()),
                 new CalciteToPrestoTranslator(),
                 indexStatements);
 
         ToH2Translator<CalciteSqlStatement> translator = new CalciteToH2Translator();
         // Initialise the data provider
-        provider = new DDlogJooqProvider(ddlogAPI,
+        provider = new DDlogJooqProvider(ddhandle,
                 Stream.concat(ddl.stream().map(x -> translator.toH2(new CalciteSqlStatement(x))),
                                 indexStatements.stream().map(H2SqlStatement::new))
                         .collect(Collectors.toList()));

--- a/sql/src/test/java/ddlog/JooqProviderPrestoTest.java
+++ b/sql/src/test/java/ddlog/JooqProviderPrestoTest.java
@@ -24,6 +24,7 @@
 package ddlog;
 
 import com.vmware.ddlog.DDlogJooqProvider;
+import com.vmware.ddlog.DDlogHandle;
 import com.vmware.ddlog.util.sql.*;
 import ddlogapi.DDlogException;
 import org.jooq.impl.DSL;
@@ -77,14 +78,14 @@ public class JooqProviderPrestoTest extends JooqProviderTestBase {
         indexStatements.add(createIndexNotNull);
         indexStatements.add(createIndexHosts);
 
-        ddlogAPI = compileAndLoad(
+        ddhandle = new DDlogHandle(
                 ddl.stream().map(PrestoSqlStatement::new).collect(Collectors.toList()),
                 sql -> sql,
                 indexStatements);
 
         ToH2Translator<PrestoSqlStatement> translator = new PrestoToH2Translator();
         // Initialise the data provider
-        provider = new DDlogJooqProvider(ddlogAPI,
+        provider = new DDlogJooqProvider(ddhandle,
                 Stream.concat(ddl.stream().map(x -> translator.toH2(new PrestoSqlStatement(x))),
                                 indexStatements.stream().map(H2SqlStatement::new))
                         .collect(Collectors.toList()));

--- a/sql/src/test/java/ddlog/JooqProviderPrestoTest.java
+++ b/sql/src/test/java/ddlog/JooqProviderPrestoTest.java
@@ -37,9 +37,11 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class JooqProviderPrestoTest extends JooqProviderTestBase {
-
     @BeforeClass
     public static void setup() throws IOException, DDlogException {
+        if (JooqProviderTestBase.skip)
+            throw new RuntimeException("Skipping");
+
         String s1 = "create table hosts (id varchar(36) with (primary_key = true), capacity integer, up boolean)";
         String v2 = "create view hostsv as select distinct * from hosts";
         String v1 = "create view good_hosts as select distinct * from hosts where capacity < 10";

--- a/sql/src/test/java/ddlog/JooqProviderTestBase.java
+++ b/sql/src/test/java/ddlog/JooqProviderTestBase.java
@@ -61,7 +61,6 @@ import static org.junit.Assert.assertThrows;
  * an example.
  */
 public abstract class JooqProviderTestBase {
-
     @Nullable
     protected static DDlogAPI ddlogAPI;
     protected static DSLContext create;
@@ -72,6 +71,7 @@ public abstract class JooqProviderTestBase {
     private final Record test1 = create.newRecord(field1, field2, field3);
     private final Record test2 = create.newRecord(field1, field2, field3);
     private final Record test3 = create.newRecord(field1, field2, field3);
+    static final boolean skip = true;  // Set to true to skip these tests
 
     public JooqProviderTestBase() {
         test1.setValue(field1, "n1");

--- a/sql/src/test/java/ddlog/JooqProviderTestBase.java
+++ b/sql/src/test/java/ddlog/JooqProviderTestBase.java
@@ -24,11 +24,7 @@
 package ddlog;
 
 import com.vmware.ddlog.DDlogJooqProvider;
-import com.vmware.ddlog.ir.DDlogProgram;
-import com.vmware.ddlog.translator.Translator;
-import com.vmware.ddlog.util.sql.SqlStatement;
-import com.vmware.ddlog.util.sql.ToPrestoTranslator;
-import ddlogapi.DDlogAPI;
+import com.vmware.ddlog.DDlogHandle;
 import ddlogapi.DDlogException;
 import org.jooq.DSLContext;
 import org.jooq.Field;
@@ -41,11 +37,6 @@ import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 
 import javax.annotation.Nullable;
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.util.List;
 import java.util.Objects;
 
 import static junit.framework.TestCase.*;
@@ -62,7 +53,7 @@ import static org.junit.Assert.assertThrows;
  */
 public abstract class JooqProviderTestBase {
     @Nullable
-    protected static DDlogAPI ddlogAPI;
+    protected static DDlogHandle ddhandle;
     protected static DSLContext create;
     protected static DDlogJooqProvider provider;
     private final Field<String> field1 = field("id", String.class);
@@ -71,7 +62,7 @@ public abstract class JooqProviderTestBase {
     private final Record test1 = create.newRecord(field1, field2, field3);
     private final Record test2 = create.newRecord(field1, field2, field3);
     private final Record test3 = create.newRecord(field1, field2, field3);
-    static final boolean skip = true;  // Set to true to skip these tests
+    static final boolean skip = false;  // Set to true to skip these tests
 
     public JooqProviderTestBase() {
         test1.setValue(field1, "n1");
@@ -99,7 +90,7 @@ public abstract class JooqProviderTestBase {
 
     @AfterClass
     public static void teardown() throws DDlogException{
-        Objects.requireNonNull(ddlogAPI).stop();
+        Objects.requireNonNull(ddhandle).stop();
     }
 
     /**
@@ -686,25 +677,4 @@ public abstract class JooqProviderTestBase {
         assertTrue(readFromInput.contains(test3));
     }
 
-    // Unfortunately, `create index` statements have to be passed separately, because neither Calcite nor Presto
-    // supports them, so we must pass them as SQL strings.
-    public static <R extends SqlStatement> DDlogAPI compileAndLoad(
-            final List<R> ddl, final ToPrestoTranslator<R> translator,
-            final List<String> createIndexStatements) throws IOException, DDlogException {
-        final Translator t = new Translator();
-        ddl.forEach(x -> t.translateSqlStatement(translator.toPresto(x)));
-        createIndexStatements.forEach(t::translateCreateIndexStatement);
-
-        final DDlogProgram dDlogProgram = t.getDDlogProgram();
-        final String fileName = "/tmp/program.dl";
-        File tmp = new File(fileName);
-        BufferedWriter bw = new BufferedWriter(new FileWriter(tmp));
-        bw.write(dDlogProgram.toString());
-        bw.close();
-        DDlogAPI.CompilationResult result = new DDlogAPI.CompilationResult(true);
-        DDlogAPI.compileDDlogProgram(fileName, result, "../lib", "./lib");
-        if (!result.isSuccess())
-            throw new RuntimeException("Failed to compile ddlog program");
-        return DDlogAPI.loadDDlog();
-    }
 }

--- a/sql/src/test/java/ddlog/NegativeTest.java
+++ b/sql/src/test/java/ddlog/NegativeTest.java
@@ -29,54 +29,122 @@ import com.vmware.ddlog.translator.TranslationException;
 import org.junit.Test;
 
 public class NegativeTest extends BaseQueriesTest {
-    @Test(expected = TranslationException.class)
-    public void testMixAggregate() {
+    void expectException(String query, String exception) {
+        try {
+            this.testTranslation(query, "");
+        } catch (TranslationException ex) {
+            String message = ex.getMessage();
+            //System.out.println(message);
+            if (message.startsWith(exception))
+                return;
+            throw new RuntimeException("Exception message is different: " + message + " instead of " + exception);
+        }
+        throw new RuntimeException("Test should have failed");
+    }
+    
+    @Test
+    public void mixAggregateTest() {
         String query = "create view v0 as select max(column1), column2 from t1";
-        this.testTranslation(query, "");
+        this.expectException(query, "SELECT with a mix of aggregates and non-aggregates.");
     }
 
-    @Test(expected = TranslationException.class)
-    public void testMixAggregate1() {
+    @Test
+    public void mixAggregate1Test() {
         String query = "create view v0 as select min(column1) + column2 from t1";
-        this.testTranslation(query, "");
+        this.expectException(query, "Operation between aggregated and non-aggregated values");
     }
 
-    @Test(expected = TranslationException.class)
-    public void testMixAggregate2() {
+    @Test
+    public void mixAggregate2Test() {
         String query = "create view v0 as select min(min(column1)) from t1";
-        this.testTranslation(query, "");
+        this.expectException(query, "Nested aggregation");
     }
 
-    @Test(expected = TranslationException.class)
+    @Test
+    public void testAmbiguousJoin() {
+        String query = "create view v0 as SELECT COUNT(t1.column2) as ct FROM t1 JOIN t2 ON column1 = t2.column1";
+        this.expectException(query, "Column name 'column1' is ambiguous; could be in either joined table ");
+    }
+
+    @Test
+    public void testNoSuchColumn() {
+        String query = "create view v0 as SELECT DISTINCT t1.column2, t2.column1, t3.column1 AS x FROM t1 JOIN " +
+                "(t2 JOIN t3 ON t2.column1 = t3.column1) ON t1.column1 = t2.column1";
+        this.expectException(query, "Column 'column1' not present in 't3'");
+    }
+
+    @Test
+    public void testNoSuchTable() {
+        String query = "create view v0 as SELECT DISTINCT t1.column2, t2.column1, t3.column1 AS x FROM t1 JOIN " +
+                "(t2 JOIN t4 ON t2.column1 = t3.column1) ON t1.column1 = t2.column1";
+        this.expectException(query, "Column 't3.column1' not in one of the joined relation");
+    }
+
+    @Test
     public void testMixAggregate3() {
         String query = "create view v0 as select *, min(column1) from t1";
-        this.testTranslation(query, "");
+        this.expectException(query, "SELECT with a mix of aggregates and non-aggregates.");
     }
 
-    @Test(expected = TranslationException.class)
+    @Test
     public void testSelectStartGroupBy() {
         String query = "create view v0 as select *, min(column1) from t1 group by column2";
-        this.testTranslation(query, "");
+        this.expectException(query, "SELECT with a mix of aggregates and non-aggregates.");
     }
 
-    @Test(expected = TranslationException.class)
+    @Test
     public void windowGroupByTest() {
         String query = "create view v1 as\n" +
                 "SELECT column2, SUM(column1), SUM(SUM(column1)) OVER (PARTITION by column3) FROM t1 GROUP BY column2";
-        this.testTranslation(query, "");
+        this.expectException(query, "SELECT with a mix of aggregates and non-aggregates.");
     }
 
-    @Test(expected = TranslationException.class)
+    @Test
     public void noColumnTest() {
         // no column2 in t2
         String query = "create view v0 as SELECT DISTINCT t1.column1, X.c FROM t1 CROSS JOIN (SELECT DISTINCT column2 AS c FROM t2 AS X)";
-        this.testTranslation(query, "");
+        this.expectException(query, "Could not resolve identifier");
     }
 
-    @Test(expected = TranslationException.class)
+    @Test
+    public void nestedAliasTest() {
+        String query = "CREATE VIEW v3 AS (SELECT DISTINCT X.column1 FROM (t2 AS X) AS Y)";
+        // AS binds to the right, so this query is parsed as
+        // CREATE VIEW v3 AS (SELECT DISTINCT X.column1 FROM ((t2 AS X) AS Y))
+        this.expectException(query, "Could not resolve relation 'X'");
+    }
+
+    @Test
     public void unionTest() {
-        // no column2 in t2
         String query = "create view v0 as SELECT DISTINCT t1.column1 FROM t1 UNION ALL SELECT DISTINCT t2.column1 FROM t1";
-        this.testTranslation(query, "");
+        this.expectException(query, "UNION ALL not supported");
+    }
+
+    @Test
+    public void duplicateColumnTest() {
+        String query = "create view v0 as select DISTINCT column1, column2 as column1 from t1";
+        this.expectException(query, "Field name column1:string is duplicated");
+    }
+
+    @Test
+    public void testRemovedColumn1() {
+        String query = "create view v0 as SELECT DISTINCT t1.column1 AS x, t2.column2 as y FROM t1 AS t2";
+        this.expectException(query, "Could not resolve relation");
+    }
+
+    @Test
+    public void testIndexException() {
+        String query = "create index idx_name on non_existent_table (column1)";
+        try {
+            this.testIndexTranslation(query, "junk program", true);
+        } catch (Exception e) {
+            assert e.getMessage().equals("Cannot find base table that index refers to");
+        }
+    }
+
+    @Test
+    public void testCastDateToBool() {
+        String query = "create view v0 as SELECT DISTINCT CAST(t3.d AS BOOLEAN) AS b FROM t3";
+        this.expectException(query, "Illegal cast");
     }
 }

--- a/sql/src/test/java/ddlog/SetTest.java
+++ b/sql/src/test/java/ddlog/SetTest.java
@@ -33,12 +33,10 @@ public class SetTest extends BaseQueriesTest {
         String query = "create view v0 as SELECT DISTINCT column1 FROM t1 UNION SELECT DISTINCT column1 FROM t2";
         String program = this.header(false) +
                 this.relations(false) +
-                "relation Rtmp[Tt2]\n" +
-                "relation Rtmp0[Tt2]\n" +
-                "relation Runion[Tt2]\n" +
-                "output relation Rv0[Tt2]\n" +
-                "Runion[v3] :- Rt1[v],var v0 = Tt2{.column1 = v.column1},var v3 = v0.\n" +
-                "Runion[v3] :- Rt2[v1],var v2 = Tt2{.column1 = v1.column1},var v3 = v2.\n" +
+                "relation Runion[TRt2]\n" +
+                "output relation Rv0[TRt2]\n" +
+                "Runion[v3] :- Rt1[v],var v0 = TRt2{.column1 = v.column1},var v3 = v0.\n" +
+                "Runion[v3] :- Rt2[v1],var v2 = TRt2{.column1 = v1.column1},var v3 = v2.\n" +
                 "Rv0[v4] :- Runion[v3],var v4 = v3.";
         this.testTranslation(query, program);
     }
@@ -49,12 +47,10 @@ public class SetTest extends BaseQueriesTest {
         String program = this.header(false) +
                 "typedef TRtmp0 = TRtmp0{column1:Option<signed<64>>}\n" +
                 this.relations(false) +
-                "relation Rtmp[Tt2]\n" +
-                "relation Rtmp0[TRtmp0]\n" +
-                "relation Rsource[Tt2]\n" +
+                "relation Rsource[TRt2]\n" +
                 "relation Runion[TRtmp0]\n" +
                 "output relation Rv0[TRtmp0]\n" +
-                "Rsource[v3] :- Rt1[v],var v0 = Tt2{.column1 = v.column1},var v3 = v0.\n" +
+                "Rsource[v3] :- Rt1[v],var v0 = TRt2{.column1 = v.column1},var v3 = v0.\n" +
                 "Runion[v4] :- Rsource[v3],var v0 = TRtmp0{.column1 = Some{.x = v3.column1}},var v4 = v0.\n" +
                 "Runion[v4] :- Rt4[v1],var v2 = TRtmp0{.column1 = v1.column1},var v4 = v2.\n" +
                 "Rv0[v5] :- Runion[v4],var v5 = v4.";
@@ -66,14 +62,12 @@ public class SetTest extends BaseQueriesTest {
         String query = "create view v0 as SELECT DISTINCT column1 FROM t1 INTERSECT SELECT DISTINCT column1 FROM t2";
         String program = this.header(false) +
                 this.relations(false) +
-                "relation Rtmp[Tt2]\n" +
-                "relation Rtmp0[Tt2]\n" +
-                "relation Rintersect[Tt2]\n" +
-                "relation Rintersect1[Tt2]\n" +
-                "output relation Rv0[Tt2]\n" +
-                "Rintersect[v3] :- Rt1[v],var v0 = Tt2{.column1 = v.column1},var v3 = v0.\n" +
-                "Rintersect1[v5] :- Rt2[v1],var v2 = Tt2{.column1 = v1.column1},var v5 = v2.\n" +
-                "Rv0[v6] :- Rintersect[v4],Rintersect1[v4],var v6 = v4.";
+                "relation Rintersect[TRt2]\n" +
+                "relation Rintersect0[TRt2]\n" +
+                "output relation Rv0[TRt2]\n" +
+                "Rintersect[v3] :- Rt1[v],var v0 = TRt2{.column1 = v.column1},var v3 = v0.\n" +
+                "Rintersect0[v5] :- Rt2[v1],var v2 = TRt2{.column1 = v1.column1},var v5 = v2.\n" +
+                "Rv0[v6] :- Rintersect[v4],Rintersect0[v4],var v6 = v4.";
         this.testTranslation(query, program);
     }
 
@@ -83,16 +77,14 @@ public class SetTest extends BaseQueriesTest {
         String program = this.header(false) +
                 "typedef TRtmp0 = TRtmp0{column1:Option<signed<64>>}\n" +
                 this.relations(false) +
-                "relation Rtmp[Tt2]\n" +
-                "relation Rtmp0[TRtmp0]\n" +
-                "relation Rsource[Tt2]\n" +
+                "relation Rsource[TRt2]\n" +
                 "relation Rintersect[TRtmp0]\n" +
-                "relation Rintersect1[TRtmp0]\n" +
+                "relation Rintersect0[TRtmp0]\n" +
                 "output relation Rv0[TRtmp0]\n" +
-                "Rsource[v3] :- Rt1[v],var v0 = Tt2{.column1 = v.column1},var v3 = v0.\n" +
+                "Rsource[v3] :- Rt1[v],var v0 = TRt2{.column1 = v.column1},var v3 = v0.\n" +
                 "Rintersect[v4] :- Rsource[v3],var v0 = TRtmp0{.column1 = Some{.x = v3.column1}},var v4 = v0.\n" +
-                "Rintersect1[v6] :- Rt4[v1],var v2 = TRtmp0{.column1 = v1.column1},var v6 = v2.\n" +
-                "Rv0[v7] :- Rintersect[v5],Rintersect1[v5],var v7 = v5.";
+                "Rintersect0[v6] :- Rt4[v1],var v2 = TRtmp0{.column1 = v1.column1},var v6 = v2.\n" +
+                "Rv0[v7] :- Rintersect[v5],Rintersect0[v5],var v7 = v5.";
         this.testTranslation(query, program);
     }
 
@@ -101,12 +93,10 @@ public class SetTest extends BaseQueriesTest {
         String query = "create view v0 as SELECT DISTINCT column1 FROM t1 EXCEPT SELECT DISTINCT column1 FROM t2";
         String program = this.header(false) +
                 this.relations(false) +
-                "relation Rtmp[Tt2]\n" +
-                "relation Rtmp0[Tt2]\n" +
-                "relation Rexcept[Tt2]\n" +
-                "output relation Rv0[Tt2]\n" +
-                "Rexcept[v3] :- Rt2[v1],var v2 = Tt2{.column1 = v1.column1},var v3 = v2.\n" +
-                "Rv0[v4] :- Rt1[v],var v0 = Tt2{.column1 = v.column1},var v3 = v0,not Rexcept[v3],var v4 = v0.";
+                "relation Rexcept[TRt2]\n" +
+                "output relation Rv0[TRt2]\n" +
+                "Rexcept[v3] :- Rt2[v1],var v2 = TRt2{.column1 = v1.column1},var v3 = v2.\n" +
+                "Rv0[v4] :- Rt1[v],var v0 = TRt2{.column1 = v.column1},var v3 = v0,not Rexcept[v3],var v4 = v0.";
         this.testTranslation(query, program);
     }
 
@@ -121,12 +111,10 @@ public class SetTest extends BaseQueriesTest {
         String query = "create view v0 as SELECT DISTINCT column1 FROM t1 UNION SELECT DISTINCT column1 FROM t2";
         String program = this.header(true) +
                 this.relations(true) +
-                "relation Rtmp[Tt2]\n" +
-                "relation Rtmp0[Tt2]\n" +
-                "relation Runion[Tt2]\n" +
-                "output relation Rv0[Tt2]\n" +
-                "Runion[v3] :- Rt1[v],var v0 = Tt2{.column1 = v.column1},var v3 = v0.\n" +
-                "Runion[v3] :- Rt2[v1],var v2 = Tt2{.column1 = v1.column1},var v3 = v2.\n" +
+                "relation Runion[TRt2]\n" +
+                "output relation Rv0[TRt2]\n" +
+                "Runion[v3] :- Rt1[v],var v0 = TRt2{.column1 = v.column1},var v3 = v0.\n" +
+                "Runion[v3] :- Rt2[v1],var v2 = TRt2{.column1 = v1.column1},var v3 = v2.\n" +
                 "Rv0[v4] :- Runion[v3],var v4 = v3.";
         this.testTranslation(query, program, true);
     }
@@ -137,12 +125,10 @@ public class SetTest extends BaseQueriesTest {
         String program = this.header(false) +
                 "typedef TRtmp0 = TRtmp0{column1:Option<signed<64>>}\n" +
                 this.relations(false) +
-                "relation Rtmp[Tt2]\n" +
-                "relation Rtmp0[TRtmp0]\n" +
-                "relation Rsource[Tt2]\n" +
+                "relation Rsource[TRt2]\n" +
                 "relation Rexcept[TRtmp0]\n" +
                 "output relation Rv0[TRtmp0]\n" +
-                "Rsource[v3] :- Rt1[v],var v0 = Tt2{.column1 = v.column1},var v3 = v0.\n" +
+                "Rsource[v3] :- Rt1[v],var v0 = TRt2{.column1 = v.column1},var v3 = v0.\n" +
                 "Rexcept[v4] :- Rt4[v1],var v2 = TRtmp0{.column1 = v1.column1},var v4 = v2.\n" +
                 "Rv0[v5] :- Rsource[v3],var v0 = TRtmp0{.column1 = Some{.x = v3.column1}},var v4 = v0,not Rexcept[v4],var v5 = v0.";
         this.testTranslation(query, program, false);
@@ -154,14 +140,12 @@ public class SetTest extends BaseQueriesTest {
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{column1:signed<64>, column2:string}\n" +
                 this.relations(false) +
-                "relation Rtmp[TRtmp]\n" +
-                "relation Rtmp0[Tt4]\n" +
                 "relation Rsource[TRtmp]\n" +
-                "relation Rexcept[Tt4]\n" +
-                "output relation Rv0[Tt4]\n" +
+                "relation Rexcept[TRt4]\n" +
+                "output relation Rv0[TRt4]\n" +
                 "Rsource[v3] :- Rt1[v],var v0 = TRtmp{.column1 = v.column1,.column2 = v.column2},var v3 = v0.\n" +
-                "Rexcept[v4] :- Rt4[v1],var v2 = Tt4{.column1 = v1.column1,.column2 = v1.column2},var v4 = v2.\n" +
-                "Rv0[v5] :- Rsource[v3],var v0 = Tt4{.column1 = Some{.x = v3.column1},.column2 = Some{.x = v3.column2}}," +
+                "Rexcept[v4] :- Rt4[v1],var v2 = TRt4{.column1 = v1.column1,.column2 = v1.column2},var v4 = v2.\n" +
+                "Rv0[v5] :- Rsource[v3],var v0 = TRt4{.column1 = Some{.x = v3.column1},.column2 = Some{.x = v3.column2}}," +
                 "var v4 = v0,not Rexcept[v4],var v5 = v0.";
         this.testTranslation(query, program, false);
     }

--- a/sql/src/test/java/ddlog/SimpleQueriesTest.java
+++ b/sql/src/test/java/ddlog/SimpleQueriesTest.java
@@ -34,9 +34,9 @@ public class SimpleQueriesTest extends BaseQueriesTest {
     public void arrayTest() {
         String query = "create table a(column1 integer not null, column2 integer not null, column3 integer array not null)";
         String program = this.header(false) +
-                "typedef Ta = Ta{column1:signed<64>, column2:signed<64>, column3:Vec<signed<64>>}\n" +
+                "typedef TRa = TRa{column1:signed<64>, column2:signed<64>, column3:Vec<signed<64>>}\n" +
                 this.relations(false) +
-                "input relation Ra[Ta]\n";
+                "input relation Ra[TRa]\n";
         this.testTranslation(query, program);
     }
 
@@ -45,10 +45,9 @@ public class SimpleQueriesTest extends BaseQueriesTest {
         String query = "create view v0 as select distinct column1 from t1 where column2 IN ('a', 'b')";
         String program = this.header(false) +
                 this.relations(false) +
-                "relation Rtmp[Tt2]\n" +
-                "output relation Rv0[Tt2]\n" +
+                "output relation Rv0[TRt2]\n" +
                 "Rv0[v1] :- Rt1[v],vec_contains(vec_push_imm(vec_push_imm(vec_empty(), \"a\"), \"b\"), v.column2)," +
-                "var v0 = Tt2{.column1 = v.column1},var v1 = v0.";
+                "var v0 = TRt2{.column1 = v.column1},var v1 = v0.";
         this.testTranslation(query, program);
     }
 
@@ -62,17 +61,17 @@ public class SimpleQueriesTest extends BaseQueriesTest {
                 "import sql\n" +
                 "import sqlop\n" +
                 "\n" +
-                "typedef Tt1 = Tt1{column1:signed<64>, column2:string, column3:bool, column4:double}\n" +
-                "typedef Tt2 = Tt2{column1:signed<64>}\n" +
-                "typedef Tt3 = Tt3{d:Date, t:Time, dt:DateTime}\n" +
-                "typedef Tt4 = Tt4{column1:Option<signed<64>>, column2:Option<string>}\n" +
-                "typedef Ta = Ta{column1:signed<64>, column2:signed<64>, column3:Vec<signed<64>>}\n" +
+                "typedef TRt1 = TRt1{column1:signed<64>, column2:string, column3:bool, column4:double}\n" +
+                "typedef TRt2 = TRt2{column1:signed<64>}\n" +
+                "typedef TRt3 = TRt3{d:Date, t:Time, dt:DateTime}\n" +
+                "typedef TRt4 = TRt4{column1:Option<signed<64>>, column2:Option<string>}\n" +
+                "typedef TRa = TRa{column1:signed<64>, column2:signed<64>, column3:Vec<signed<64>>}\n" +
                 "\n" +
-                "input relation Rt1[Tt1]\n" +
-                "input relation Rt2[Tt2]\n" +
-                "input relation Rt3[Tt3]\n" +
-                "input relation Rt4[Tt4]\n" +
-                "input relation Ra[Ta] primary key (row) (row.column1, row.column2, row.column3)\n";
+                "input relation Rt1[TRt1]\n" +
+                "input relation Rt2[TRt2]\n" +
+                "input relation Rt3[TRt3]\n" +
+                "input relation Rt4[TRt4]\n" +
+                "input relation Ra[TRa] primary key (row) (row.column1, row.column2, row.column3)\n";
         this.testTranslation(query, program, false);
     }
 
@@ -82,12 +81,11 @@ public class SimpleQueriesTest extends BaseQueriesTest {
                 "create table a(column1 integer not null, column2 integer not null, column3 integer array not null)",
                 "create view v0 as select distinct column1 from a where array_contains(column3, column1)");
         String program = this.header(false) +
-                "typedef Ta = Ta{column1:signed<64>, column2:signed<64>, column3:Vec<signed<64>>}\n" +
+                "typedef TRa = TRa{column1:signed<64>, column2:signed<64>, column3:Vec<signed<64>>}\n" +
                 this.relations(false) +
-                "input relation Ra[Ta]\n" +
-                "relation Rtmp[Tt2]\n" +
-                "output relation Rv0[Tt2]\n" +
-                "Rv0[v1] :- Ra[v],sql_array_contains(v.column3, v.column1),var v0 = Tt2{.column1 = v.column1},var v1 = v0.";
+                "input relation Ra[TRa]\n" +
+                "output relation Rv0[TRt2]\n" +
+                "Rv0[v1] :- Ra[v],sql_array_contains(v.column3, v.column1),var v0 = TRt2{.column1 = v.column1},var v1 = v0.";
         this.testTranslation(queries, program, false);
     }
 
@@ -97,56 +95,18 @@ public class SimpleQueriesTest extends BaseQueriesTest {
         String program = this.header(false) +
             "typedef TRtmp = TRtmp{column1:signed<64>, column2:string}\n" +
             this.relations(false) +
-            "relation Rtmp[TRtmp]\n" +
             "output relation Rv0[TRtmp]\n" +
             "Rv0[v1] :- Rt1[v],var v0 = TRtmp{.column1 = v.column1,.column2 = v.column2},var v1 = v0.";
         this.testTranslation(query, program);
     }
 
-    @Test
-    public void testSelectStar() {
-        String query = "create view v0 as select DISTINCT *, column1 as C1 from t1";
-        String program = this.header(false) +
-                "typedef TRtmp = TRtmp{" +
-                "column1:signed<64>, column2:string, column3:bool, column4:double, c1:signed<64>}\n" +
-                this.relations(false) +
-                "relation Rtmp[TRtmp]\n" +
-                "output relation Rv0[TRtmp]\n" +
-                "Rv0[v1] :- Rt1[v],var v0 = TRtmp{" +
-                ".column1 = v.column1,.column2 = v.column2,.column3 = v.column3,.column4 = v.column4,.c1 = v.column1}," +
-                "var v1 = v0.";
-        this.testTranslation(query, program);
-    }
-
-    @Test
-    public void test2SelectStar() {
-        String query0 = "create view v0 as select DISTINCT *, column1 as C1 from t1";
-        String query1 = "create view v1 as select DISTINCT *, column1 as C1 from t1";
-        String program = this.header(false) +
-                "typedef TRtmp = TRtmp{" +
-                "column1:signed<64>, column2:string, column3:bool, column4:double, c1:signed<64>}\n" +
-                this.relations(false) +
-                "relation Rtmp[TRtmp]\n" +
-                "output relation Rv0[TRtmp]\n" +
-                "relation Rtmp0[TRtmp]\n" +
-                "output relation Rv1[TRtmp]\n" +
-                "Rv0[v1] :- Rt1[v],var v0 = TRtmp{" +
-                ".column1 = v.column1,.column2 = v.column2,.column3 = v.column3,.column4 = v.column4,.c1 = v.column1}," +
-                "var v1 = v0.\n" +
-                "Rv1[v1] :- Rt1[v],var v0 = TRtmp{" +
-                ".column1 = v.column1,.column2 = v.column2,.column3 = v.column3,.column4 = v.column4,.c1 = v.column1}," +
-                "var v1 = v0.";
-        this.testTranslation(Arrays.asList(query0, query1), program, false);
-    }
-
-    @Test
+   @Test
     public void testSelectWNull() {
         String query = "create view v0 as select distinct column1, column2 from t1";
         String program = this.header(true) +
             this.relations(true) +
-            "relation Rtmp[Tt4]\n" +
-            "output relation Rv0[Tt4]\n" +
-            "Rv0[v1] :- Rt1[v],var v0 = Tt4{.column1 = v.column1,.column2 = v.column2},var v1 = v0.";
+            "output relation Rv0[TRt4]\n" +
+            "Rv0[v1] :- Rt1[v],var v0 = TRt4{.column1 = v.column1,.column2 = v.column2},var v1 = v0.";
         this.testTranslation(query, program, true);
     }
 
@@ -155,7 +115,7 @@ public class SimpleQueriesTest extends BaseQueriesTest {
         String query = "create view v0 as select distinct * from t1";
         String program = this.header(false) +
                 this.relations(false) +
-                "output relation Rv0[Tt1]\n" +
+                "output relation Rv0[TRt1]\n" +
                 "Rv0[v0] :- Rt1[v],var v0 = v.";
         this.testTranslation(query, program);
     }
@@ -165,7 +125,7 @@ public class SimpleQueriesTest extends BaseQueriesTest {
         String query = "create view v0 as select distinct * from t1";
         String program = this.header(true) +
             this.relations(true) +
-            "output relation Rv0[Tt1]\n" +
+            "output relation Rv0[TRt1]\n" +
             "Rv0[v0] :- Rt1[v],var v0 = v.";
         this.testTranslation(query, program, true);
     }
@@ -175,7 +135,7 @@ public class SimpleQueriesTest extends BaseQueriesTest {
         String query = "create view v1 as select distinct * from t1 where column1 = 10";
         String program = this.header(false) +
                 this.relations(false) +
-                "output relation Rv1[Tt1]\n" +
+                "output relation Rv1[TRt1]\n" +
                 "Rv1[v0] :- Rt1[v],(v.column1 == 64'sd10),var v0 = v.";
         this.testTranslation(query, program);
     }
@@ -185,7 +145,7 @@ public class SimpleQueriesTest extends BaseQueriesTest {
         String query = "create view v1 as select distinct * from t1 where column1 = 10";
         String program = this.header(true) +
             this.relations(true) +
-            "output relation Rv1[Tt1]\n" +
+            "output relation Rv1[TRt1]\n" +
             "Rv1[v0] :- Rt1[v],unwrapBool(a_eq_NR(v.column1, 64'sd10)),var v0 = v.";
         this.testTranslation(query, program, true);
     }
@@ -195,7 +155,7 @@ public class SimpleQueriesTest extends BaseQueriesTest {
         String query = "create view v2 as select distinct * from t1 where column1 = 10 and column2 = 'something'";
         String program = this.header(false) +
                 this.relations(false) +
-                "output relation Rv2[Tt1]\n" +
+                "output relation Rv2[TRt1]\n" +
                 "Rv2[v0] :- Rt1[v],((v.column1 == 64'sd10) and (v.column2 == \"something\")),var v0 = v.";
         this.testTranslation(query, program);
     }
@@ -205,7 +165,7 @@ public class SimpleQueriesTest extends BaseQueriesTest {
         String query = "create view v2 as select distinct * from t1 where column1 = 10 and column2 = 'something'";
         String program = this.header(true) +
             this.relations(true) +
-            "output relation Rv2[Tt1]\n" +
+            "output relation Rv2[TRt1]\n" +
             "Rv2[v0] :- Rt1[v],unwrapBool(b_and_NN(a_eq_NR(v.column1, 64'sd10), s_eq_NR(v.column2, \"something\"))),var v0 = v.";
         this.testTranslation(query, program, true);
     }
@@ -217,7 +177,6 @@ public class SimpleQueriesTest extends BaseQueriesTest {
                 this.header(false) +
                         "typedef TRtmp = TRtmp{i:signed<64>}\n" +
                         this.relations(false) +
-                        "relation Rtmp[TRtmp]\n" +
                         "output relation Rv0[TRtmp]\n" +
                         "Rv0[v1] :- Rt1[v],var v0 = TRtmp{.i = if ((v.column1 == 64'sd1)) {\n" +
                         "64'sd1} else {\n" +
@@ -234,7 +193,6 @@ public class SimpleQueriesTest extends BaseQueriesTest {
             this.header(true) +
                 "typedef TRtmp = TRtmp{i:Option<signed<64>>}\n" +
                 this.relations(true) +
-                "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
                 "Rv0[v1] :- Rt1[v],var v0 = TRtmp{.i = if (unwrapBool(a_eq_NR(v.column1, 64'sd1))) {\n" +
                 "None{}: Option<signed<64>>} else {\n" +
@@ -249,7 +207,6 @@ public class SimpleQueriesTest extends BaseQueriesTest {
                 this.header(true) +
                         "typedef TRtmp = TRtmp{i:signed<64>}\n" +
                         this.relations(true) +
-                        "relation Rtmp[TRtmp]\n" +
                         "output relation Rv0[TRtmp]\n" +
                         "Rv0[v1] :- Rt1[v],var v0 = TRtmp{.i = if (unwrapBool(a_eq_NR(v.column1, 64'sd1))) {\n" +
                         "64'sd1} else {\n" +
@@ -260,67 +217,23 @@ public class SimpleQueriesTest extends BaseQueriesTest {
     }
 
     @Test
-    public void testAlias() {
-        String query = "create view v0 as SELECT DISTINCT t2.column1 FROM t1 AS t2";
-        String program = this.header(false) +
-                this.relations(false) +
-                "relation Rtmp[Tt2]\n" +
-                "output relation Rv0[Tt2]\n" +
-                "Rv0[v1] :- Rt1[v],var v0 = Tt2{.column1 = v.column1},var v1 = v0.";
-        this.testTranslation(query, program);
-    }
-
-    @Test
-    public void testAliasWNull() {
-        String query = "create view v0 as SELECT DISTINCT t2.column1 FROM t1 AS t2";
-        String program = this.header(true) +
-            this.relations(true) +
-            "relation Rtmp[Tt2]\n" +
-            "output relation Rv0[Tt2]\n" +
-            "Rv0[v1] :- Rt1[v],var v0 = Tt2{.column1 = v.column1},var v1 = v0.";
-        this.testTranslation(query, program, true);
-    }
-
-    @Test
-    public void testScope() {
-        String query = "create view v0 as SELECT DISTINCT t1.column1 FROM t1";
-        String program = this.header(false) +
-                this.relations(false) +
-                "relation Rtmp[Tt2]\n" +
-                "output relation Rv0[Tt2]\n" +
-                "Rv0[v1] :- Rt1[v],var v0 = Tt2{.column1 = v.column1},var v1 = v0.";
-        this.testTranslation(query, program);
-    }
-
-    @Test
     public void testLimit() {
         String query = "create view v0 as SELECT DISTINCT * FROM t1 LIMIT 10";
         String program = this.header(false) +
                 this.relations(false) +
-                "relation Rlimit[Tt1]\n" +
-                "output relation Rv0[Tt1]\n" +
+                "relation Rlimit[TRt1]\n" +
+                "output relation Rv0[TRt1]\n" +
                 "Rlimit[v0] :- Rt1[v],var v0 = v.\n" +
                 "Rv0[v1] :- Rlimit[v0],var g = v0.group_by(()),var agg = limit(g, 10),var limited = FlatMap(agg),var v1 = limited.";
         this.testTranslation(query, program);
     }
 
     @Test
-    public void testScopeWNulls() {
-        String query = "create view v0 as SELECT DISTINCT t1.column1 FROM t1";
-        String program = this.header(true) +
-            this.relations(true) +
-            "relation Rtmp[Tt2]\n" +
-            "output relation Rv0[Tt2]\n" +
-            "Rv0[v1] :- Rt1[v],var v0 = Tt2{.column1 = v.column1},var v1 = v0.";
-        this.testTranslation(query, program, true);
-    }
-    @Test
     public void testAbs() {
         String query = "create view v0 as SELECT DISTINCT ABS(column1) AS i FROM t1";
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{i:signed<64>}\n" +
                 this.relations(false) +
-                "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
                 "Rv0[v1] :- Rt1[v],var v0 = TRtmp{.i = sql_abs(v.column1)},var v1 = v0.";
         this.testTranslation(query, program);
@@ -332,7 +245,6 @@ public class SimpleQueriesTest extends BaseQueriesTest {
         String program = this.header(true) +
                 "typedef TRtmp = TRtmp{i:Option<signed<64>>}\n" +
                 this.relations(true) +
-                "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
                 "Rv0[v1] :- Rt1[v],var v0 = TRtmp{.i = sql_abs_N(v.column1)},var v1 = v0.";
         this.testTranslation(query, program, true);
@@ -344,7 +256,6 @@ public class SimpleQueriesTest extends BaseQueriesTest {
         String translation = this.header(false) +
                 "typedef TRtmp = TRtmp{tmp:bool, gb1:string, column2:string}\n" +
                 this.relations(false) +
-                "relation Rtmp[TRtmp]\n" +
                 "output relation Rv[TRtmp]\n" +
                 "Rv[v1] :- Rt1[v],var v0 = TRtmp{.tmp = v.column3,.gb1 = v.column2,.column2 = v.column2},var v1 = v0.";
         this.testTranslation(query, translation);
@@ -356,7 +267,6 @@ public class SimpleQueriesTest extends BaseQueriesTest {
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{column1:signed<64>, column2:string}\n" +
                 this.relations(false) +
-                "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
                 "Rv0[v1] :- Rt1[v],(((- 64'sd1) <= v.column1) and (v.column1 <= 64'sd10)),var v0 = TRtmp{.column1 = v.column1,.column2 = v.column2},var v1 = v0.";
         this.testTranslation(query, program);
@@ -367,9 +277,8 @@ public class SimpleQueriesTest extends BaseQueriesTest {
         String query = "create view v0 as SELECT DISTINCT column1, column2 FROM t1 WHERE column1 BETWEEN -1 and 10";
         String program = this.header(true) +
             this.relations(true) +
-            "relation Rtmp[Tt4]\n" +
-            "output relation Rv0[Tt4]\n" +
-            "Rv0[v1] :- Rt1[v],unwrapBool(b_and_NN(a_lte_RN((- 64'sd1), v.column1), a_lte_NR(v.column1, 64'sd10))),var v0 = Tt4{.column1 = v.column1,.column2 = v.column2},var v1 = v0.";
+            "output relation Rv0[TRt4]\n" +
+            "Rv0[v1] :- Rt1[v],unwrapBool(b_and_NN(a_lte_RN((- 64'sd1), v.column1), a_lte_NR(v.column1, 64'sd10))),var v0 = TRt4{.column1 = v.column1,.column2 = v.column2},var v1 = v0.";
         this.testTranslation(query, program, true);
     }
 
@@ -379,7 +288,6 @@ public class SimpleQueriesTest extends BaseQueriesTest {
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{s:string}\n" +
                 this.relations(false) +
-                "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
                 "Rv0[v1] :- Rt1[v],var v0 = TRtmp{.s = sql_substr(v.column2, 64'sd3, 64'sd5)},var v1 = v0.";
         this.testTranslation(query, program);
@@ -391,7 +299,6 @@ public class SimpleQueriesTest extends BaseQueriesTest {
         String program = this.header(true) +
             "typedef TRtmp = TRtmp{s:Option<string>}\n" +
             this.relations(true) +
-            "relation Rtmp[TRtmp]\n" +
             "output relation Rv0[TRtmp]\n" +
             "Rv0[v1] :- Rt1[v],var v0 = TRtmp{.s = sql_substr_N(v.column2, 64'sd3, 64'sd5)},var v1 = v0.";
         this.testTranslation(query, program, true);
@@ -403,9 +310,8 @@ public class SimpleQueriesTest extends BaseQueriesTest {
         String program =
                 this.header(true) +
                 this.relations(true) +
-                "relation Rtmp[Tt4]\n" +
-                "output relation Rv0[Tt4]\n" +
-                "Rv0[v1] :- Rt1[v],var v0 = Tt4{.column1 = v.column1,.column2 = v.column2},var v1 = v0.";
+                "output relation Rv0[TRt4]\n" +
+                "Rv0[v1] :- Rt1[v],var v0 = TRt4{.column1 = v.column1,.column2 = v.column2},var v1 = v0.";
         this.testTranslation(query, program, true);
     }
     
@@ -414,20 +320,19 @@ public class SimpleQueriesTest extends BaseQueriesTest {
         String query = "create view v3 as select distinct * from (select distinct * from t1 where column1 = 10) where column2 = 'something'";
         String program = this.header(false) +
                 this.relations(false) +
-                "relation Rtmp0[Tt1]\n" +
-                "output relation Rv3[Tt1]\n" +
+                "relation Rtmp0[TRt1]\n" +
+                "output relation Rv3[TRt1]\n" +
                 "Rtmp0[v0] :- Rt1[v],(v.column1 == 64'sd10),var v0 = v.\n" +
                 "Rv3[v1] :- Rtmp0[v0],(v0.column2 == \"something\"),var v1 = v0.";
         this.testTranslation(query, program);
     }
 
-    @Test
+   @Test
     public void testConcat() {
         String query = "create view v3 as select distinct concat(t1.column1, t1.column2, t1.column3) as c from t1";
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{c:string}\n" +
                 this.relations(false) +
-                "relation Rtmp[TRtmp]\n" +
                 "output relation Rv3[TRtmp]\n" +
                 "Rv3[v1] :- Rt1[v],var v0 = TRtmp{.c = sql_concat(sql_concat([|${v.column1}|], v.column2), [|${v.column3}|])},var v1 = v0.";
         this.testTranslation(query, program);
@@ -439,7 +344,6 @@ public class SimpleQueriesTest extends BaseQueriesTest {
         String program = this.header(true) +
                 "typedef TRtmp = TRtmp{c:Option<string>}\n" +
                 this.relations(true) +
-                "relation Rtmp[TRtmp]\n" +
                 "output relation Rv3[TRtmp]\n" +
                 "Rv3[v1] :- Rt1[v],var v0 = TRtmp{.c = sql_concat_N(sql_concat_N(match(v.column1) {None{}: Option<signed<64>> -> None{}: Option<string>,\n" +
                 "Some{.x = var x} -> Some{.x = [|${x}|]}\n" +
@@ -454,8 +358,8 @@ public class SimpleQueriesTest extends BaseQueriesTest {
         String query = "create view v3 as select distinct * from (select distinct * from t1 where column1 = 10) where column2 = 'something'";
         String program = this.header(true) +
             this.relations(true) +
-            "relation Rtmp0[Tt1]\n" +
-            "output relation Rv3[Tt1]\n" +
+            "relation Rtmp0[TRt1]\n" +
+            "output relation Rv3[TRt1]\n" +
             "Rtmp0[v0] :- Rt1[v],unwrapBool(a_eq_NR(v.column1, 64'sd10)),var v0 = v.\n" +
             "Rv3[v1] :- Rtmp0[v0],unwrapBool(s_eq_NR(v0.column2, \"something\")),var v1 = v0.";
         this.testTranslation(query, program, true);
@@ -466,7 +370,7 @@ public class SimpleQueriesTest extends BaseQueriesTest {
         String query = "create index idx_name on t1 (column1, column2)";
         String program = this.header(true) +
                 this.relations(true) + "\n" +
-                "index Iidx_name(column1:Option<signed<64>>,column2:Option<string>) on Rt1[Tt1{column1,column2,_,_}]";
+                "index Iidx_name(column1:Option<signed<64>>,column2:Option<string>) on Rt1[TRt1{column1,column2,_,_}]";
         this.testIndexTranslation(query, program, true);
     }
 
@@ -475,17 +379,7 @@ public class SimpleQueriesTest extends BaseQueriesTest {
         String query = "create index idx_name on t1 (column1)";
         String program = this.header(true) +
                 this.relations(true) + "\n" +
-                "index Iidx_name(column1:Option<signed<64>>) on Rt1[Tt1{column1,_,_,_}]";
+                "index Iidx_name(column1:Option<signed<64>>) on Rt1[TRt1{column1,_,_,_}]";
         this.testIndexTranslation(query, program, true);
-    }
-
-    @Test
-    public void testIndexException() {
-        String query = "create index idx_name on non_existent_table (column1)";
-        try {
-            this.testIndexTranslation(query, "junk program", true);
-        } catch (Exception e) {
-            assert e.getMessage().equals("Cannot find base table that index refers to");
-        }
     }
 }

--- a/sql/src/test/java/ddlog/TimeTest.java
+++ b/sql/src/test/java/ddlog/TimeTest.java
@@ -36,7 +36,6 @@ public class TimeTest extends BaseQueriesTest {
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{y:signed<64>}\n" +
                 this.relations(false) +
-                "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
                 "Rv0[v1] :- Rt3[v],var v0 = TRtmp{.y = sql_extract_year(v.d)},var v1 = v0.";
         this.testTranslation(query, program);
@@ -48,7 +47,6 @@ public class TimeTest extends BaseQueriesTest {
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{m:signed<64>}\n" +
                 this.relations(false) +
-                "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
                 "Rv0[v1] :- Rt3[v],var v0 = TRtmp{.m = sql_extract_month(v.d)},var v1 = v0.";
         this.testTranslation(query, program);
@@ -60,7 +58,6 @@ public class TimeTest extends BaseQueriesTest {
         String program = this.header(false) +
                 "typedef TRtmp = TRtmp{h:signed<64>}\n" +
                 this.relations(false) +
-                "relation Rtmp[TRtmp]\n" +
                 "output relation Rv0[TRtmp]\n" +
                 "Rv0[v1] :- Rt3[v],var v0 = TRtmp{.h = sql_extract_hour(v.t)},var v1 = v0.";
         this.testTranslation(query, program);

--- a/sql/src/test/java/ddlog/WeaveTest.java
+++ b/sql/src/test/java/ddlog/WeaveTest.java
@@ -92,7 +92,7 @@ public class WeaveTest extends BaseQueriesTest {
                         "  host_ip varchar(100) not null,\n" +
                         "  host_port integer not null,\n" +
                         "  host_protocol varchar(10) not null\n" +
-                        "  /*,foreign key(pod_name) references pod_info(pod_name) on delete cascade\n*/" +
+                        "  -- ,foreign key(pod_name) references pod_info(pod_name) on delete cascade\n" +
                         ")";
         create = translatePrestoSqlStatement(pod_ports_request);
         Assert.assertNotNull(create);
@@ -366,17 +366,15 @@ public class WeaveTest extends BaseQueriesTest {
         create = translatePrestoSqlStatement(pod_node_selectors);
         Assert.assertNotNull(create);
 
-        /*
-        indexes are not supported by Presto
-        String indexes =
-                "create index pod_info_idx on pod_info (status, node_name);\n" +
-                "create index pod_node_selector_labels_fk_idx on pod_node_selector_labels (pod_name);\n" +
-                "create index node_labels_idx on node_labels (label_key, label_value);\n" +
-                "create index pod_affinity_match_expressions_idx on pod_affinity_match_expressions (pod_name);\n" +
-                "create index pod_labels_idx on pod_labels (label_key, label_value);\n";
-        create = t.translateSqlStatement(indexes);
-        Assert.assertNotNull(create);
-         */
+        // indexes are not supported by Presto
+        //String indexes =
+        //        "create index pod_info_idx on pod_info (status, node_name);\n" +
+        //        "create index pod_node_selector_labels_fk_idx on pod_node_selector_labels (pod_name);\n" +
+        //        "create index node_labels_idx on node_labels (label_key, label_value);\n" +
+        //        "create index pod_affinity_match_expressions_idx on pod_affinity_match_expressions (pod_name);\n" +
+        //        "create index pod_labels_idx on pod_labels (label_key, label_value);\n";
+        //create = t.translateSqlStatement(indexes);
+        //Assert.assertNotNull(create);
 
         String inter_pod_affinity =
                 "-- Inter pod affinity\n" +
@@ -416,11 +414,10 @@ public class WeaveTest extends BaseQueriesTest {
                 "select distinct *, count(*) over (partition by pod_name) as num_matches from inter_pod_affinity_matches_inner";
         create = translatePrestoSqlStatement(inter_pod_affinity_matches);
         Assert.assertNotNull(create);
-
         String spare_capacity =
                 "-- Spare capacity\n" +
                 "create view spare_capacity_per_node as\n" +
-                "select node_info.name as name,\n" +
+                "select DISTINCT node_info.name as name,\n" +
                 "       cast(node_info.cpu_allocatable - sum(pod_info.cpu_request) as integer) as cpu_remaining,\n" +
                 "       cast(node_info.memory_allocatable - sum(pod_info.memory_request) as integer) as memory_remaining,\n" +
                 "       cast(node_info.pods_allocatable - sum(pod_info.pods_request) as integer) as pods_remaining\n" +
@@ -479,498 +476,215 @@ public class WeaveTest extends BaseQueriesTest {
         DDlogProgram program = t.getDDlogProgram();
         String p = program.toString();
         Assert.assertNotNull(p);
-        String expected = "import fp\nimport time\nimport sql\nimport sqlop\n" + "\n" +
-                "typedef Tnode_info = Tnode_info{name:string, unschedulable:bool, out_of_disk:bool, memory_pressure:bool, " +
-                "disk_pressure:bool, pid_pressure:bool, ready:bool, network_unavailable:bool, cpu_capacity:bigint, " +
-                "memory_capacity:bigint, ephemeral_storage_capacity:bigint, pods_capacity:bigint, cpu_allocatable:bigint, " +
-                "memory_allocatable:bigint, ephemeral_storage_allocatable:bigint, pods_allocatable:bigint}\n" +
-
-                "typedef Tpod_info = Tpod_info{pod_name:string, status:string, node_name:Option<string>, namespace:string, " +
-                "cpu_request:bigint, memory_request:bigint, ephemeral_storage_request:bigint, pods_request:bigint, " +
-                "owner_name:string, creation_timestamp:string, priority:signed<64>, schedulerName:Option<string>, " +
-                "has_node_selector_labels:bool, has_pod_affinity_requirements:bool}\n" +
-
-                "typedef Tpod_ports_request = Tpod_ports_request{pod_name:string, host_ip:string, host_port:signed<64>, " +
-                "host_protocol:string}\n" +
-
-                "typedef Tcontainer_host_ports = Tcontainer_host_ports{pod_name:string, node_name:string, host_ip:string, " +
-                "host_port:signed<64>, host_protocol:string}\n" +
-
-                "typedef Tpod_node_selector_labels = Tpod_node_selector_labels{pod_name:string, term:signed<64>, " +
-                "match_expression:signed<64>, num_match_expressions:signed<64>, label_key:string, label_operator:string, " +
-                "label_value:Option<string>}\n" +
-
-                "typedef Tpod_affinity_match_expressions = Tpod_affinity_match_expressions{pod_name:string, " +
-                "label_selector:signed<64>, match_expression:signed<64>, num_match_expressions:signed<64>, " +
-                "label_key:string, label_operator:string, label_value:string, topology_key:string}\n" +
-
-                "typedef Tpod_anti_affinity_match_expressions = Tpod_anti_affinity_match_expressions{pod_name:string, " +
-                "label_key:string, label_operator:string, label_value:string, topology_key:string}\n" +
-
-                "typedef Tpod_labels = Tpod_labels{pod_name:string, label_key:string, label_value:string}\n" +
-
-                "typedef Tnode_labels = Tnode_labels{node_name:string, label_key:string, label_value:string}\n" +
-
-                "typedef Tvolume_labels = Tvolume_labels{volume_name:string, pod_name:string, label_key:string, " +
-                "label_value:string}\n" +
-
-                "typedef Tpod_by_service = Tpod_by_service{pod_name:string, service_name:string}\n" +
-
-                "typedef Tservice_affinity_labels = Tservice_affinity_labels{label_key:string}\n" +
-
-                "typedef Tlabels_to_check_for_presence = Tlabels_to_check_for_presence{label_key:string, present:bool}\n" +
-
-                "typedef Tnode_taints = Tnode_taints{node_name:string, taint_key:string, taint_value:Option<string>, " +
-                "taint_effect:string}\n" +
-
-                "typedef Tpod_tolerations = Tpod_tolerations{pod_name:string, tolerations_key:Option<string>, " +
-                "tolerations_value:Option<string>, tolerations_effect:Option<string>, tolerations_operator:Option<string>}\n" +
-
-                "typedef Tnode_images = Tnode_images{node_name:string, image_name:string, image_size:bigint}\n" +
-
-                "typedef Tpod_images = Tpod_images{pod_name:string, image_name:string}\n" +
-
-                "typedef TRtmp = TRtmp{pod_name:string, status:string, controllable__node_name:Option<string>, " +
-                "namespace:string, cpu_request:bigint, memory_request:bigint, ephemeral_storage_request:bigint, " +
-                "pods_request:bigint, " +
-                "owner_name:string, creation_timestamp:string, has_node_selector_labels:bool, " +
-                "has_pod_affinity_requirements:bool}\n" +
-
-                "typedef Tbatch_size = Tbatch_size{pendingPodsLimit:signed<64>}\n" +
-
-                "typedef Ttmp = Ttmp{pod_name:string, status:string, controllable__node_name:Option<string>, " +
-                "namespace:string, cpu_request:bigint, memory_request:bigint, ephemeral_storage_request:bigint, " +
-                "pods_request:bigint, " +
-                "owner_name:string, creation_timestamp:string, has_node_selector_labels:bool, " +
-                "has_pod_affinity_requirements:bool, pod_name0:string, host_ip:string, host_port:signed<64>, " +
-                "host_protocol:string}\n" +
-
-                "typedef TRtmp1 = TRtmp1{controllable__node_name:Option<string>, host_port:signed<64>, host_ip:string, " +
-                "host_protocol:string}\n" +
-
-                "typedef Ttmp2 = Ttmp2{pod_name:string, status:string, controllable__node_name:Option<string>, " +
-                "namespace:string, cpu_request:bigint, memory_request:bigint, ephemeral_storage_request:bigint, " +
-                "pods_request:bigint, " +
-                "owner_name:string, creation_timestamp:string, has_node_selector_labels:bool, " +
-                "has_pod_affinity_requirements:bool, pod_name0:string, term:signed<64>, match_expression:signed<64>, " +
-                "num_match_expressions:signed<64>, " +
-                "label_key:string, label_operator:string, label_value:Option<string>}\n" +
-
-                "typedef Ttmp3 = Ttmp3{pod_name:string, status:string, controllable__node_name:Option<string>, " +
-                "namespace:string, cpu_request:bigint, memory_request:bigint, ephemeral_storage_request:bigint, " +
-                "pods_request:bigint, " +
-                "owner_name:string, creation_timestamp:string, has_node_selector_labels:bool, " +
-                "has_pod_affinity_requirements:bool, pod_name0:string, term:signed<64>, match_expression:signed<64>, " +
-                "num_match_expressions:signed<64>, " +
-                "label_key:string, label_operator:string, label_value:Option<string>, node_name:string, " +
-                "label_key0:string, label_value0:string}\n" +
-
-                "typedef TRtmp4 = TRtmp4{pod_name:string, node_name:string}\n" +
-
+        String expected = "import fp\n" +
+                "import time\n" +
+                "import sql\n" +
+                "import sqlop\n" +
+                "\n" +
+                "typedef TRnode_info = TRnode_info{name:string, unschedulable:bool, out_of_disk:bool, memory_pressure:bool, disk_pressure:bool, pid_pressure:bool, ready:bool, network_unavailable:bool, cpu_capacity:bigint, memory_capacity:bigint, ephemeral_storage_capacity:bigint, pods_capacity:bigint, cpu_allocatable:bigint, memory_allocatable:bigint, ephemeral_storage_allocatable:bigint, pods_allocatable:bigint}\n" +
+                "typedef TRpod_info = TRpod_info{pod_name:string, status:string, node_name:Option<string>, namespace:string, cpu_request:bigint, memory_request:bigint, ephemeral_storage_request:bigint, pods_request:bigint, owner_name:string, creation_timestamp:string, priority:signed<64>, schedulerName:Option<string>, has_node_selector_labels:bool, has_pod_affinity_requirements:bool}\n" +
+                "typedef TRpod_ports_request = TRpod_ports_request{pod_name:string, host_ip:string, host_port:signed<64>, host_protocol:string}\n" +
+                "typedef TRcontainer_host_ports = TRcontainer_host_ports{pod_name:string, node_name:string, host_ip:string, host_port:signed<64>, host_protocol:string}\n" +
+                "typedef TRpod_node_selector_labels = TRpod_node_selector_labels{pod_name:string, term:signed<64>, match_expression:signed<64>, num_match_expressions:signed<64>, label_key:string, label_operator:string, label_value:Option<string>}\n" +
+                "typedef TRpod_affinity_match_expressions = TRpod_affinity_match_expressions{pod_name:string, label_selector:signed<64>, match_expression:signed<64>, num_match_expressions:signed<64>, label_key:string, label_operator:string, label_value:string, topology_key:string}\n" +
+                "typedef TRpod_anti_affinity_match_expressions = TRpod_anti_affinity_match_expressions{pod_name:string, label_key:string, label_operator:string, label_value:string, topology_key:string}\n" +
+                "typedef TRpod_labels = TRpod_labels{pod_name:string, label_key:string, label_value:string}\n" +
+                "typedef TRnode_labels = TRnode_labels{node_name:string, label_key:string, label_value:string}\n" +
+                "typedef TRvolume_labels = TRvolume_labels{volume_name:string, pod_name:string, label_key:string, label_value:string}\n" +
+                "typedef TRpod_by_service = TRpod_by_service{pod_name:string, service_name:string}\n" +
+                "typedef TRservice_affinity_labels = TRservice_affinity_labels{label_key:string}\n" +
+                "typedef TRlabels_to_check_for_presence = TRlabels_to_check_for_presence{label_key:string, present:bool}\n" +
+                "typedef TRnode_taints = TRnode_taints{node_name:string, taint_key:string, taint_value:Option<string>, taint_effect:string}\n" +
+                "typedef TRpod_tolerations = TRpod_tolerations{pod_name:string, tolerations_key:Option<string>, tolerations_value:Option<string>, tolerations_effect:Option<string>, tolerations_operator:Option<string>}\n" +
+                "typedef TRnode_images = TRnode_images{node_name:string, image_name:string, image_size:bigint}\n" +
+                "typedef TRpod_images = TRpod_images{pod_name:string, image_name:string}\n" +
+                "typedef TRtmp = TRtmp{pod_name:string, status:string, controllable__node_name:Option<string>, namespace:string, cpu_request:bigint, memory_request:bigint, ephemeral_storage_request:bigint, pods_request:bigint, owner_name:string, creation_timestamp:string, has_node_selector_labels:bool, has_pod_affinity_requirements:bool}\n" +
+                "typedef TRbatch_size = TRbatch_size{pendingPodsLimit:signed<64>}\n" +
+                "typedef Ttmp = Ttmp{pod_name:string, status:string, controllable__node_name:Option<string>, namespace:string, cpu_request:bigint, memory_request:bigint, ephemeral_storage_request:bigint, pods_request:bigint, owner_name:string, creation_timestamp:string, has_node_selector_labels:bool, has_pod_affinity_requirements:bool, host_ip:string, host_port:signed<64>, host_protocol:string}\n" +
+                "typedef TRtmp1 = TRtmp1{controllable__node_name:Option<string>, host_port:signed<64>, host_ip:string, host_protocol:string}\n" +
+                "typedef Ttmp0 = Ttmp0{pod_name:string, status:string, controllable__node_name:Option<string>, namespace:string, cpu_request:bigint, memory_request:bigint, ephemeral_storage_request:bigint, pods_request:bigint, owner_name:string, creation_timestamp:string, has_node_selector_labels:bool, has_pod_affinity_requirements:bool, term:signed<64>, match_expression:signed<64>, num_match_expressions:signed<64>, label_key:string, label_operator:string, label_value:Option<string>}\n" +
+                "typedef Ttmp1 = Ttmp1{pod_name:string, status:string, controllable__node_name:Option<string>, namespace:string, cpu_request:bigint, memory_request:bigint, ephemeral_storage_request:bigint, pods_request:bigint, owner_name:string, creation_timestamp:string, has_node_selector_labels:bool, has_pod_affinity_requirements:bool, term:signed<64>, match_expression:signed<64>, num_match_expressions:signed<64>, label_key:string, label_operator:string, label_value:Option<string>, node_name:string, label_key0:string, label_value0:string}\n" +
+                "typedef TRtmp3 = TRtmp3{pod_name:string, node_name:string}\n" +
                 "typedef Tagg = Tagg{col:Option<bool>}\n" +
-
-                "typedef Ttmp5 = Ttmp5{pod_name:string, status:string, controllable__node_name:Option<string>, " +
-                "namespace:string, cpu_request:bigint, memory_request:bigint, ephemeral_storage_request:bigint, " +
-                "pods_request:bigint, owner_name:string, creation_timestamp:string, has_node_selector_labels:bool, " +
-                "has_pod_affinity_requirements:bool, pod_name0:string, label_selector:signed<64>, " +
-                "match_expression:signed<64>, num_match_expressions:signed<64>, label_key:string, label_operator:string, " +
-                "label_value:string, topology_key:string}\n" +
-
-                "typedef Ttmp6 = Ttmp6{pod_name:string, status:string, controllable__node_name:Option<string>, " +
-                "namespace:string, cpu_request:bigint, memory_request:bigint, ephemeral_storage_request:bigint, " +
-                "pods_request:bigint, owner_name:string, creation_timestamp:string, has_node_selector_labels:bool, " +
-                "has_pod_affinity_requirements:bool, pod_name0:string, label_selector:signed<64>, " +
-                "match_expression:signed<64>, num_match_expressions:signed<64>, label_key:string, label_operator:string, " +
-                "label_value:string, topology_key:string, pod_name1:string, label_key0:string, label_value0:string}\n" +
-
-                "typedef Ttmp7 = Ttmp7{pod_name:string, status:string, controllable__node_name:Option<string>, " +
-                "namespace:string, cpu_request:bigint, memory_request:bigint, ephemeral_storage_request:bigint, " +
-                "pods_request:bigint, owner_name:string, creation_timestamp:string, has_node_selector_labels:bool, " +
-                "has_pod_affinity_requirements:bool, pod_name0:string, label_selector:signed<64>, " +
-                "match_expression:signed<64>, " +
-                "num_match_expressions:signed<64>, label_key:string, label_operator:string, label_value:string, " +
-                "topology_key:string, pod_name1:string, label_key0:string, label_value0:string, pod_name2:string, " +
-                "status0:string, " +
-                "node_name:Option<string>, namespace0:string, cpu_request0:bigint, memory_request0:bigint, " +
-                "ephemeral_storage_request0:bigint, pods_request0:bigint, owner_name0:string, creation_timestamp0:string, " +
-                "priority:signed<64>, " +
-                "schedulerName:Option<string>, has_node_selector_labels0:bool, has_pod_affinity_requirements0:bool}\n" +
-
-                "typedef TRtmp8 = TRtmp8{pod_name:string, matches:string, node_name:Option<string>}\n" +
-                "typedef Tagg9 = Tagg9{col:bool}\n" +
-                "typedef TRtmp10 = TRtmp10{gb:string, pod_name:string, matches:string, node_name:Option<string>}\n" +
-                "typedef TRtmp11 = TRtmp11{gb:string, count:signed<64>}\n" +
-                "typedef Tagg12 = Tagg12{count:signed<64>}\n" +
-                "typedef Ttmp13 = Ttmp13{gb:string, pod_name:string, matches:string, node_name:Option<string>, count:signed<64>}\n" +
-                "typedef TRtmp14 = TRtmp14{pod_name:string, matches:string, node_name:Option<string>, num_matches:signed<64>}\n" +
-
-                "typedef Ttmp15 = Ttmp15{name:string, unschedulable:bool, out_of_disk:bool, memory_pressure:bool, " +
-                "disk_pressure:bool, pid_pressure:bool, ready:bool, network_unavailable:bool, cpu_capacity:bigint, " +
-                "memory_capacity:bigint, ephemeral_storage_capacity:bigint, pods_capacity:bigint, cpu_allocatable:bigint, " +
-                "memory_allocatable:bigint, ephemeral_storage_allocatable:bigint, pods_allocatable:bigint, " +
-                "pod_name:string, status:string, node_name:Option<string>, namespace:string, cpu_request:bigint, " +
-                "memory_request:bigint, ephemeral_storage_request:bigint, pods_request:bigint, owner_name:string, " +
-                "creation_timestamp:string, priority:signed<64>, schedulerName:Option<string>, " +
-                "has_node_selector_labels:bool, has_pod_affinity_requirements:bool}\n" +
-
-                "typedef TRtmp16 = TRtmp16{name:string, cpu_remaining:signed<64>, memory_remaining:signed<64>, pods_remaining:signed<64>}\n" +
-
-                "typedef Tagg17 = Tagg17{cpu_remaining:signed<64>, memory_remaining:signed<64>, pods_remaining:signed<64>}\n" +
-
-                "typedef TRtmp18 = TRtmp18{node_name:string}\n" +
-
-                "typedef Ttmp19 = Ttmp19{pod_name:string, status:string, controllable__node_name:Option<string>," +
-                " namespace:string, cpu_request:bigint, memory_request:bigint, ephemeral_storage_request:bigint, " +
-                "pods_request:bigint, owner_name:string, creation_timestamp:string, has_node_selector_labels:bool, " +
-                "has_pod_affinity_requirements:bool, pod_name0:string, tolerations_key:Option<string>, " +
-                "tolerations_value:Option<string>, tolerations_effect:Option<string>, " +
-                "tolerations_operator:Option<string>}\n" +
-
-                "typedef TRtmp21 = TRtmp21{gb:string, node_name:string, taint_key:string, taint_value:Option<string>, " +
-                "taint_effect:string}\n" +
-
-                "typedef Ttmp25 = Ttmp25{gb:string, node_name:string, taint_key:string, taint_value:Option<string>, " +
-                "taint_effect:string, count:signed<64>}\n" +
-
-                "typedef TRtmp26 = TRtmp26{node_name:string, taint_key:string, taint_value:Option<string>, " +
-                "taint_effect:string, num_taints:signed<64>}\n" +
-
-                "typedef Ttmp28 = Ttmp28{pod_name:string, status:string, controllable__node_name:Option<string>, " +
-                "namespace:string, cpu_request:bigint, memory_request:bigint, ephemeral_storage_request:bigint, " +
-                "pods_request:bigint, owner_name:string, creation_timestamp:string, has_node_selector_labels:bool, " +
-                "has_pod_affinity_requirements:bool, pod_name0:string, tolerations_key:Option<string>, " +
-                "tolerations_value:Option<string>, tolerations_effect:Option<string>, " +
-                "tolerations_operator:Option<string>, node_name:string, taint_key:string, taint_value:Option<string>, " +
-                "taint_effect:string, num_taints:signed<64>}\n" +
-
-                "typedef TRtmp31 = TRtmp31{pod_name:string, status:string, node_name:Option<string>, namespace:string, " +
-                "cpu_request:bigint, memory_request:bigint, ephemeral_storage_request:bigint, pods_request:bigint, " +
-                "owner_name:string, creation_timestamp:string, has_node_selector_labels:bool, " +
-                "has_pod_affinity_requirements:bool}\n" +
-
-                "function agg(g: Group<(string, string, signed<64>, string, signed<64>), " +
-                "(TRtmp, Tpod_node_selector_labels, Tnode_labels)>):Tagg {\n" +
-                "(var gb, var gb4, var gb5, var gb6, var gb7) = group_key(g);\n" +
+                "typedef Ttmp2 = Ttmp2{pod_name:string, status:string, controllable__node_name:Option<string>, namespace:string, cpu_request:bigint, memory_request:bigint, ephemeral_storage_request:bigint, pods_request:bigint, owner_name:string, creation_timestamp:string, has_node_selector_labels:bool, has_pod_affinity_requirements:bool, label_selector:signed<64>, match_expression:signed<64>, num_match_expressions:signed<64>, label_key:string, label_operator:string, label_value:string, topology_key:string}\n" +
+                "typedef Ttmp3 = Ttmp3{pod_name:string, status:string, controllable__node_name:Option<string>, namespace:string, cpu_request:bigint, memory_request:bigint, ephemeral_storage_request:bigint, pods_request:bigint, owner_name:string, creation_timestamp:string, has_node_selector_labels:bool, has_pod_affinity_requirements:bool, label_selector:signed<64>, match_expression:signed<64>, num_match_expressions:signed<64>, label_key:string, label_operator:string, label_value:string, topology_key:string, pod_name0:string, label_key0:string, label_value0:string}\n" +
+                "typedef Ttmp4 = Ttmp4{pod_name:string, status:string, controllable__node_name:Option<string>, namespace:string, cpu_request:bigint, memory_request:bigint, ephemeral_storage_request:bigint, pods_request:bigint, owner_name:string, creation_timestamp:string, has_node_selector_labels:bool, has_pod_affinity_requirements:bool, label_selector:signed<64>, match_expression:signed<64>, num_match_expressions:signed<64>, label_key:string, label_operator:string, label_value:string, topology_key:string, pod_name0:string, label_key0:string, label_value0:string, status0:string, node_name:Option<string>, namespace0:string, cpu_request0:bigint, memory_request0:bigint, ephemeral_storage_request0:bigint, pods_request0:bigint, owner_name0:string, creation_timestamp0:string, priority:signed<64>, schedulerName:Option<string>, has_node_selector_labels0:bool, has_pod_affinity_requirements0:bool}\n" +
+                "typedef TRtmp6 = TRtmp6{pod_name:string, matches:string, node_name:Option<string>}\n" +
+                "typedef Tagg0 = Tagg0{col:bool}\n" +
+                "typedef TRtmp7 = TRtmp7{gb:string, pod_name:string, matches:string, node_name:Option<string>}\n" +
+                "typedef TRtmp8 = TRtmp8{gb:string, count:signed<64>}\n" +
+                "typedef Tagg1 = Tagg1{count:signed<64>}\n" +
+                "typedef Ttmp5 = Ttmp5{gb:string, pod_name:string, matches:string, node_name:Option<string>, count:signed<64>}\n" +
+                "typedef TRtmp9 = TRtmp9{pod_name:string, matches:string, node_name:Option<string>, num_matches:signed<64>}\n" +
+                "typedef Ttmp6 = Ttmp6{name:string, unschedulable:bool, out_of_disk:bool, memory_pressure:bool, disk_pressure:bool, pid_pressure:bool, ready:bool, network_unavailable:bool, cpu_capacity:bigint, memory_capacity:bigint, ephemeral_storage_capacity:bigint, pods_capacity:bigint, cpu_allocatable:bigint, memory_allocatable:bigint, ephemeral_storage_allocatable:bigint, pods_allocatable:bigint, pod_name:string, status:string, node_name:Option<string>, namespace:string, cpu_request:bigint, memory_request:bigint, ephemeral_storage_request:bigint, pods_request:bigint, owner_name:string, creation_timestamp:string, priority:signed<64>, schedulerName:Option<string>, has_node_selector_labels:bool, has_pod_affinity_requirements:bool}\n" +
+                "typedef TRtmp10 = TRtmp10{name:string, cpu_remaining:signed<64>, memory_remaining:signed<64>, pods_remaining:signed<64>}\n" +
+                "typedef Tagg2 = Tagg2{cpu_remaining:signed<64>, memory_remaining:signed<64>, pods_remaining:signed<64>}\n" +
+                "typedef TRtmp11 = TRtmp11{node_name:string}\n" +
+                "typedef Ttmp7 = Ttmp7{pod_name:string, status:string, controllable__node_name:Option<string>, namespace:string, cpu_request:bigint, memory_request:bigint, ephemeral_storage_request:bigint, pods_request:bigint, owner_name:string, creation_timestamp:string, has_node_selector_labels:bool, has_pod_affinity_requirements:bool, tolerations_key:Option<string>, tolerations_value:Option<string>, tolerations_effect:Option<string>, tolerations_operator:Option<string>}\n" +
+                "typedef TRtmp12 = TRtmp12{gb:string, node_name:string, taint_key:string, taint_value:Option<string>, taint_effect:string}\n" +
+                "typedef Ttmp8 = Ttmp8{gb:string, node_name:string, taint_key:string, taint_value:Option<string>, taint_effect:string, count:signed<64>}\n" +
+                "typedef TRtmp14 = TRtmp14{node_name:string, taint_key:string, taint_value:Option<string>, taint_effect:string, num_taints:signed<64>}\n" +
+                "typedef Ttmp9 = Ttmp9{pod_name:string, status:string, controllable__node_name:Option<string>, namespace:string, cpu_request:bigint, memory_request:bigint, ephemeral_storage_request:bigint, pods_request:bigint, owner_name:string, creation_timestamp:string, has_node_selector_labels:bool, has_pod_affinity_requirements:bool, tolerations_key:Option<string>, tolerations_value:Option<string>, tolerations_effect:Option<string>, tolerations_operator:Option<string>, node_name:string, taint_key:string, taint_value:Option<string>, taint_effect:string, num_taints:signed<64>}\n" +
+                "typedef TRtmp18 = TRtmp18{pod_name:string, status:string, node_name:Option<string>, namespace:string, cpu_request:bigint, memory_request:bigint, ephemeral_storage_request:bigint, pods_request:bigint, owner_name:string, creation_timestamp:string, has_node_selector_labels:bool, has_pod_affinity_requirements:bool}\n" +
+                "function agg(g: Group<(string, string, signed<64>, string, signed<64>), (Ttmp0, Ttmp0, TRnode_labels, Ttmp1)>):Tagg {\n" +
+                "(var gb, var gb0, var gb1, var gb2, var gb3) = group_key(g);\n" +
                 "(var any = Some{false}: Option<bool>);\n" +
-                "(var any9 = false: bool);\n" +
+                "(var any0 = false: bool);\n" +
                 "(var count_distinct = set_empty(): Set<signed<64>>);\n" +
                 "(for ((i, _) in g) {\n" +
-                "var v = i.0;\n" +
-                "(var v0 = i.1);\n" +
-                "(var v2 = i.2);\n" +
-                "(var incr = b_and_RN((v0.label_key == v2.label_key), s_eq_NR(v0.label_value, v2.label_value)));\n" +
-                "(any = agg_any_N(any, incr));\n" +
-                "(var incr8 = (v0.label_key == v2.label_key));\n" +
-                "(any9 = agg_any_R(any9, incr8));\n" +
-                "(var incr10 = v0.match_expression);\n" +
-                "(set_insert(count_distinct, incr10))}\n" +
-                ");\n" +
-                "(Tagg{.col = if ((gb6 == \"NotIn\")) {\n" +
-                "b_not_N(any)} else {\n" +
-                "if ((gb6 == \"DoesNotExist\")) {\n" +
-                "Some{.x = (not any9)}} else {\n" +
-                "Some{.x = (set_size(count_distinct) as signed<64> == gb7)}}}})\n}\n\n" +
-
-                "function agg9(g: Group<(string, string, signed<64>, string, string, signed<64>, Option<string>), " +
-                "(TRtmp, Tpod_affinity_match_expressions, Tpod_labels, Tpod_info)>):Tagg9 {\n" +
-                "(var gb, var gb6, var gb7, var gb8, var gb9, var gb10, var gb11) = group_key(g);\n" +
-                "(var any = false: bool);\n" +
-                "(var any13 = false: bool);\n" +
-                "(var count_distinct = set_empty(): Set<signed<64>>);\n" +
-                "(for ((i, _) in g) {\n" +
-                "var v = i.0;\n" +
-                "(var v0 = i.1);\n" +
+                "var v1 = i.0;\n" +
+                "(var v3 = i.1);\n" +
                 "(var v2 = i.2);\n" +
                 "(var v4 = i.3);\n" +
-                "(var incr = ((v0.label_key == v2.label_key) and (v0.label_value == v2.label_value)));\n" +
-                "(any = agg_any_R(any, incr));\n" +
-                "(var incr12 = (v0.label_key == v2.label_key));\n" +
-                "(any13 = agg_any_R(any13, incr12));\n" +
-                "(var incr14 = v0.match_expression);\n" +
-                "(set_insert(count_distinct, incr14))}\n" +
+                "(var incr = b_and_RN((v4.label_key == v4.label_key0), s_eq_NR(v4.label_value, v4.label_value0)));\n" +
+                "(any = agg_any_N(any, incr));\n" +
+                "(var incr0 = (v4.label_key == v4.label_key0));\n" +
+                "(any0 = agg_any_R(any0, incr0));\n" +
+                "(var incr1 = v4.match_expression);\n" +
+                "(set_insert(count_distinct, incr1))}\n" +
                 ");\n" +
-                "(Tagg9{.col = if ((gb9 == \"NotIn\")) {\n" +
+                "(Tagg{.col = if ((gb2 == \"NotIn\")) {\n" +
+                "b_not_N(any)} else {\n" +
+                "if ((gb2 == \"DoesNotExist\")) {\n" +
+                "Some{.x = (not any0)}} else {\n" +
+                "Some{.x = (set_size(count_distinct) as signed<64> == gb3)}}}})\n" +
+                "}\n" +
+                "\n" +
+                "function agg0(g: Group<(string, string, signed<64>, string, string, signed<64>, Option<string>), Ttmp4>):Tagg0 {\n" +
+                "(var gb, var gb0, var gb1, var gb2, var gb3, var gb4, var gb5) = group_key(g);\n" +
+                "(var any = false: bool);\n" +
+                "(var any0 = false: bool);\n" +
+                "(var count_distinct = set_empty(): Set<signed<64>>);\n" +
+                "(for ((i, _) in g) {\n" +
+                "var v7 = i;\n" +
+                "(var incr = ((v7.label_key == v7.label_key0) and (v7.label_value == v7.label_value0)));\n" +
+                "(any = agg_any_R(any, incr));\n" +
+                "(var incr0 = (v7.label_key == v7.label_key0));\n" +
+                "(any0 = agg_any_R(any0, incr0));\n" +
+                "(var incr1 = v7.match_expression);\n" +
+                "(set_insert(count_distinct, incr1))}\n" +
+                ");\n" +
+                "(Tagg0{.col = if ((gb3 == \"NotIn\")) {\n" +
                 "(not any)} else {\n" +
-                "if ((gb9 == \"DoesNotExist\")) {\n" +
-                "(not any13)} else {\n" +
-                "(set_size(count_distinct) as signed<64> == gb10)}}})\n}\n\n" +
-
-                "function agg12(g: Group<string, TRtmp10>):Tagg12 {\n" +
-                "(var gb4) = group_key(g);\n" +
-                "(var count5 = 64'sd0: signed<64>);\n" +
+                "if ((gb3 == \"DoesNotExist\")) {\n" +
+                "(not any0)} else {\n" +
+                "(set_size(count_distinct) as signed<64> == gb4)}}})\n" +
+                "}\n" +
+                "\n" +
+                "function agg1(g: Group<string, TRtmp7>):Tagg1 {\n" +
+                "(var gb0) = group_key(g);\n" +
+                "(var count0 = 64'sd0: signed<64>);\n" +
                 "(for ((i, _) in g) {\n" +
                 "var v3 = i;\n" +
-                "(count5 = agg_count_R(count5, 64'sd1))}\n" +
+                "(count0 = agg_count_R(count0, 64'sd1))}\n" +
                 ");\n" +
-                "(Tagg12{.count = count5})\n" +
-                "}\n\n" +
-
-                "function agg17(g: Group<(string, bigint, bigint, bigint), (Tnode_info, Tpod_info)>):Tagg17 {\n" +
-                "(var gb, var gb2, var gb3, var gb4) = group_key(g);\n" +
+                "(Tagg1{.count = count0})\n" +
+                "}\n" +
+                "\n" +
+                "function agg2(g: Group<(string, bigint, bigint, bigint), (TRnode_info, TRpod_info, Ttmp6)>):Tagg2 {\n" +
+                "(var gb, var gb0, var gb1, var gb2) = group_key(g);\n" +
                 "(var sum = 0: bigint);\n" +
-                "(var sum6 = 0: bigint);\n" +
-                "(var sum8 = 0: bigint);\n" +
+                "(var sum0 = 0: bigint);\n" +
+                "(var sum1 = 0: bigint);\n" +
                 "(for ((i, _) in g) {\n" +
                 "var v = i.0;\n" +
                 "(var v0 = i.1);\n" +
-                "(var incr = v0.cpu_request);\n" +
+                "(var v1 = i.2);\n" +
+                "(var incr = v1.cpu_request);\n" +
                 "(sum = agg_sum_int_R(sum, incr));\n" +
-                "(var incr5 = v0.memory_request);\n" +
-                "(sum6 = agg_sum_int_R(sum6, incr5));\n" +
-                "(var incr7 = v0.pods_request);\n" +
-                "(sum8 = agg_sum_int_R(sum8, incr7))}\n" +
+                "(var incr0 = v1.memory_request);\n" +
+                "(sum0 = agg_sum_int_R(sum0, incr0));\n" +
+                "(var incr1 = v1.pods_request);\n" +
+                "(sum1 = agg_sum_int_R(sum1, incr1))}\n" +
                 ");\n" +
-                "(Tagg17{.cpu_remaining = (gb2 - sum) as signed<64>,.memory_remaining = (gb3 - sum6) as signed<64>," +
-                ".pods_remaining = (gb4 - sum8) as signed<64>})" +
-                "\n}\n\n" +
-
-                "function agg24(g: Group<string, TRtmp21>):Tagg12 {\n" +
-                "(var gb7) = group_key(g);\n" +
-                "(var count8 = 64'sd0: signed<64>);\n" +
+                "(Tagg2{.cpu_remaining = (gb0 - sum) as signed<64>,.memory_remaining = (gb1 - sum0) as signed<64>,.pods_remaining = (gb2 - sum1) as signed<64>})\n" +
+                "}\n" +
+                "\n" +
+                "function agg3(g: Group<string, TRtmp12>):Tagg1 {\n" +
+                "(var gb0) = group_key(g);\n" +
+                "(var count0 = 64'sd0: signed<64>);\n" +
                 "(for ((i, _) in g) {\n" +
                 "var v6 = i;\n" +
-                "(count8 = agg_count_R(count8, 64'sd1))}\n" +
+                "(count0 = agg_count_R(count0, 64'sd1))}\n" +
                 ");\n" +
-                "(Tagg12{.count = count8})\n" +
-                "}\n\n" +
-
-                "function agg30(g20: Group<(string, string, signed<64>), " +
-                "(TRtmp, Tpod_tolerations, TRtmp26)>):Tagg9 {\n" +
-                "(var gb17, var gb18, var gb19) = group_key(g20);\n" +
-                "(var count22 = 64'sd0: signed<64>);\n" +
-                "(for ((i21, _) in g20) {\n" +
-                "var v = i21.0;\n" +
-                "(var v0 = i21.1);\n" +
-                "(var v15 = i21.2);\n" +
-                "(count22 = agg_count_R(count22, 64'sd1))}\n" +
+                "(Tagg1{.count = count0})\n" +
+                "}\n" +
+                "\n" +
+                "function agg4(g0: Group<(string, string, signed<64>), (Ttmp7, Ttmp7, TRtmp14, Ttmp9)>):Tagg0 {\n" +
+                "(var gb3, var gb4, var gb5) = group_key(g0);\n" +
+                "(var count2 = 64'sd0: signed<64>);\n" +
+                "(for ((i0, _) in g0) {\n" +
+                "var v1 = i0.0;\n" +
+                "(var v14 = i0.1);\n" +
+                "(var v13 = i0.2);\n" +
+                "(var v15 = i0.3);\n" +
+                "(count2 = agg_count_R(count2, 64'sd1))}\n" +
                 ");\n" +
-                "(Tagg9{.col = (count22 == gb19)})\n" +
-                "}\n\n" +
-
-                "input relation Rnode_info[Tnode_info] primary key (row) (row.name)\n" +
-                "input relation Rpod_info[Tpod_info] primary key (row) (row.pod_name)\n" +
-                "input relation Rpod_ports_request[Tpod_ports_request]\n" +
-                "input relation Rcontainer_host_ports[Tcontainer_host_ports]\n" +
-                "input relation Rpod_node_selector_labels[Tpod_node_selector_labels]\n" +
-                "input relation Rpod_affinity_match_expressions[Tpod_affinity_match_expressions]\n" +
-                "input relation Rpod_anti_affinity_match_expressions[Tpod_anti_affinity_match_expressions]\n" +
-                "input relation Rpod_labels[Tpod_labels]\n" +
-                "input relation Rnode_labels[Tnode_labels]\n" +
-                "input relation Rvolume_labels[Tvolume_labels]\n" +
-                "input relation Rpod_by_service[Tpod_by_service]\n" +
-                "input relation Rservice_affinity_labels[Tservice_affinity_labels]\n" +
-                "input relation Rlabels_to_check_for_presence[Tlabels_to_check_for_presence]\n" +
-                "input relation Rnode_taints[Tnode_taints]\n" +
-                "input relation Rpod_tolerations[Tpod_tolerations]\n" +
-                "input relation Rnode_images[Tnode_images]\n" +
-                "input relation Rpod_images[Tpod_images]\n" +
-
-                "relation Rtmp[TRtmp]\n" +
+                "(Tagg0{.col = (count2 == gb5)})\n" +
+                "}\n" +
+                "\n" +
+                "input relation Rnode_info[TRnode_info] primary key (row) (row.name)\n" +
+                "input relation Rpod_info[TRpod_info] primary key (row) (row.pod_name)\n" +
+                "input relation Rpod_ports_request[TRpod_ports_request]\n" +
+                "input relation Rcontainer_host_ports[TRcontainer_host_ports]\n" +
+                "input relation Rpod_node_selector_labels[TRpod_node_selector_labels]\n" +
+                "input relation Rpod_affinity_match_expressions[TRpod_affinity_match_expressions]\n" +
+                "input relation Rpod_anti_affinity_match_expressions[TRpod_anti_affinity_match_expressions]\n" +
+                "input relation Rpod_labels[TRpod_labels]\n" +
+                "input relation Rnode_labels[TRnode_labels]\n" +
+                "input relation Rvolume_labels[TRvolume_labels]\n" +
+                "input relation Rpod_by_service[TRpod_by_service]\n" +
+                "input relation Rservice_affinity_labels[TRservice_affinity_labels]\n" +
+                "input relation Rlabels_to_check_for_presence[TRlabels_to_check_for_presence]\n" +
+                "input relation Rnode_taints[TRnode_taints]\n" +
+                "input relation Rpod_tolerations[TRpod_tolerations]\n" +
+                "input relation Rnode_images[TRnode_images]\n" +
+                "input relation Rpod_images[TRpod_images]\n" +
                 "output relation Rpods_to_assign_no_limit[TRtmp]\n" +
-                "input relation Rbatch_size[Tbatch_size] primary key (row) (row.pendingPodsLimit)\n" +
+                "input relation Rbatch_size[TRbatch_size] primary key (row) (row.pendingPodsLimit)\n" +
                 "output relation Rpods_to_assign[TRtmp]\n" +
-                "relation Rtmp1[TRtmp1]\n" +
                 "output relation Rpods_with_port_requests[TRtmp1]\n" +
-                "relation Rtmp4[TRtmp4]\n" +
-                "output relation Rpod_node_selector_matches[TRtmp4]\n" +
+                "relation Rtmp2[Ttmp0]\n" +
+                "relation Rtmp3[TRtmp3]\n" +
+                "output relation Rpod_node_selector_matches[TRtmp3]\n" +
+                "relation Rtmp4[Ttmp2]\n" +
+                "relation Rtmp5[Ttmp3]\n" +
+                "relation Rtmp6[TRtmp6]\n" +
+                "output relation Rinter_pod_affinity_matches_inner[TRtmp6]\n" +
+                "relation Roverinput[TRtmp7]\n" +
                 "relation Rtmp8[TRtmp8]\n" +
-                "output relation Rinter_pod_affinity_matches_inner[TRtmp8]\n" +
+                "relation Rover[TRtmp8]\n" +
+                "output relation Rinter_pod_affinity_matches[TRtmp9]\n" +
                 "relation Rtmp10[TRtmp10]\n" +
-                "relation Roverinput[TRtmp10]\n" +
-                "relation Rtmp11[TRtmp11]\n" +
-                "relation Rover[TRtmp11]\n" +
-                "relation Rtmp14[TRtmp14]\n" +
-                "output relation Rinter_pod_affinity_matches[TRtmp14]\n" +
-                "relation Rtmp16[TRtmp16]\n" +
-                "output relation Rspare_capacity_per_node[TRtmp16]\n" +
-                "relation Rtmp18[TRtmp18]\n" +
-                "output relation Rnodes_that_have_tolerations[TRtmp18]\n" +
-                "relation Rtmp21[TRtmp21]\n" +
-                "relation Roverinput20[TRtmp21]\n" +
-                "relation Rtmp23[TRtmp11]\n" +
-                "relation Rover22[TRtmp11]\n" +
-                "relation Rtmp26[TRtmp26]\n" +
-                "relation Rtmp27[TRtmp26]\n" +
-                "relation Rtmp29[TRtmp4]\n" +
-                "output relation Rpods_that_tolerate_node_taints[TRtmp4]\n" +
-                "relation Rtmp31[TRtmp31]\n" +
-                "output relation Rassigned_pods[TRtmp31]\n" +
-
-                "Rpods_to_assign_no_limit[v1] :- Rpod_info[v],unwrapBool(b_and_RN(((v.status == \"Pending\") and is_null(v.node_name))," +
-                " s_eq_NR(v.schedulerName, \"dcm-scheduler\")))," +
-                "var v0 = TRtmp{.pod_name = v.pod_name,.status = v.status,.controllable__node_name = v.node_name," +
-                ".namespace = v.namespace,.cpu_request = v.cpu_request,.memory_request = v.memory_request," +
-                ".ephemeral_storage_request = v.ephemeral_storage_request,.pods_request = v.pods_request," +
-                ".owner_name = v.owner_name,.creation_timestamp = v.creation_timestamp," +
-                ".has_node_selector_labels = v.has_node_selector_labels," +
-                ".has_pod_affinity_requirements = v.has_pod_affinity_requirements}," +
-                "var v1 = v0.\n" +
-
+                "output relation Rspare_capacity_per_node[TRtmp10]\n" +
+                "output relation Rnodes_that_have_tolerations[TRtmp11]\n" +
+                "relation Roverinput0[TRtmp12]\n" +
+                "relation Rtmp13[TRtmp8]\n" +
+                "relation Rover0[TRtmp8]\n" +
+                "relation Rtmp15[TRtmp14]\n" +
+                "relation Rtmp16[Ttmp7]\n" +
+                "relation Rtmp17[TRtmp3]\n" +
+                "output relation Rpods_that_tolerate_node_taints[TRtmp3]\n" +
+                "output relation Rassigned_pods[TRtmp18]\n" +
+                "Rpods_to_assign_no_limit[v1] :- Rpod_info[v],unwrapBool(b_and_RN(((v.status == \"Pending\") and is_null(v.node_name)), s_eq_NR(v.schedulerName, \"dcm-scheduler\"))),var v0 = TRtmp{.pod_name = v.pod_name,.status = v.status,.controllable__node_name = v.node_name,.namespace = v.namespace,.cpu_request = v.cpu_request,.memory_request = v.memory_request,.ephemeral_storage_request = v.ephemeral_storage_request,.pods_request = v.pods_request,.owner_name = v.owner_name,.creation_timestamp = v.creation_timestamp,.has_node_selector_labels = v.has_node_selector_labels,.has_pod_affinity_requirements = v.has_pod_affinity_requirements},var v1 = v0.\n" +
                 "Rpods_to_assign[v0] :- Rpods_to_assign_no_limit[v],var v0 = v.\n" +
-
-                "Rpods_with_port_requests[v3] :- Rpods_to_assign[v],Rpod_ports_request[v0]," +
-                "(v0.pod_name == v.pod_name),true,var v1 = Ttmp{.pod_name = v.pod_name,.status = v.status," +
-                ".controllable__node_name = v.controllable__node_name,.namespace = v.namespace," +
-                ".cpu_request = v.cpu_request,.memory_request = v.memory_request," +
-                ".ephemeral_storage_request = v.ephemeral_storage_request,.pods_request = v.pods_request," +
-                ".owner_name = v.owner_name,.creation_timestamp = v.creation_timestamp," +
-                ".has_node_selector_labels = v.has_node_selector_labels," +
-                ".has_pod_affinity_requirements = v.has_pod_affinity_requirements,.pod_name0 = v0.pod_name," +
-                ".host_ip = v0.host_ip,.host_port = v0.host_port,.host_protocol = v0.host_protocol}," +
-                "var v2 = TRtmp1{.controllable__node_name = v.controllable__node_name,.host_port = v0.host_port," +
-                ".host_ip = v0.host_ip,.host_protocol = v0.host_protocol},var v3 = v2.\n" +
-
-                "Rpod_node_selector_matches[v12] :- Rpods_to_assign[v],Rpod_node_selector_labels[v0]," +
-                "(v.pod_name == v0.pod_name),true,var v1 = Ttmp2{.pod_name = v.pod_name,.status = v.status," +
-                ".controllable__node_name = v.controllable__node_name,.namespace = v.namespace," +
-                ".cpu_request = v.cpu_request,.memory_request = v.memory_request," +
-                ".ephemeral_storage_request = v.ephemeral_storage_request,.pods_request = v.pods_request," +
-                ".owner_name = v.owner_name,.creation_timestamp = v.creation_timestamp," +
-                ".has_node_selector_labels = v.has_node_selector_labels," +
-                ".has_pod_affinity_requirements = v.has_pod_affinity_requirements,.pod_name0 = v0.pod_name," +
-                ".term = v0.term,.match_expression = v0.match_expression,.num_match_expressions = v0.num_match_expressions," +
-                ".label_key = v0.label_key,.label_operator = v0.label_operator,.label_value = v0.label_value},Rnode_labels[v2]," +
-                "unwrapBool(b_or_NR(b_or_NR(b_or_NR(b_and_RN(((v0.label_operator == \"In\") and (v0.label_key == v2.label_key))," +
-                " s_eq_NR(v0.label_value, v2.label_value)), ((v0.label_operator == \"Exists\") and (v0.label_key == v2.label_key)))," +
-                " (v0.label_operator == \"NotIn\"))," +
-                " (v0.label_operator == \"DoesNotExist\"))),true,var v3 = Ttmp3{.pod_name = v1.pod_name," +
-                ".status = v1.status,.controllable__node_name = v1.controllable__node_name,.namespace = v1.namespace," +
-                ".cpu_request = v1.cpu_request,.memory_request = v1.memory_request," +
-                ".ephemeral_storage_request = v1.ephemeral_storage_request,.pods_request = v1.pods_request," +
-                ".owner_name = v1.owner_name,.creation_timestamp = v1.creation_timestamp," +
-                ".has_node_selector_labels = v1.has_node_selector_labels," +
-                ".has_pod_affinity_requirements = v1.has_pod_affinity_requirements,.pod_name0 = v1.pod_name0," +
-                ".term = v1.term,.match_expression = v1.match_expression," +
-                ".num_match_expressions = v1.num_match_expressions,.label_key = v1.label_key," +
-                ".label_operator = v1.label_operator,.label_value = v1.label_value,.node_name = v2.node_name," +
-                ".label_key0 = v2.label_key,.label_value0 = v2.label_value},var gb = v.pod_name,var gb4 = v2.node_name" +
-                ",var gb5 = v0.term,var gb6 = v0.label_operator,var gb7 = v0.num_match_expressions," +
-                "var groupResult = (v, v0, v2).group_by((gb, gb4, gb5, gb6, gb7)),var aggResult = agg(groupResult)," +
-                "var v11 = TRtmp4{.pod_name = gb,.node_name = gb4},unwrapBool(aggResult.col),var v12 = v11.\n" +
-
-                "Rinter_pod_affinity_matches_inner[v16] :- Rpods_to_assign[v],Rpod_affinity_match_expressions[v0]," +
-                "(v.pod_name == v0.pod_name),true,var v1 = Ttmp5{.pod_name = v.pod_name,.status = v.status," +
-                ".controllable__node_name = v.controllable__node_name,.namespace = v.namespace," +
-                ".cpu_request = v.cpu_request,.memory_request = v.memory_request," +
-                ".ephemeral_storage_request = v.ephemeral_storage_request,.pods_request = v.pods_request," +
-                ".owner_name = v.owner_name,.creation_timestamp = v.creation_timestamp," +
-                ".has_node_selector_labels = v.has_node_selector_labels," +
-                ".has_pod_affinity_requirements = v.has_pod_affinity_requirements,.pod_name0 = v0.pod_name," +
-                ".label_selector = v0.label_selector,.match_expression = v0.match_expression," +
-                ".num_match_expressions = v0.num_match_expressions," +
-                ".label_key = v0.label_key,.label_operator = v0.label_operator,.label_value = v0.label_value," +
-                ".topology_key = v0.topology_key},Rpod_labels[v2]," +
-                "((((((v0.label_operator == \"In\") and (v0.label_key == v2.label_key)) and " +
-                "(v0.label_value == v2.label_value)) or ((v0.label_operator == \"Exists\") and " +
-                "(v0.label_key == v2.label_key))) or (v0.label_operator == \"NotIn\")) " +
-                "or (v0.label_operator == \"DoesNotExist\")),true," +
-                "var v3 = Ttmp6{.pod_name = v1.pod_name,.status = v1.status,.controllable__node_name = v1.controllable__node_name," +
-                ".namespace = v1.namespace,.cpu_request = v1.cpu_request,.memory_request = v1.memory_request," +
-                ".ephemeral_storage_request = v1.ephemeral_storage_request,.pods_request = v1.pods_request," +
-                ".owner_name = v1.owner_name,.creation_timestamp = v1.creation_timestamp," +
-                ".has_node_selector_labels = v1.has_node_selector_labels," +
-                ".has_pod_affinity_requirements = v1.has_pod_affinity_requirements,.pod_name0 = v1.pod_name0," +
-                ".label_selector = v1.label_selector,.match_expression = v1.match_expression," +
-                ".num_match_expressions = v1.num_match_expressions," +
-                ".label_key = v1.label_key,.label_operator = v1.label_operator,.label_value = v1.label_value," +
-                ".topology_key = v1.topology_key,.pod_name1 = v2.pod_name,.label_key0 = v2.label_key," +
-                ".label_value0 = v2.label_value}," +
-                "Rpod_info[v4],(v2.pod_name == v4.pod_name),true,var v5 = Ttmp7{.pod_name = v3.pod_name,.status = v3.status," +
-                ".controllable__node_name = v3.controllable__node_name,.namespace = v3.namespace," +
-                ".cpu_request = v3.cpu_request," +
-                ".memory_request = v3.memory_request,.ephemeral_storage_request = v3.ephemeral_storage_request," +
-                ".pods_request = v3.pods_request,.owner_name = v3.owner_name,.creation_timestamp = v3.creation_timestamp," +
-                ".has_node_selector_labels = v3.has_node_selector_labels," +
-                ".has_pod_affinity_requirements = v3.has_pod_affinity_requirements,.pod_name0 = v3.pod_name0," +
-                ".label_selector = v3.label_selector,.match_expression = v3.match_expression," +
-                ".num_match_expressions = v3.num_match_expressions,.label_key = v3.label_key," +
-                ".label_operator = v3.label_operator,.label_value = v3.label_value,.topology_key = v3.topology_key," +
-                ".pod_name1 = v3.pod_name1,.label_key0 = v3.label_key0,.label_value0 = v3.label_value0," +
-                ".pod_name2 = v4.pod_name,.status0 = v4.status,.node_name = v4.node_name,.namespace0 = v4.namespace," +
-                ".cpu_request0 = v4.cpu_request," +
-                ".memory_request0 = v4.memory_request,.ephemeral_storage_request0 = v4.ephemeral_storage_request," +
-                ".pods_request0 = v4.pods_request,.owner_name0 = v4.owner_name,.creation_timestamp0 = v4.creation_timestamp," +
-                ".priority = v4.priority,.schedulerName = v4.schedulerName," +
-                ".has_node_selector_labels0 = v4.has_node_selector_labels," +
-                ".has_pod_affinity_requirements0 = v4.has_pod_affinity_requirements}," +
-                "var gb = v.pod_name,var gb6 = v2.pod_name,var gb7 = v0.label_selector,var gb8 = v0.topology_key," +
-                "var gb9 = v0.label_operator,var gb10 = v0.num_match_expressions,var gb11 = v4.node_name," +
-                "var groupResult = (v, v0, v2, v4).group_by((gb, gb6, gb7, gb8, gb9, gb10, gb11)),var aggResult = agg9(groupResult)," +
-                "var v15 = TRtmp8{.pod_name = gb,.matches = gb6,.node_name = gb11},aggResult.col,var v16 = v15.\n" +
-
-                "Roverinput[v2] :- Rinter_pod_affinity_matches_inner[v0],var v1 = TRtmp10{.gb = v0.pod_name," +
-                ".pod_name = v0.pod_name,.matches = v0.matches,.node_name = v0.node_name},var v2 = v1.\n" +
-                "Rover[v7] :- Roverinput[v3],var gb4 = v3.gb,var groupResult = (v3).group_by((gb4)),var aggResult = agg12(groupResult)," +
-                "var v6 = TRtmp11{.gb = gb4,.count = aggResult.count},var v7 = v6.\n" +
-                "Rinter_pod_affinity_matches[v12] :- Roverinput[v8],Rover[v9],(true and (v8.gb == v9.gb))," +
-                "var v10 = Ttmp13{.gb = v8.gb,.pod_name = v8.pod_name,.matches = v8.matches,.node_name = v8.node_name," +
-                ".count = v9.count},var v11 = TRtmp14{.pod_name = v8.pod_name,.matches = v8.matches," +
-                ".node_name = v8.node_name,.num_matches = v9.count},var v12 = v11.\n" +
-
-                "Rspare_capacity_per_node[v10] :- Rnode_info[v],Rpod_info[v0],unwrapBool(b_and_NN(s_eq_NR(v0.node_name, v.name), " +
-                "s_neq_NR(v0.node_name, \"null\"))),true," +
-                "var v1 = Ttmp15{.name = v.name,.unschedulable = v.unschedulable,.out_of_disk = v.out_of_disk," +
-                ".memory_pressure = v.memory_pressure,.disk_pressure = v.disk_pressure,.pid_pressure = v.pid_pressure," +
-                ".ready = v.ready,.network_unavailable = v.network_unavailable,.cpu_capacity = v.cpu_capacity," +
-                ".memory_capacity = v.memory_capacity,.ephemeral_storage_capacity = v.ephemeral_storage_capacity," +
-                ".pods_capacity = v.pods_capacity,.cpu_allocatable = v.cpu_allocatable,.memory_allocatable = v.memory_allocatable," +
-                ".ephemeral_storage_allocatable = v.ephemeral_storage_allocatable,.pods_allocatable = v.pods_allocatable," +
-                ".pod_name = v0.pod_name,.status = v0.status,.node_name = v0.node_name,.namespace = v0.namespace," +
-                ".cpu_request = v0.cpu_request,.memory_request = v0.memory_request,.ephemeral_storage_request = v0.ephemeral_storage_request," +
-                ".pods_request = v0.pods_request,.owner_name = v0.owner_name,.creation_timestamp = v0.creation_timestamp," +
-                ".priority = v0.priority,.schedulerName = v0.schedulerName,.has_node_selector_labels = v0.has_node_selector_labels," +
-                ".has_pod_affinity_requirements = v0.has_pod_affinity_requirements}," +
-                "var gb = v.name,var gb2 = v.cpu_allocatable,var gb3 = v.memory_allocatable,var gb4 = v.pods_allocatable," +
-                "var groupResult = (v, v0).group_by((gb, gb2, gb3, gb4)),var aggResult = agg17(groupResult)," +
-                "var v9 = TRtmp16{.name = gb,.cpu_remaining = aggResult.cpu_remaining,.memory_remaining = aggResult.memory_remaining," +
-                ".pods_remaining = aggResult.pods_remaining},var v10 = v9.\n" +
-                "Rnodes_that_have_tolerations[v1] :- Rnode_taints[v],var v0 = TRtmp18{.node_name = v.node_name},var v1 = v0.\n" +
-
-                "Roverinput20[v5] :- Rnode_taints[v3],var v4 = TRtmp21{.gb = v3.node_name," +
-                ".node_name = v3.node_name,.taint_key = v3.taint_key,.taint_value = v3.taint_value," +
-                ".taint_effect = v3.taint_effect},var v5 = v4.\n" +
-                "Rover22[v10] :- Roverinput20[v6],var gb7 = v6.gb,var groupResult = (v6).group_by((gb7)),var aggResult = agg24(groupResult)," +
-                "var v9 = TRtmp11{.gb = gb7,.count = aggResult.count},var v10 = v9.\n" +
-                "Rtmp27[v15] :- Roverinput20[v11],Rover22[v12],(true and (v11.gb == v12.gb))," +
-                "var v13 = Ttmp25{.gb = v11.gb,.node_name = v11.node_name,.taint_key = v11.taint_key," +
-                ".taint_value = v11.taint_value,.taint_effect = v11.taint_effect,.count = v12.count}," +
-                "var v14 = TRtmp26{.node_name = v11.node_name,.taint_key = v11.taint_key," +
-                ".taint_value = v11.taint_value,.taint_effect = v11.taint_effect,.num_taints = v12.count}," +
-                "var v15 = v14.\n" +
-                "Rpods_that_tolerate_node_taints[v26] :- Rpods_to_assign[v],Rpod_tolerations[v0]," +
-                "(v.pod_name == v0.pod_name),true,var v1 = Ttmp19{.pod_name = v.pod_name,.status = v.status," +
-                ".controllable__node_name = v.controllable__node_name,.namespace = v.namespace," +
-                ".cpu_request = v.cpu_request,.memory_request = v.memory_request," +
-                ".ephemeral_storage_request = v.ephemeral_storage_request,.pods_request = v.pods_request," +
-                ".owner_name = v.owner_name,.creation_timestamp = v.creation_timestamp," +
-                ".has_node_selector_labels = v.has_node_selector_labels," +
-                ".has_pod_affinity_requirements = v.has_pod_affinity_requirements,.pod_name0 = v0.pod_name," +
-                ".tolerations_key = v0.tolerations_key,.tolerations_value = v0.tolerations_value," +
-                ".tolerations_effect = v0.tolerations_effect,.tolerations_operator = v0.tolerations_operator}," +
-                "Rtmp27[v15],unwrapBool(b_and_NN(b_and_NN(s_eq_NR(v0.tolerations_key, v15.taint_key), " +
-                "b_or_NN(s_eq_NN(v0.tolerations_effect, None{}: Option<string>), " +
-                "s_eq_NR(v0.tolerations_effect, v15.taint_effect))), b_or_NN(s_eq_NR(v0.tolerations_operator, \"Exists\"), "+
-                "s_eq_NN(v0.tolerations_value, v15.taint_value)))),true,var v16 = Ttmp28{.pod_name = v1.pod_name," +
-                ".status = v1.status,.controllable__node_name = v1.controllable__node_name,.namespace = v1.namespace," +
-                ".cpu_request = v1.cpu_request,.memory_request = v1.memory_request," +
-                ".ephemeral_storage_request = v1.ephemeral_storage_request,.pods_request = v1.pods_request," +
-                ".owner_name = v1.owner_name,.creation_timestamp = v1.creation_timestamp," +
-                ".has_node_selector_labels = v1.has_node_selector_labels," +
-                ".has_pod_affinity_requirements = v1.has_pod_affinity_requirements,.pod_name0 = v1.pod_name0," +
-                ".tolerations_key = v1.tolerations_key,.tolerations_value = v1.tolerations_value," +
-                ".tolerations_effect = v1.tolerations_effect,.tolerations_operator = v1.tolerations_operator," +
-                ".node_name = v15.node_name,.taint_key = v15.taint_key,.taint_value = v15.taint_value," +
-                ".taint_effect = v15.taint_effect,.num_taints = v15.num_taints},var gb17 = v0.pod_name," +
-                "var gb18 = v15.node_name,var gb19 = v15.num_taints,var groupResult25 = (v, v0, v15).group_by((gb17, gb18, gb19))," +
-                "var aggResult24 = agg30(groupResult25),var v23 = TRtmp4{.pod_name = gb17,.node_name = gb18}," +
-                "aggResult24.col,var v26 = v23.\n" +
-                "Rassigned_pods[v1] :- Rpod_info[v],(not is_null(v.node_name))," +
-                "var v0 = TRtmp31{.pod_name = v.pod_name,.status = v.status,.node_name = v.node_name," +
-                ".namespace = v.namespace,.cpu_request = v.cpu_request,.memory_request = v.memory_request," +
-                ".ephemeral_storage_request = v.ephemeral_storage_request,.pods_request = v.pods_request," +
-                ".owner_name = v.owner_name,.creation_timestamp = v.creation_timestamp," +
-                ".has_node_selector_labels = v.has_node_selector_labels," +
-                ".has_pod_affinity_requirements = v.has_pod_affinity_requirements},var v1 = v0.";
+                "Rpods_with_port_requests[v3] :- Rpods_to_assign[TRtmp{.pod_name = pod_name,.status = status,.controllable__node_name = controllable__node_name,.namespace = namespace,.cpu_request = cpu_request,.memory_request = memory_request,.ephemeral_storage_request = ephemeral_storage_request,.pods_request = pods_request,.owner_name = owner_name,.creation_timestamp = creation_timestamp,.has_node_selector_labels = has_node_selector_labels,.has_pod_affinity_requirements = has_pod_affinity_requirements}],Rpod_ports_request[TRpod_ports_request{.pod_name = pod_name,.host_ip = host_ip,.host_port = host_port,.host_protocol = host_protocol}],var v1 = Ttmp{.pod_name = pod_name,.status = status,.controllable__node_name = controllable__node_name,.namespace = namespace,.cpu_request = cpu_request,.memory_request = memory_request,.ephemeral_storage_request = ephemeral_storage_request,.pods_request = pods_request,.owner_name = owner_name,.creation_timestamp = creation_timestamp,.has_node_selector_labels = has_node_selector_labels,.has_pod_affinity_requirements = has_pod_affinity_requirements,.host_ip = host_ip,.host_port = host_port,.host_protocol = host_protocol},var v2 = TRtmp1{.controllable__node_name = v1.controllable__node_name,.host_port = v1.host_port,.host_ip = v1.host_ip,.host_protocol = v1.host_protocol},var v3 = v2.\n" +
+                "Rtmp2[v3] :- Rpods_to_assign[TRtmp{.pod_name = pod_name,.status = status,.controllable__node_name = controllable__node_name,.namespace = namespace,.cpu_request = cpu_request,.memory_request = memory_request,.ephemeral_storage_request = ephemeral_storage_request,.pods_request = pods_request,.owner_name = owner_name,.creation_timestamp = creation_timestamp,.has_node_selector_labels = has_node_selector_labels,.has_pod_affinity_requirements = has_pod_affinity_requirements}],Rpod_node_selector_labels[TRpod_node_selector_labels{.pod_name = pod_name,.term = term,.match_expression = match_expression,.num_match_expressions = num_match_expressions,.label_key = label_key,.label_operator = label_operator,.label_value = label_value}],var v1 = Ttmp0{.pod_name = pod_name,.status = status,.controllable__node_name = controllable__node_name,.namespace = namespace,.cpu_request = cpu_request,.memory_request = memory_request,.ephemeral_storage_request = ephemeral_storage_request,.pods_request = pods_request,.owner_name = owner_name,.creation_timestamp = creation_timestamp,.has_node_selector_labels = has_node_selector_labels,.has_pod_affinity_requirements = has_pod_affinity_requirements,.term = term,.match_expression = match_expression,.num_match_expressions = num_match_expressions,.label_key = label_key,.label_operator = label_operator,.label_value = label_value},var v3 = v1.\n" +
+                "Rpod_node_selector_matches[v6] :- Rpods_to_assign[TRtmp{.pod_name = pod_name,.status = status,.controllable__node_name = controllable__node_name,.namespace = namespace,.cpu_request = cpu_request,.memory_request = memory_request,.ephemeral_storage_request = ephemeral_storage_request,.pods_request = pods_request,.owner_name = owner_name,.creation_timestamp = creation_timestamp,.has_node_selector_labels = has_node_selector_labels,.has_pod_affinity_requirements = has_pod_affinity_requirements}],Rpod_node_selector_labels[TRpod_node_selector_labels{.pod_name = pod_name,.term = term,.match_expression = match_expression,.num_match_expressions = num_match_expressions,.label_key = label_key,.label_operator = label_operator,.label_value = label_value}],var v1 = Ttmp0{.pod_name = pod_name,.status = status,.controllable__node_name = controllable__node_name,.namespace = namespace,.cpu_request = cpu_request,.memory_request = memory_request,.ephemeral_storage_request = ephemeral_storage_request,.pods_request = pods_request,.owner_name = owner_name,.creation_timestamp = creation_timestamp,.has_node_selector_labels = has_node_selector_labels,.has_pod_affinity_requirements = has_pod_affinity_requirements,.term = term,.match_expression = match_expression,.num_match_expressions = num_match_expressions,.label_key = label_key,.label_operator = label_operator,.label_value = label_value},var v3 = v1,Rnode_labels[v2],unwrapBool(b_or_NR(b_or_NR(b_or_NR(b_and_RN(((v1.label_operator == \"In\") and (v1.label_key == v2.label_key)), s_eq_NR(v1.label_value, v2.label_value)), ((v1.label_operator == \"Exists\") and (v1.label_key == v2.label_key))), (v1.label_operator == \"NotIn\")), (v1.label_operator == \"DoesNotExist\"))),var v4 = Ttmp1{.pod_name = v1.pod_name,.status = v1.status,.controllable__node_name = v1.controllable__node_name,.namespace = v1.namespace,.cpu_request = v1.cpu_request,.memory_request = v1.memory_request,.ephemeral_storage_request = v1.ephemeral_storage_request,.pods_request = v1.pods_request,.owner_name = v1.owner_name,.creation_timestamp = v1.creation_timestamp,.has_node_selector_labels = v1.has_node_selector_labels,.has_pod_affinity_requirements = v1.has_pod_affinity_requirements,.term = v1.term,.match_expression = v1.match_expression,.num_match_expressions = v1.num_match_expressions,.label_key = v1.label_key,.label_operator = v1.label_operator,.label_value = v1.label_value,.node_name = v2.node_name,.label_key0 = v2.label_key,.label_value0 = v2.label_value},var gb = v4.pod_name,var gb0 = v4.node_name,var gb1 = v4.term,var gb2 = v4.label_operator,var gb3 = v4.num_match_expressions,var groupResult = (v1, v3, v2, v4).group_by((gb, gb0, gb1, gb2, gb3)),var aggResult = agg(groupResult),var v5 = TRtmp3{.pod_name = gb,.node_name = gb0},unwrapBool(aggResult.col),var v6 = v5.\n" +
+                "Rtmp4[v3] :- Rpods_to_assign[TRtmp{.pod_name = pod_name,.status = status,.controllable__node_name = controllable__node_name,.namespace = namespace,.cpu_request = cpu_request,.memory_request = memory_request,.ephemeral_storage_request = ephemeral_storage_request,.pods_request = pods_request,.owner_name = owner_name,.creation_timestamp = creation_timestamp,.has_node_selector_labels = has_node_selector_labels,.has_pod_affinity_requirements = has_pod_affinity_requirements}],Rpod_affinity_match_expressions[TRpod_affinity_match_expressions{.pod_name = pod_name,.label_selector = label_selector,.match_expression = match_expression,.num_match_expressions = num_match_expressions,.label_key = label_key,.label_operator = label_operator,.label_value = label_value,.topology_key = topology_key}],var v1 = Ttmp2{.pod_name = pod_name,.status = status,.controllable__node_name = controllable__node_name,.namespace = namespace,.cpu_request = cpu_request,.memory_request = memory_request,.ephemeral_storage_request = ephemeral_storage_request,.pods_request = pods_request,.owner_name = owner_name,.creation_timestamp = creation_timestamp,.has_node_selector_labels = has_node_selector_labels,.has_pod_affinity_requirements = has_pod_affinity_requirements,.label_selector = label_selector,.match_expression = match_expression,.num_match_expressions = num_match_expressions,.label_key = label_key,.label_operator = label_operator,.label_value = label_value,.topology_key = topology_key},var v3 = v1.\n" +
+                "Rtmp5[v6] :- Rpods_to_assign[TRtmp{.pod_name = pod_name,.status = status,.controllable__node_name = controllable__node_name,.namespace = namespace,.cpu_request = cpu_request,.memory_request = memory_request,.ephemeral_storage_request = ephemeral_storage_request,.pods_request = pods_request,.owner_name = owner_name,.creation_timestamp = creation_timestamp,.has_node_selector_labels = has_node_selector_labels,.has_pod_affinity_requirements = has_pod_affinity_requirements}],Rpod_affinity_match_expressions[TRpod_affinity_match_expressions{.pod_name = pod_name,.label_selector = label_selector,.match_expression = match_expression,.num_match_expressions = num_match_expressions,.label_key = label_key,.label_operator = label_operator,.label_value = label_value,.topology_key = topology_key}],var v1 = Ttmp2{.pod_name = pod_name,.status = status,.controllable__node_name = controllable__node_name,.namespace = namespace,.cpu_request = cpu_request,.memory_request = memory_request,.ephemeral_storage_request = ephemeral_storage_request,.pods_request = pods_request,.owner_name = owner_name,.creation_timestamp = creation_timestamp,.has_node_selector_labels = has_node_selector_labels,.has_pod_affinity_requirements = has_pod_affinity_requirements,.label_selector = label_selector,.match_expression = match_expression,.num_match_expressions = num_match_expressions,.label_key = label_key,.label_operator = label_operator,.label_value = label_value,.topology_key = topology_key},var v3 = v1,Rpod_labels[v2],((((((v1.label_operator == \"In\") and (v1.label_key == v2.label_key)) and (v1.label_value == v2.label_value)) or ((v1.label_operator == \"Exists\") and (v1.label_key == v2.label_key))) or (v1.label_operator == \"NotIn\")) or (v1.label_operator == \"DoesNotExist\")),var v4 = Ttmp3{.pod_name = v1.pod_name,.status = v1.status,.controllable__node_name = v1.controllable__node_name,.namespace = v1.namespace,.cpu_request = v1.cpu_request,.memory_request = v1.memory_request,.ephemeral_storage_request = v1.ephemeral_storage_request,.pods_request = v1.pods_request,.owner_name = v1.owner_name,.creation_timestamp = v1.creation_timestamp,.has_node_selector_labels = v1.has_node_selector_labels,.has_pod_affinity_requirements = v1.has_pod_affinity_requirements,.label_selector = v1.label_selector,.match_expression = v1.match_expression,.num_match_expressions = v1.num_match_expressions,.label_key = v1.label_key,.label_operator = v1.label_operator,.label_value = v1.label_value,.topology_key = v1.topology_key,.pod_name0 = v2.pod_name,.label_key0 = v2.label_key,.label_value0 = v2.label_value},var v6 = v4.\n" +
+                "Rinter_pod_affinity_matches_inner[v9] :- Rtmp5[Ttmp3{.pod_name = pod_name2,.status = status0,.controllable__node_name = controllable__node_name0,.namespace = namespace0,.cpu_request = cpu_request0,.memory_request = memory_request0,.ephemeral_storage_request = ephemeral_storage_request0,.pods_request = pods_request0,.owner_name = owner_name0,.creation_timestamp = creation_timestamp0,.has_node_selector_labels = has_node_selector_labels0,.has_pod_affinity_requirements = has_pod_affinity_requirements0,.label_selector = label_selector0,.match_expression = match_expression0,.num_match_expressions = num_match_expressions0,.label_key = label_key1,.label_operator = label_operator0,.label_value = label_value1,.topology_key = topology_key0,.pod_name0 = pod_name00,.label_key0 = label_key00,.label_value0 = label_value00}],Rpod_info[TRpod_info{.pod_name = pod_name2,.status = status1,.node_name = node_name,.namespace = namespace1,.cpu_request = cpu_request1,.memory_request = memory_request1,.ephemeral_storage_request = ephemeral_storage_request1,.pods_request = pods_request1,.owner_name = owner_name1,.creation_timestamp = creation_timestamp1,.priority = priority,.schedulerName = schedulerName,.has_node_selector_labels = has_node_selector_labels1,.has_pod_affinity_requirements = has_pod_affinity_requirements1}],var v7 = Ttmp4{.pod_name = pod_name2,.status = status0,.controllable__node_name = controllable__node_name0,.namespace = namespace0,.cpu_request = cpu_request0,.memory_request = memory_request0,.ephemeral_storage_request = ephemeral_storage_request0,.pods_request = pods_request0,.owner_name = owner_name0,.creation_timestamp = creation_timestamp0,.has_node_selector_labels = has_node_selector_labels0,.has_pod_affinity_requirements = has_pod_affinity_requirements0,.label_selector = label_selector0,.match_expression = match_expression0,.num_match_expressions = num_match_expressions0,.label_key = label_key1,.label_operator = label_operator0,.label_value = label_value1,.topology_key = topology_key0,.pod_name0 = pod_name00,.label_key0 = label_key00,.label_value0 = label_value00,.status0 = status1,.node_name = node_name,.namespace0 = namespace1,.cpu_request0 = cpu_request1,.memory_request0 = memory_request1,.ephemeral_storage_request0 = ephemeral_storage_request1,.pods_request0 = pods_request1,.owner_name0 = owner_name1,.creation_timestamp0 = creation_timestamp1,.priority = priority,.schedulerName = schedulerName,.has_node_selector_labels0 = has_node_selector_labels1,.has_pod_affinity_requirements0 = has_pod_affinity_requirements1},var gb = v7.pod_name,var gb0 = v7.pod_name0,var gb1 = v7.label_selector,var gb2 = v7.topology_key,var gb3 = v7.label_operator,var gb4 = v7.num_match_expressions,var gb5 = v7.node_name,var groupResult = (v7).group_by((gb, gb0, gb1, gb2, gb3, gb4, gb5)),var aggResult = agg0(groupResult),var v8 = TRtmp6{.pod_name = gb,.matches = gb0,.node_name = gb5},aggResult.col,var v9 = v8.\n" +
+                "Roverinput[v2] :- Rinter_pod_affinity_matches_inner[v0],var v1 = TRtmp7{.gb = v0.pod_name,.pod_name = v0.pod_name,.matches = v0.matches,.node_name = v0.node_name},var v2 = v1.\n" +
+                "Rover[v5] :- Roverinput[v3],var gb0 = v3.gb,var groupResult = (v3).group_by((gb0)),var aggResult = agg1(groupResult),var v4 = TRtmp8{.gb = gb0,.count = aggResult.count},var v5 = v4.\n" +
+                "Rinter_pod_affinity_matches[v10] :- Roverinput[TRtmp7{.gb = gb1,.pod_name = pod_name,.matches = matches,.node_name = node_name}],Rover[TRtmp8{.gb = gb1,.count = count1}],var v8 = Ttmp5{.gb = gb1,.pod_name = pod_name,.matches = matches,.node_name = node_name,.count = count1},var v9 = TRtmp9{.pod_name = v8.pod_name,.matches = v8.matches,.node_name = v8.node_name,.num_matches = v8.count},var v10 = v9.\n" +
+                "Rspare_capacity_per_node[v3] :- Rnode_info[v],Rpod_info[v0],unwrapBool(b_and_NN(s_eq_NR(v0.node_name, v.name), s_neq_NR(v0.node_name, \"null\"))),var v1 = Ttmp6{.name = v.name,.unschedulable = v.unschedulable,.out_of_disk = v.out_of_disk,.memory_pressure = v.memory_pressure,.disk_pressure = v.disk_pressure,.pid_pressure = v.pid_pressure,.ready = v.ready,.network_unavailable = v.network_unavailable,.cpu_capacity = v.cpu_capacity,.memory_capacity = v.memory_capacity,.ephemeral_storage_capacity = v.ephemeral_storage_capacity,.pods_capacity = v.pods_capacity,.cpu_allocatable = v.cpu_allocatable,.memory_allocatable = v.memory_allocatable,.ephemeral_storage_allocatable = v.ephemeral_storage_allocatable,.pods_allocatable = v.pods_allocatable,.pod_name = v0.pod_name,.status = v0.status,.node_name = v0.node_name,.namespace = v0.namespace,.cpu_request = v0.cpu_request,.memory_request = v0.memory_request,.ephemeral_storage_request = v0.ephemeral_storage_request,.pods_request = v0.pods_request,.owner_name = v0.owner_name,.creation_timestamp = v0.creation_timestamp,.priority = v0.priority,.schedulerName = v0.schedulerName,.has_node_selector_labels = v0.has_node_selector_labels,.has_pod_affinity_requirements = v0.has_pod_affinity_requirements},var gb = v1.name,var gb0 = v1.cpu_allocatable,var gb1 = v1.memory_allocatable,var gb2 = v1.pods_allocatable,var groupResult = (v, v0, v1).group_by((gb, gb0, gb1, gb2)),var aggResult = agg2(groupResult),var v2 = TRtmp10{.name = gb,.cpu_remaining = aggResult.cpu_remaining,.memory_remaining = aggResult.memory_remaining,.pods_remaining = aggResult.pods_remaining},var v3 = v2.\n" +
+                "Rnodes_that_have_tolerations[v1] :- Rnode_taints[v],var v0 = TRtmp11{.node_name = v.node_name},var v1 = v0.\n" +
+                "Roverinput0[v5] :- Rnode_taints[v3],var v4 = TRtmp12{.gb = v3.node_name,.node_name = v3.node_name,.taint_key = v3.taint_key,.taint_value = v3.taint_value,.taint_effect = v3.taint_effect},var v5 = v4.\n" +
+                "Rover0[v8] :- Roverinput0[v6],var gb0 = v6.gb,var groupResult = (v6).group_by((gb0)),var aggResult = agg3(groupResult),var v7 = TRtmp8{.gb = gb0,.count = aggResult.count},var v8 = v7.\n" +
+                "Rtmp15[v13] :- Roverinput0[TRtmp12{.gb = gb1,.node_name = node_name,.taint_key = taint_key,.taint_value = taint_value,.taint_effect = taint_effect}],Rover0[TRtmp8{.gb = gb1,.count = count1}],var v11 = Ttmp8{.gb = gb1,.node_name = node_name,.taint_key = taint_key,.taint_value = taint_value,.taint_effect = taint_effect,.count = count1},var v12 = TRtmp14{.node_name = v11.node_name,.taint_key = v11.taint_key,.taint_value = v11.taint_value,.taint_effect = v11.taint_effect,.num_taints = v11.count},var v13 = v12.\n" +
+                "Rtmp16[v14] :- Rpods_to_assign[TRtmp{.pod_name = pod_name,.status = status,.controllable__node_name = controllable__node_name,.namespace = namespace,.cpu_request = cpu_request,.memory_request = memory_request,.ephemeral_storage_request = ephemeral_storage_request,.pods_request = pods_request,.owner_name = owner_name,.creation_timestamp = creation_timestamp,.has_node_selector_labels = has_node_selector_labels,.has_pod_affinity_requirements = has_pod_affinity_requirements}],Rpod_tolerations[TRpod_tolerations{.pod_name = pod_name,.tolerations_key = tolerations_key,.tolerations_value = tolerations_value,.tolerations_effect = tolerations_effect,.tolerations_operator = tolerations_operator}],var v1 = Ttmp7{.pod_name = pod_name,.status = status,.controllable__node_name = controllable__node_name,.namespace = namespace,.cpu_request = cpu_request,.memory_request = memory_request,.ephemeral_storage_request = ephemeral_storage_request,.pods_request = pods_request,.owner_name = owner_name,.creation_timestamp = creation_timestamp,.has_node_selector_labels = has_node_selector_labels,.has_pod_affinity_requirements = has_pod_affinity_requirements,.tolerations_key = tolerations_key,.tolerations_value = tolerations_value,.tolerations_effect = tolerations_effect,.tolerations_operator = tolerations_operator},var v14 = v1.\n" +
+                "Rpods_that_tolerate_node_taints[v17] :- Rpods_to_assign[TRtmp{.pod_name = pod_name,.status = status,.controllable__node_name = controllable__node_name,.namespace = namespace,.cpu_request = cpu_request,.memory_request = memory_request,.ephemeral_storage_request = ephemeral_storage_request,.pods_request = pods_request,.owner_name = owner_name,.creation_timestamp = creation_timestamp,.has_node_selector_labels = has_node_selector_labels,.has_pod_affinity_requirements = has_pod_affinity_requirements}],Rpod_tolerations[TRpod_tolerations{.pod_name = pod_name,.tolerations_key = tolerations_key,.tolerations_value = tolerations_value,.tolerations_effect = tolerations_effect,.tolerations_operator = tolerations_operator}],var v1 = Ttmp7{.pod_name = pod_name,.status = status,.controllable__node_name = controllable__node_name,.namespace = namespace,.cpu_request = cpu_request,.memory_request = memory_request,.ephemeral_storage_request = ephemeral_storage_request,.pods_request = pods_request,.owner_name = owner_name,.creation_timestamp = creation_timestamp,.has_node_selector_labels = has_node_selector_labels,.has_pod_affinity_requirements = has_pod_affinity_requirements,.tolerations_key = tolerations_key,.tolerations_value = tolerations_value,.tolerations_effect = tolerations_effect,.tolerations_operator = tolerations_operator},var v14 = v1,Rtmp15[v13],unwrapBool(b_and_NN(b_and_NN(s_eq_NR(v1.tolerations_key, v13.taint_key), b_or_NN(s_eq_NN(v1.tolerations_effect, None{}: Option<string>), s_eq_NR(v1.tolerations_effect, v13.taint_effect))), b_or_NN(s_eq_NR(v1.tolerations_operator, \"Exists\"), s_eq_NN(v1.tolerations_value, v13.taint_value)))),var v15 = Ttmp9{.pod_name = v1.pod_name,.status = v1.status,.controllable__node_name = v1.controllable__node_name,.namespace = v1.namespace,.cpu_request = v1.cpu_request,.memory_request = v1.memory_request,.ephemeral_storage_request = v1.ephemeral_storage_request,.pods_request = v1.pods_request,.owner_name = v1.owner_name,.creation_timestamp = v1.creation_timestamp,.has_node_selector_labels = v1.has_node_selector_labels,.has_pod_affinity_requirements = v1.has_pod_affinity_requirements,.tolerations_key = v1.tolerations_key,.tolerations_value = v1.tolerations_value,.tolerations_effect = v1.tolerations_effect,.tolerations_operator = v1.tolerations_operator,.node_name = v13.node_name,.taint_key = v13.taint_key,.taint_value = v13.taint_value,.taint_effect = v13.taint_effect,.num_taints = v13.num_taints},var gb3 = v15.pod_name,var gb4 = v15.node_name,var gb5 = v15.num_taints,var groupResult0 = (v1, v14, v13, v15).group_by((gb3, gb4, gb5)),var aggResult0 = agg4(groupResult0),var v16 = TRtmp3{.pod_name = gb3,.node_name = gb4},aggResult0.col,var v17 = v16.\n" +
+                "Rassigned_pods[v1] :- Rpod_info[v],(not is_null(v.node_name)),var v0 = TRtmp18{.pod_name = v.pod_name,.status = v.status,.node_name = v.node_name,.namespace = v.namespace,.cpu_request = v.cpu_request,.memory_request = v.memory_request,.ephemeral_storage_request = v.ephemeral_storage_request,.pods_request = v.pods_request,.owner_name = v.owner_name,.creation_timestamp = v.creation_timestamp,.has_node_selector_labels = v.has_node_selector_labels,.has_pod_affinity_requirements = v.has_pod_affinity_requirements},var v1 = v0.";
         Assert.assertEquals(expected, p);
         this.compiledDDlog(p);
     }

--- a/sql/src/test/java/ddlog/WindowTest.java
+++ b/sql/src/test/java/ddlog/WindowTest.java
@@ -38,31 +38,24 @@ public class WindowTest extends BaseQueriesTest {
                 "typedef Ttmp = Ttmp{tmp:bool, gb:string, column1:signed<64>, column2:string, column3:bool, column4:double, count:signed<64>}\n" +
                 "typedef TRtmp1 = TRtmp1{column1:signed<64>, column2:string, column3:bool, column4:double, c2:signed<64>}\n" +
                 "function agg(g: Group<string, TRtmp>):Tagg {\n" +
-                "(var gb4) = group_key(g);\n" +
-                "(var count5 = 64'sd0: signed<64>);\n" +
+                "(var gb0) = group_key(g);\n" +
+                "(var count0 = 64'sd0: signed<64>);\n" +
                 "(for ((i, _) in g) {\n" +
                 "var v3 = i;\n" +
                 "(var incr = v3.tmp);\n" +
-                "(count5 = agg_count_R(count5, incr))}\n" +
+                "(count0 = agg_count_R(count0, incr))}\n" +
                 ");\n" +
-                "(Tagg{.count = count5})\n" +
+                "(Tagg{.count = count0})\n" +
                 "}\n" +
                 this.relations(false) +
-                "relation Rtmp[TRtmp]\n" +
                 "relation Roverinput[TRtmp]\n" +
                 "relation Rtmp0[TRtmp0]\n" +
                 "relation Rover[TRtmp0]\n" +
-                "relation Rtmp1[TRtmp1]\n" +
                 "output relation Rv1[TRtmp1]\n" +
                 "Roverinput[v2] :- Rt1[v0],var v1 = TRtmp{.tmp = v0.column3,.gb = v0.column2,.column1 = v0.column1," +
                 ".column2 = v0.column2,.column3 = v0.column3,.column4 = v0.column4},var v2 = v1.\n" +
-                "Rover[v7] :- Roverinput[v3],var gb4 = v3.gb,var groupResult = (v3).group_by((gb4)),var aggResult = agg(groupResult)," +
-                "var v6 = TRtmp0{.gb = gb4,.count = aggResult.count},var v7 = v6.\n" +
-                "Rv1[v12] :- Roverinput[v8],Rover[v9],(true and (v8.gb == v9.gb))," +
-                "var v10 = Ttmp{.tmp = v8.tmp,.gb = v8.gb,.column1 = v8.column1,.column2 = v8.column2," +
-                ".column3 = v8.column3,.column4 = v8.column4,.count = v9.count}," +
-                "var v11 = TRtmp1{.column1 = v8.column1,.column2 = v8.column2,.column3 = v8.column3," +
-                ".column4 = v8.column4,.c2 = v9.count},var v12 = v11.";
+                "Rover[v5] :- Roverinput[v3],var gb0 = v3.gb,var groupResult = (v3).group_by((gb0)),var aggResult = agg(groupResult),var v4 = TRtmp0{.gb = gb0,.count = aggResult.count},var v5 = v4.\n" +
+                "Rv1[v10] :- Roverinput[TRtmp{.tmp = tmp0,.gb = gb1,.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4}],Rover[TRtmp0{.gb = gb1,.count = count1}],var v8 = Ttmp{.tmp = tmp0,.gb = gb1,.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4,.count = count1},var v9 = TRtmp1{.column1 = v8.column1,.column2 = v8.column2,.column3 = v8.column3,.column4 = v8.column4,.c2 = v8.count},var v10 = v9.";
         this.testTranslation(query, translation);
     }
 
@@ -77,31 +70,24 @@ public class WindowTest extends BaseQueriesTest {
                 "typedef Ttmp = Ttmp{tmp:bool, gb:string, column1:signed<64>, column2:string, column3:bool, column4:double, count:signed<64>}\n" +
                 "typedef TRtmp1 = TRtmp1{column1:signed<64>, column2:string, column3:bool, column4:double, c2:signed<64>}\n" +
                 "function agg(g: Group<string, TRtmp>):Tagg {\n" +
-                "(var gb4) = group_key(g);\n" +
-                "(var count5 = 64'sd0: signed<64>);\n" +
+                "(var gb0) = group_key(g);\n" +
+                "(var count0 = 64'sd0: signed<64>);\n" +
                 "(for ((i, _) in g) {\n" +
                 "var v3 = i;\n" +
                 "(var incr = v3.tmp);\n" +
-                "(count5 = agg_count_R(count5, incr))}\n" +
+                "(count0 = agg_count_R(count0, incr))}\n" +
                 ");\n" +
-                "(Tagg{.count = count5})\n" +
+                "(Tagg{.count = count0})\n" +
                 "}\n" +
                 this.relations(false) +
-                "relation Rtmp[TRtmp]\n" +
                 "relation Roverinput[TRtmp]\n" +
                 "relation Rtmp0[TRtmp0]\n" +
                 "relation Rover[TRtmp0]\n" +
-                "relation Rtmp1[TRtmp1]\n" +
                 "output relation Rv1[TRtmp1]\n" +
                 "Roverinput[v2] :- Rt1[v0],var v1 = TRtmp{.tmp = v0.column3,.gb = v0.column2,.column1 = v0.column1," +
                 ".column2 = v0.column2,.column3 = v0.column3,.column4 = v0.column4},var v2 = v1.\n" +
-                "Rover[v7] :- Roverinput[v3],var gb4 = v3.gb,var groupResult = (v3).group_by((gb4)),var aggResult = agg(groupResult)," +
-                "var v6 = TRtmp0{.gb = gb4,.count = aggResult.count},var v7 = v6.\n" +
-                "Rv1[v12] :- Roverinput[v8],Rover[v9],(true and (v8.gb == v9.gb))," +
-                "var v10 = Ttmp{.tmp = v8.tmp,.gb = v8.gb,.column1 = v8.column1,.column2 = v8.column2," +
-                ".column3 = v8.column3,.column4 = v8.column4,.count = v9.count}," +
-                "var v11 = TRtmp1{.column1 = v8.column1,.column2 = v8.column2,.column3 = v8.column3,.column4 = v8.column4,.c2 = (64'sd3 + v9.count)}," +
-                "var v12 = v11.";
+                "Rover[v5] :- Roverinput[v3],var gb0 = v3.gb,var groupResult = (v3).group_by((gb0)),var aggResult = agg(groupResult),var v4 = TRtmp0{.gb = gb0,.count = aggResult.count},var v5 = v4.\n" +
+                "Rv1[v10] :- Roverinput[TRtmp{.tmp = tmp0,.gb = gb1,.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4}],Rover[TRtmp0{.gb = gb1,.count = count1}],var v8 = Ttmp{.tmp = tmp0,.gb = gb1,.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4,.count = count1},var v9 = TRtmp1{.column1 = v8.column1,.column2 = v8.column2,.column3 = v8.column3,.column4 = v8.column4,.c2 = (64'sd3 + v8.count)},var v10 = v9.";
         this.testTranslation(query, translation);
     }
 
@@ -116,32 +102,24 @@ public class WindowTest extends BaseQueriesTest {
                 "typedef Ttmp = Ttmp{tmp:string, gb:bool, column1:signed<64>, column2:string, column3:bool, column4:double, count:signed<64>}\n" +
                 "typedef TRtmp1 = TRtmp1{column1:signed<64>, column2:string, column3:bool, column4:double, c2:signed<64>}\n" +
                 "function agg(g: Group<bool, TRtmp>):Tagg {\n" +
-                "(var gb4) = group_key(g);\n" +
-                "(var count5 = 64'sd0: signed<64>);\n" +
+                "(var gb0) = group_key(g);\n" +
+                "(var count0 = 64'sd0: signed<64>);\n" +
                 "(for ((i, _) in g) {\n" +
                 "var v3 = i;\n" +
                 "(var incr = v3.tmp);\n" +
-                "(count5 = agg_count_R(count5, incr))}\n" +
+                "(count0 = agg_count_R(count0, incr))}\n" +
                 ");\n" +
-                "(Tagg{.count = count5})\n" +
+                "(Tagg{.count = count0})\n" +
                 "}\n" +
                 this.relations(false) +
-                "relation Rtmp[TRtmp]\n" +
                 "relation Roverinput[TRtmp]\n" +
                 "relation Rtmp0[TRtmp0]\n" +
                 "relation Rover[TRtmp0]\n" +
-                "relation Rtmp1[TRtmp1]\n" +
                 "output relation Rv1[TRtmp1]\n" +
                 "Roverinput[v2] :- Rt1[v0],var v1 = TRtmp{.tmp = sql_substr(v0.column2, 64'sd3, 64'sd3),.gb = v0.column3," +
                 ".column1 = v0.column1,.column2 = v0.column2,.column3 = v0.column3,.column4 = v0.column4},var v2 = v1.\n" +
-                "Rover[v7] :- Roverinput[v3],var gb4 = v3.gb,var groupResult = (v3).group_by((gb4)),var aggResult = agg(groupResult)," +
-                "var v6 = TRtmp0{.gb = gb4,.count = aggResult.count},var v7 = v6.\n" +
-                "Rv1[v12] :- Roverinput[v8],Rover[v9],(true and (v8.gb == v9.gb))," +
-                "var v10 = Ttmp{.tmp = v8.tmp,.gb = v8.gb,.column1 = v8.column1,.column2 = v8.column2," +
-                ".column3 = v8.column3,.column4 = v8.column4,.count = v9.count}," +
-                "var v11 = TRtmp1{.column1 = v8.column1,.column2 = v8.column2,.column3 = v8.column3," +
-                ".column4 = v8.column4,.c2 = (64'sd3 + v9.count)}," +
-                "var v12 = v11.";
+                "Rover[v5] :- Roverinput[v3],var gb0 = v3.gb,var groupResult = (v3).group_by((gb0)),var aggResult = agg(groupResult),var v4 = TRtmp0{.gb = gb0,.count = aggResult.count},var v5 = v4.\n" +
+                "Rv1[v10] :- Roverinput[TRtmp{.tmp = tmp0,.gb = gb1,.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4}],Rover[TRtmp0{.gb = gb1,.count = count1}],var v8 = Ttmp{.tmp = tmp0,.gb = gb1,.column1 = column1,.column2 = column2,.column3 = column3,.column4 = column4,.count = count1},var v9 = TRtmp1{.column1 = v8.column1,.column2 = v8.column2,.column3 = v8.column3,.column4 = v8.column4,.c2 = (64'sd3 + v8.count)},var v10 = v9.";
         this.testTranslation(query, translation);
     }
 
@@ -150,56 +128,48 @@ public class WindowTest extends BaseQueriesTest {
         String query = "create view v1 as\n" +
                 "select DISTINCT count(column3) over (partition by column2) + COUNT(column2) over (partition by column3) as X from t1";
         String translation = this.header(false) +
-                "typedef TRtmp = TRtmp{tmp:bool, tmp1:string, gb:string, gb0:bool}\n" +
+                "typedef TRtmp = TRtmp{tmp:bool, tmp0:string, gb:string, gb0:bool}\n" +
                 "typedef TRtmp0 = TRtmp0{gb:string, count:signed<64>}\n" +
                 "typedef Tagg = Tagg{count:signed<64>}\n" +
-                "typedef TRtmp2 = TRtmp2{gb0:bool, count2:signed<64>}\n" +
-                "typedef Tagg3 = Tagg3{count2:signed<64>}\n" +
-                "typedef Ttmp = Ttmp{tmp:bool, tmp1:string, gb:string, gb0:bool, count:signed<64>}\n" +
-                "typedef Ttmp4 = Ttmp4{tmp:bool, tmp1:string, gb:string, gb0:bool, count:signed<64>, " +
-                "count2:signed<64>}\n" +
-                "typedef TRtmp5 = TRtmp5{x:signed<64>}\n" +
+                "typedef TRtmp1 = TRtmp1{gb0:bool, count0:signed<64>}\n" +
+                "typedef Tagg0 = Tagg0{count0:signed<64>}\n" +
+                "typedef Ttmp = Ttmp{tmp:bool, tmp0:string, gb:string, gb0:bool, count:signed<64>}\n" +
+                "typedef Ttmp0 = Ttmp0{tmp:bool, tmp0:string, gb:string, gb0:bool, count:signed<64>, count0:signed<64>}\n" +
+                "typedef TRtmp3 = TRtmp3{x:signed<64>}\n" +
                 "function agg(g: Group<string, TRtmp>):Tagg {\n" +
-                "(var gb7) = group_key(g);\n" +
-                "(var count8 = 64'sd0: signed<64>);\n" +
+                "(var gb1) = group_key(g);\n" +
+                "(var count1 = 64'sd0: signed<64>);\n" +
                 "(for ((i, _) in g) {\n" +
-                "var v6 = i;\n" +
-                "(var incr = v6.tmp);\n" +
-                "(count8 = agg_count_R(count8, incr))}\n" +
+                "var v3 = i;\n" +
+                "(var incr = v3.tmp);\n" +
+                "(count1 = agg_count_R(count1, incr))}\n" +
                 ");\n" +
-                "(Tagg{.count = count8})\n" +
+                "(Tagg{.count = count1})\n" +
                 "}\n" +
                 "\n" +
-                "function agg3(g13: Group<bool, TRtmp>):Tagg3 {\n" +
-                "(var gb12) = group_key(g13);\n" +
-                "(var count16 = 64'sd0: signed<64>);\n" +
-                "(for ((i14, _) in g13) {\n" +
-                "var v11 = i14;\n" +
-                "(var incr15 = v11.tmp1);\n" +
-                "(count16 = agg_count_R(count16, incr15))}\n" +
+                "function agg0(g0: Group<bool, TRtmp>):Tagg0 {\n" +
+                "(var gb2) = group_key(g0);\n" +
+                "(var count2 = 64'sd0: signed<64>);\n" +
+                "(for ((i0, _) in g0) {\n" +
+                "var v6 = i0;\n" +
+                "(var incr0 = v6.tmp0);\n" +
+                "(count2 = agg_count_R(count2, incr0))}\n" +
                 ");\n" +
-                "(Tagg3{.count2 = count16})\n" +
+                "(Tagg0{.count0 = count2})\n" +
                 "}\n" +
                 this.relations(false) +
-                "relation Rtmp[TRtmp]\n" +
                 "relation Roverinput[TRtmp]\n" +
                 "relation Rtmp0[TRtmp0]\n" +
                 "relation Rover[TRtmp0]\n" +
-                "relation Rtmp2[TRtmp2]\n" +
-                "relation Rover1[TRtmp2]\n" +
-                "relation Rtmp5[TRtmp5]\n" +
-                "output relation Rv1[TRtmp5]\n" +
-                "Roverinput[v5] :- Rt1[v3],var v4 = TRtmp{.tmp = v3.column3,.tmp1 = v3.column2,.gb = v3.column2," +
-                ".gb0 = v3.column3},var v5 = v4.\n" +
-                "Rover[v10] :- Roverinput[v6],var gb7 = v6.gb,var groupResult = (v6).group_by((gb7))," +
-                "var aggResult = agg(groupResult),var v9 = TRtmp0{.gb = gb7,.count = aggResult.count},var v10 = v9.\n" +
-                "Rover1[v20] :- Roverinput[v11],var gb12 = v11.gb0,var groupResult19 = (v11).group_by((gb12))," +
-                "var aggResult18 = agg3(groupResult19),var v17 = TRtmp2{.gb0 = gb12,.count2 = aggResult18.count2},var v20 = v17.\n" +
-                "Rv1[v27] :- Roverinput[v21],Rover[v22],(true and (v21.gb == v22.gb))," +
-                "var v23 = Ttmp{.tmp = v21.tmp,.tmp1 = v21.tmp1,.gb = v21.gb,.gb0 = v21.gb0,.count = v22.count}," +
-                "Rover1[v24],(true and (v23.gb0 == v24.gb0))," +
-                "var v25 = Ttmp4{.tmp = v23.tmp,.tmp1 = v23.tmp1,.gb = v23.gb,.gb0 = v23.gb0,.count = v23.count,.count2 = v24.count2}," +
-                "var v26 = TRtmp5{.x = (v22.count + v24.count2)},var v27 = v26.";
+                "relation Rtmp1[TRtmp1]\n" +
+                "relation Rover0[TRtmp1]\n" +
+                "relation Rtmp2[Ttmp]\n" +
+                "output relation Rv1[TRtmp3]\n" +
+                "Roverinput[v2] :- Rt1[v0],var v1 = TRtmp{.tmp = v0.column3,.tmp0 = v0.column2,.gb = v0.column2,.gb0 = v0.column3},var v2 = v1.\n" +
+                "Rover[v5] :- Roverinput[v3],var gb1 = v3.gb,var groupResult = (v3).group_by((gb1)),var aggResult = agg(groupResult),var v4 = TRtmp0{.gb = gb1,.count = aggResult.count},var v5 = v4.\n" +
+                "Rover0[v8] :- Roverinput[v6],var gb2 = v6.gb0,var groupResult0 = (v6).group_by((gb2)),var aggResult0 = agg0(groupResult0),var v7 = TRtmp1{.gb0 = gb2,.count0 = aggResult0.count0},var v8 = v7.\n" +
+                "Rtmp2[v13] :- Roverinput[TRtmp{.tmp = tmp1,.tmp0 = tmp00,.gb = gb3,.gb0 = gb00}],Rover[TRtmp0{.gb = gb3,.count = count3}],var v11 = Ttmp{.tmp = tmp1,.tmp0 = tmp00,.gb = gb3,.gb0 = gb00,.count = count3},var v13 = v11.\n" +
+                "Rv1[v16] :- Rtmp2[Ttmp{.tmp = tmp2,.tmp0 = tmp01,.gb = gb5,.gb0 = gb01,.count = count4}],Rover0[TRtmp1{.gb0 = gb01,.count0 = count00}],var v14 = Ttmp0{.tmp = tmp2,.tmp0 = tmp01,.gb = gb5,.gb0 = gb01,.count = count4,.count0 = count00},var v15 = TRtmp3{.x = (v14.count + v14.count0)},var v16 = v15.";
         this.testTranslation(query, translation);
     }
 
@@ -211,48 +181,42 @@ public class WindowTest extends BaseQueriesTest {
                 "typedef TRtmp = TRtmp{tmp:signed<64>, gb1:bool, column2:string, s:signed<64>}\n" +
                 "typedef Tagg = Tagg{tmp:signed<64>, s:signed<64>}\n" +
                 "typedef TRtmp0 = TRtmp0{gb1:bool, min:signed<64>}\n" +
-                "typedef Tagg1 = Tagg1{min:signed<64>}\n" +
+                "typedef Tagg0 = Tagg0{min:signed<64>}\n" +
                 "typedef Ttmp = Ttmp{tmp:signed<64>, gb1:bool, column2:string, s:signed<64>, min:signed<64>}\n" +
-                "typedef TRtmp2 = TRtmp2{column2:string, s:signed<64>, min:signed<64>}\n" +
-                "function agg(g: Group<(string, bool), Tt1>):Tagg {\n" +
-                "(var gb3, var gb4) = group_key(g);\n" +
+                "typedef TRtmp1 = TRtmp1{column2:string, s:signed<64>, min:signed<64>}\n" +
+                "function agg(g: Group<(string, bool), TRt1>):Tagg {\n" +
+                "(var gb2, var gb3) = group_key(g);\n" +
                 "(var avg = (64'sd0, 64'sd0): (signed<64>, signed<64>));\n" +
                 "(var sum = 64'sd0: signed<64>);\n" +
                 "(for ((i, _) in g) {\n" +
-                "var v2 = i;\n" +
-                "(var incr = v2.column1);\n" +
+                "var v0 = i;\n" +
+                "(var incr = v0.column1);\n" +
                 "(avg = agg_avg_signed_R(avg, incr));\n" +
-                "(var incr5 = v2.column1);\n" +
-                "(sum = agg_sum_signed_R(sum, incr5))}\n" +
+                "(var incr0 = v0.column1);\n" +
+                "(sum = agg_sum_signed_R(sum, incr0))}\n" +
                 ");\n" +
                 "(Tagg{.tmp = avg_signed_R(avg),.s = sum})\n" +
                 "}\n" +
                 "\n" +
-                "function agg1(g10: Group<bool, TRtmp>):Tagg1 {\n" +
-                "(var gb9) = group_key(g10);\n" +
-                "(var min13 = (true, 64'sd0): (bool, signed<64>));\n" +
-                "(for ((i11, _) in g10) {\n" +
-                "var v8 = i11;\n" +
-                "(var incr12 = v8.tmp);\n" +
-                "(min13 = agg_min_R(min13, incr12))}\n" +
+                "function agg0(g0: Group<bool, TRtmp>):Tagg0 {\n" +
+                "(var gb4) = group_key(g0);\n" +
+                "(var min0 = (true, 64'sd0): (bool, signed<64>));\n" +
+                "(for ((i0, _) in g0) {\n" +
+                "var v3 = i0;\n" +
+                "(var incr1 = v3.tmp);\n" +
+                "(min0 = agg_min_R(min0, incr1))}\n" +
                 ");\n" +
-                "(Tagg1{.min = min13.1})\n" +
+                "(Tagg0{.min = min0.1})\n" +
                 "}\n" +
                 this.relations(false) +
                 "relation Rtmp[TRtmp]\n" +
                 "relation Roverinput[TRtmp]\n" +
                 "relation Rtmp0[TRtmp0]\n" +
                 "relation Rover[TRtmp0]\n" +
-                "relation Rtmp2[TRtmp2]\n" +
-                "output relation Rv1[TRtmp2]\n" +
-                "Roverinput[v7] :- Rt1[v2],var gb3 = v2.column2,var gb4 = v2.column3," +
-                "var groupResult = (v2).group_by((gb3, gb4)),var aggResult = agg(groupResult)," +
-                "var v6 = TRtmp{.column2 = gb3,.gb1 = gb4,.tmp = aggResult.tmp,.s = aggResult.s},var v7 = v6.\n" +
-                "Rover[v17] :- Roverinput[v8],var gb9 = v8.gb1,var groupResult16 = (v8).group_by((gb9))," +
-                "var aggResult15 = agg1(groupResult16),var v14 = TRtmp0{.gb1 = gb9,.min = aggResult15.min},var v17 = v14.\n" +
-                "Rv1[v22] :- Roverinput[v18],Rover[v19],(true and (v18.gb1 == v19.gb1))," +
-                "var v20 = Ttmp{.tmp = v18.tmp,.gb1 = v18.gb1,.column2 = v18.column2,.s = v18.s,.min = v19.min}," +
-                "var v21 = TRtmp2{.column2 = v18.column2,.s = v18.s,.min = v19.min},var v22 = v21.";
+                "output relation Rv1[TRtmp1]\n" +
+                "Roverinput[v2] :- Rt1[v0],var gb2 = v0.column2,var gb3 = v0.column3,var groupResult = (v0).group_by((gb2, gb3)),var aggResult = agg(groupResult),var v1 = TRtmp{.column2 = gb2,.gb1 = gb3,.tmp = aggResult.tmp,.s = aggResult.s},var v2 = v1.\n" +
+                "Rover[v5] :- Roverinput[v3],var gb4 = v3.gb1,var groupResult0 = (v3).group_by((gb4)),var aggResult0 = agg0(groupResult0),var v4 = TRtmp0{.gb1 = gb4,.min = aggResult0.min},var v5 = v4.\n" +
+                "Rv1[v10] :- Roverinput[TRtmp{.tmp = tmp0,.gb1 = gb10,.column2 = column2,.s = s}],Rover[TRtmp0{.gb1 = gb10,.min = min1}],var v8 = Ttmp{.tmp = tmp0,.gb1 = gb10,.column2 = column2,.s = s,.min = min1},var v9 = TRtmp1{.column2 = v8.column2,.s = v8.s,.min = v8.min},var v10 = v9.";
         this.testTranslation(query, translation);
     }
 
@@ -263,34 +227,28 @@ public class WindowTest extends BaseQueriesTest {
                 "typedef TRtmp = TRtmp{tmp:bool, gb1:string, column2:string}\n" +
                 "typedef Tagg = Tagg{}\n" +
                 "typedef TRtmp0 = TRtmp0{gb1:string, count:signed<64>}\n" +
-                "typedef Tagg1 = Tagg1{count:signed<64>}\n" +
+                "typedef Tagg0 = Tagg0{count:signed<64>}\n" +
                 "typedef Ttmp = Ttmp{tmp:bool, gb1:string, column2:string, count:signed<64>}\n" +
-                "typedef TRtmp2 = TRtmp2{column2:string, count:signed<64>}\n" +
-                "function agg1(g9: Group<string, TRtmp>):Tagg1 {\n" +
-                "(var gb8) = group_key(g9);\n" +
-                "(var count11 = 64'sd0: signed<64>);\n" +
-                "(for ((i10, _) in g9) {\n" +
-                "var v7 = i10;\n" +
-                "(var incr = v7.tmp);\n" +
-                "(count11 = agg_count_R(count11, incr))}\n" +
+                "typedef TRtmp1 = TRtmp1{column2:string, count:signed<64>}\n" +
+                "function agg0(g0: Group<string, TRtmp>):Tagg0 {\n" +
+                "(var gb4) = group_key(g0);\n" +
+                "(var count0 = 64'sd0: signed<64>);\n" +
+                "(for ((i0, _) in g0) {\n" +
+                "var v3 = i0;\n" +
+                "(var incr = v3.tmp);\n" +
+                "(count0 = agg_count_R(count0, incr))}\n" +
                 ");\n" +
-                "(Tagg1{.count = count11})\n" +
+                "(Tagg0{.count = count0})\n" +
                 "}\n" +
                 this.relations(false) +
                 "relation Rtmp[TRtmp]\n" +
                 "relation Roverinput[TRtmp]\n" +
                 "relation Rtmp0[TRtmp0]\n" +
                 "relation Rover[TRtmp0]\n" +
-                "relation Rtmp2[TRtmp2]\n" +
-                "output relation Rv0[TRtmp2]\n" +
-                "Roverinput[v6] :- Rt1[v2],var gb3 = v2.column2,var gb4 = v2.column3," +
-                "var groupResult = (v2).group_by((gb3, gb4))," +
-                "var v5 = TRtmp{.gb1 = gb3,.column2 = gb3,.tmp = gb4},var v6 = v5.\n" +
-                "Rover[v15] :- Roverinput[v7],var gb8 = v7.gb1,var groupResult14 = (v7).group_by((gb8))," +
-                "var aggResult13 = agg1(groupResult14),var v12 = TRtmp0{.gb1 = gb8,.count = aggResult13.count},var v15 = v12.\n" +
-                "Rv0[v20] :- Roverinput[v16],Rover[v17],(true and (v16.gb1 == v17.gb1))," +
-                "var v18 = Ttmp{.tmp = v16.tmp,.gb1 = v16.gb1,.column2 = v16.column2,.count = v17.count}," +
-                "var v19 = TRtmp2{.column2 = v16.column2,.count = v17.count},var v20 = v19.";
+                "output relation Rv0[TRtmp1]\n" +
+                "Roverinput[v2] :- Rt1[v0],var gb2 = v0.column2,var gb3 = v0.column3,var groupResult = (v0).group_by((gb2, gb3)),var v1 = TRtmp{.gb1 = gb2,.column2 = gb2,.tmp = gb3},var v2 = v1.\n" +
+                "Rover[v5] :- Roverinput[v3],var gb4 = v3.gb1,var groupResult0 = (v3).group_by((gb4)),var aggResult0 = agg0(groupResult0),var v4 = TRtmp0{.gb1 = gb4,.count = aggResult0.count},var v5 = v4.\n" +
+                "Rv0[v10] :- Roverinput[TRtmp{.tmp = tmp0,.gb1 = gb10,.column2 = column2}],Rover[TRtmp0{.gb1 = gb10,.count = count1}],var v8 = Ttmp{.tmp = tmp0,.gb1 = gb10,.column2 = column2,.count = count1},var v9 = TRtmp1{.column2 = v8.column2,.count = v8.count},var v10 = v9.";
         this.testTranslation(query, translation);
     }
 
@@ -301,45 +259,39 @@ public class WindowTest extends BaseQueriesTest {
                 "typedef TRtmp = TRtmp{tmp:signed<64>, gb1:bool, column2:string, col:signed<64>}\n" +
                 "typedef Tagg = Tagg{tmp:signed<64>, col:signed<64>}\n" +
                 "typedef TRtmp0 = TRtmp0{gb1:bool, sum:signed<64>}\n" +
-                "typedef Tagg1 = Tagg1{sum:signed<64>}\n" +
+                "typedef Tagg0 = Tagg0{sum:signed<64>}\n" +
                 "typedef Ttmp = Ttmp{tmp:signed<64>, gb1:bool, column2:string, col:signed<64>, sum:signed<64>}\n" +
-                "typedef TRtmp2 = TRtmp2{column2:string, col:signed<64>, sum:signed<64>}\n" +
-                "function agg(g: Group<(string, bool), Tt1>):Tagg {\n" +
-                "(var gb3, var gb4) = group_key(g);\n" +
-                "(var sum5 = 64'sd0: signed<64>);\n" +
+                "typedef TRtmp1 = TRtmp1{column2:string, col:signed<64>, sum:signed<64>}\n" +
+                "function agg(g: Group<(string, bool), TRt1>):Tagg {\n" +
+                "(var gb2, var gb3) = group_key(g);\n" +
+                "(var sum0 = 64'sd0: signed<64>);\n" +
                 "(for ((i, _) in g) {\n" +
-                "var v2 = i;\n" +
-                "(var incr = v2.column1);\n" +
-                "(sum5 = agg_sum_signed_R(sum5, incr))}\n" +
+                "var v0 = i;\n" +
+                "(var incr = v0.column1);\n" +
+                "(sum0 = agg_sum_signed_R(sum0, incr))}\n" +
                 ");\n" +
-                "(Tagg{.tmp = sum5,.col = sum5})\n" +
+                "(Tagg{.tmp = sum0,.col = sum0})\n" +
                 "}\n" +
                 "\n" +
-                "function agg1(g10: Group<bool, TRtmp>):Tagg1 {\n" +
-                "(var gb9) = group_key(g10);\n" +
-                "(var sum13 = 64'sd0: signed<64>);\n" +
-                "(for ((i11, _) in g10) {\n" +
-                "var v8 = i11;\n" +
-                "(var incr12 = v8.tmp);\n" +
-                "(sum13 = agg_sum_signed_R(sum13, incr12))}\n" +
+                "function agg0(g0: Group<bool, TRtmp>):Tagg0 {\n" +
+                "(var gb4) = group_key(g0);\n" +
+                "(var sum1 = 64'sd0: signed<64>);\n" +
+                "(for ((i0, _) in g0) {\n" +
+                "var v3 = i0;\n" +
+                "(var incr0 = v3.tmp);\n" +
+                "(sum1 = agg_sum_signed_R(sum1, incr0))}\n" +
                 ");\n" +
-                "(Tagg1{.sum = sum13})\n" +
+                "(Tagg0{.sum = sum1})\n" +
                 "}\n" +
                 this.relations(false) +
                 "relation Rtmp[TRtmp]\n" +
                 "relation Roverinput[TRtmp]\n" +
                 "relation Rtmp0[TRtmp0]\n" +
                 "relation Rover[TRtmp0]\n" +
-                "relation Rtmp2[TRtmp2]\n" +
-                "output relation Rv0[TRtmp2]\n" +
-                "Roverinput[v7] :- Rt1[v2],var gb3 = v2.column2,var gb4 = v2.column3,var groupResult = (v2).group_by((gb3, gb4))," +
-                "var aggResult = agg(groupResult),var v6 = TRtmp{.column2 = gb3,.gb1 = gb4,.tmp = aggResult.tmp,.col = aggResult.col}," +
-                "var v7 = v6.\n" +
-                "Rover[v17] :- Roverinput[v8],var gb9 = v8.gb1,var groupResult16 = (v8).group_by((gb9))," +
-                "var aggResult15 = agg1(groupResult16),var v14 = TRtmp0{.gb1 = gb9,.sum = aggResult15.sum},var v17 = v14.\n" +
-                "Rv0[v22] :- Roverinput[v18],Rover[v19],(true and (v18.gb1 == v19.gb1))," + "" +
-                "var v20 = Ttmp{.tmp = v18.tmp,.gb1 = v18.gb1,.column2 = v18.column2,.col = v18.col,.sum = v19.sum}," +
-                "var v21 = TRtmp2{.column2 = v18.column2,.col = v18.col,.sum = v19.sum},var v22 = v21.";
+                "output relation Rv0[TRtmp1]\n" +
+                "Roverinput[v2] :- Rt1[v0],var gb2 = v0.column2,var gb3 = v0.column3,var groupResult = (v0).group_by((gb2, gb3)),var aggResult = agg(groupResult),var v1 = TRtmp{.column2 = gb2,.gb1 = gb3,.tmp = aggResult.tmp,.col = aggResult.col},var v2 = v1.\n" +
+                "Rover[v5] :- Roverinput[v3],var gb4 = v3.gb1,var groupResult0 = (v3).group_by((gb4)),var aggResult0 = agg0(groupResult0),var v4 = TRtmp0{.gb1 = gb4,.sum = aggResult0.sum},var v5 = v4.\n" +
+                "Rv0[v10] :- Roverinput[TRtmp{.tmp = tmp0,.gb1 = gb10,.column2 = column2,.col = col0}],Rover[TRtmp0{.gb1 = gb10,.sum = sum2}],var v8 = Ttmp{.tmp = tmp0,.gb1 = gb10,.column2 = column2,.col = col0,.sum = sum2},var v9 = TRtmp1{.column2 = v8.column2,.col = v8.col,.sum = v8.sum},var v10 = v9.";
         this.testTranslation(query, translation);
     }
 
@@ -348,37 +300,29 @@ public class WindowTest extends BaseQueriesTest {
         String query = "CREATE VIEW v0 as SELECT DISTINCT t1.column2, AVG(t2.column1) OVER (PARTITION by t1.column3) AS avg\n" +
                 "         FROM t1 JOIN t2 ON t1.column1 = t2.column1\n";
         String translation = this.header(false) +
-                "typedef Ttmp = Ttmp{column1:signed<64>, column2:string, column3:bool, column4:double, column10:signed<64>}\n" +
                 "typedef TRtmp = TRtmp{tmp:signed<64>, gb:bool, column2:string}\n" +
                 "typedef TRtmp0 = TRtmp0{gb:bool, avg:signed<64>}\n" +
                 "typedef Tagg = Tagg{avg:signed<64>}\n" +
-                "typedef Ttmp1 = Ttmp1{tmp:signed<64>, gb:bool, column2:string, avg:signed<64>}\n" +
-                "typedef TRtmp2 = TRtmp2{column2:string, avg:signed<64>}\n" +
+                "typedef Ttmp = Ttmp{tmp:signed<64>, gb:bool, column2:string, avg:signed<64>}\n" +
+                "typedef TRtmp1 = TRtmp1{column2:string, avg:signed<64>}\n" +
                 "function agg(g: Group<bool, TRtmp>):Tagg {\n" +
-                "(var gb8) = group_key(g);\n" +
-                "(var avg9 = (64'sd0, 64'sd0): (signed<64>, signed<64>));\n" +
+                "(var gb0) = group_key(g);\n" +
+                "(var avg0 = (64'sd0, 64'sd0): (signed<64>, signed<64>));\n" +
                 "(for ((i, _) in g) {\n" +
                 "var v7 = i;\n" +
                 "(var incr = v7.tmp);\n" +
-                "(avg9 = agg_avg_signed_R(avg9, incr))}\n" +
+                "(avg0 = agg_avg_signed_R(avg0, incr))}\n" +
                 ");\n" +
-                "(Tagg{.avg = avg_signed_R(avg9)})\n" +
+                "(Tagg{.avg = avg_signed_R(avg0)})\n" +
                 "}\n" +
                 this.relations(false) +
-                "relation Rtmp[TRtmp]\n" +
                 "relation Roverinput[TRtmp]\n" +
                 "relation Rtmp0[TRtmp0]\n" +
                 "relation Rover[TRtmp0]\n" +
-                "relation Rtmp2[TRtmp2]\n" +
-                "output relation Rv0[TRtmp2]\n" +
-                "Roverinput[v6] :- Rt1[v2],Rt2[v3],(v2.column1 == v3.column1),true," +
-                "var v4 = Ttmp{.column1 = v2.column1,.column2 = v2.column2,.column3 = v2.column3,.column4 = v2.column4,.column10 = v3.column1}" +
-                ",var v5 = TRtmp{.tmp = v3.column1,.gb = v2.column3,.column2 = v2.column2},var v6 = v5.\n" +
-                "Rover[v11] :- Roverinput[v7],var gb8 = v7.gb,var groupResult = (v7).group_by((gb8))," +
-                "var aggResult = agg(groupResult),var v10 = TRtmp0{.gb = gb8,.avg = aggResult.avg},var v11 = v10.\n" +
-                "Rv0[v16] :- Roverinput[v12],Rover[v13],(true and (v12.gb == v13.gb))," +
-                "var v14 = Ttmp1{.tmp = v12.tmp,.gb = v12.gb,.column2 = v12.column2,.avg = v13.avg}," +
-                "var v15 = TRtmp2{.column2 = v12.column2,.avg = v13.avg},var v16 = v15.";
+                "output relation Rv0[TRtmp1]\n" +
+                "Roverinput[v6] :- Rt1[TRt1{.column1 = column11,.column2 = column20,.column3 = column30,.column4 = column40}],Rt2[TRt2{.column1 = column11}],var v4 = TRt1{.column1 = column11,.column2 = column20,.column3 = column30,.column4 = column40},var v5 = TRtmp{.tmp = v4.column1,.gb = v4.column3,.column2 = v4.column2},var v6 = v5.\n" +
+                "Rover[v9] :- Roverinput[v7],var gb0 = v7.gb,var groupResult = (v7).group_by((gb0)),var aggResult = agg(groupResult),var v8 = TRtmp0{.gb = gb0,.avg = aggResult.avg},var v9 = v8.\n" +
+                "Rv0[v14] :- Roverinput[TRtmp{.tmp = tmp0,.gb = gb1,.column2 = column21}],Rover[TRtmp0{.gb = gb1,.avg = avg1}],var v12 = Ttmp{.tmp = tmp0,.gb = gb1,.column2 = column21,.avg = avg1},var v13 = TRtmp1{.column2 = v12.column2,.avg = v12.avg},var v14 = v13.";
         this.testTranslation(query, translation);
     }
 
@@ -387,38 +331,29 @@ public class WindowTest extends BaseQueriesTest {
         String query = "CREATE VIEW v0 as SELECT DISTINCT t1.column2 as test_alias, AVG(t2.column1) OVER (PARTITION by t1.column3) AS avg\n" +
                 "         FROM t1 JOIN t2 ON t1.column1 = t2.column1\n";
         String translation = this.header(false) +
-                "typedef Ttmp = Ttmp{column1:signed<64>, column2:string, column3:bool, column4:double, column10:signed<64>}\n" +
                 "typedef TRtmp = TRtmp{tmp:signed<64>, gb:bool, test_alias:string}\n" +
                 "typedef TRtmp0 = TRtmp0{gb:bool, avg:signed<64>}\n" +
                 "typedef Tagg = Tagg{avg:signed<64>}\n" +
-                "typedef Ttmp1 = Ttmp1{tmp:signed<64>, gb:bool, test_alias:string, avg:signed<64>}\n" +
-                "typedef TRtmp2 = TRtmp2{test_alias:string, avg:signed<64>}\n" +
+                "typedef Ttmp = Ttmp{tmp:signed<64>, gb:bool, test_alias:string, avg:signed<64>}\n" +
+                "typedef TRtmp1 = TRtmp1{test_alias:string, avg:signed<64>}\n" +
                 "function agg(g: Group<bool, TRtmp>):Tagg {\n" +
-                "(var gb8) = group_key(g);\n" +
-                "(var avg9 = (64'sd0, 64'sd0): (signed<64>, signed<64>));\n" +
+                "(var gb0) = group_key(g);\n" +
+                "(var avg0 = (64'sd0, 64'sd0): (signed<64>, signed<64>));\n" +
                 "(for ((i, _) in g) {\n" +
                 "var v7 = i;\n" +
                 "(var incr = v7.tmp);\n" +
-                "(avg9 = agg_avg_signed_R(avg9, incr))}\n" +
+                "(avg0 = agg_avg_signed_R(avg0, incr))}\n" +
                 ");\n" +
-                "(Tagg{.avg = avg_signed_R(avg9)})\n" +
+                "(Tagg{.avg = avg_signed_R(avg0)})\n" +
                 "}\n" +
                 this.relations(false) +
-                "relation Rtmp[TRtmp]\n" +
                 "relation Roverinput[TRtmp]\n" +
                 "relation Rtmp0[TRtmp0]\n" +
                 "relation Rover[TRtmp0]\n" +
-                "relation Rtmp2[TRtmp2]\n" +
-                "output relation Rv0[TRtmp2]\n" +
-                "Roverinput[v6] :- Rt1[v2],Rt2[v3],(v2.column1 == v3.column1),true," +
-                "var v4 = Ttmp{.column1 = v2.column1,.column2 = v2.column2,.column3 = v2.column3,.column4 = v2.column4,.column10 = v3.column1}," +
-                "var v5 = TRtmp{.tmp = v3.column1,.gb = v2.column3,.test_alias = v2.column2},var v6 = v5.\n" +
-                "Rover[v11] :- Roverinput[v7],var gb8 = v7.gb,var groupResult = (v7).group_by((gb8))," +
-                "var aggResult = agg(groupResult),var v10 = TRtmp0{.gb = gb8,.avg = aggResult.avg},var v11 = v10.\n" +
-                "Rv0[v16] :- Roverinput[v12],Rover[v13],(true and (v12.gb == v13.gb))," +
-                "var v14 = Ttmp1{.tmp = v12.tmp,.gb = v12.gb,.test_alias = v12.test_alias,.avg = v13.avg}," +
-                "var v15 = TRtmp2{.test_alias = v12.test_alias,.avg = v13.avg}," +
-                "var v16 = v15.";
+                "output relation Rv0[TRtmp1]\n" +
+                "Roverinput[v6] :- Rt1[TRt1{.column1 = column11,.column2 = column20,.column3 = column30,.column4 = column40}],Rt2[TRt2{.column1 = column11}],var v4 = TRt1{.column1 = column11,.column2 = column20,.column3 = column30,.column4 = column40},var v5 = TRtmp{.tmp = v4.column1,.gb = v4.column3,.test_alias = v4.column2},var v6 = v5.\n" +
+                "Rover[v9] :- Roverinput[v7],var gb0 = v7.gb,var groupResult = (v7).group_by((gb0)),var aggResult = agg(groupResult),var v8 = TRtmp0{.gb = gb0,.avg = aggResult.avg},var v9 = v8.\n" +
+                "Rv0[v14] :- Roverinput[TRtmp{.tmp = tmp0,.gb = gb1,.test_alias = test_alias}],Rover[TRtmp0{.gb = gb1,.avg = avg1}],var v12 = Ttmp{.tmp = tmp0,.gb = gb1,.test_alias = test_alias,.avg = avg1},var v13 = TRtmp1{.test_alias = v12.test_alias,.avg = v12.avg},var v14 = v13.";
         this.testTranslation(query, translation);
     }
 
@@ -427,38 +362,29 @@ public class WindowTest extends BaseQueriesTest {
         String query = "CREATE VIEW v0 as SELECT DISTINCT AVG(t2.column1) OVER (PARTITION by t1.column3) AS avg, t1.column2 as test_alias\n" +
                 "         FROM t1 JOIN t2 ON t1.column1 = t2.column1\n";
         String translation = this.header(false) +
-                "typedef Ttmp = Ttmp{column1:signed<64>, column2:string, column3:bool, column4:double, column10:signed<64>}\n" +
                 "typedef TRtmp = TRtmp{tmp:signed<64>, gb:bool, test_alias:string}\n" +
                 "typedef TRtmp0 = TRtmp0{gb:bool, avg:signed<64>}\n" +
                 "typedef Tagg = Tagg{avg:signed<64>}\n" +
-                "typedef Ttmp1 = Ttmp1{tmp:signed<64>, gb:bool, test_alias:string, avg:signed<64>}\n" +
-                "typedef TRtmp2 = TRtmp2{avg:signed<64>, test_alias:string}\n" +
+                "typedef Ttmp = Ttmp{tmp:signed<64>, gb:bool, test_alias:string, avg:signed<64>}\n" +
+                "typedef TRtmp1 = TRtmp1{avg:signed<64>, test_alias:string}\n" +
                 "function agg(g: Group<bool, TRtmp>):Tagg {\n" +
-                "(var gb8) = group_key(g);\n" +
-                "(var avg9 = (64'sd0, 64'sd0): (signed<64>, signed<64>));\n" +
+                "(var gb0) = group_key(g);\n" +
+                "(var avg0 = (64'sd0, 64'sd0): (signed<64>, signed<64>));\n" +
                 "(for ((i, _) in g) {\n" +
                 "var v7 = i;\n" +
                 "(var incr = v7.tmp);\n" +
-                "(avg9 = agg_avg_signed_R(avg9, incr))}\n" +
+                "(avg0 = agg_avg_signed_R(avg0, incr))}\n" +
                 ");\n" +
-                "(Tagg{.avg = avg_signed_R(avg9)})\n" +
+                "(Tagg{.avg = avg_signed_R(avg0)})\n" +
                 "}\n" +
                 this.relations(false) +
-                "relation Rtmp[TRtmp]\n" +
                 "relation Roverinput[TRtmp]\n" +
                 "relation Rtmp0[TRtmp0]\n" +
                 "relation Rover[TRtmp0]\n" +
-                "relation Rtmp2[TRtmp2]\n" +
-                "output relation Rv0[TRtmp2]\n" +
-                "Roverinput[v6] :- Rt1[v2],Rt2[v3],(v2.column1 == v3.column1),true," +
-                "var v4 = Ttmp{.column1 = v2.column1,.column2 = v2.column2,.column3 = v2.column3,.column4 = v2.column4,.column10 = v3.column1}," +
-                "var v5 = TRtmp{.tmp = v3.column1,.gb = v2.column3,.test_alias = v2.column2},var v6 = v5.\n" +
-                "Rover[v11] :- Roverinput[v7],var gb8 = v7.gb,var groupResult = (v7).group_by((gb8))," +
-                "var aggResult = agg(groupResult),var v10 = TRtmp0{.gb = gb8,.avg = aggResult.avg},var v11 = v10.\n" +
-                "Rv0[v16] :- Roverinput[v12],Rover[v13],(true and (v12.gb == v13.gb))," +
-                "var v14 = Ttmp1{.tmp = v12.tmp,.gb = v12.gb,.test_alias = v12.test_alias,.avg = v13.avg}," +
-                "var v15 = TRtmp2{.avg = v13.avg,.test_alias = v12.test_alias}," +
-                "var v16 = v15.";
+                "output relation Rv0[TRtmp1]\n" +
+                "Roverinput[v6] :- Rt1[TRt1{.column1 = column11,.column2 = column20,.column3 = column30,.column4 = column40}],Rt2[TRt2{.column1 = column11}],var v4 = TRt1{.column1 = column11,.column2 = column20,.column3 = column30,.column4 = column40},var v5 = TRtmp{.tmp = v4.column1,.gb = v4.column3,.test_alias = v4.column2},var v6 = v5.\n" +
+                "Rover[v9] :- Roverinput[v7],var gb0 = v7.gb,var groupResult = (v7).group_by((gb0)),var aggResult = agg(groupResult),var v8 = TRtmp0{.gb = gb0,.avg = aggResult.avg},var v9 = v8.\n" +
+                "Rv0[v14] :- Roverinput[TRtmp{.tmp = tmp0,.gb = gb1,.test_alias = test_alias}],Rover[TRtmp0{.gb = gb1,.avg = avg1}],var v12 = Ttmp{.tmp = tmp0,.gb = gb1,.test_alias = test_alias,.avg = avg1},var v13 = TRtmp1{.avg = v12.avg,.test_alias = v12.test_alias},var v14 = v13.";
 
         this.testTranslation(query, translation);
     }


### PR DESCRIPTION
Previously joins were implemented as cartesian products followed by filtering.
With this PR they are implemented as DDlog joins.
The PR is more complicated than expected because it had to rework the way objects are named and looked-up.
Joins were also incorrect: one should not join on null values. This is fixed in this PR.
Note: left joins are still not implemented, but they should be easier to do with this infrastructure.