### PR TITLE
Add missing Record::as_string() method.

### DIFF
--- a/rust/template/differential_datalog/src/record/mod.rs
+++ b/rust/template/differential_datalog/src/record/mod.rs
@@ -165,6 +165,13 @@ impl Record {
         }
     }
 
+    pub fn as_string(&self) -> Option<&String> {
+        match self {
+            Self::String(ref string) => Some(string),
+            _ => None,
+        }
+    }
+
     pub fn get_struct_field(&self, field_name: &str) -> Option<&Self> {
         match self {
             Self::NamedStruct(_, fields) => fields


### PR DESCRIPTION
This seems to just be an oversight, since Record::is_string() did exist.

Signed-off-by: Ben Pfaff <bpfaff@vmware.com>