### PR TITLE
Fix version of `internment` dependency.

### DIFF
--- a/lib/internment.toml
+++ b/lib/internment.toml
@@ -1,3 +1,3 @@
 [dependencies.internment]
-version="0.5.4"
+version="=0.5.4"
 features=["arc"]


### PR DESCRIPTION
Because of this issue:
https://github.com/droundy/internment/issues/34
we had to fix the dependency to 0.5.4 to maintain compatibility with
Rust 1.52.1.

Signed-off-by: Leonid Ryzhyk <lryzhyk@vmware.com>