### PR TITLE
Don't recompile Rust when only debug_info changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Quality-of-life improvements
+
+- Avoid recompiling Rust crates when only arrangement debug info changes.
+
 ## [1.2.2] - Dec 9, 2021
 
 ### Bug fixes

--- a/rust/template/differential_datalog/src/program/mod.rs
+++ b/rust/template/differential_datalog/src/program/mod.rs
@@ -866,6 +866,19 @@ impl Arrangement {
         }
     }
 
+    pub fn set_debug_info(mut self, dbg_info: ArrangementDebugInfo) -> Self {
+        match self {
+            Self::Map {
+                ref mut debug_info, ..
+            } => *debug_info = dbg_info,
+            Self::Set {
+                ref mut debug_info, ..
+            } => *debug_info = dbg_info,
+        };
+
+        self
+    }
+
     fn build_arrangement_root<S>(
         &self,
         render_context: &RenderContext,


### PR DESCRIPTION
Recent improvements of the self-profiler infrastructure caused
regression in Rust compilation times.  We now store detailed debug
info with each arrangement, including the list of source code locations
where the arrangement is used.  Every time the user as much as changes
the formatting in one of these locations, debug info changes causing the
crate that declares the relation to recompile.  The workaround is to
generate arrangements without debug_info and inject debug info from the
root crate, which always gets re-compiled anyway.