### PR TITLE
Use fixed version of `criterion` for benchmarking.

### DIFF
--- a/rust/ddlog_benches/Cargo.toml
+++ b/rust/ddlog_benches/Cargo.toml
@@ -5,13 +5,14 @@ edition = "2018"
 license = "MIT"
 
 [features]
-# Use the following to run with checked_weights: 
+# Use the following to run with checked_weights:
 # panic on weight overflow.
 #default = ["benchmarks_ddlog/checked_weights"]
 default = []
 
 [dependencies]
-criterion = "0.3.3"
+# criterion-0.3.6 and later require Rust 2021, which is supported since rustc 1.56 compiler.
+criterion = "=0.3.3"
 flate2 = "1.0.19"
 csv = "1.1.5"
 


### PR DESCRIPTION
criterion-0.3.6 requires Rust 2021, which is not supported by older
rust compilers.  Since this is our only dependency that requires newer
Rust than our officially supported 1.52.1+, I hard coded version
`0.3.3` for now.