### PR TITLE
sql: bump H2 and JOOQ to latest versions and address array syntax change

### DIFF
--- a/sql/pom.xml
+++ b/sql/pom.xml
@@ -11,7 +11,7 @@
     <dependency>
       <groupId>org.jooq</groupId>
       <artifactId>jooq</artifactId>
-      <version>3.13.1</version>
+      <version>3.16.2</version>
     </dependency>
     <dependency>
       <groupId>com.facebook.presto</groupId>
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>1.4.199</version>
+      <version>2.1.210</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -51,8 +51,8 @@
     </dependency>
   </dependencies>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
   </properties>
 
   <build>

--- a/sql/src/main/java/com/vmware/ddlog/util/sql/CalciteToH2Translator.java
+++ b/sql/src/main/java/com/vmware/ddlog/util/sql/CalciteToH2Translator.java
@@ -73,21 +73,13 @@ class CalciteToH2 extends CalciteDDLVisitorBase {
     @Override
     public String visit(SqlCall call) {
         if (call instanceof SqlColumnDeclaration) {
-
             SqlColumnDeclaration castColumn = (SqlColumnDeclaration) call;
             String type = castColumn.dataType.toString();
-
-            if (castColumn.dataType.getCollectionsTypeName() != null &&
-                    castColumn.dataType.getCollectionsTypeName().toString().equals("ARRAY")) {
-                type = "array";
-            }
-
             String nullOperand = (castColumn.strategy == ColumnStrategy.NULLABLE) ? "null" : "not null";
             if (castColumn.expression != null) {
                 throw new UnsupportedOperationException(
                         "Don't know how to translate Calcite column expressions yet");
             }
-
             String transcribed = String.format("%s %s %s",
                     castColumn.name.toString(),
                     type,

--- a/sql/src/main/java/com/vmware/ddlog/util/sql/PrestoToH2Translator.java
+++ b/sql/src/main/java/com/vmware/ddlog/util/sql/PrestoToH2Translator.java
@@ -64,7 +64,9 @@ class PrestoToH2 extends AstVisitor<String, String> {
                 final Pattern arrayType = Pattern.compile("ARRAY\\((.+)\\)");
                 Matcher m = arrayType.matcher(h2Type);
                 if (m.find()) {
-                    h2Type = "array";
+                    final String match = m.group();
+                    final String arrayTypeStr = match.substring(6, match.length() - 1);
+                    h2Type = arrayTypeStr + " array";
                 }
 
                 if (cd.getProperties().size() == 1) {

--- a/sql/src/test/java/ddlog/DynamicTest.java
+++ b/sql/src/test/java/ddlog/DynamicTest.java
@@ -50,7 +50,7 @@ public class DynamicTest extends BaseQueriesTest {
         properties.setProperty("foreign_keys", "true");
         try {
             // Create a fresh database
-            final String connectionURL = "jdbc:h2:mem:;create=true";
+            final String connectionURL = "jdbc:h2:mem:";
             final Connection conn = DriverManager.getConnection(connectionURL, properties);
             conn.setSchema("PUBLIC");
             return DSL.using(conn, SQLDialect.H2);


### PR DESCRIPTION
The new H2 version uses the standard SQL syntax for arrays (that is, qualified with the type of the array). 

@mbudiu-vmw I addressed most issues, but two tests still fail. They both relate to a type-confusion on the return type of array_agg(). I couldn't immediately tell if it's to do with the jooq code or whether it's on the ddlog -> sql compiler side. Please have a look, otherwise I'll dig deeper later this week.

Signed-off-by: Lalith Suresh <lsuresh@vmware.com>