### PR TITLE
Treat DECIMAL types as Long in DDlogJooqProvider

### DIFF
--- a/sql/src/main/java/com/vmware/ddlog/ParseLiterals.java
+++ b/sql/src/main/java/com/vmware/ddlog/ParseLiterals.java
@@ -39,7 +39,7 @@ class ParseLiterals extends SqlBasicVisitor<DDlogRecord> {
             case BOOLEAN:
                 return new DDlogRecord(sqlLiteral.booleanValue());
             case DECIMAL:
-                return new DDlogRecord(sqlLiteral.intValue(false));
+                return new DDlogRecord(sqlLiteral.longValue(false));
             case CHAR:
                 try {
                     return new DDlogRecord(sqlLiteral.toValue());

--- a/sql/src/test/java/ddlog/JooqProviderCalciteTest.java
+++ b/sql/src/test/java/ddlog/JooqProviderCalciteTest.java
@@ -36,6 +36,10 @@ public class JooqProviderCalciteTest extends JooqProviderTestBase {
         String checkArrayType = "create view check_array_type as select distinct col3, " +
                 "ARRAY_AGG(capacity) over (partition by col3) as agg " +
                 "from base_array_table";
+        String bigIntTable = "create table big_int_table (id bigint)";
+
+        String bigIntTableViewName = DDlogJooqProvider.toIdentityViewName("big_int_table");
+        String bigIntTableView = String.format("create view %s as select distinct * from big_int_table", bigIntTableViewName);
 
         String identityViewName = DDlogJooqProvider.toIdentityViewName("hosts");
         String hostIdentityView = String.format("create view %s as select distinct * from hosts", identityViewName);
@@ -57,6 +61,8 @@ public class JooqProviderCalciteTest extends JooqProviderTestBase {
         ddl.add(checkArrayType);
         ddl.add(hostIdentityView);
         ddl.add(notNullIdentityView);
+        ddl.add(bigIntTable);
+        ddl.add(bigIntTableView);
 
         List<String> indexStatements = new ArrayList<>();
         indexStatements.add(createIndexNotNull);

--- a/sql/src/test/java/ddlog/JooqProviderPrestoTest.java
+++ b/sql/src/test/java/ddlog/JooqProviderPrestoTest.java
@@ -53,6 +53,10 @@ public class JooqProviderPrestoTest extends JooqProviderTestBase {
         String checkArrayType = "create view check_array_type as select distinct col3, " +
                 "ARRAY_AGG(capacity) over (partition by col3) as agg " +
                 "from base_array_table";
+        String bigIntTable = "create table big_int_table (id bigint)";
+
+        String bigIntTableViewName = DDlogJooqProvider.toIdentityViewName("big_int_table");
+        String bigIntTableView = String.format("create view %s as select distinct * from big_int_table", bigIntTableViewName);
 
         String identityViewName = DDlogJooqProvider.toIdentityViewName("hosts");
         String hostIdentityView = String.format("create view %s as select distinct * from hosts", identityViewName);
@@ -73,6 +77,8 @@ public class JooqProviderPrestoTest extends JooqProviderTestBase {
         ddl.add(checkArrayType);
         ddl.add(hostIdentityView);
         ddl.add(notNullIdentityView);
+        ddl.add(bigIntTable);
+        ddl.add(bigIntTableView);
 
         List<String> indexStatements = new ArrayList<>();
         indexStatements.add(createIndexNotNull);

--- a/sql/src/test/java/ddlog/JooqProviderTestBase.java
+++ b/sql/src/test/java/ddlog/JooqProviderTestBase.java
@@ -687,4 +687,14 @@ public abstract class JooqProviderTestBase {
         assertTrue(readFromInput.contains(test3));
     }
 
+    @Test
+    public void testBigInt() {
+        create.execute("insert into big_int_table values (10000000000)");
+        Result<Record> readFromInput = create.fetch("select * from big_int_table");
+
+        final Field<Long> testCol1 = field("id", Long.class);
+        final Record testLong = create.newRecord(testCol1);
+        testLong.setValue(testCol1, 10000000000L);
+        assertTrue(readFromInput.contains(testLong));
+    }
 }


### PR DESCRIPTION
Jooq translates BIGINT types into Types.DECIMAL, which means they should be treated as Longs to prevent overflow.

Signed-off-by: Amy Tai <amy.tai.2009@gmail.com>